### PR TITLE
feat: add Requesty as an OpenAI-compatible LLM provider

### DIFF
--- a/cli/v4/keyValidator.ts
+++ b/cli/v4/keyValidator.ts
@@ -97,6 +97,14 @@ function buildRequest(
         method: 'GET',
         headers: { Authorization: `Bearer ${apiKey}` },
       };
+    case 'requesty':
+      // Requesty has no /auth/key endpoint — validate via the generic
+      // OpenAI-compatible /models GET (like openai/groq above).
+      return {
+        url: 'https://router.requesty.ai/v1/models',
+        method: 'GET',
+        headers: { Authorization: `Bearer ${apiKey}` },
+      };
     case 'together':
       return {
         url: 'https://api.together.xyz/v1/models',

--- a/core/agentLoop.ts
+++ b/core/agentLoop.ts
@@ -448,6 +448,7 @@ export async function streamGeminiResponse(
 const OPENAI_COMPAT_ENDPOINTS: Record<string, string> = {
   groq:       'https://api.groq.com/openai/v1/chat/completions',
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
+  requesty:   'https://router.requesty.ai/v1/chat/completions',
   cerebras:   'https://api.cerebras.ai/v1/chat/completions',
   nvidia:     'https://integrate.api.nvidia.com/v1/chat/completions',
   github:     'https://models.inference.ai.azure.com/v1/chat/completions',
@@ -3174,7 +3175,7 @@ export async function callLLM(
       return extractChatMessageContent(d?.choices?.[0]?.message?.content)
 
     } else {
-      // OpenAI-compatible: groq, openrouter, cerebras, nvidia, github
+      // OpenAI-compatible: groq, openrouter, requesty, cerebras, nvidia, github
       const url     = OPENAI_COMPAT_ENDPOINTS[providerName] || OPENAI_COMPAT_ENDPOINTS.groq
       const headers = buildHeaders(providerName, apiKey)
       const r = await fetch(url, {

--- a/core/auxiliaryClient.ts
+++ b/core/auxiliaryClient.ts
@@ -21,6 +21,7 @@ const AUX_ENDPOINTS: Record<string, string> = {
   groq:       'https://api.groq.com/openai/v1/chat/completions',
   cerebras:   'https://api.cerebras.ai/v1/chat/completions',
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
+  requesty:   'https://router.requesty.ai/v1/chat/completions',
   nvidia:     'https://integrate.api.nvidia.com/v1/chat/completions',
   github:     'https://models.inference.ai.azure.com/chat/completions',
   boa:        'https://api.boa.ai/v1/chat/completions',

--- a/core/modelRegistry.ts
+++ b/core/modelRegistry.ts
@@ -103,6 +103,41 @@ export const MODEL_REGISTRY: Record<string, ModelConfig[]> = {
     },
   ],
 
+  requesty: [
+    {
+      id: 'openai/gpt-4o-mini',
+      contextWindow: 128_000,
+      pricing: 'paid',
+      quality: 'high',
+      speed: 'fast',
+      notes: 'Cheap, fast default via Requesty gateway',
+    },
+    {
+      id: 'openai/gpt-4o',
+      contextWindow: 128_000,
+      pricing: 'paid',
+      quality: 'high',
+      speed: 'medium',
+      notes: 'Flagship OpenAI model via Requesty',
+    },
+    {
+      id: 'anthropic/claude-sonnet-4-5',
+      contextWindow: 200_000,
+      pricing: 'paid',
+      quality: 'high',
+      speed: 'medium',
+      notes: 'Strong reasoning + tool calling via Requesty',
+    },
+    {
+      id: 'deepseek/deepseek-chat',
+      contextWindow: 64_000,
+      pricing: 'paid',
+      quality: 'high',
+      speed: 'medium',
+      notes: 'Low-cost capable model via Requesty',
+    },
+  ],
+
   together: [
     {
       id: 'meta-llama/llama-3.1-405b-instruct',

--- a/core/v4/providers/modelFetch.ts
+++ b/core/v4/providers/modelFetch.ts
@@ -188,6 +188,10 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
         // available subset — we use the public list to populate the picker.
         raws = await fetchOpenAICompat('https://openrouter.ai/api/v1/models', { apiKey: apiKey || 'anon', timeoutMs, fetchImpl });
         break;
+      case 'requesty':
+        if (!apiKey) return fallbackFor('requesty', 'no API key');
+        raws = await fetchOpenAICompat('https://router.requesty.ai/v1/models', { apiKey, timeoutMs, fetchImpl });
+        break;
       case 'gemini':
         if (!apiKey) return fallbackFor('gemini', 'no API key');
         raws = await fetchGemini({ apiKey, timeoutMs, fetchImpl });

--- a/core/v4/providers/probe.ts
+++ b/core/v4/providers/probe.ts
@@ -118,6 +118,10 @@ function buildAuthRequest(o: ProbeOptions): ProbeRequest | null {
       return { url: 'https://api.groq.com/openai/v1/models', method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } };
     case 'openrouter':
       return { url: 'https://openrouter.ai/api/v1/auth/key', method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } };
+    case 'requesty':
+      // Requesty has no /auth/key endpoint — use the generic OpenAI-compatible
+      // /models GET (like the openai/groq path) to validate the key.
+      return { url: 'https://router.requesty.ai/v1/models', method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } };
     case 'gemini':
       return { url: `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`, method: 'GET', headers: {} };
     case 'together':
@@ -182,6 +186,7 @@ function buildToolCheckRequest(o: ProbeOptions): ProbeRequest | null {
     case 'openai':
     case 'groq':
     case 'openrouter':
+    case 'requesty':
     case 'together':
     case 'nvidia':
       return {
@@ -191,9 +196,11 @@ function buildToolCheckRequest(o: ProbeOptions): ProbeRequest | null {
             ? 'https://api.groq.com/openai/v1/chat/completions'
             : o.providerId === 'openrouter'
               ? 'https://openrouter.ai/api/v1/chat/completions'
-              : o.providerId === 'together'
-                ? 'https://api.together.xyz/v1/chat/completions'
-                : 'https://integrate.api.nvidia.com/v1/chat/completions',
+              : o.providerId === 'requesty'
+                ? 'https://router.requesty.ai/v1/chat/completions'
+                : o.providerId === 'together'
+                  ? 'https://api.together.xyz/v1/chat/completions'
+                  : 'https://integrate.api.nvidia.com/v1/chat/completions',
         method: 'POST',
         headers: { Authorization: `Bearer ${o.apiKey}`, 'content-type': 'application/json' },
         body: JSON.stringify({

--- a/dashboard-next/app/page.tsx
+++ b/dashboard-next/app/page.tsx
@@ -82,6 +82,7 @@ const PROVIDER_INFO: Record<string, {
   groq:       { label: 'Groq',       color: '#f55036', freeUrl: 'https://console.groq.com',                   defaultModel: 'llama-3.3-70b-versatile',           models: ['llama-3.3-70b-versatile', 'llama-3.1-70b-versatile', 'mixtral-8x7b-32768', 'gemma2-9b-it'] },
   gemini:     { label: 'Gemini',     color: '#4285f4', freeUrl: 'https://aistudio.google.com/app/apikey',     defaultModel: 'gemini-1.5-flash',                  models: ['gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-2.0-flash-exp'] },
   openrouter: { label: 'OpenRouter', color: '#7c3aed', freeUrl: 'https://openrouter.ai/keys',                 defaultModel: 'meta-llama/llama-3.3-70b-instruct', models: ['meta-llama/llama-3.3-70b-instruct', 'google/gemini-flash-1.5', 'mistralai/mistral-7b-instruct:free'] },
+  requesty:   { label: 'Requesty',   color: '#2dd4bf', freeUrl: 'https://app.requesty.ai/api-keys',           defaultModel: 'openai/gpt-4o-mini',                models: ['openai/gpt-4o-mini', 'openai/gpt-4o', 'anthropic/claude-sonnet-4-5'] },
   cerebras:   { label: 'Cerebras',   color: '#059669', freeUrl: 'https://cloud.cerebras.ai',                  defaultModel: 'llama3.1-8b',                       models: ['llama3.1-8b', 'llama3.3-70b'] },
   nvidia:     { label: 'NVIDIA NIM', color: '#76b900', freeUrl: 'https://build.nvidia.com/explore/discover',  defaultModel: 'meta/llama-3.3-70b-instruct',       models: ['meta/llama-3.3-70b-instruct', 'meta/llama-3.1-405b-instruct'] },
 }

--- a/dashboard-next/components/Onboarding.tsx
+++ b/dashboard-next/components/Onboarding.tsx
@@ -27,6 +27,7 @@ const PROVIDER_INFO: Record<string, {
   groq:       { label:'Groq',       color:'#f55036', freeUrl:'https://console.groq.com',                   defaultModel:'llama-3.3-70b-versatile',           models:['llama-3.3-70b-versatile','llama-3.1-70b-versatile','mixtral-8x7b-32768','gemma2-9b-it'] },
   gemini:     { label:'Gemini',     color:'#4285f4', freeUrl:'https://aistudio.google.com/app/apikey',     defaultModel:'gemini-1.5-flash',                  models:['gemini-1.5-flash','gemini-1.5-pro','gemini-2.0-flash-exp'] },
   openrouter: { label:'OpenRouter', color:'#7c3aed', freeUrl:'https://openrouter.ai/keys',                 defaultModel:'meta-llama/llama-3.3-70b-instruct',  models:['meta-llama/llama-3.3-70b-instruct','google/gemini-flash-1.5','mistralai/mistral-7b-instruct:free'] },
+  requesty:   { label:'Requesty',   color:'#2dd4bf', freeUrl:'https://app.requesty.ai/api-keys',           defaultModel:'openai/gpt-4o-mini',                 models:['openai/gpt-4o-mini','openai/gpt-4o','anthropic/claude-sonnet-4-5'] },
   cerebras:   { label:'Cerebras',   color:'#059669', freeUrl:'https://cloud.cerebras.ai',                  defaultModel:'llama3.1-8b',                       models:['llama3.1-8b','llama3.3-70b'] },
   nvidia:     { label:'NVIDIA NIM', color:'#76b900', freeUrl:'https://build.nvidia.com/explore/discover',  defaultModel:'meta/llama-3.3-70b-instruct',       models:['meta/llama-3.3-70b-instruct','meta/llama-3.1-405b-instruct','mistralai/mistral-7b-instruct-v0.3'] },
 }

--- a/providers/requesty.ts
+++ b/providers/requesty.ts
@@ -1,0 +1,75 @@
+// ============================================================
+// DevOS — Autonomous AI Execution System
+// Copyright (c) 2026 Shiva Deore. All rights reserved.
+// ============================================================
+
+// providers/requesty.ts — Requesty provider (OpenAI-compatible LLM gateway)
+// Mirrors the OpenRouter provider: same OpenAI-compatible chat/completions
+// path, pointed at https://router.requesty.ai/v1 with provider/model naming
+// (e.g. openai/gpt-4o-mini).
+
+import { Provider } from './types'
+
+export function createRequestyProvider(apiKey: string): Provider {
+  return {
+    name: 'requesty',
+
+    async generate(messages, model) {
+      const res = await fetch('https://router.requesty.ai/v1/chat/completions', {
+        method:  'POST',
+        headers: {
+          'Content-Type':  'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+          'HTTP-Referer':  'http://localhost:3000',
+          'X-Title':       'DevOS',
+        },
+        body: JSON.stringify({ model, messages }),
+      })
+      const data = await res.json() as any
+      return data?.choices?.[0]?.message?.content || ''
+    },
+
+    async generateStream(messages, model, onToken) {
+      try {
+        const res = await fetch('https://router.requesty.ai/v1/chat/completions', {
+          method:  'POST',
+          headers: {
+            'Content-Type':  'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+            'HTTP-Referer':  'http://localhost:3000',
+            'X-Title':       'DevOS',
+          },
+          body: JSON.stringify({ model, messages, stream: true }),
+        })
+        if (!res.ok) {
+          const err = await res.text()
+          throw new Error(`${res.status}: ${err}`)
+        }
+        if (!res.body) return
+        const reader  = (res.body as any).getReader()
+        const decoder = new TextDecoder()
+        let buf = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buf += decoder.decode(value, { stream: true })
+          const lines = buf.split('\n')
+          buf = lines.pop() ?? ''
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            const raw = line.replace('data: ', '').trim()
+            if (raw === '[DONE]') return
+            try {
+              const parsed = JSON.parse(raw) as any
+              const token  = parsed?.choices?.[0]?.delta?.content
+              if (token) onToken(token)
+            } catch {}
+          }
+        }
+      } catch (err) {
+        throw err
+      }
+    },
+  }
+}

--- a/providers/router.ts
+++ b/providers/router.ts
@@ -10,6 +10,7 @@ import { loadConfig, saveConfig, APIEntry, CustomProviderEntry } from './index'
 import { ollamaProvider } from './ollama'
 import { createGroqProvider } from './groq'
 import { createOpenRouterProvider } from './openrouter'
+import { createRequestyProvider } from './requesty'
 import { createGeminiProvider } from './gemini'
 import { createCerebrasProvider } from './cerebras'
 import { createNvidiaProvider } from './nvidia'
@@ -26,6 +27,7 @@ const RATE_LIMIT_WINDOWS: Record<string, number> = {
   groq:       15  * 1000,  // Groq free tier resets in ~10–15 s
   gemini:     90  * 1000,  // Gemini resets in ~60–90 s
   openrouter: 30  * 1000,  // OpenRouter rarely rate-limits; 30 s is safe
+  requesty:   30  * 1000,  // Requesty gateway — rarely rate-limits; 30 s is safe
   together:   30  * 1000,
   mistral:    60  * 1000,
   cohere:     60  * 1000,
@@ -113,6 +115,7 @@ function buildProvider(entry: APIEntry): Provider {
   switch (entry.provider) {
     case 'groq':       return createGroqProvider(key)
     case 'openrouter': return createOpenRouterProvider(key)
+    case 'requesty':   return createRequestyProvider(key)
     case 'gemini':     return createGeminiProvider(key)
     case 'cerebras':   return createCerebrasProvider(key)
     case 'nvidia':     return createNvidiaProvider(key)

--- a/providers/v4/modelCatalog.ts
+++ b/providers/v4/modelCatalog.ts
@@ -563,6 +563,56 @@ export const MODEL_CATALOG: ModelEntry[] = [
     tier: 'standard',
   },
 
+  // ─── requesty ────────────────────────────────────────────────────────────
+  // Requesty — OpenAI-compatible LLM gateway. provider/model naming.
+  {
+    id: 'openai/gpt-4o-mini',
+    displayName: 'GPT-4o mini (via Requesty)',
+    providerId: 'requesty',
+    contextLength: 128_000,
+    supportsToolCalling: true,
+    supportsVision: true,
+    supportsReasoning: false,
+    pricing: { inputPerM: 0.15, outputPerM: 0.6 },
+    isDefault: true,
+    tier: 'standard',
+  },
+  {
+    id: 'openai/gpt-4o',
+    displayName: 'GPT-4o (via Requesty)',
+    providerId: 'requesty',
+    contextLength: 128_000,
+    supportsToolCalling: true,
+    supportsVision: true,
+    supportsReasoning: false,
+    pricing: { inputPerM: 2.5, outputPerM: 10.0 },
+    isDefault: false,
+    tier: 'flagship',
+  },
+  {
+    id: 'anthropic/claude-sonnet-4-5',
+    displayName: 'Claude Sonnet 4.5 (via Requesty)',
+    providerId: 'requesty',
+    contextLength: 200_000,
+    supportsToolCalling: true,
+    supportsVision: true,
+    supportsReasoning: true,
+    pricing: { inputPerM: 3.0, outputPerM: 15.0 },
+    isDefault: false,
+    tier: 'flagship',
+  },
+  {
+    id: 'deepseek/deepseek-chat',
+    displayName: 'DeepSeek Chat (via Requesty)',
+    providerId: 'requesty',
+    contextLength: 64_000,
+    supportsToolCalling: true,
+    supportsVision: false,
+    supportsReasoning: false,
+    isDefault: false,
+    tier: 'standard',
+  },
+
   // ─── together ────────────────────────────────────────────────────────────
   // Phase 16f: Qwen3-235B is the new Together default — strong tool-calling,
   // MoE 22B active params, throughput tier ~$0.20/M. Replaces Groq Llama-3.3

--- a/providers/v4/registry.ts
+++ b/providers/v4/registry.ts
@@ -251,6 +251,28 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
       'qwen/qwen-2.5-72b-instruct',
     ],
   },
+  requesty: {
+    id: 'requesty',
+    displayName: 'Requesty',
+    apiMode: 'chat_completions',
+    baseUrl: 'https://router.requesty.ai/v1',
+    apiKeyEnvVar: 'REQUESTY_API_KEY',
+    description: 'Requesty — OpenAI-compatible LLM gateway routing many models through one API.',
+    tier: 'paid',
+    hasFreeTier: false,
+    extraHeaders: {
+      'HTTP-Referer': 'https://aiden.ai',
+      'X-Title': 'Aiden',
+    },
+    docsUrl: 'https://docs.requesty.ai',
+    supportsToolCalling: true,
+    modelIds: [
+      'openai/gpt-4o-mini',
+      'openai/gpt-4o',
+      'anthropic/claude-sonnet-4-5',
+      'deepseek/deepseek-chat',
+    ],
+  },
   together: {
     id: 'together',
     displayName: 'Together AI',


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible LLM provider

This adds [Requesty](https://requesty.ai) as a native provider, mirroring the existing OpenRouter integration as closely as possible. Requesty is an OpenAI-compatible LLM gateway, so it slots into the same chat/completions path the codebase already uses for OpenRouter, Groq, NVIDIA, etc.

### Integration details
- **Base URL:** `https://router.requesty.ai/v1` (chat → `/chat/completions`, models → `/models`)
- **Auth:** `Authorization: Bearer <key>`, read from `REQUESTY_API_KEY`
- **Model naming:** `provider/model` (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`)

### Wiring sites updated
- `providers/requesty.ts`: new `createRequestyProvider` mirroring `providers/openrouter.ts`, pointed at the Requesty base URL.
- `providers/router.ts`: import, per-provider rate-limit window, and factory `case 'requesty'`.
- `core/auxiliaryClient.ts` & `core/agentLoop.ts`, added `requesty` to the OpenAI-compatible chat/completions endpoint maps (it routes through the same generic OpenAI-compatible branch).
- `core/v4/providers/modelFetch.ts`: `case 'requesty'` fetching the live model list via `fetchOpenAICompat('https://router.requesty.ai/v1/models', ...)`.
- `core/v4/providers/probe.ts` & `cli/v4/keyValidator.ts`, validation probe. **Note:** unlike OpenRouter's `/auth/key` (which is OpenRouter-specific), Requesty has no such endpoint, so the probe uses a generic `GET /v1/models` with the Bearer key, the same pattern used for the OpenAI/Groq paths in these files. The model-access step then checks membership in the returned `{ data: [...] }` list.
- `providers/v4/registry.ts`: new `PROVIDER_REGISTRY` entry so Requesty appears in the picker.
- `providers/v4/modelCatalog.ts` & `core/modelRegistry.ts`, curated catalog/registry entries for real Requesty models: `openai/gpt-4o-mini`, `openai/gpt-4o`, `anthropic/claude-sonnet-4-5`, `deepseek/deepseek-chat`.
- `dashboard-next/app/page.tsx` & `dashboard-next/components/Onboarding.tsx`, `requesty` provider UI config (label, color, key URL, default model, model list).

### Verification
- `npm run typecheck` (`tsc --noEmit`) passes with no errors.
- Ran a live chat completion against `https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini`, returned HTTP 200 with a real completion.

Docs: https://requesty.ai · https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

