### PR TITLE
release: v4.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Prepare terminal test helper
+        if: runner.os == 'macOS'
+        shell: bash
+        run: chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper
+
       - name: TypeScript type check
         run: npx tsc --noEmit -p tsconfig.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v4.15.1 — 2026-07-22
+
+### Provider reliability
+
+- Managed credentials entered during setup are persisted, reloaded, and verified before setup completes.
+- Provider discovery, request cancellation, streaming, structured tool calls, and restart behavior are more reliable.
+- Ollama model selection uses the live installed-model inventory, accepts exact tags, and never pulls a model without approval.
+- Groq throughput limits, context-window limits, and request-size limits now produce distinct guidance.
+
+### Token efficiency
+
+- Economy, Balanced, and Thorough modes provide explicit context and output-budget controls.
+- Provider attempts, retries, fallbacks, auxiliary work, subagents, aggregation, compression, cache usage, and reasoning usage are recorded consistently.
+- Repeated file and tool results consume less context, while compression and usage state survive restart.
+- New `/usage`, `/usage details`, `/usage --json`, `/estimate`, and `/budget` controls expose session usage without treating unknown cost as zero.
+
+### Packaging and compatibility
+
+- Human-readable usage output remains bounded on narrow terminals while machine-readable JSON stays stable.
+- Packaged global and package-runner installations exercise setup, provider calls, tools, usage, compression, and restart behavior.
+
+---
+
 ## v4.14.8 — 2026-07-11
 
 - **Removed the subscription-OAuth impersonation path.** Aiden previously routed a Claude Pro/Max subscription through Anthropic's billing by impersonating a different vendor's CLI — a spoofed client identity in the system prompt, a foreign `user-agent`, an `x-app: cli` header, and OAuth beta-flag headers. That path is gone end to end. The Anthropic **API-key** provider is unchanged.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Give Aiden a goal. It can work across your files, terminal, browser, supported a
 ![Built solo](https://img.shields.io/badge/Built-solo-B8A893?style=flat-square)
 ![By Taracod](https://img.shields.io/badge/By-Taracod-FF6B35?style=flat-square)
 ![White Lotus](https://img.shields.io/badge/Brand-White_Lotus-FFB088?style=flat-square)
-![v4.15.0](https://img.shields.io/badge/Latest-v4.15.0-4ADE80?style=flat-square)
+![v4.15.1](https://img.shields.io/badge/Latest-v4.15.1-4ADE80?style=flat-square)
 
 </details>
 
@@ -204,20 +204,20 @@ https://github.com/user-attachments/assets/7a66bc19-8b17-4b01-be85-3aa5945a1b3b
 
 <br>
 
-## What's new in v4.15.0
+## What's new in v4.15.1
 
-**Aiden’s terminal interaction and runtime verification layer is now significantly more reliable.**
+**Provider setup and runtime usage are now more reliable, measurable, and efficient.**
 
-This release makes Aiden calmer to operate, easier to steer while it works, and more honest about approvals, failures, verification, and completion.
+This release keeps setup, provider execution, usage reporting, and restart behavior aligned from the first credential prompt through later sessions.
 
-- **Single-owner terminal lifecycle.** Activity rows, timers, approval states, and the bottom input region now share one coordinated lifecycle, eliminating duplicate “running” rows, ghost timers, and UI collisions.
-- **Queue input while Aiden works.** Follow-up messages can be typed during tool execution and are preserved in exact FIFO order, without corrupting the active turn.
-- **Truthful approvals and outcomes.** Pending approvals, denials, interruptions, non-zero exits, verification results, and completed work are presented as distinct states instead of being collapsed into a generic success or running label.
-- **Stronger runtime verification.** Claims are checked against real evidence, with better handling for stale artifacts, retries, partial coverage, unrelated successful work, and uncertain producer attribution.
-- **Responsive startup and recovery UX.** The startup dashboard, help, model guidance, first-task hints, and recovery messaging now adapt more cleanly across terminal widths.
-- **Safer dependency paths.** Discord, email, Docker, and Telegram integrations were hardened, with the production dependency audit returning zero advisories.
+- **Reliable provider onboarding.** Managed credentials are persisted and verified before setup completes, and the same configuration is used after restart.
+- **Live Ollama inventory.** Installed models are discovered from the local runtime, exact tags are accepted, and unavailable recommendations are not presented as installed.
+- **Clear provider diagnostics.** Throughput limits, context-window limits, and request-size limits are classified separately with appropriate recovery guidance.
+- **Usage modes and controls.** Economy, Balanced, and Thorough modes work with new usage, estimate, and budget commands.
+- **Complete attempt accounting.** Primary calls, retries, fallbacks, auxiliary work, subagents, aggregation, compression, cache usage, and reasoning usage are visible without reporting unknown cost as zero.
+- **Persistent efficiency.** Repeated tool and file context is reduced, while compression and usage state survive restart.
 
-See the full [v4.15.0 release notes](https://github.com/taracodlabs/aiden/releases/tag/v4.15.0).
+See the full [v4.15.1 release notes](https://github.com/taracodlabs/aiden/releases/tag/v4.15.1).
 
 <details>
 <summary><strong>Earlier v4 release highlights — v4.13 through v4.5</strong></summary>
@@ -729,7 +729,7 @@ The future `skills.taracod.com` marketplace will ship community skills under the
 | 📦 **npm** | [aiden-runtime](https://www.npmjs.com/package/aiden-runtime) |
 | 🐙 **Source** | [github.com/taracodlabs/aiden](https://github.com/taracodlabs/aiden) |
 | 📁 **Standalone releases** | [github.com/taracodlabs/aiden-releases](https://github.com/taracodlabs/aiden-releases) |
-| 🧾 **Release notes** | [v4.15.0](https://github.com/taracodlabs/aiden/releases/tag/v4.15.0) · [v4.13.0](https://github.com/taracodlabs/aiden/releases/tag/v4.13.0) · [v4.12.0](https://github.com/taracodlabs/aiden/releases/tag/v4.12.0) · [v4.11.0](https://github.com/taracodlabs/aiden/releases/tag/v4.11.0) · [v4.10.0](https://github.com/taracodlabs/aiden/releases/tag/v4.10.0) |
+| 🧾 **Release notes** | [v4.15.1](https://github.com/taracodlabs/aiden/releases/tag/v4.15.1) · [v4.15.0](https://github.com/taracodlabs/aiden/releases/tag/v4.15.0) · [v4.13.0](https://github.com/taracodlabs/aiden/releases/tag/v4.13.0) · [v4.12.0](https://github.com/taracodlabs/aiden/releases/tag/v4.12.0) · [v4.11.0](https://github.com/taracodlabs/aiden/releases/tag/v4.11.0) |
 | 📖 **Book — Omega** | [Amazon](https://amzn.to/49ceO8l) |
 | 📚 **Docs** | [`docs/v4.5/`](docs/v4.5/) (in this repo) |
 | 💖 **Sponsor (Razorpay)** | [razorpay.me/@whitelotus9625](https://razorpay.me/@whitelotus9625) |

--- a/api/server.ts
+++ b/api/server.ts
@@ -45,6 +45,15 @@ import { pwClose } from '../core/playwrightBridge'
 // The shared `bootstrapDaemon` module handles every responsibility — db open,
 // runtime lock, crash recovery, health endpoints, signal handlers.
 import { bootstrapDaemon } from '../core/v4/daemon'
+import { resolveAidenPaths } from '../core/v4/paths'
+import { estimateCompatibilityUsage } from '../core/v4/compatibilityUsage'
+import {
+  beginPhysicalProviderAttempt,
+  byteLength as providerByteLength,
+  configureProviderAttemptLedger,
+  createLogicalProviderCallId,
+  currentProviderAttemptLedger,
+} from '../providers/v4/providerAttemptAccounting'
 import { getScreenSize, takeScreenshot as captureScreen } from '../core/computerControl'
 import { planWithLLM, executePlan, respondWithResults, callLLM, surfaceRelevantMemories, interruptCurrentCall, getBudgetState, setStatusEmitter } from '../core/agentLoop'
 import { getVerb } from '../core/statusVerbs'
@@ -481,6 +490,7 @@ const kbProgress = new Map<string, { status: 'processing' | 'done' | 'error'; pr
 // â”€â”€ App factory â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 export function createApiServer(): Express {
+  configureProviderAttemptLedger(resolveAidenPaths().sessionsDb)
   const app = express()
 
   // â”€â”€ Middleware â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -3830,8 +3840,35 @@ export function createApiServer(): Express {
       // ── Multi-day history (last 7 days from JSONL files) ──────
       const dailyHistory: Array<{ date: string; totalUSD: number; systemUSD: number; userUSD: number; totalTokens: number; calls: number }> = []
       const providerStats: Record<string, { calls: number; totalCost: number; inputTokens: number; outputTokens: number }> = {}
+      const usageLedger = currentProviderAttemptLedger()
+      const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+      const ledgerRecords = usageLedger?.query({ since: sevenDaysAgo }) ?? []
 
-      if (fs.existsSync(costDir)) {
+      if (ledgerRecords.length > 0) {
+        const days = new Map<string, { totalUSD: number; systemUSD: number; userUSD: number; totalTokens: number; calls: number }>()
+        for (const record of ledgerRecords) {
+          const date = new Date(record.startedAt).toISOString().slice(0, 10)
+          const day = days.get(date) ?? { totalUSD: 0, systemUSD: 0, userUSD: 0, totalTokens: 0, calls: 0 }
+          const inputTokens = record.providerInputTokens ?? record.estimatedInputTokens ?? 0
+          const outputTokens = record.providerOutputTokens ?? record.estimatedOutputTokens ?? 0
+          const cost = record.costAmount ?? 0
+          day.totalUSD += cost
+          day.totalTokens += inputTokens + outputTokens
+          day.calls += 1
+          if (record.purpose === 'setup' || record.purpose === 'readiness') day.systemUSD += cost
+          else day.userUSD += cost
+          days.set(date, day)
+          const provider = record.providerActual ?? record.providerConfigured ?? 'unknown'
+          if (!providerStats[provider]) providerStats[provider] = { calls: 0, totalCost: 0, inputTokens: 0, outputTokens: 0 }
+          providerStats[provider].calls += 1
+          providerStats[provider].totalCost += cost
+          providerStats[provider].inputTokens += inputTokens
+          providerStats[provider].outputTokens += outputTokens
+        }
+        for (const [date, values] of [...days.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+          dailyHistory.push({ date, ...values })
+        }
+      } else if (fs.existsSync(costDir)) {
         const costFiles = fs.readdirSync(costDir)
           .filter(f => f.endsWith('.jsonl'))
           .sort()
@@ -3891,15 +3928,30 @@ export function createApiServer(): Express {
 
       // ── Today's live summary ───────────────────────────────────
       const today = costTracker.getDailySummary()
+      const todayStart = new Date(); todayStart.setHours(0, 0, 0, 0)
+      const ledgerToday = usageLedger?.project({ since: todayStart.getTime(), includeSetup: true }) ?? null
+      const ledgerTodayRecords = usageLedger?.query({ since: todayStart.getTime() }) ?? []
+      const ledgerTodaySystemCost = ledgerTodayRecords.reduce((sum, record) =>
+        sum + ((record.purpose === 'setup' || record.purpose === 'readiness') ? record.costAmount ?? 0 : 0), 0)
+      const ledgerTodayUserCost = ledgerTodayRecords.reduce((sum, record) =>
+        sum + ((record.purpose !== 'setup' && record.purpose !== 'readiness') ? record.costAmount ?? 0 : 0), 0)
+      const ledgerTodayByProvider = ledgerTodayRecords.reduce<Record<string, number>>((totals, record) => {
+        const provider = record.providerActual ?? record.providerConfigured ?? 'unknown'
+        totals[provider] = (totals[provider] ?? 0) + (record.costAmount ?? 0)
+        return totals
+      }, {})
+      const hasLedgerToday = !!ledgerToday && ledgerToday.physicalAttempts > 0
 
       res.json({
         today: {
-          cost:         today.totalUSD,
-          userCost:     today.userUSD,
-          systemCost:   today.systemUSD,
-          byProvider:   today.byProvider,
+          cost:         hasLedgerToday ? ledgerToday.knownCostAmount : today.totalUSD,
+          userCost:     hasLedgerToday ? ledgerTodayUserCost : today.userUSD,
+          systemCost:   hasLedgerToday ? ledgerTodaySystemCost : today.systemUSD,
+          byProvider:   hasLedgerToday ? ledgerTodayByProvider : today.byProvider,
           currency:     'USD',
           budget:       costTracker.getDailyBudget(),
+          costStatus:   hasLedgerToday && ledgerToday.unknownCostAttempts > 0 ? 'partially_unknown' : 'estimated',
+          physicalAttempts: ledgerToday?.physicalAttempts ?? 0,
         },
         dailyHistory,
         toolStats: Object.entries(toolStats)
@@ -5271,6 +5323,31 @@ export function createApiServer(): Express {
     const created      = Math.floor(Date.now() / 1000)
     const modelName    = model || 'aiden-3.13'
     const port         = (req.socket as any)?.localPort ?? 4200
+    const normalizedUsageMessages = messages.map((message) => ({
+      role: message.role,
+      content: textOf(message.content),
+    }))
+    const requestForAccounting = {
+      messages: normalizedUsageMessages as import('../providers/v4/types').Message[],
+      tools: [],
+      usageContext: {
+        logicalCallId: createLogicalProviderCallId(),
+        sessionId,
+        entryPoint: 'compatibility_api',
+        purpose: 'legacy_api' as const,
+        providerConfigured: 'legacy-router',
+        modelConfigured: modelName,
+      },
+    }
+    const attempt = beginPhysicalProviderAttempt(requestForAccounting, {
+      providerActual: 'legacy-router',
+      modelActual: modelName,
+      apiMode: 'chat_completions',
+      transport: 'local-loopback-sse',
+      attemptIndex: 0,
+      logicalCallId: requestForAccounting.usageContext.logicalCallId,
+      requestBytes: providerByteLength(JSON.stringify(normalizedUsageMessages)),
+    })
 
     if (stream) {
       // ── Streaming: translate agent token events → OpenAI deltas ─
@@ -5288,14 +5365,24 @@ export function createApiServer(): Express {
       res.write(chunk({ role: 'assistant' }, null))
 
       try {
-        await _driveAgentSSE(userText, history, sessionId, port, (tok) => {
+        const fullText = await _driveAgentSSE(userText, history, sessionId, port, (tok) => {
           res.write(chunk({ content: tok }, null))
         })
+        const usage = estimateCompatibilityUsage(normalizedUsageMessages, fullText)
+        attempt.success({ content: fullText, toolCalls: [], finishReason: 'stop', usage: { inputTokens: 0, outputTokens: 0 } }, providerByteLength(fullText))
+        res.write(`data: ${JSON.stringify({
+          id: completionId,
+          object: 'chat.completion.chunk',
+          created,
+          model: modelName,
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+          usage,
+        })}\n\n`)
       } catch (e: any) {
+        attempt.failure(e, { sent: true })
         res.write(`data: ${JSON.stringify({ error: e.message })}\n\n`)
       }
 
-      res.write(chunk({}, 'stop'))
       res.write('data: [DONE]\n\n')
       res.end()
 
@@ -5303,19 +5390,18 @@ export function createApiServer(): Express {
       // ── Non-streaming: collect full response, return as JSON ────
       try {
         const fullText = await _driveAgentSSE(userText, history, sessionId, port, () => {})
+        const usage = estimateCompatibilityUsage(normalizedUsageMessages, fullText)
+        attempt.success({ content: fullText, toolCalls: [], finishReason: 'stop', usage: { inputTokens: 0, outputTokens: 0 } }, providerByteLength(fullText))
         res.json({
           id:      completionId,
           object:  'chat.completion',
           created,
           model:   modelName,
           choices: [{ index: 0, message: { role: 'assistant', content: fullText }, finish_reason: 'stop' }],
-          usage: {
-            prompt_tokens:     Math.ceil(userText.length / 4),
-            completion_tokens: Math.ceil(fullText.length / 4),
-            total_tokens:      Math.ceil((userText.length + fullText.length) / 4),
-          },
+          usage,
         })
       } catch (e: any) {
+        attempt.failure(e, { sent: true })
         res.status(500).json({ error: { message: e.message, type: 'server_error' } })
       }
     }

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -41,7 +41,7 @@ import { CliCallbacks } from './callbacks';
 // runtime smoke can find it in the bundled artifact.
 import { AIDEN_UI_BUILD } from './uiBuild';
 export { AIDEN_UI_BUILD };
-import { runSetupWizard, isFreshInstall } from './setupWizard';
+import { runSetupWizard, isFreshInstall, setupRequiresRecoveryMode } from './setupWizard';
 import { runDoctorCli } from './doctor';
 import { runModelPicker } from './commands/modelPicker';
 import { allCommands } from './commands';
@@ -94,6 +94,7 @@ import { PromptBuilder, narrowSkillDesc } from '../../core/v4/promptBuilder';
 import { readinessNote } from '../../core/v4/skillReadiness';
 import { PersonalityManager } from '../../core/v4/personality';
 import { AuxiliaryClient } from '../../core/v4/auxiliaryClient';
+import { deduplicateRuntimeSlots, providerRuntimeIdentity } from '../../providers/v4/providerIdentity';
 // v4.11 preflight compression — wire the dormant Phase 13 compressor
 // into production. Both modules existed pre-v4.11 but ContextCompressor
 // was never constructed at boot, so the `if (this.contextCompressor)`
@@ -155,6 +156,9 @@ import { RuntimeResolver } from '../../providers/v4/runtimeResolver';
 import { withMessagePreflight } from '../../providers/v4/preflightAdapter';
 import { ChatCompletionsAdapter } from '../../providers/v4/chatCompletionsAdapter';
 import { findModel } from '../../providers/v4/modelCatalog';
+import {
+  providerMainDefault,
+} from '../../providers/v4/providerModelAuthority';
 import {
   FallbackAdapter,
   buildDefaultSlots,
@@ -266,6 +270,7 @@ function buildAgentFallbackSlots(
   primaryAdapter: import('../../providers/v4/types').ProviderAdapter,
   primaryProviderId: string,
   primaryModelId: string,
+  primaryIdentity?: string,
 ): ProviderSlot[] {
   const defaults = buildDefaultSlots({
     adapterFactory: (cfg) =>
@@ -286,12 +291,20 @@ function buildAgentFallbackSlots(
     modelId: primaryModelId,
     keyPresent: true,
     keyTail: null,
+    identity: primaryIdentity,
     build: () => primaryAdapter,
   };
   // Filter out env-var slots whose providerId matches the primary AND
   // whose env-var-derived key would shadow it (avoids double-trying the
   // same Groq account at slots 0 and 1).
-  return [primarySlot, ...defaults];
+  const uniqueDefaults = deduplicateRuntimeSlots(
+    defaults,
+    primaryIdentity ? [primaryIdentity] : [],
+  );
+  return [
+    primarySlot,
+    ...uniqueDefaults,
+  ];
 }
 
 export interface MainOptions {
@@ -1464,6 +1477,12 @@ export async function buildAgentRuntime(
       // Flagged here and consumed below where the adapter is built.
       exploreMode = true;
     }
+    if (setupRequiresRecoveryMode(result)) {
+      // The selected provider remains persisted for explicit recovery, but a
+      // failed readiness transaction must not silently route the first turn
+      // through another provider.
+      exploreMode = true;
+    }
 
     // 'configured' (or 'skipped' — we still want the env/.env reload
     // for slash commands like /providers that read fresh state) →
@@ -1509,7 +1528,7 @@ export async function buildAgentRuntime(
       // so the legacy first-run path (manual API-key entry into .env)
       // still works.
       providerId = 'groq';
-      modelId    = 'llama-3.3-70b-versatile';
+      modelId    = providerMainDefault('groq')!;
       bootSource = 'hardcoded-fallback';
     }
   } catch (err) {
@@ -1648,7 +1667,16 @@ export async function buildAgentRuntime(
     adapter.apiMode === 'chat_completions' &&
     (providerId === 'groq' || providerId === 'together')
   ) {
-    const slots = buildAgentFallbackSlots(adapter, providerId, modelId);
+    const activeResolution = await resolver.describe({ providerId, modelId, config, paths });
+    const primaryIdentity = activeResolution.effectiveCredential
+      ? providerRuntimeIdentity({
+          provider: providerId,
+          endpointFingerprint: activeResolution.effectiveCredential.endpointFingerprint,
+          credentialFingerprint: activeResolution.effectiveCredential.credentialFingerprint,
+          model: modelId,
+        })
+      : undefined;
+    const slots = buildAgentFallbackSlots(adapter, providerId, modelId, primaryIdentity);
     const reachable = slots.filter((s) => s.keyPresent);
     if (reachable.length >= 2) {
       fallbackAdapter = new FallbackAdapter({
@@ -1925,29 +1953,22 @@ export async function buildAgentRuntime(
     } catch { /* refresh is best-effort; never crash a turn */ }
   });
 
-  // Auxiliary client (compression / risk-assessment / session-summary
-  // / skill-describe). v4.8.0 Slice 11 — route through Groq's cheap
-  // 8B model as the default, with the parent provider/model as the
-  // fallback when Groq isn't configured. Fixes the ChatGPT Plus +
-  // gpt-5 routing bug: pre-Slice-11 auxiliary inherited the parent
-  // (codex backend, accepts only `gpt-5-codex`/`gpt-4.1-mini`/etc.)
-  // and every aux call returned a 400 model-not-supported. Groq is
-  // cheap, fast, and reliable for the cheap classify/summarise jobs
-  // auxiliary is designed for. If the user has no GROQ_API_KEY, the
-  // resolver throws and we fall through to the parent — no regression
-  // for non-codex users.
-  //
-  // Skip the parent fallback when the parent IS already the Groq cheap
-  // model — same identity attempt twice is just noise in the verbose
-  // log. (Resolver dedup; the auxiliary client itself doesn't filter.)
-  const AUX_DEFAULT_PROVIDER = 'groq';
-  const AUX_DEFAULT_MODEL    = 'llama-3.1-8b-instant';
-  const parentSameAsDefault =
-    providerId === AUX_DEFAULT_PROVIDER && modelId === AUX_DEFAULT_MODEL;
+  // Auxiliary work is lazy and inherits the already-resolved parent runtime
+  // unless the user explicitly configures a separate provider and model.
+  // Optional classifier and summarisation work cannot block primary startup.
+  const configuredAuxProvider = config.get('auxiliary.provider');
+  const configuredAuxModel = config.get('auxiliary.model');
+  const auxiliaryProvider = configuredAuxProvider && configuredAuxModel
+    ? configuredAuxProvider
+    : providerId;
+  const auxiliaryModel = configuredAuxProvider && configuredAuxModel
+    ? configuredAuxModel
+    : modelId;
+  const auxiliaryUsesParent = auxiliaryProvider === providerId && auxiliaryModel === modelId;
   const auxiliaryClient = new AuxiliaryClient({
-    defaultProvider: AUX_DEFAULT_PROVIDER,
-    defaultModel:    AUX_DEFAULT_MODEL,
-    fallbacks: parentSameAsDefault
+    defaultProvider: auxiliaryProvider,
+    defaultModel: auxiliaryModel,
+    fallbacks: auxiliaryUsesParent
       ? []
       : [{ providerId, modelId }],
     // Phase 21 #5: ensure the auxiliary path also honors entry.oauth →

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -101,6 +101,7 @@ import { deduplicateRuntimeSlots, providerRuntimeIdentity } from '../../provider
 // branch at aidenAgent.ts:754 stayed dead at runtime and `/compress`
 // reported "Compressor or session not wired."
 import { ContextCompressor } from '../../core/v4/contextCompressor';
+import { configureToolResultArtifactStore } from '../../core/v4/toolResultBoundary';
 import { ModelMetadata } from '../../core/v4/modelMetadata';
 import { applyToolDeferral } from '../../core/v4/toolDeferral';
 import { MemoryManager } from '../../core/v4/memoryManager';
@@ -367,6 +368,7 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
   // which is the only entry point that genuinely benefits from the
   // foundation (long-running session = useful daemon).
   const program = new Command();
+  let actionExitCode = 0;
 
   program
     .name('aiden')
@@ -412,10 +414,10 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
       // long-lived machinery. Handle it BEFORE the daemon bootstrap below.
       const qOpts = program.opts() as { query?: string };
       if (qOpts.query != null) {
-        if (opts.runQueryHook) {
-          process.exit(await opts.runQueryHook(program.opts()));
-        }
-        process.exit(await runQuery(qOpts.query, program.opts(), opts));
+        actionExitCode = opts.runQueryHook
+          ? await opts.runQueryHook(program.opts())
+          : await runQuery(qOpts.query, program.opts(), opts);
+        return;
       }
 
       // v4.5 Phase 1 — daemon foundation bootstrap. Lazy-imported so
@@ -483,12 +485,12 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
       const merged = { ...program.opts(), ...cmdOpts };
       if (merged.query == null) {
         process.stderr.write('usage: aiden chat -q "<prompt>"\n');
-        process.exit(2);
+        actionExitCode = 2;
+        return;
       }
-      if (opts.runQueryHook) {
-        process.exit(await opts.runQueryHook(merged));
-      }
-      process.exit(await runQuery(merged.query, merged, opts));
+      actionExitCode = opts.runQueryHook
+        ? await opts.runQueryHook(merged)
+        : await runQuery(merged.query, merged, opts);
     });
 
   // v4.14.6 — Aiden Workbench launcher. Serves a read-only live dashboard page
@@ -966,7 +968,7 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
 
   try {
     await program.parseAsync(argv);
-    return 0;
+    return actionExitCode;
   } catch (err) {
     const out = opts.writeOut ?? ((t) => process.stderr.write(t));
     out(`${(err as Error).message}\n`);
@@ -2463,6 +2465,9 @@ export async function buildAgentRuntime(
     /*compressionThreshold=*/ 0.5,
     compressionHealth,
   );
+  const toolResultArtifactStore = configureToolResultArtifactStore(
+    path.join(paths.root, 'tool-results'),
+  );
 
   // ── Build agent with all moat layers attached ────────────────────────
   const agent = new AidenAgent({
@@ -2471,6 +2476,7 @@ export async function buildAgentRuntime(
     // v4.11 preflight compression — wire the compressor so
     // runConversation step 7 actually runs at the 50% threshold.
     contextCompressor,
+    toolResultArtifactStore: toolResultArtifactStore ?? undefined,
     // v4.6 Phase 1 — 'repl' context filter excludes tools tagged
     // daemon-only (none today) and INCLUDES tools tagged repl-only
     // (e.g. spawn_sub_agent, registered after this line). Tools with
@@ -2507,6 +2513,7 @@ export async function buildAgentRuntime(
     maxTurns: config.getValue<number>('agent.max_turns', 90)!,
     // v4.12 BE.1 — per-session token cap (money-safety). 0/unset → no cap.
     sessionTokenCap: config.getValue<number>('budget.session_token_cap', 0)! || undefined,
+    sessionCostCap: config.getValue<number>('budget.session_cost_cap_usd', 0)! || undefined,
     auxiliaryClient,
     plannerGuard,
     honestyEnforcement,
@@ -2894,6 +2901,13 @@ export async function buildAgentRuntime(
   // resolvers, run store. No widening — the coordinator's API
   // accepts the existing SpawnSubAgentDeps verbatim.
   const subagentCoordinator = new SubagentCoordinator({
+    resolveResourceLimits: () => ({
+      estimatedTokensPerChild: config.getValue<number>('budget.subagent_estimated_tokens', 0),
+      providerCallsPerChild: config.getValue<number>('budget.subagent_provider_calls', 0),
+      aggregateEstimatedTokens: config.getValue<number>('budget.subagent_fanout_estimated_tokens', 0),
+      parentBudgetPercentage: config.getValue<number>('budget.subagent_parent_percentage', 0),
+      parentTokenBudget: config.getValue<number>('budget.session_token_cap', 0),
+    }),
     spawnDeps: {
       toolRegistry,
       parentToolContext: {
@@ -3094,7 +3108,12 @@ export async function buildAgentRuntime(
       const history: import('../../providers/v4/types').Message[] = [...past, userTurn];
 
       // 3. Run one agent turn.
-      const result = await agent.runConversation(history);
+      const result = await agent.runConversation(history, {
+        sessionId: storeSid,
+        runId: `gateway-${randomUUID()}`,
+        entryPoint: 'gateway',
+        purpose: 'primary',
+      });
 
       // 4. Persist the new tail (everything past the loaded history) so
       //    the next inbound resumes seamlessly. Mirror chatSession's
@@ -3759,7 +3778,10 @@ export interface AgentRuntime {
  *  `toolCallTrace` carries the REAL HonestyTraceEntry[] (previously under-typed
  *  to `{ error? }[]`) so the divergence audit can finalize + compare over it. */
 interface OneShotAgent {
-  runConversation(history: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>): Promise<{
+  runConversation(
+    history: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>,
+    options?: { sessionId?: string; runId?: string; entryPoint?: string; purpose?: 'primary' },
+  ): Promise<{
     finalContent?:  string;
     finishReason?:  string;
     toolCallTrace?: HonestyTraceEntry[];
@@ -3794,7 +3816,11 @@ export async function executeOneShotTurn(deps: OneShotDeps): Promise<number> {
   const err = deps.writeErr ?? ((s: string) => { process.stderr.write(s); });
   let code = 0;
   try {
-    const result = await deps.agent.runConversation([{ role: 'user', content: deps.prompt }]);
+    const oneShotId = `oneshot-${randomUUID()}`;
+    const result = await deps.agent.runConversation(
+      [{ role: 'user', content: deps.prompt }],
+      { sessionId: oneShotId, runId: oneShotId, entryPoint: 'oneshot', purpose: 'primary' },
+    );
     const answer = result.finalContent ?? '';
     // stdout carries ONLY the answer (newline-terminated for pipe hygiene).
     out(answer.endsWith('\n') ? answer : `${answer}\n`);
@@ -3893,6 +3919,12 @@ export async function runQuery(
 
 async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void> {
   const runtime = await buildAgentRuntime(cliOpts, opts);
+  const resumedActiveState = runtime.resumeSessionId
+    ? runtime.sessionManager.resumeActiveState(runtime.resumeSessionId)
+    : null;
+  const resumedHistory = runtime.resumeSessionId
+    ? resumedActiveState?.messages ?? runtime.sessionManager.loadHistory(runtime.resumeSessionId)
+    : undefined;
 
   // v4.5 Phase 7c — install the REAL agent runner now that the
   // REPL agent is built. The daemon foundation already came up
@@ -3945,6 +3977,10 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
     // pill ("persisted from prior session" / "auto-picked" / …).
     initialBootSource: runtime.bootSource,
     resumeSessionId: runtime.resumeSessionId,
+    resumeHistory: resumedHistory,
+    resumeUsage: resumedActiveState?.cumulativeUsage,
+    resumeCompressionCount: resumedActiveState?.compressionCount,
+    resumeBudgetState: resumedActiveState?.budgetState,
     yoloMode: !!cliOpts.yolo,
     fallbackAdapter: runtime.fallbackAdapter,
     paths: runtime.paths,
@@ -4230,7 +4266,7 @@ async function runSkillsSubcommand(
 if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   main(process.argv).then((code) => {
-    if (code !== 0) process.exit(code);
+    process.exitCode = code;
   });
 }
 

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -779,12 +779,14 @@ Reply with ONE word: safe, caution, or dangerous.`;
     level: 'caution' | 'warning',
     current: number,
     max: number,
-    kind: 'iterations' | 'tokens' = 'iterations',
+    kind: 'iterations' | 'tokens' | 'cost' = 'iterations',
   ): void => {
     // v4.12 BE.1 — token budget reports token counts; iterations report turns.
     const msg = kind === 'tokens'
       ? `Tokens ${current.toLocaleString()}/${max.toLocaleString()}`
-      : `Turn ${current}/${max}`;
+      : kind === 'cost'
+        ? `Estimated cost $${current.toFixed(4)}/$${max.toFixed(4)}`
+        : `Turn ${current}/${max}`;
     if (level === 'warning') {
       this.display.warn(`Budget: ${msg} — approaching the cap.`);
     } else if (isVerbose()) {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -67,6 +67,11 @@ import type { CliCallbacks } from './callbacks';
 import type { SessionManager } from '../../core/v4/sessionManager';
 import type { ContextCompressor } from '../../core/v4/contextCompressor';
 import type { AuxiliaryClient } from '../../core/v4/auxiliaryClient';
+import {
+  currentProviderAttemptLedger,
+  runWithProviderUsageContext,
+} from '../../providers/v4/providerAttemptAccounting';
+import { classifyBudgetState, parseUsageMode } from '../../core/v4/usagePolicy';
 import type { ApprovalEngine } from '../../moat/approvalEngine';
 import type { McpClient } from '../../core/v4/mcpClient';
 import type { SkinEngine } from './skinEngine';
@@ -364,6 +369,9 @@ export interface ChatSessionOptions {
   resumeSessionId?: string;
   /** Pre-loaded history when resuming. */
   resumeHistory?: Message[];
+  resumeUsage?: { inputTokens: number; outputTokens: number };
+  resumeCompressionCount?: number;
+  resumeBudgetState?: Record<string, unknown> | null;
 
   /** YOLO mode override — flips approvalEngine to 'off' at boot. */
   yoloMode?: boolean;
@@ -551,6 +559,8 @@ export class ChatSession implements ChatSessionLike {
   private currentProviderId: string;
   private currentModelId: string;
   private totalUsage = { inputTokens: 0, outputTokens: 0 };
+  private compressionCount = 0;
+  private budgetState: Record<string, unknown> | null = null;
   private startedAt = Date.now();
   private queuedSystemPrompts: string[] = [];
   private modelMetadata: ModelMetadata;
@@ -683,6 +693,10 @@ export class ChatSession implements ChatSessionLike {
     // still applies after the engine is frozen at boot.
     if (opts.yoloMode) opts.approvalEngine.setMode('off', { userInitiated: true });
     if (opts.resumeHistory) this.history = [...opts.resumeHistory];
+    if (opts.resumeUsage) this.totalUsage = { ...opts.resumeUsage };
+    this.compressionCount = Math.max(0, Math.floor(opts.resumeCompressionCount ?? 0));
+    this.budgetState = opts.resumeBudgetState ?? null;
+    opts.agent.restoreCompressionCount?.(this.compressionCount);
     // v4.14 — restore the persisted preferred busy-mode (agent.busyMode) so a
     // /busy choice survives a restart. Default 'queue' when unset/garbage.
     try { this.duringTurnInput.setMode(resolveConfiguredBusyMode(opts.config)); } catch { /* safe */ }
@@ -708,6 +722,15 @@ export class ChatSession implements ChatSessionLike {
   // ── ChatSessionLike API ────────────────────────────────────────────
   setHistory(messages: Message[]): void {
     this.history = messages;
+    this.compressionCount += 1;
+    if (this.sessionId) {
+      this.opts.sessionManager.persistActiveState(this.sessionId, {
+        messages: this.history,
+        compressionCount: this.compressionCount,
+        cumulativeUsage: this.totalUsage,
+        budgetState: this.budgetState,
+      });
+    }
   }
   clearHistory(): void {
     this.history = [];
@@ -1778,7 +1801,6 @@ export class ChatSession implements ChatSessionLike {
     }
     this.queuedSystemPrompts = [];
 
-    const turnStart = this.history.length;
     const baseHistory = newHistory.length > 0
       ? [...this.history, ...newHistory, userMsg]
       : [...this.history, userMsg];
@@ -2142,12 +2164,31 @@ export class ChatSession implements ChatSessionLike {
     p2aHeartbeat?.unref?.();
 
     try {
+      const selectedMode = typeof this.opts.config?.getValue === 'function'
+        ? parseUsageMode(this.opts.config.getValue<string>('usage.mode', 'balanced')) ?? 'balanced'
+        : 'balanced';
+      const selectedProfile = typeof this.opts.config?.getValue === 'function'
+        ? this.opts.config.getValue<string>('agent.tool_profile', 'standard') ?? 'standard'
+        : 'standard';
       emitP2aDiag('turn.agent_run.start', {
         aborted: turnAbort.signal.aborted,
         pendingPromises: ['agent.runConversation'],
       });
-      const result = await this.opts.agent.runConversation(baseHistory, {
+      const result = await runWithProviderUsageContext({
+        sessionId: this.sessionId,
+        taskId: replTaskId,
+        runId: replRunId,
+        entryPoint: 'cli',
+        selectedMode,
+        selectedProfile,
+      }, () => this.opts.agent.runConversation(baseHistory, {
         stream: streamingEnabled,
+        sessionId: this.sessionId,
+        taskId: replTaskId,
+        runId: replRunId,
+        entryPoint: 'cli',
+        selectedMode,
+        selectedProfile,
         // v4.12 BE.1 — seed the per-session token cap with tokens already spent
         // this session, so the cap enforces across turns (not just this run).
         sessionTokensSoFar: this.sessionId
@@ -2289,7 +2330,7 @@ export class ChatSession implements ChatSessionLike {
               progressBar.update(outputTokens, maxTokens);
             })
           : undefined,
-      });
+      }));
       emitP2aDiag('turn.agent_run.complete', {
         aborted: turnAbort.signal.aborted,
         finishReason: result.finishReason,
@@ -2304,6 +2345,7 @@ export class ChatSession implements ChatSessionLike {
       if (streamingActive) { flushStreamDeltas(); this.opts.display.streamComplete(); }
 
       this.history = result.messages;
+      this.compressionCount = result.compressionEvents;
       this.totalUsage.inputTokens += result.totalUsage.inputTokens;
       this.totalUsage.outputTokens += result.totalUsage.outputTokens;
       // v4.11 Slice 4 — roll subagent token spend into the parent
@@ -2318,6 +2360,29 @@ export class ChatSession implements ChatSessionLike {
         this.totalUsage.inputTokens  += turnContext.costAccumulator.inputTokens;
         this.totalUsage.outputTokens += turnContext.costAccumulator.outputTokens;
       }
+      const tokenBudget = typeof this.opts.config?.getValue === 'function'
+        ? this.opts.config.getValue<number>('budget.session_token_cap', 0) ?? 0
+        : 0;
+      const costBudget = typeof this.opts.config?.getValue === 'function'
+        ? this.opts.config.getValue<number>('budget.session_cost_cap_usd', 0) ?? 0
+        : 0;
+      const projection = this.sessionId
+        ? currentProviderAttemptLedger()?.project({ sessionId: this.sessionId }) ?? null
+        : null;
+      const usedTokens = projection
+        ? (projection.providerInputTokens + projection.providerOutputTokens
+          || projection.estimatedInputTokens + projection.estimatedOutputTokens)
+        : this.totalUsage.inputTokens + this.totalUsage.outputTokens;
+      this.budgetState = {
+        state: classifyBudgetState(usedTokens, tokenBudget),
+        usedTokens,
+        tokenBudget: tokenBudget || null,
+        knownEstimatedCost: projection?.knownCostAmount ?? null,
+        estimatedCostBudget: costBudget || null,
+        costState: projection && projection.unknownCostAttempts === 0
+          ? classifyBudgetState(projection.knownCostAmount, costBudget)
+          : 'unknown',
+      };
       // v4.14 Pillar 5 Slice C — cost_updated: the running token total (parent
       // + children) after the turn. One emit per turn (inherently ≤1/sec), so
       // no throttle needed here. emitPillarEvent never throws; wrapped anyway.
@@ -2560,6 +2625,25 @@ export class ChatSession implements ChatSessionLike {
         this.opts.display.taskOutcome(_taskOutcome);
       }
 
+      if (replRunId !== null) {
+        const turnUsage = currentProviderAttemptLedger()?.project({ runId: String(replRunId) });
+        if (turnUsage && turnUsage.physicalAttempts > 0) {
+          const reportedInput = turnUsage.providerInputTokens || turnUsage.estimatedInputTokens;
+          const reportedOutput = turnUsage.providerOutputTokens || turnUsage.estimatedOutputTokens;
+          const toolBytesSaved = Math.max(0, turnUsage.rawToolResultBytes - turnUsage.transmittedToolResultBytes);
+          const savings = [
+            toolBytesSaved > 0 ? `${toolBytesSaved.toLocaleString()} tool bytes externalized` : null,
+            turnUsage.deferredSchemaCount > 0 ? `${turnUsage.deferredSchemaCount} schemas deferred` : null,
+          ].filter((value): value is string => value !== null);
+          const cost = turnUsage.unknownCostAttempts > 0
+            ? 'cost unknown'
+            : `$${turnUsage.knownCostAmount.toFixed(4)} estimated`;
+          this.opts.display.dim(
+            `Usage: ${turnUsage.physicalAttempts} provider attempt${turnUsage.physicalAttempts === 1 ? '' : 's'} · ${reportedInput} in / ${reportedOutput} out · ${cost}${savings.length > 0 ? ` · ${savings.join(', ')}` : ''}`,
+          );
+        }
+      }
+
       // v4.1.6 Polish 2 — post-render skill-proposal handler.
       // The agent loop now SKIPS the inquirer prompt when a
       // prompt callback is wired, surfacing the SkillProposal
@@ -2593,11 +2677,18 @@ export class ChatSession implements ChatSessionLike {
 
       if (this.sessionId) {
         // Only persist the new tail of messages — what got added this turn.
-        const newSlice = this.history.slice(turnStart);
+        const newSlice = [...newHistory, userMsg, ...(result.turnMessages ?? [])];
         this.opts.sessionManager.recordTurn(
           this.sessionId,
           newSlice,
           result.totalUsage,
+          undefined,
+          {
+            messages: this.history,
+            compressionCount: this.compressionCount,
+            cumulativeUsage: this.totalUsage,
+            budgetState: this.budgetState,
+          },
         );
       }
 
@@ -2734,7 +2825,7 @@ export class ChatSession implements ChatSessionLike {
       // the user sees WHICH provider blew up (matters when fallback
       // adapters rotate slots mid-turn).
       const cls = classifyProviderError(err);
-      const tailored = suggestForErrorClass(cls, this.currentProviderId);
+      const tailored = suggestForErrorClass(cls, this.currentProviderId, err);
       // v4.1.3-essentials: on `auth` class errors we have enough state
       // (which provider, what to run) to render a capability card —
       // structured "what auth's missing, what you can still do, how to

--- a/cli/v4/commands/budget.ts
+++ b/cli/v4/commands/budget.ts
@@ -16,6 +16,8 @@
  */
 
 import type { SlashCommand } from '../commandRegistry';
+import { currentProviderAttemptLedger } from '../../../providers/v4/providerAttemptAccounting';
+import { classifyBudgetState } from '../../../core/v4/usagePolicy';
 
 export const budget: SlashCommand = {
   name: 'budget',
@@ -24,13 +26,39 @@ export const budget: SlashCommand = {
   icon: '💰',
   handler: async (ctx) => {
     const cap = ctx.config?.getValue<number>('budget.session_token_cap', 0) ?? 0;
+    const costCap = ctx.config?.getValue<number>('budget.session_cost_cap_usd', 0) ?? 0;
     const arg = (ctx.args[0] ?? '').trim();
+    const asJson = ctx.args.includes('--json');
+
+    if (/^cost$/i.test(arg)) {
+      const raw = (ctx.args[1] ?? '').trim();
+      if (!raw) {
+        ctx.display.info(costCap > 0
+          ? `Estimated-cost cap: $${costCap.toFixed(4)} per session.`
+          : 'Estimated-cost cap: off.');
+        return {};
+      }
+      const amount = /^off$/i.test(raw) ? 0 : Number(raw);
+      if (!Number.isFinite(amount) || amount < 0) {
+        ctx.display.printError('Usage: /budget cost <usd | off>');
+        return {};
+      }
+      try {
+        ctx.config?.set('budget.session_cost_cap_usd', amount);
+        await ctx.config?.save();
+      } catch { /* best-effort */ }
+      ctx.display.success(amount === 0
+        ? 'Session estimated-cost cap disabled.'
+        : `Session estimated-cost cap set to $${amount.toFixed(4)}. Applies to new sessions.`);
+      return {};
+    }
 
     // Set path — `/budget <n>` (or `/budget off`).
-    if (arg) {
-      const n = /^off$/i.test(arg) ? 0 : Number.parseInt(arg, 10);
+    if (arg && arg !== '--json') {
+      const raw = /^tokens$/i.test(arg) ? (ctx.args[1] ?? '') : arg;
+      const n = /^off$/i.test(raw) ? 0 : Number.parseInt(raw, 10);
       if (!Number.isFinite(n) || n < 0) {
-        ctx.display.printError('Usage: /budget [<max_tokens> | off]');
+        ctx.display.printError('Usage: /budget [<max_tokens> | off | cost <usd | off>]');
         return {};
       }
       try { ctx.config?.set('budget.session_token_cap', n); await ctx.config?.save(); } catch { /* best-effort */ }
@@ -44,15 +72,49 @@ export const budget: SlashCommand = {
 
     // View path.
     const id = ctx.session?.getSessionId?.();
-    const used = id && ctx.sessionManager ? ctx.sessionManager.getSessionTokens(id) : 0;
+    const ledger = currentProviderAttemptLedger();
+    const projection = id && ledger ? ledger.project({ sessionId: id }) : null;
+    const used = projection
+      ? (projection.providerInputTokens + projection.providerOutputTokens
+        || projection.estimatedInputTokens + projection.estimatedOutputTokens)
+      : id && ctx.sessionManager ? ctx.sessionManager.getSessionTokens(id) : 0;
+    const state = classifyBudgetState(used, cap);
+    if (asJson) {
+      ctx.display.write(`${JSON.stringify({
+        sessionId: id ?? null,
+        usedTokens: used,
+        tokenBudget: cap || null,
+        estimatedCostBudget: costCap || null,
+        state,
+        cost: projection ? {
+          knownAmount: projection.knownCostAmount,
+          currency: projection.costCurrency,
+          unknownAttempts: projection.unknownCostAttempts,
+        } : null,
+      })}\n`);
+      return {};
+    }
     if (cap > 0) {
-      const pct = Math.min(100, Math.round((used / cap) * 100));
+      const pct = Math.round((used / cap) * 100);
       ctx.display.info(`Budget: ${used.toLocaleString()} / ${cap.toLocaleString()} tokens (${pct}%) this session.`);
-      if (pct >= 90) ctx.display.warn('  Near the cap — the agent will finalize gracefully rather than overspend.');
+      ctx.display.info(`  State: ${state}`);
+      if (pct >= 100) ctx.display.warn('  Budget reached. Optional exploration and new expensive branches are blocked.');
+      else if (pct >= 80) ctx.display.warn('  Budget warning. Optional exploration is disabled; required safety and verification continue.');
       ctx.display.info('  Set with `/budget <max_tokens>` or config `budget.session_token_cap`; `/budget off` to disable.');
     } else {
       ctx.display.info(`Budget: ${used.toLocaleString()} tokens used this session — no cap set.`);
       ctx.display.info('  Set a cap with `/budget <max_tokens>` (money-safety: stops before overspending).');
+    }
+    if (projection) {
+      const costState = projection.unknownCostAttempts > 0
+        ? 'unknown'
+        : classifyBudgetState(projection.knownCostAmount, costCap);
+      ctx.display.info(costCap > 0
+        ? `  Estimated cost: $${projection.knownCostAmount.toFixed(4)} / $${costCap.toFixed(4)} (${costState}).`
+        : `  Known estimated cost: $${projection.knownCostAmount.toFixed(4)} (no cost cap).`);
+      if (projection.unknownCostAttempts > 0) {
+        ctx.display.warn(`  Cost remains unknown for ${projection.unknownCostAttempts} attempt(s).`);
+      }
     }
     return {};
   },

--- a/cli/v4/commands/compress.ts
+++ b/cli/v4/commands/compress.ts
@@ -11,6 +11,7 @@
  * session's history and replaces it with the compressed version.
  */
 import type { SlashCommand } from '../commandRegistry';
+import { runWithProviderUsageContext } from '../../../providers/v4/providerAttemptAccounting';
 
 export const compress: SlashCommand = {
   name: 'compress',
@@ -28,10 +29,21 @@ export const compress: SlashCommand = {
     const spinner = ctx.display.startSpinner('Compressing context…');
     let result;
     try {
-      result = await ctx.compressor.forceCompress(
-        ctx.session.history,
-        providerId,
-        modelId,
+      const sessionId = ctx.session.getSessionId?.() ?? null;
+      result = await runWithProviderUsageContext(
+        {
+          sessionId,
+          runId: sessionId,
+          entryPoint: 'cli',
+          purpose: 'compression',
+          providerConfigured: providerId,
+          modelConfigured: modelId,
+        },
+        () => ctx.compressor!.forceCompress(
+          ctx.session!.history,
+          providerId,
+          modelId,
+        ),
       );
     } catch (err) {
       spinner.stop();
@@ -39,12 +51,14 @@ export const compress: SlashCommand = {
       return {};
     }
     spinner.stop();
-    if (result.refused) {
-      ctx.display.dim('Conversation too short — nothing compressed.');
+    if (result.error) {
+      ctx.display.warn(result.errorMessage
+        ? `Compression failed safely: ${result.errorMessage}`
+        : 'Compression auxiliary call failed; history unchanged.');
       return {};
     }
-    if (result.error) {
-      ctx.display.warn('Compression auxiliary call failed; history unchanged.');
+    if (result.refused) {
+      ctx.display.dim('Conversation too short — nothing compressed.');
       return {};
     }
     ctx.session.setHistory(result.compressedMessages);

--- a/cli/v4/commands/estimate.ts
+++ b/cli/v4/commands/estimate.ts
@@ -1,0 +1,42 @@
+import type { SlashCommand } from '../commandRegistry';
+import { findModel } from '../../../providers/v4/modelCatalog';
+import { estimateTaskUsage, parseUsageMode } from '../../../core/v4/usagePolicy';
+
+export const estimate: SlashCommand = {
+  name: 'estimate',
+  description: 'Estimate tokens, provider calls, cost, and main drivers locally.',
+  category: 'system',
+  icon: '#',
+  handler: async (ctx) => {
+    const asJson = ctx.args.includes('--json');
+    const task = ctx.args.filter((arg) => arg !== '--json').join(' ').trim();
+    if (!task) {
+      ctx.display.warn('Usage: /estimate [--json] <task>');
+      return {};
+    }
+    const provider = ctx.session?.getCurrentProvider() ?? '';
+    const model = ctx.session?.getCurrentModel() ?? '';
+    const catalog = findModel(provider, model);
+    const mode = parseUsageMode(ctx.config?.getValue<string>('usage.mode', 'balanced')) ?? 'balanced';
+    const result = estimateTaskUsage({
+      task,
+      messages: ctx.session?.history ?? [],
+      tools: ctx.toolRegistry?.getSchemas(undefined, 'repl') ?? [],
+      mode,
+      tokenBudget: ctx.config?.getValue<number>('budget.session_token_cap', 0) ?? 0,
+      pricing: catalog?.pricing ?? null,
+    });
+    if (asJson) {
+      ctx.display.write(`${JSON.stringify(result)}\n`);
+      return {};
+    }
+    ctx.display.info(`Estimate: ${result.complexity} · ${result.confidence} confidence · ${result.selectedMode}`);
+    ctx.display.write(`  Tokens: ${result.estimatedTokenLow.toLocaleString()}–${result.estimatedTokenHigh.toLocaleString()}\n`);
+    ctx.display.write(`  Provider calls: ${result.estimatedCallsLow}–${result.estimatedCallsHigh}\n`);
+    if (result.costStatus === 'unknown') ctx.display.dim('  Cost: unknown for the selected model');
+    else ctx.display.write(`  Estimated cost: $${result.estimatedCostLow!.toFixed(4)}–$${result.estimatedCostHigh!.toFixed(4)}\n`);
+    ctx.display.write(`  Main drivers: ${result.mainCostDrivers.join(', ')}\n`);
+    if (result.configuredBudget) ctx.display.write(`  Token budget: ${result.configuredBudget.toLocaleString()}\n`);
+    return {};
+  },
+};

--- a/cli/v4/commands/help.ts
+++ b/cli/v4/commands/help.ts
@@ -90,6 +90,7 @@ export const SUBSECTION_MAP: Readonly<Record<string, Subsection>> = {
   // v4.12.1 Pillar 4 Slice 2b — mid-turn redirect.
   redirect: 'System',
   usage: 'System',
+  estimate: 'System',
   cron: 'System',
   setup: 'System',
   channel: 'System',

--- a/cli/v4/commands/index.ts
+++ b/cli/v4/commands/index.ts
@@ -20,6 +20,7 @@ import { save } from './save';
 import { title } from './title';
 import { compress } from './compress';
 import { usage } from './usage';
+import { estimate } from './estimate';
 import { undo } from './undo';
 import { retry } from './retry';
 import { yolo } from './yolo';
@@ -91,6 +92,7 @@ export {
   title,
   compress,
   usage,
+  estimate,
   undo,
   retry,
   yolo,
@@ -163,6 +165,7 @@ export const allCommands: SlashCommand[] = [
   title,
   compress,
   usage,
+  estimate,
   undo,
   retry,
   yolo,

--- a/cli/v4/commands/mcp.ts
+++ b/cli/v4/commands/mcp.ts
@@ -62,6 +62,7 @@ import {
 } from '../envSources';
 import { CredentialResolver } from '../../../providers/v4/credentialResolver';
 import { RuntimeResolver } from '../../../providers/v4/runtimeResolver';
+import { providerMainDefault } from '../../../providers/v4/providerModelAuthority';
 import type { ProviderAdapter } from '../../../providers/v4/types';
 import type { ProviderOption } from '../../../core/v4/subagent/providerRotation';
 // v4.6 Phase 2R — MCP-mode subagent_fanout now routes children
@@ -254,7 +255,7 @@ async function wireSubagentFanout(opts: WireOptions): Promise<void> {
   }
 
   const providerId = config.getValue<string>('model.provider', 'groq')!;
-  const modelId    = config.getValue<string>('model.modelId', 'llama-3.3-70b-versatile')!;
+  const modelId    = config.getValue<string>('model.modelId', providerMainDefault(providerId) ?? '')!;
 
   const credentialResolver = new CredentialResolver(opts.paths.authJson);
   const resolver           = new RuntimeResolver(credentialResolver);

--- a/cli/v4/commands/mode.ts
+++ b/cli/v4/commands/mode.ts
@@ -22,6 +22,7 @@
 import type { SlashCommand } from '../commandRegistry';
 import { type AutonomyLevel, AUTONOMY_LEVELS } from '../../../moat/autonomy';
 import { applyAndPersistAutonomy } from './autonomy';
+import { parseUsageMode } from '../../../core/v4/usagePolicy';
 
 /** Friendly aliases → the canonical dial level. */
 const ALIASES: Readonly<Record<string, AutonomyLevel>> = {
@@ -45,18 +46,32 @@ export function modeStatusLine(level: AutonomyLevel): string {
 
 export const mode: SlashCommand = {
   name: 'mode',
-  description: 'Show or set the trust level: safe (default) | auto | observer. Persists.',
+  description: 'Show or set trust or token-usage behavior. Persists.',
   category: 'system',
   icon: '🎚️',
   handler: async (ctx) => {
+    const arg = (ctx.args[0] ?? '').trim().toLowerCase();
+    const usageMode = parseUsageMode(ctx.config?.getValue<string>('usage.mode', 'balanced')) ?? 'balanced';
+    const requestedUsageMode = parseUsageMode(arg);
+    if (requestedUsageMode) {
+      try {
+        ctx.config?.set('usage.mode', requestedUsageMode);
+        await ctx.config?.save();
+      } catch {
+        ctx.display.warn('Usage mode could not be persisted.');
+        return {};
+      }
+      ctx.display.success(`Usage mode: ${requestedUsageMode} (applies on the next provider request).`);
+      return {};
+    }
+
     const engine = ctx.approvalEngine;
     if (!engine) { ctx.display.warn('Approval engine not wired in this context.'); return {}; }
     const current = engine.getAutonomyPolicy()?.level ?? 'Assistant';
-
-    const arg = (ctx.args[0] ?? '').trim().toLowerCase();
     if (!arg) {
       // View: current + all options, active one marked, in plain language.
       ctx.display.info(modeStatusLine(current));
+      ctx.display.info(`Usage: ${usageMode} (economy | balanced | thorough).`);
       for (const lvl of AUTONOMY_LEVELS) {
         ctx.display.dim(`  ${lvl === current ? '●' : '○'} ${lvl} — ${PLAIN[lvl]}`);
       }
@@ -66,7 +81,7 @@ export const mode: SlashCommand = {
 
     const level = ALIASES[arg] ?? AUTONOMY_LEVELS.find((l) => l.toLowerCase() === arg);
     if (!level) {
-      ctx.display.warn(`Unknown mode "${arg}". Try: safe | auto | observer.`);
+      ctx.display.warn(`Unknown mode "${arg}". Try: safe | auto | observer | economy | balanced | thorough.`);
       return {};
     }
 

--- a/cli/v4/commands/modelPicker.ts
+++ b/cli/v4/commands/modelPicker.ts
@@ -31,6 +31,7 @@ import {
   type ProviderRegistryEntry,
 } from '../../../providers/v4/registry';
 import { listModelsForProvider } from '../../../providers/v4/modelCatalog';
+import type { FetchModelsResult } from '../../../core/v4/providers/modelFetch';
 import { termWidth } from '../../../core/v4/ui/theme';
 
 export type ProviderTier = 'pro' | 'free' | 'paid' | 'local' | 'subscription';
@@ -58,12 +59,22 @@ export interface ModelPickerOptions {
    * and the `aiden model` CLI path working without extra plumbing.
    */
   isProviderAuthed?: (providerId: string) => boolean;
+  /** Live local-inventory seam. Production uses global fetch. */
+  fetchImpl?: typeof fetch;
+  ollamaBaseUrl?: string;
+}
+
+interface PickerChoice {
+  name: string;
+  value: string;
+  description?: string;
+  disabled?: boolean | string;
 }
 
 export interface PickerPrompts {
   select(opts: {
     message: string;
-    choices: { name: string; value: string; description?: string }[];
+    choices: PickerChoice[];
   }): Promise<string>;
 }
 
@@ -77,6 +88,7 @@ const TIER_BADGE: Record<string, string> = {
 
 const BACK_VALUE = '__back__';
 const CANCEL_VALUE = '__cancel__';
+const OLLAMA_UNAVAILABLE_VALUE = '__ollama_unavailable__';
 
 /** Auth badge rendered into stage-1 provider rows. */
 function authBadge(entry: ProviderRegistryEntry, authed: boolean): string {
@@ -160,10 +172,18 @@ function modelChoice(
   providerId: string,
   isCurrent: boolean,
   layout: PickerLayout,
-): { name: string; value: string; description?: string } {
+  availability?: 'installed' | 'not_installed',
+): PickerChoice {
   const m = listModelsForProvider(providerId).find((x) => x.id === modelId);
   if (!m) {
-    return { name: modelId, value: modelId };
+    const flags = [
+      availability === 'installed' ? '✓ installed' : null,
+      isCurrent ? '← current' : null,
+    ].filter((flag): flag is string => flag !== null);
+    return {
+      name: flags.length > 0 ? `${modelId}  ${flags.join('  ')}` : modelId,
+      value: modelId,
+    };
   }
 
   // Strip "(deprecating <date>)" from the Name cell → trailing flag, so the
@@ -175,15 +195,25 @@ function modelChoice(
   if (depM)         flags.push(`⚠ deprecating ${depM[2]}`);
   // Phase 22 Task 3: ModelEntry.isDefault is the catalog's "recommended" signal.
   if (m.isDefault)  flags.push('⭐');
-  if (isCurrent)    flags.push('← current');
+  if (availability === 'installed') flags.push('✓ installed');
+  if (availability === 'not_installed') flags.push(`not installed · ollama pull ${m.id}`);
+  if (isCurrent && availability !== 'not_installed') flags.push('← current');
   const trail = flags.length ? `  ${flags.join('  ')}` : '';
+  const disabled = availability === 'not_installed'
+    ? `Run ollama pull ${m.id} first`
+    : undefined;
 
   if (layout.mode === 'plain') {
     // Narrow-terminal fallback — single-line concat (legacy shape) so a
     // tight terminal never wraps a padded table into a mess.
     const ctx = ` ${(m.contextLength / 1000).toFixed(0)}K ctx`;
     const pricing = m.pricing ? ` $${m.pricing.inputPerM}/$${m.pricing.outputPerM} per M` : '';
-    return { name: `${baseName}${ctx}${pricing}${trail}`, value: m.id, description: m.notes };
+    return {
+      name: `${baseName}${ctx}${pricing}${trail}`,
+      value: m.id,
+      description: m.notes,
+      disabled,
+    };
   }
 
   const name = truncate(baseName, layout.nameW).padEnd(layout.nameW);
@@ -198,7 +228,7 @@ function modelChoice(
   const row = layout.mode === 'full'
     ? `${name} ${ctx} ${(m.pricing ? `$${m.pricing.inputPerM}/$${m.pricing.outputPerM}` : '—').padEnd(PRICE_W)} ${tools}`
     : `${name} ${ctx} ${tools}`;
-  return { name: `${row}${trail}`, value: m.id, description: m.notes };
+  return { name: `${row}${trail}`, value: m.id, description: m.notes, disabled };
 }
 
 /** Resolve `@inquirer/prompts` lazily so unit tests can swap it out. */
@@ -231,6 +261,23 @@ export async function runModelPicker(
 
   const prompts = opts.promptModule ?? (await defaultPrompts());
   const isAuthed = opts.isProviderAuthed ?? (() => true);
+  // Injected prompts alone are the legacy unit-test seam and remain offline.
+  // Production and tests that explicitly inject fetch use the live local
+  // inventory so a curated catalog row is never mistaken for an installation.
+  const useLiveOllamaInventory = opts.promptModule === undefined || opts.fetchImpl !== undefined;
+  let ollamaInventory: FetchModelsResult | null = null;
+  const loadOllamaInventory = async (): Promise<FetchModelsResult | null> => {
+    if (!useLiveOllamaInventory) return null;
+    if (ollamaInventory) return ollamaInventory;
+    ollamaInventory = await resolver.getLocalModelInventory({
+      baseUrl: opts.ollamaBaseUrl,
+      fetchImpl: opts.fetchImpl,
+      forceRefresh: true,
+    });
+    return ollamaInventory;
+  };
+
+  if (currentProviderId === 'ollama') await loadOllamaInventory();
 
   const providerEntries = Object.values(PROVIDER_REGISTRY).filter(
     (e) => !tier || e.tier === tier,
@@ -244,21 +291,38 @@ export async function runModelPicker(
     // Stage 1 — provider picker.
     const hintParts: string[] = [];
     if (currentProviderId && currentModelId) {
-      hintParts.push(`Current: ${currentProviderId} on ${currentModelId}`);
+      if (currentProviderId === 'ollama' && ollamaInventory?.source !== 'live') {
+        hintParts.push(`Configured: ollama on ${currentModelId} (inventory unavailable)`);
+      } else {
+        const currentInstalled = currentProviderId !== 'ollama'
+          || ollamaInventory === null
+          || ollamaInventory.models.some((model) => model.id === currentModelId);
+        hintParts.push(currentInstalled
+          ? `Current: ${currentProviderId} on ${currentModelId}`
+          : `Configured: ollama on ${currentModelId} (not installed)`);
+      }
     }
     const stage1Message =
       hintParts.length > 0
         ? `⚙ Model Picker — Select Provider · ${hintParts.join(' · ')}`
         : '⚙ Model Picker — Select Provider';
 
-    const providerChoices = providerEntries.map((e) =>
-      providerChoice(
+    const providerChoices = providerEntries.map((e) => {
+      const localModels = e.id === 'ollama' && ollamaInventory
+        ? ollamaInventory.models
+        : null;
+      const currentInstalled = e.id !== 'ollama'
+        || localModels === null
+        || ollamaInventory?.source !== 'live'
+        || !currentModelId
+        || localModels.some((model) => model.id === currentModelId);
+      return providerChoice(
         e,
-        listModelsForProvider(e.id).length,
+        localModels?.length ?? listModelsForProvider(e.id).length,
         isAuthed(e.id),
-        e.id === currentProviderId,
-      ),
-    );
+        e.id === currentProviderId && currentInstalled,
+      );
+    });
     providerChoices.push({ name: 'Cancel', value: CANCEL_VALUE });
 
     let providerId: string;
@@ -272,8 +336,18 @@ export async function runModelPicker(
     }
     if (providerId === CANCEL_VALUE) return null;
 
-    const models = listModelsForProvider(providerId);
-    if (models.length === 0) return null;
+    const catalogModels = listModelsForProvider(providerId);
+    const liveOllama = providerId === 'ollama' ? await loadOllamaInventory() : null;
+    const inventoryAvailable = liveOllama?.source === 'live';
+    const installedModels = inventoryAvailable ? liveOllama.models : [];
+    const installedIds = inventoryAvailable
+      ? new Set(installedModels.map((model) => model.id))
+      : null;
+    const models = liveOllama ? installedModels : catalogModels;
+    const pullableModels = inventoryAvailable
+      ? catalogModels.filter((model) => !installedIds?.has(model.id))
+      : [];
+    if (!liveOllama && models.length === 0) return null;
 
     // Stage 2 — model picker with breadcrumb.
     const providerEntry = PROVIDER_REGISTRY[providerId];
@@ -282,9 +356,14 @@ export async function runModelPicker(
     // the same column widths; degrades by terminal width.
     const layout = pickerLayout(termWidth());
     const header = modelTableHeader(layout);
+    const availabilitySummary = liveOllama
+      ? inventoryAvailable
+        ? `${models.length} installed · ${pullableModels.length} available to pull`
+        : 'inventory unavailable · start Ollama and reopen /model'
+      : `${models.length} available`;
     const stage2Message = header
-      ? `⚙ Model Picker — ${breadcrumb} · Select a model (${models.length} available)\n${header}`
-      : `⚙ Model Picker — ${breadcrumb} · Select a model (${models.length} available)`;
+      ? `⚙ Model Picker — ${breadcrumb} · Select a model (${availabilitySummary})\n${header}`
+      : `⚙ Model Picker — ${breadcrumb} · Select a model (${availabilitySummary})`;
 
     const modelChoices = models.map((m) =>
       modelChoice(
@@ -292,8 +371,25 @@ export async function runModelPicker(
         providerId,
         providerId === currentProviderId && m.id === currentModelId,
         layout,
+        inventoryAvailable ? 'installed' : undefined,
       ),
     );
+    for (const model of pullableModels) {
+      modelChoices.push(modelChoice(
+        model.id,
+        providerId,
+        false,
+        layout,
+        'not_installed',
+      ));
+    }
+    if (liveOllama && !inventoryAvailable) {
+      modelChoices.push({
+        name: 'Ollama unavailable · start `ollama serve`, then reopen /model',
+        value: OLLAMA_UNAVAILABLE_VALUE,
+        disabled: 'Installed models cannot be verified while Ollama is offline',
+      });
+    }
     modelChoices.push({ name: '← Back', value: BACK_VALUE });
     modelChoices.push({ name: 'Cancel', value: CANCEL_VALUE });
 
@@ -308,6 +404,8 @@ export async function runModelPicker(
     }
     if (modelId === CANCEL_VALUE) return null;
     if (modelId === BACK_VALUE) continue; // re-prompt stage 1
+    if (modelId === OLLAMA_UNAVAILABLE_VALUE) continue;
+    if (installedIds && !installedIds.has(modelId)) continue;
 
     return { providerId, modelId };
   }

--- a/cli/v4/commands/usage.ts
+++ b/cli/v4/commands/usage.ts
@@ -14,6 +14,231 @@
 import type { SlashCommand } from '../commandRegistry';
 import { findModel } from '../../../providers/v4/modelCatalog';
 import { renderTable } from '../table';
+import { currentProviderAttemptLedger } from '../../../providers/v4/providerAttemptAccounting';
+import type {
+  ProviderAttemptPurpose,
+  ProviderAttemptRecord,
+  ProviderUsageProjection,
+} from '../../../core/v4/usageLedger';
+
+const JSON_PURPOSES: ProviderAttemptPurpose[] = [
+  'primary', 'retry', 'fallback', 'auxiliary', 'subagent', 'aggregation', 'compression',
+];
+
+const DETAIL_PURPOSES: ProviderAttemptPurpose[] = [
+  'primary', 'retry', 'fallback', 'auxiliary', 'subagent', 'aggregation', 'compression',
+  'distillation', 'title', 'memory_review', 'legacy_api', 'setup', 'readiness',
+];
+
+type PurposeProjection = Partial<Record<ProviderAttemptPurpose, ProviderUsageProjection>>;
+
+export interface UsageProviderBreakdown {
+  provider: string;
+  model: string;
+  projection: ProviderUsageProjection;
+}
+
+export interface UsagePresentation {
+  providerId: string;
+  modelId: string;
+  total: ProviderUsageProjection;
+  byPurpose: PurposeProjection;
+  providers: readonly UsageProviderBreakdown[];
+  records: readonly ProviderAttemptRecord[];
+}
+
+function compactNumber(value: number): string {
+  const absolute = Math.abs(value);
+  if (absolute < 1_000) return String(Math.round(value));
+  if (absolute < 1_000_000) return `${(value / 1_000).toFixed(absolute < 10_000 ? 1 : 0)}K`;
+  return `${(value / 1_000_000).toFixed(absolute < 10_000_000 ? 1 : 0)}M`;
+}
+
+function compactBytes(value: number): string {
+  if (value < 1_024) return `${Math.round(value)} B`;
+  if (value < 1_048_576) return `${(value / 1_024).toFixed(value < 10_240 ? 1 : 0)} KB`;
+  return `${(value / 1_048_576).toFixed(value < 10_485_760 ? 1 : 0)} MB`;
+}
+
+function tokenSource(total: ProviderUsageProjection): 'reported' | 'estimated' | 'mixed' | 'unknown' {
+  if (total.providerReportedAttempts > 0 && total.estimatedAttempts > 0) return 'mixed';
+  if (total.providerReportedAttempts > 0) return 'reported';
+  if (total.estimatedAttempts > 0) return 'estimated';
+  return 'unknown';
+}
+
+function tokenTotals(total: ProviderUsageProjection): { input: number; output: number } {
+  if (total.providerReportedAttempts > 0) {
+    return { input: total.providerInputTokens, output: total.providerOutputTokens };
+  }
+  return { input: total.estimatedInputTokens, output: total.estimatedOutputTokens };
+}
+
+function splitLongWord(word: string, width: number): string[] {
+  const parts: string[] = [];
+  for (let index = 0; index < word.length; index += width) parts.push(word.slice(index, index + width));
+  return parts;
+}
+
+function wrapPlain(value: string, width: number): string[] {
+  const safeWidth = Math.max(8, width);
+  const words = value.trim().split(/\s+/).flatMap((word) => (
+    word.length > safeWidth ? splitLongWord(word, safeWidth) : [word]
+  ));
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= safeWidth) {
+      current = next;
+    } else {
+      if (current) lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+function labelled(label: string, value: string, width: number): string[] {
+  const safeWidth = Math.max(24, width);
+  const inlinePrefix = `${label.padEnd(12)} `;
+  if (inlinePrefix.length + value.length <= safeWidth) return [`${inlinePrefix}${value}`];
+  return [label, ...wrapPlain(value, safeWidth - 2).map((line) => `  ${line}`)];
+}
+
+function costSummary(total: ProviderUsageProjection): string {
+  if (total.unknownCostAttempts > 0) {
+    const known = total.knownCostAmount > 0
+      ? `; known estimate ${total.knownCostAmount.toFixed(4)} ${total.costCurrency ?? 'currency unknown'}`
+      : '';
+    return `Unknown for ${total.unknownCostAttempts} ${total.unknownCostAttempts === 1 ? 'call' : 'calls'}${known}`;
+  }
+  return `${total.knownCostAmount.toFixed(4)} ${total.costCurrency ?? 'currency unknown'} estimated`;
+}
+
+function routeSummary(input: UsagePresentation): string {
+  const route = input.records
+    .map((record) => record.providerActual)
+    .filter((provider): provider is string => !!provider)
+    .filter((provider, index, providers) => index === 0 || provider !== providers[index - 1]);
+  if (route.length === 0) return `${input.providerId}:${input.modelId}`;
+  return route.join(' -> ');
+}
+
+function activitySummary(byPurpose: PurposeProjection): string[] {
+  const rows: string[] = [];
+  const add = (label: string, purpose: ProviderAttemptPurpose): void => {
+    const attempts = byPurpose[purpose]?.physicalAttempts ?? 0;
+    if (attempts > 0) rows.push(`${label}: ${attempts}`);
+  };
+  add('Retries', 'retry');
+  add('Fallback attempts', 'fallback');
+  add('Auxiliary calls', 'auxiliary');
+  add('Subagent calls', 'subagent');
+  add('Aggregation calls', 'aggregation');
+  add('Compression calls', 'compression');
+  return rows;
+}
+
+export function formatUsageSummary(input: UsagePresentation, width = 80): string {
+  const total = input.total;
+  const tokens = tokenTotals(total);
+  const source = tokenSource(total);
+  const schemaExposures = total.coreSchemaCount + total.mcpSchemaCount + total.pluginSchemaCount;
+  const memoryTokens = total.memoryTokens + total.userProfileTokens + total.projectMemoryTokens;
+  const skillTokens = total.skillIndexTokens + total.loadedSkillTokens;
+  const rows: string[] = ['Usage — Current session', ''];
+  rows.push(...labelled('Route', routeSummary(input), width));
+  rows.push(...labelled('Calls', `${total.successfulAttempts} successful · ${total.failedAttempts} failed`, width));
+  rows.push(...labelled(
+    `Tokens (${source})`,
+    `${compactNumber(tokens.input)} input · ${compactNumber(tokens.output)} output · ${compactNumber(total.reasoningTokens)} reasoning`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Context',
+    `${compactNumber(total.estimatedSchemaTokens)} schemas · ${compactNumber(skillTokens)} skills · ${compactNumber(memoryTokens)} memory`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Schemas',
+    `${compactNumber(schemaExposures)} cumulative exposures · ${compactNumber(total.deferredSchemaCount)} deferred`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Tool data',
+    `${compactBytes(total.transmittedToolResultBytes)} sent · ${compactBytes(total.rawToolResultBytes)} raw`,
+    width,
+  ));
+  rows.push(...labelled('Cost', costSummary(total), width));
+  for (const activity of activitySummary(input.byPurpose)) {
+    const [label, value] = activity.split(': ', 2);
+    rows.push(...labelled(label, value, width));
+  }
+  return `${rows.join('\n')}\n`;
+}
+
+function projectionSummary(projection: ProviderUsageProjection): string {
+  const tokens = tokenTotals(projection);
+  return `${projection.successfulAttempts} ok, ${projection.failedAttempts} failed; `
+    + `${compactNumber(tokens.input)} in, ${compactNumber(tokens.output)} out`;
+}
+
+export function formatUsageDetails(input: UsagePresentation, width = 80): string {
+  const total = input.total;
+  const rows: string[] = ['Usage details — Current session', ''];
+  rows.push(...labelled('Configured', `${input.providerId}:${input.modelId}`, width));
+  const modes = input.records
+    .map((record) => record.selectedMode)
+    .filter((mode): mode is NonNullable<ProviderAttemptRecord['selectedMode']> => !!mode);
+  if (modes.length > 0) rows.push(...labelled('Mode', modes[modes.length - 1]!, width));
+  rows.push('', 'Providers and models');
+  for (const provider of input.providers) {
+    rows.push(...labelled(`${provider.provider}:`, provider.model, width));
+    rows.push(...labelled('  Calls', projectionSummary(provider.projection), width));
+  }
+  rows.push('', 'Purposes');
+  for (const purpose of DETAIL_PURPOSES) {
+    const projection = input.byPurpose[purpose];
+    if (!projection || projection.physicalAttempts === 0) continue;
+    rows.push(...labelled(purpose, projectionSummary(projection), width));
+  }
+  rows.push('', 'Accounting');
+  rows.push(...labelled(
+    'Usage source',
+    `${total.providerReportedAttempts} provider-reported · ${total.estimatedAttempts} locally estimated`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Cache',
+    `${compactNumber(total.cacheReadTokens)} read · ${compactNumber(total.cacheWriteTokens)} write`,
+    width,
+  ));
+  rows.push(...labelled('Reasoning', `${compactNumber(total.reasoningTokens)} tokens`, width));
+  rows.push(...labelled(
+    'Memory',
+    `${compactNumber(total.memoryTokens)} memory · ${compactNumber(total.userProfileTokens)} profile · ${compactNumber(total.projectMemoryTokens)} project`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Skills',
+    `${compactNumber(total.skillIndexTokens)} index · ${compactNumber(total.loadedSkillTokens)} loaded`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Schemas',
+    `${compactNumber(total.coreSchemaCount)} core · ${compactNumber(total.mcpSchemaCount)} MCP · ${compactNumber(total.pluginSchemaCount)} plugin · ${compactNumber(total.deferredSchemaCount)} deferred; cumulative exposures`,
+    width,
+  ));
+  rows.push(...labelled(
+    'Tool results',
+    `${compactBytes(total.rawToolResultBytes)} raw · ${compactBytes(total.transmittedToolResultBytes)} transmitted`,
+    width,
+  ));
+  rows.push(...labelled('Cost status', costSummary(total), width));
+  return `${rows.join('\n')}\n`;
+}
 
 export const usage: SlashCommand = {
   name: 'usage',
@@ -28,6 +253,62 @@ export const usage: SlashCommand = {
     }
     const providerId = session.getCurrentProvider();
     const modelId = session.getCurrentModel();
+    const sessionId = session.getSessionId?.();
+    const includeSetup = ctx.args.includes('--include-setup');
+    const asJson = ctx.args.includes('--json');
+    const details = ctx.args.includes('details');
+    const ledger = currentProviderAttemptLedger();
+    if (ledger && sessionId) {
+      const total = ledger.project({ sessionId, includeSetup });
+      const purposes = [
+        ...JSON_PURPOSES,
+        ...(includeSetup ? ['setup', 'readiness'] as ProviderAttemptPurpose[] : []),
+      ];
+      const byPurpose = Object.fromEntries(purposes.map((purpose) => [
+        purpose,
+        ledger.project({ sessionId, purpose, includeSetup: true }),
+      ])) as Record<ProviderAttemptPurpose, ProviderUsageProjection>;
+      const report = { sessionId, providerId, modelId, includeSetup, total, byPurpose };
+      if (asJson) {
+        ctx.display.write(`${JSON.stringify(report)}\n`);
+        return {};
+      }
+      const records = ledger.query({ sessionId }).filter((record) => (
+        includeSetup || (record.purpose !== 'setup' && record.purpose !== 'readiness')
+      ));
+      const detailPurposes = DETAIL_PURPOSES.filter((purpose) => (
+        includeSetup || (purpose !== 'setup' && purpose !== 'readiness')
+      ));
+      const completeByPurpose = Object.fromEntries(detailPurposes.map((purpose) => [
+        purpose,
+        ledger.project({ sessionId, purpose, includeSetup: true }),
+      ])) as Record<ProviderAttemptPurpose, ProviderUsageProjection>;
+      const pairs = records.reduce<Array<{ provider: string; model: string }>>((found, record) => {
+        const provider = record.providerActual ?? record.providerConfigured;
+        const model = record.modelActual ?? record.modelConfigured;
+        if (!provider || !model || found.some((pair) => pair.provider === provider && pair.model === model)) {
+          return found;
+        }
+        found.push({ provider, model });
+        return found;
+      }, []);
+      const presentation: UsagePresentation = {
+        providerId,
+        modelId,
+        total,
+        byPurpose: completeByPurpose,
+        providers: pairs.map((pair) => ({
+          ...pair,
+          projection: ledger.project({ sessionId, provider: pair.provider, model: pair.model, includeSetup }),
+        })),
+        records,
+      };
+      const width = Math.max(24, ctx.display.terminalColumns());
+      ctx.display.write(details
+        ? formatUsageDetails(presentation, width)
+        : formatUsageSummary(presentation, width));
+      return {};
+    }
     const usage = session.getTotalUsage?.() ?? { inputTokens: 0, outputTokens: 0 };
     const entry = findModel(providerId, modelId);
 

--- a/cli/v4/keyValidator.ts
+++ b/cli/v4/keyValidator.ts
@@ -16,6 +16,8 @@
  * passed through to the request only.
  */
 
+import { RequestLifecycle, requestDeadlines } from '../../providers/v4/requestLifecycle';
+
 export interface ValidationResult {
   valid: boolean;
   /** Human-readable reason. Never contains the apiKey value. */
@@ -152,7 +154,8 @@ function buildRequest(
         method: 'GET',
         headers: { Authorization: `Bearer ${apiKey}` },
       };
-    case 'custom': {
+    case 'custom':
+    case 'custom_openai': {
       const root = (baseUrl ?? '').replace(/\/+$/, '');
       if (!root) {
         // No baseUrl — can't validate. Caller should always provide one for custom.
@@ -215,20 +218,21 @@ export async function validateProviderKey(
     return { valid: false, reason: 'Network error: fetch is not available in this runtime' };
   }
 
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  const lifecycle = new RequestLifecycle(providerId, requestDeadlines(TIMEOUT_MS));
 
   try {
-    const res = await f(spec.url, {
+    const res = await lifecycle.race(f(spec.url, {
       method: spec.method,
       headers: spec.headers,
       body: spec.body,
-      signal: ctrl.signal,
-    });
+      signal: lifecycle.signal,
+    }));
+    lifecycle.markHeaders();
+    await lifecycle.readText(res);
     return classifyStatus(res.status);
   } catch (err) {
-    return { valid: false, reason: networkErrorReason(err) };
+    return { valid: false, reason: networkErrorReason(lifecycle.classify(err)) };
   } finally {
-    clearTimeout(timer);
+    lifecycle.cleanup();
   }
 }

--- a/cli/v4/onboarding/backNavInput.ts
+++ b/cli/v4/onboarding/backNavInput.ts
@@ -81,7 +81,14 @@ export const backNavInput = createPrompt<string | BackSentinel, BackNavInputConf
       if (status !== 'idle') return;
 
       if (isEnterKey(key)) {
-        const final = rl.line.length > 0 ? rl.line : (config.default ?? '');
+        // readline clears `rl.line` before the Enter callback on a real TTY.
+        // Keep submission tied to the last observed edit instead of that
+        // already-cleared transport buffer. This is especially important for
+        // masked credentials because the rendered value is intentionally not
+        // recoverable from the screen.
+        const final = prevLineRef.current.length > 0
+          ? prevLineRef.current
+          : (config.default ?? '');
         setValue(final);
         setStatus('done');
         done(final);

--- a/cli/v4/setupWizard.ts
+++ b/cli/v4/setupWizard.ts
@@ -62,6 +62,26 @@ import { BundledManifest } from '../../core/v4/skillBundledManifest';
 import { glyphs } from './design/tokens';
 import { fetchModels } from '../../core/v4/providers/modelFetch';
 import { runProbe, type ProbeResult } from '../../core/v4/providers/probe';
+import {
+  providerMainDefault,
+  type ModelVerification,
+} from '../../providers/v4/providerModelAuthority';
+import { PROVIDER_MODEL_POLICIES } from '../../providers/v4/providerPolicies';
+import { CredentialResolver } from '../../providers/v4/credentialResolver';
+import { RuntimeResolver } from '../../providers/v4/runtimeResolver';
+import {
+  initialReadiness,
+  markConfiguredUnverified,
+  runRuntimeReadinessTransaction,
+  type ProviderReadinessRecord,
+} from '../../providers/v4/providerReadiness';
+import {
+  persistManagedCredential,
+  restoreManagedCredentialFile,
+  snapshotManagedCredentialFile,
+  type ManagedCredentialFileSnapshot,
+  type PersistedManagedCredential,
+} from '../../providers/v4/credentialAuthority';
 
 export interface ProviderOption {
   id: string;
@@ -110,12 +130,12 @@ export const PROVIDERS: ProviderOption[] = [
   {
     id: 'groq',
     shortLabel: 'Groq',
-    label: 'Groq — free, fast, limited messages per minute',
+    label: 'Groq — fast hosted inference; API key required',
     kind: 'key',
     envVar: 'GROQ_API_KEY',
     keyUrl: 'https://console.groq.com/keys',
-    defaultModel: 'llama-3.3-70b-versatile',
-    models: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'mixtral-8x7b-32768'],
+    defaultModel: providerMainDefault('groq'),
+    models: [...PROVIDER_MODEL_POLICIES.groq.curatedModels],
   },
   {
     id: 'gemini',
@@ -175,16 +195,12 @@ export const PROVIDERS: ProviderOption[] = [
   {
     id: 'together',
     shortLabel: 'Together AI',
-    label: 'Together AI — paid, fast & reliable',
+    label: 'Together AI — broad hosted open-model catalogue; usage billed',
     kind: 'key',
     envVar: 'TOGETHER_API_KEY',
     keyUrl: 'https://api.together.xyz/settings/api-keys',
-    defaultModel: 'openai/gpt-oss-120b',
-    models: [
-      'openai/gpt-oss-120b',
-      'meta-llama/Llama-3.3-70B-Instruct-Turbo',
-      'openai/gpt-oss-20b',
-    ],
+    defaultModel: providerMainDefault('together'),
+    models: [...PROVIDER_MODEL_POLICIES.together.curatedModels],
   },
   // ── Subscription sign-ins ──
   {
@@ -198,10 +214,11 @@ export const PROVIDERS: ProviderOption[] = [
   {
     id: 'deepseek',
     shortLabel: 'DeepSeek',
-    label: 'DeepSeek — paid',
+    label: 'DeepSeek — direct API; API key and balance required',
     kind: 'key',
     envVar: 'DEEPSEEK_API_KEY',
-    defaultModel: 'deepseek-chat',
+    defaultModel: providerMainDefault('deepseek'),
+    models: [...PROVIDER_MODEL_POLICIES.deepseek.curatedModels],
   },
   {
     id: 'mistral',
@@ -224,7 +241,7 @@ export const PROVIDERS: ProviderOption[] = [
     shortLabel: 'Kimi',
     label: 'Kimi / Moonshot — paid',
     kind: 'key',
-    envVar: 'MOONSHOT_API_KEY',
+    envVar: 'KIMI_API_KEY',
     defaultModel: 'moonshot-v1-128k',
   },
   {
@@ -238,13 +255,14 @@ export const PROVIDERS: ProviderOption[] = [
   {
     id: 'huggingface',
     shortLabel: 'Hugging Face',
-    label: 'Hugging Face — free tier',
+    label: 'Hugging Face — one token across multiple inference providers',
     kind: 'key',
-    envVar: 'HF_API_KEY',
-    defaultModel: 'meta-llama/Llama-3.3-70B-Instruct',
+    envVar: 'HF_TOKEN',
+    defaultModel: providerMainDefault('huggingface'),
+    models: [...PROVIDER_MODEL_POLICIES.huggingface.curatedModels],
   },
   {
-    id: 'vercel',
+    id: 'vercel_gateway',
     shortLabel: 'Vercel AI Gateway',
     label: 'Vercel AI Gateway — paid',
     kind: 'key',
@@ -252,18 +270,19 @@ export const PROVIDERS: ProviderOption[] = [
     defaultModel: 'anthropic/claude-opus-4',
   },
   {
-    id: 'nous',
+    id: 'nous_portal',
     shortLabel: 'Nous Portal',
     label: 'Nous Portal — subscription',
     kind: 'subscription',
+    envVar: 'NOUS_PORTAL_API_KEY',
     defaultModel: 'hermes-3-llama-3.1-405b',
   },
   {
-    id: 'custom',
+    id: 'custom_openai',
     shortLabel: 'custom endpoint',
     label: 'Custom OpenAI-compatible endpoint',
     kind: 'custom',
-    envVar: 'CUSTOM_API_KEY',
+    envVar: 'CUSTOM_OPENAI_API_KEY',
   },
 ];
 
@@ -338,6 +357,7 @@ export interface SetupOptions {
     provider: OAuthProvider;
     tokens: { expiresAtMs: number; account?: string };
   };
+  readinessVerifier?: typeof runRuntimeReadinessTransaction;
 }
 
 /**
@@ -366,6 +386,15 @@ export interface SetupResult {
   skipReason?: string;
   config?: AidenConfig;
   envFile?: string;
+  readiness?: ProviderReadinessRecord;
+}
+
+/** Failed automatic readiness enters local recovery instead of silent fallback. */
+export function setupRequiresRecoveryMode(result: SetupResult): boolean {
+  return result.status === 'configured'
+    && !!result.readiness
+    && (result.readiness.state === 'failed_retryable'
+      || result.readiness.state === 'failed_requires_user_action');
 }
 
 // ─── v4.9.5 Slice 1.5: finalizeWithCuratedStep ─────────────────────
@@ -742,29 +771,6 @@ async function runRecoveryMenu(
  * key are replaced. New entries are appended to the bottom. Keys are
  * uppercased automatically.
  */
-async function upsertEnvVar(envFile: string, key: string, value: string): Promise<void> {
-  const k = key.toUpperCase();
-  let body = '';
-  try {
-    body = await fs.readFile(envFile, 'utf8');
-  } catch {
-    body = '';
-  }
-  const lines = body.split(/\r?\n/);
-  let replaced = false;
-  for (let i = 0; i < lines.length; i += 1) {
-    if (lines[i].startsWith(`${k}=`)) {
-      lines[i] = `${k}=${value}`;
-      replaced = true;
-    }
-  }
-  if (!replaced) lines.push(`${k}=${value}`);
-  // collapse trailing blank lines
-  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
-  await fs.mkdir(path.dirname(envFile), { recursive: true });
-  await fs.writeFile(envFile, `${lines.join('\n')}\n`, 'utf8');
-}
-
 export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResult> {
   const paths = opts.paths ?? resolveAidenPaths();
   const display = opts.display ?? new Display();
@@ -772,9 +778,38 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
   const fetchImpl = opts.fetchImpl ?? fetch;
 
   if (!opts.force && !(await isFreshInstall(paths))) {
-    // Existing config — wizard wasn't needed. Treat as already-configured
-    // so the boot path proceeds to resolver (which will surface real
-    // credential issues with its own error contract).
+    const existing = new ConfigManager(paths);
+    const loaded = await existing.load();
+    const persisted = existing.getValue<ProviderReadinessRecord>(
+      `providers.${loaded.model.provider}.readiness`,
+    );
+    const resumable = persisted && ![
+      'complete',
+      'configured_unverified',
+      'failed_requires_user_action',
+    ].includes(persisted.state);
+    if (resumable) {
+      const verifyReadiness = opts.readinessVerifier ?? runRuntimeReadinessTransaction;
+      const readiness = await verifyReadiness({
+        paths,
+        config: existing,
+        resolver: new RuntimeResolver(new CredentialResolver(paths.authJson)),
+        providerId: loaded.model.provider,
+        modelId: loaded.model.modelId,
+        modelVerification: existing.get(
+          `providers.${loaded.model.provider}.modelVerification`,
+        ) as ModelVerification | undefined,
+      });
+      return {
+        status: 'configured',
+        ran: true,
+        config: loaded,
+        envFile: paths.envFile,
+        readiness,
+      };
+    }
+    // Existing complete, deliberately unverified, or user-actionable config
+    // proceeds to normal boot without replaying setup prompts.
     return {
       status: 'configured',
       ran: false,
@@ -832,7 +867,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
   display.write(stepHeader(1));
   display.write('  Welcome — let\'s pick a provider.\n');
   display.write(
-    `  ${kleur.dim('(Press Enter to accept Groq — free + fastest setup.)')}\n\n`,
+    `  ${kleur.dim('(Press Enter to accept Groq — fast hosted inference; API key required.)')}\n\n`,
   );
 
   // Phase 30.2.1 — Groq is the new recommended default for first-time
@@ -964,7 +999,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
         ...(DEFAULT_CONFIG.providers ?? {}),
         // Marker for /providers + future tooling. The actual bearer
         // lives in tokenStore — config.yaml does NOT carry the secret.
-        [provider.id]: { auth: 'oauth' },
+        [provider.id]: { auth: 'oauth', modelVerification: 'curated' },
       },
       terminal: { backend: 'auto' },
     };
@@ -986,10 +1021,25 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
 
     const cm = new ConfigManager(paths);
     await cm.save(config);
+    await cm.load();
+    const verifyReadiness = opts.readinessVerifier ?? runRuntimeReadinessTransaction;
+    const oauthReadiness = opts.prompts && !opts.readinessVerifier
+      ? await markConfiguredUnverified(cm, initialReadiness(provider.id, modelId))
+      : await verifyReadiness({
+          paths,
+          config: cm,
+          resolver: new RuntimeResolver(new CredentialResolver(paths.authJson)),
+          providerId: provider.id,
+          modelId,
+          modelVerification: 'curated',
+        });
 
     // Confirmation surface — what's wired now.
     const expIso = new Date(tokens.expiresAtMs).toISOString();
     display.write(`\n✓ ${provider.shortLabel} authed.\n`);
+    if (oauthReadiness.state !== 'complete') {
+      display.write(`${kleur.yellow('  Runtime is configured but not fully verified.')}\n`);
+    }
     if (tokens.account) display.write(`  Account: ${tokens.account}\n`);
     if (oauthProvider.defaultModels?.length) {
       display.write(
@@ -1015,9 +1065,11 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     // ONB1 slice 8: success screen replaces the prior "Try: aiden" tail.
     // The wizard already returns to the boot path, which then drops into
     // the REPL — no process restart needed.
-    renderSuccessScreen({ out: process.stdout });
+    if (oauthReadiness.state === 'complete' || opts.prompts) {
+      renderSuccessScreen({ out: process.stdout });
+    }
 
-    return { status: 'configured', ran: true, config, envFile: paths.envFile };
+    return { status: 'configured', ran: true, config, envFile: paths.envFile, readiness: oauthReadiness };
   }
 
   // ONB1-WIRE-2 Slice B — flow reorder + live model fetch.
@@ -1042,6 +1094,44 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
   }
   let apiKey: string | undefined;
   let baseUrl: string | undefined;
+  let persistedCredential: PersistedManagedCredential | undefined;
+  let credentialSnapshot: ManagedCredentialFileSnapshot | undefined;
+
+  const collectRequiredCredential = async (question: string): Promise<string | typeof BACK> => {
+    while (true) {
+      const answer = await prompts.input(question, { mask: true });
+      if (answer === BACK) return BACK;
+      const credential = answer.trim();
+      if (credential.length > 0) return credential;
+      display.write(display.error(
+        'API key is required.',
+        'Enter a non-empty key, or backspace on the empty field to choose another provider.',
+      ));
+    }
+  };
+
+  const persistCurrentCredential = async (): Promise<void> => {
+    if (opts.smokeTest || !provider.envVar || !apiKey) return;
+    credentialSnapshot ??= await snapshotManagedCredentialFile(paths);
+    persistedCredential = await persistManagedCredential({
+      paths,
+      envVar: provider.envVar,
+      credential: apiKey,
+      env: opts.env ?? process.env,
+    });
+  };
+
+  const rollbackCurrentCredential = async (): Promise<void> => {
+    if (!credentialSnapshot || !provider.envVar) return;
+    await restoreManagedCredentialFile({
+      paths,
+      snapshot: credentialSnapshot,
+      envVar: provider.envVar,
+      env: opts.env ?? process.env,
+    });
+    credentialSnapshot = undefined;
+    persistedCredential = undefined;
+  };
 
   if (provider.kind === 'local') {
     const reachable = await probeOllama({ fetchImpl });
@@ -1058,9 +1148,10 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     }
   } else if (provider.kind === 'key' || provider.kind === 'subscription') {
     if (provider.envVar) {
-      const ans = await prompts.input(`API key for ${provider.shortLabel}`, { mask: true });
+      const ans = await collectRequiredCredential(`API key for ${provider.shortLabel}`);
       if (ans === BACK) continue outer;
       apiKey = ans;
+      await persistCurrentCredential();
     }
   }
   // provider.kind === 'custom' — defer credential prompts until AFTER
@@ -1076,6 +1167,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
   // resolve to .ts without a loader, and tests don't need a network
   // round-trip anyway. Matches the picker-upgrade gate (slice 5).
   let modelId = provider.defaultModel ?? '';
+  let modelVerification: ModelVerification = 'curated';
   if (opts.prompts) {
     // Legacy curated path — unchanged from pre-Slice-B behaviour.
     if (provider.models && provider.models.length > 1) {
@@ -1083,18 +1175,29 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
         `Pick a model for ${provider.shortLabel}\n  ${modelMenuHint}`,
         [...provider.models, BACK_CHOICE],
       );
-      if (modelIndex === provider.models.length + 1) continue outer; // ← Back
+      if (modelIndex === provider.models.length + 1) {
+        await rollbackCurrentCredential();
+        continue outer;
+      }
       modelId = provider.models[modelIndex - 1];
     } else if (provider.kind === 'local') {
       const ans = await prompts.input('Ollama model id', {
         default: provider.defaultModel ?? 'llama3.1:8b',
       });
-      if (ans === BACK) continue outer;
+      if (ans === BACK) {
+        await rollbackCurrentCredential();
+        continue outer;
+      }
       modelId = ans;
+      modelVerification = 'unverified';
     } else if (!modelId) {
       const ans = await prompts.input('Model id', { default: '' });
-      if (ans === BACK) continue outer;
+      if (ans === BACK) {
+        await rollbackCurrentCredential();
+        continue outer;
+      }
       modelId = ans;
+      modelVerification = 'unverified';
     }
   } else {
     const spinner = display.startSpinner(`Fetching available models for ${provider.shortLabel}…`);
@@ -1113,6 +1216,10 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
       display.write(
         `${kleur.dim(`  Live from ${provider.shortLabel} API · ${fetchResult.models.length} model${fetchResult.models.length === 1 ? '' : 's'}`)}\n`,
       );
+    } else if (fetchResult.source === 'last-known-good') {
+      display.write(
+        `${kleur.dim(`  Last-known-good ${provider.shortLabel} catalogue · refresh unavailable`)}\n`,
+      );
     }
 
     if (fetchResult.models.length === 0) {
@@ -1121,32 +1228,94 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
         const ans = await prompts.input('Ollama model id', {
           default: provider.defaultModel ?? 'llama3.1:8b',
         });
-        if (ans === BACK) continue outer;
+        if (ans === BACK) {
+          await rollbackCurrentCredential();
+          continue outer;
+        }
         modelId = ans;
+        modelVerification = 'unverified';
       } else {
         const ans = await prompts.input('Model id', { default: provider.defaultModel ?? '' });
-        if (ans === BACK) continue outer;
+        if (ans === BACK) {
+          await rollbackCurrentCredential();
+          continue outer;
+        }
         modelId = ans;
+        modelVerification = 'unverified';
       }
-    } else if (fetchResult.models.length === 1) {
+    } else if (fetchResult.models.length === 1 && fetchResult.source === 'fallback') {
       modelId = fetchResult.models[0].id;
+      modelVerification = fetchResult.source === 'live'
+        ? 'live'
+        : fetchResult.source === 'last-known-good'
+          ? 'unverified'
+          : 'curated';
       display.write(`${kleur.dim(`  Only one model available — using ${modelId}.`)}\n`);
     } else {
-      // Render picker. modelFetch already sorts recommended first; we
-      // append a `· recommended` marker so the user spots them visually.
-      const labels = fetchResult.models.map((m) =>
-        m.recommended ? `${m.displayName} · recommended` : m.displayName,
-      );
-      const recIdx = fetchResult.models.findIndex((m) => m.recommended);
-      const defaultIdx = recIdx >= 0 ? recIdx + 1 : 1;
-      const labelsWithBack = [...labels, BACK_CHOICE];
-      const idx = await prompts.choose(
-        `Pick a model for ${provider.shortLabel}\n  ${modelMenuHint}`,
-        labelsWithBack,
-        defaultIdx,
-      );
-      if (idx === labelsWithBack.length) continue outer; // ← Back
-      modelId = fetchResult.models[idx - 1].id;
+      let pickerResult = fetchResult;
+      let showAll = false;
+      while (true) {
+        const labels = pickerResult.models.map((m) => {
+          const provenance = m.creator && m.hostedBy
+            ? ` · ${m.creator} open-weight model · hosted by ${m.hostedBy}`
+            : '';
+          const recommended = m.recommended ? ' · recommended' : '';
+          const incompatible = m.compatibleWithAgent === false
+            ? ` · incompatible: ${m.incompatibilityReason ?? 'agent capabilities unverified'}`
+            : '';
+          return `${m.displayName}${provenance}${recommended}${incompatible}`;
+        });
+        const actions = pickerResult.source === 'fallback'
+          ? ['Enter a model ID', BACK_CHOICE]
+          : showAll
+            ? ['Refresh live catalogue', 'Enter a model ID', BACK_CHOICE]
+            : ['Show all live models', 'Refresh live catalogue', 'Enter a model ID', BACK_CHOICE];
+        const choices = [...labels, ...actions];
+        const recIdx = pickerResult.models.findIndex((m) => m.recommended);
+        const idx = await prompts.choose(
+          `Pick a model for ${provider.shortLabel}\n  ${modelMenuHint}`,
+          choices,
+          recIdx >= 0 ? recIdx + 1 : 1,
+        );
+        if (idx <= pickerResult.models.length) {
+          const selected = pickerResult.models[idx - 1];
+          modelId = selected.id;
+          modelVerification = pickerResult.source === 'live' && selected.compatibleWithAgent !== false
+            ? 'live'
+            : pickerResult.source === 'fallback'
+              ? 'curated'
+              : 'unverified';
+          break;
+        }
+
+        const action = actions[idx - pickerResult.models.length - 1];
+        if (action === BACK_CHOICE) {
+          await rollbackCurrentCredential();
+          continue outer;
+        }
+        if (action === 'Enter a model ID') {
+          const answer = await prompts.input('Model id', { default: modelId });
+          if (answer === BACK) continue;
+          modelId = answer;
+          modelVerification = 'unverified';
+          break;
+        }
+
+        const spinner = display.startSpinner(`Refreshing available models for ${provider.shortLabel}…`);
+        try {
+          showAll = action === 'Show all live models' ? true : showAll;
+          pickerResult = await fetchModels({
+            providerId: provider.id,
+            apiKey,
+            baseUrl,
+            fetchImpl,
+            includeIncompatible: showAll,
+            refresh: true,
+          });
+        } finally {
+          spinner.stop();
+        }
+      }
     }
   }
 
@@ -1156,9 +1325,10 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     const burl = await prompts.input('Base URL (e.g. https://api.example.com/v1)');
     if (burl === BACK) continue outer;
     baseUrl = burl;
-    const akey = await prompts.input('API key', { mask: true });
+    const akey = await collectRequiredCredential('API key');
     if (akey === BACK) continue outer;
     apiKey = akey;
+    await persistCurrentCredential();
   }
 
   // Step 3.5: validate the API key against the provider endpoint.
@@ -1169,6 +1339,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     !opts.skipValidation &&
     typeof apiKey === 'string' &&
     apiKey.length > 0;
+  let saveUnverified = !!opts.skipValidation || (!!opts.prompts && !opts.readinessVerifier);
 
   if (shouldValidate) {
     // ONB1-WIRE-2 Slice C — three-step probe replaces the legacy
@@ -1215,7 +1386,6 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     const maxAttempts = 3;
     let attempt = 1;
     let validated = false;
-    let skipValidationForSave = false;
 
     // Validation loop: at most 3 attempts before falling through to
     // the recovery menu. First attempt uses the already-collected key;
@@ -1283,6 +1453,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
         //   [5] exit             → clean exit
         const choice = await runRecoveryMenu(provider, prompts, display);
         if (choice.kind === 'try-different') {
+          await rollbackCurrentCredential();
           continue outer;
         }
         if (choice.kind === 'get-key') {
@@ -1298,18 +1469,26 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
               'Base URL (e.g. https://api.example.com/v1)',
               { default: baseUrl },
             );
-            if (burl === BACK) continue outer;
+            if (burl === BACK) {
+              await rollbackCurrentCredential();
+              continue outer;
+            }
             baseUrl = burl;
-            const akey = await prompts.input('API key', { mask: true });
-            if (akey === BACK) continue outer;
+            const akey = await collectRequiredCredential('API key');
+            if (akey === BACK) {
+              await rollbackCurrentCredential();
+              continue outer;
+            }
             apiKey = akey;
+            await persistCurrentCredential();
           } else {
-            const akey = await prompts.input(
-              `API key for ${provider.shortLabel}`,
-              { mask: true },
-            );
-            if (akey === BACK) continue outer;
+            const akey = await collectRequiredCredential(`API key for ${provider.shortLabel}`);
+            if (akey === BACK) {
+              await rollbackCurrentCredential();
+              continue outer;
+            }
             apiKey = akey;
+            await persistCurrentCredential();
           }
           continue validation;
         }
@@ -1317,10 +1496,11 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
           display.write(
             `${kleur.yellow('Saving without validation. The key will be tested on your first chat.')}\n`,
           );
-          skipValidationForSave = true;
+          saveUnverified = true;
           break validation;
         }
         if (choice.kind === 'skip') {
+          await rollbackCurrentCredential();
           display.write('\nEntering explore mode — chat is disabled but slash commands work.\n');
           return {
             status: 'skipped',
@@ -1329,6 +1509,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
           };
         }
         // choice.kind === 'exit'
+        await rollbackCurrentCredential();
         display.write('\nExited. Run `aiden setup` to try again.\n');
         return { status: 'exited', ran: false, skipReason: 'recovery-exited' };
       }
@@ -1338,15 +1519,26 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
         const burl = await prompts.input('Base URL (e.g. https://api.example.com/v1)', {
           default: baseUrl,
         });
-        if (burl === BACK) continue outer;
+        if (burl === BACK) {
+          await rollbackCurrentCredential();
+          continue outer;
+        }
         baseUrl = burl;
-        const akey = await prompts.input('API key', { mask: true });
-        if (akey === BACK) continue outer;
+        const akey = await collectRequiredCredential('API key');
+        if (akey === BACK) {
+          await rollbackCurrentCredential();
+          continue outer;
+        }
         apiKey = akey;
+        await persistCurrentCredential();
       } else {
-        const akey = await prompts.input(`API key for ${provider.shortLabel}`, { mask: true });
-        if (akey === BACK) continue outer;
+        const akey = await collectRequiredCredential(`API key for ${provider.shortLabel}`);
+        if (akey === BACK) {
+          await rollbackCurrentCredential();
+          continue outer;
+        }
         apiKey = akey;
+        await persistCurrentCredential();
       }
       attempt += 1;
     }
@@ -1357,7 +1549,6 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     // currently unused outside this block but documented for
     // post-save UX hooks.)
     void validated;
-    void skipValidationForSave;
   }
 
   // Step 4: terminal backend (basic — keeps wizard in scope for 14a).
@@ -1368,7 +1559,13 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
   const config: AidenConfig = {
     ...DEFAULT_CONFIG,
     model: { provider: provider.id, modelId },
-    agent: { ...DEFAULT_CONFIG.agent, max_turns: DEFAULT_CONFIG.agent.max_turns },
+    agent: {
+      ...DEFAULT_CONFIG.agent,
+      max_turns: DEFAULT_CONFIG.agent.max_turns,
+      ...(PROVIDER_MODEL_POLICIES[provider.id]?.setupToolProfile
+        ? { tool_profile: PROVIDER_MODEL_POLICIES[provider.id].setupToolProfile }
+        : {}),
+    },
     display: { ...DEFAULT_CONFIG.display, skin: 'default' },
     memory: { ...DEFAULT_CONFIG.memory },
     providers: {
@@ -1376,6 +1573,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
       [provider.id]: {
         ...(baseUrl ? { baseUrl } : {}),
         ...(provider.envVar ? { apiKey: `\${${provider.envVar}}` } : {}),
+        modelVerification,
       },
     },
     terminal: { backend: terminalBackend },
@@ -1388,7 +1586,7 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
       display.write(`(would have written ${provider.envVar}=*** to ${paths.envFile})\n`);
     }
     if (baseUrl && provider.kind === 'custom') {
-      display.write(`(would have written CUSTOM_BASE_URL=${baseUrl} to ${paths.envFile})\n`);
+      display.write(`(would have saved the custom endpoint in ${paths.configYaml})\n`);
     }
     display.write('(no files written because --smoke-test was passed)\n');
     return {
@@ -1403,27 +1601,49 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
   const cm = new ConfigManager(paths);
   await cm.save(config);
 
-  if (apiKey && provider.envVar) {
-    await upsertEnvVar(paths.envFile, provider.envVar, apiKey);
+  if (apiKey && provider.envVar && !persistedCredential) {
+    persistedCredential = await persistManagedCredential({
+      paths,
+      envVar: provider.envVar,
+      credential: apiKey,
+      env: opts.env ?? process.env,
+    });
   }
-  if (baseUrl && provider.kind === 'custom') {
-    await upsertEnvVar(paths.envFile, 'CUSTOM_BASE_URL', baseUrl);
-  }
+  await cm.load();
+  const verifyReadiness = opts.readinessVerifier ?? runRuntimeReadinessTransaction;
+  const readiness = saveUnverified
+    ? await markConfiguredUnverified(cm, initialReadiness(provider.id, modelId))
+    : await verifyReadiness({
+        paths,
+        config: cm,
+        resolver: new RuntimeResolver(new CredentialResolver(paths.authJson)),
+        providerId: provider.id,
+        modelId,
+        modelVerification,
+      });
 
   // Step 5: success — wizard drops straight into the REPL via the
   // outer boot path. No "Try: aiden" advice needed; the user is
   // already on their way to chat.
-  display.write(
-    `\n${kleur.green(`✓ ${provider.shortLabel}`)} configured with model ${kleur.cyan(modelId)}.\n`,
-  );
+  if (readiness.state === 'complete') {
+    display.write(
+      `\n${kleur.green(`✓ ${provider.shortLabel}`)} configured and verified with model ${kleur.cyan(modelId)}.\n`,
+    );
+  } else {
+    display.write(
+      `\n${kleur.yellow(`${provider.shortLabel} settings were saved, but runtime readiness did not complete.`)}\n`,
+    );
+  }
   // v4.9.5 Slice 1.5: curated-skills Step 4 — shared with the OAuth
   // branch via finalizeWithCuratedStep. Slice 1 inlined this here;
   // Slice 1.5 extracted it so subscription providers fire it too.
   await _finalizeImpl({ paths, display, prompts, opts, stepHeader });
   // ONB1 slice 8: success screen + REPL handoff.
-  renderSuccessScreen({ out: process.stdout });
+  if (readiness.state === 'complete' || opts.prompts) {
+    renderSuccessScreen({ out: process.stdout });
+  }
 
-  return { status: 'configured', ran: true, config, envFile: paths.envFile };
+  return { status: 'configured', ran: true, config, envFile: paths.envFile, readiness };
   } // end of outer: while (true) — every path inside either continues,
     // returns, or breaks. Reaching this `}` is impossible (guarded by
     // the no-constant-condition eslint comment above the outer label).

--- a/cli/v4/setupWizard.ts
+++ b/cli/v4/setupWizard.ts
@@ -82,6 +82,7 @@ import {
   type ManagedCredentialFileSnapshot,
   type PersistedManagedCredential,
 } from '../../providers/v4/credentialAuthority';
+import { runWithProviderAttemptLedger } from '../../providers/v4/providerAttemptAccounting';
 
 export interface ProviderOption {
   id: string;
@@ -773,6 +774,14 @@ async function runRecoveryMenu(
  */
 export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResult> {
   const paths = opts.paths ?? resolveAidenPaths();
+  return runWithProviderAttemptLedger(
+    paths.sessionsDb,
+    () => runSetupWizardWithLedger({ ...opts, paths }),
+  );
+}
+
+async function runSetupWizardWithLedger(opts: SetupOptions): Promise<SetupResult> {
+  const paths = opts.paths ?? resolveAidenPaths();
   const display = opts.display ?? new Display();
   const prompts = opts.prompts ?? (await defaultPrompts());
   const fetchImpl = opts.fetchImpl ?? fetch;
@@ -1223,18 +1232,17 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
     }
 
     if (fetchResult.models.length === 0) {
-      // No models from live or static catalog — fall back to a free-text input.
       if (provider.kind === 'local') {
-        const ans = await prompts.input('Ollama model id', {
-          default: provider.defaultModel ?? 'llama3.1:8b',
-        });
-        if (ans === BACK) {
-          await rollbackCurrentCredential();
-          continue outer;
-        }
-        modelId = ans;
-        modelVerification = 'unverified';
+        display.write(
+          display.error(
+            'No installed Ollama models were found.',
+            'Run `ollama pull <model>`, then reopen setup. A catalog model is not usable until it is installed.',
+          ),
+        );
+        continue outer;
       } else {
+        // Hosted providers may still accept a model id that their discovery
+        // endpoint omitted. Local inventory is handled above and never guesses.
         const ans = await prompts.input('Model id', { default: provider.defaultModel ?? '' });
         if (ans === BACK) {
           await rollbackCurrentCredential();
@@ -1250,12 +1258,17 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
         : fetchResult.source === 'last-known-good'
           ? 'unverified'
           : 'curated';
-      display.write(`${kleur.dim(`  Only one model available — using ${modelId}.`)}\n`);
+      display.write(`${kleur.dim(
+        provider.kind === 'local'
+          ? `  One installed model found — using ${modelId}.`
+          : `  Only one model available — using ${modelId}.`,
+      )}\n`);
     } else {
       let pickerResult = fetchResult;
       let showAll = false;
       while (true) {
         const labels = pickerResult.models.map((m) => {
+          const installed = provider.kind === 'local' ? ' · installed' : '';
           const provenance = m.creator && m.hostedBy
             ? ` · ${m.creator} open-weight model · hosted by ${m.hostedBy}`
             : '';
@@ -1263,13 +1276,15 @@ export async function runSetupWizard(opts: SetupOptions = {}): Promise<SetupResu
           const incompatible = m.compatibleWithAgent === false
             ? ` · incompatible: ${m.incompatibilityReason ?? 'agent capabilities unverified'}`
             : '';
-          return `${m.displayName}${provenance}${recommended}${incompatible}`;
+          return `${m.displayName}${installed}${provenance}${recommended}${incompatible}`;
         });
-        const actions = pickerResult.source === 'fallback'
-          ? ['Enter a model ID', BACK_CHOICE]
-          : showAll
-            ? ['Refresh live catalogue', 'Enter a model ID', BACK_CHOICE]
-            : ['Show all live models', 'Refresh live catalogue', 'Enter a model ID', BACK_CHOICE];
+        const actions = provider.kind === 'local'
+          ? ['Refresh live catalogue', BACK_CHOICE]
+          : pickerResult.source === 'fallback'
+            ? ['Enter a model ID', BACK_CHOICE]
+            : showAll
+              ? ['Refresh live catalogue', 'Enter a model ID', BACK_CHOICE]
+              : ['Show all live models', 'Refresh live catalogue', 'Enter a model ID', BACK_CHOICE];
         const choices = [...labels, ...actions];
         const recIdx = pickerResult.models.findIndex((m) => m.recommended);
         const idx = await prompts.choose(

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -50,6 +50,16 @@ import type {
   ProviderAdapter,
   ProviderCallOutput,
 } from '../../providers/v4/types';
+import {
+  serializeToolResultForModel,
+  type ToolResultArtifactStore,
+} from './toolResultBoundary';
+import { selectEconomyTools } from './usagePolicy';
+import {
+  createLogicalProviderCallId,
+  currentProviderAttemptLedger,
+} from '../../providers/v4/providerAttemptAccounting';
+import { findModel } from '../../providers/v4/modelCatalog';
 import type {
   PlannerGuard,
   PlannerGuardDecision,
@@ -268,6 +278,8 @@ export interface AidenAgentOptions {
   provider:                ProviderAdapter;
   toolExecutor:            ToolExecutor;
   tools:                   ToolSchema[];
+  /** Optional local store for sanitized tool-result bodies externalized at the model boundary. */
+  toolResultArtifactStore?: ToolResultArtifactStore;
   /**
    * v4.9.4 Slice 1 — test seam. Override TurnState construction so
    * regression tests can drive deterministic surface / cooldown /
@@ -299,6 +311,8 @@ export interface AidenAgentOptions {
    * behaviour, byte-identical.
    */
   sessionTokenCap?:        number;
+  /** Optional estimated USD cap. Unknown pricing is reported but never treated as zero. */
+  sessionCostCap?:         number;
   fallback?:               FallbackStrategy;
   /**
    * Phase v4.1.2-slice3 telemetry. Optional aggregator the caller
@@ -334,7 +348,7 @@ export interface AidenAgentOptions {
     level:   'caution' | 'warning',
     current: number,
     max:     number,
-    kind?:   'iterations' | 'tokens',
+    kind?:   'iterations' | 'tokens' | 'cost',
   ) => void;
   // ── Moat ─────────────────────────────────────────────────────────────
   plannerGuard?:           PlannerGuard;
@@ -429,6 +443,8 @@ export interface AidenAgentOptions {
 export interface AidenAgentResult {
   finalContent:        string;
   messages:            Message[];
+  /** Messages appended by the provider/tool loop, excluding the input history. */
+  turnMessages?:       Message[];
   turnCount:           number;
   toolCallCount:       number;
   fallbackActivated:   boolean;
@@ -489,6 +505,16 @@ export interface AidenAgentResult {
 
 export interface RunConversationOptions {
   stream?:           boolean;
+  sessionId?:        string | null;
+  taskId?:           string | null;
+  runId?:            string | number | null;
+  entryPoint?:       string;
+  purpose?:          import('./usageLedger').ProviderAttemptPurpose;
+  selectedMode?:     import('./usageLedger').UsageMode;
+  selectedProfile?:  string;
+  deferredSchemaCount?: number;
+  economySchemaSavings?: number;
+  providerAttemptBudgets?: import('../../providers/v4/types').ProviderAttemptBudget[];
   /**
    * v4.12 BE.1 — tokens already spent in THIS session before this run (from
    * sessionStore totals). The per-session token cap enforces on
@@ -601,10 +627,12 @@ export class AidenAgent {
 
   private readonly toolExecutor:                ToolExecutor;
   private readonly tools:                       ToolSchema[];
+  private readonly toolResultArtifactStore?:    ToolResultArtifactStore;
   // v4.9.4 Slice 1 — TurnState test seam (undefined in production).
   private readonly turnStateFactory?:           () => TurnState;
   private readonly maxTurns:                    number;
   private readonly sessionTokenCap?:            number;
+  private readonly sessionCostCap?:             number;
   // v4.12 BE.1 — stateless token estimator for the budget check (getLimits +
   // estimateMessageTokens/estimateToolTokens). No per-model state carried.
   private readonly modelMetadata = new ModelMetadata();
@@ -702,6 +730,7 @@ export class AidenAgent {
     this.provider                 = opts.provider;
     this.toolExecutor             = opts.toolExecutor;
     this.tools                    = opts.tools;
+    this.toolResultArtifactStore  = opts.toolResultArtifactStore;
     this.turnStateFactory         = opts.turnStateFactory;
     // Iterations get their own field, one meaning. A maxTurns of 0 (or unset /
     // negative) must NOT mean "run zero iterations" — it means "use the sane
@@ -712,6 +741,7 @@ export class AidenAgent {
       ? opts.maxTurns
       : DEFAULT_MAX_TURNS;
     this.sessionTokenCap          = opts.sessionTokenCap;
+    this.sessionCostCap           = opts.sessionCostCap;
     this.fallback                 = opts.fallback;
     this.onToolCall               = opts.onToolCall;
     this.onToolActivity           = opts.onToolActivity;
@@ -893,6 +923,10 @@ export class AidenAgent {
     return this._currentSignal;
   }
 
+  restoreCompressionCount(count: number): void {
+    this.compressionEvents = Math.max(0, Math.floor(count));
+  }
+
   /**
    * v4.11 Slice 4 — return the live TurnRuntimeContext for the active
    * turn (or `undefined` if the agent is between turns / the caller
@@ -927,7 +961,18 @@ export class AidenAgent {
     ) {
       this.pendingRequiredClarification = null;
     }
-    const narrowedTools   = await this.narrowTools(lastUserContent, history);
+    const profiledTools = await this.narrowTools(lastUserContent, history);
+    const economySelection = selectEconomyTools(profiledTools, lastUserContent);
+    const selectedMode = options.selectedMode ?? 'balanced';
+    const narrowedTools = selectedMode === 'economy'
+      ? economySelection.selected
+      : profiledTools;
+    const effectiveOptions: RunConversationOptions = {
+      ...options,
+      selectedMode,
+      deferredSchemaCount: economySelection.deferredCount,
+      economySchemaSavings: economySelection.estimatedSchemaSavings,
+    };
 
     // 4. Build per-call trackers, then Stage-0 intent pre-arm.
     //    The tracker's preArm() bumps `preArmed` itself; the loop just
@@ -944,8 +989,11 @@ export class AidenAgent {
     }
 
     // 5. Compose initial conversation, prepending the system prompt.
+    const activeHistory = systemPrompt && history[0]?.role === 'system'
+      ? history.slice(1)
+      : history;
     let messages: Message[] = systemPrompt
-      ? [{ role: 'system', content: systemPrompt }, ...history]
+      ? [{ role: 'system', content: systemPrompt }, ...activeHistory]
       : [...history];
 
     // 6. Apply prompt-caching markers (helper no-ops for non-Anthropic).
@@ -1010,7 +1058,7 @@ export class AidenAgent {
       messages,
       narrowedTools,
       trackers,
-      options,
+      effectiveOptions,
     );
 
     // 9. Honesty post-loop scan (only if loop ended with a normal stop).
@@ -1139,6 +1187,7 @@ export class AidenAgent {
     return {
       finalContent,
       messages:           resultMessages,
+      turnMessages:       loopResult.turnMessages,
       turnCount:          loopResult.turnCount,
       toolCallCount:      loopResult.toolCallCount,
       fallbackActivated:  loopResult.fallbackActivated,
@@ -1274,6 +1323,7 @@ export class AidenAgent {
   ): Promise<{
     finalContent:       string;
     messages:           Message[];
+    turnMessages:       Message[];
     turnCount:          number;
     toolCallCount:      number;
     fallbackActivated:  boolean;
@@ -1338,7 +1388,10 @@ export class AidenAgent {
     let   warningFired      = false;
     let   tokenCautionFired = false; // v4.12 BE.1 — token warn-ladder (80/90%)
     let   tokenWarningFired = false;
+    let   costCautionFired  = false;
+    let   costWarningFired  = false;
     let   emptyRetriesUsed  = 0;
+    const toolResultMetrics = { rawBytes: 0, transmittedBytes: 0 };
     let   finishReason: 'stop' | 'budget_exhausted' | 'error' | 'tool_loop' | 'interrupted' = 'stop';
     let   finalContent      = '';
     let   resumeHandoff: AidenAgentResult['resumeHandoff'];
@@ -1472,6 +1525,40 @@ export class AidenAgent {
         }
       }
 
+      // Estimated-cost cap uses the same durable physical-attempt ledger as
+      // reporting. When catalog pricing is unavailable the amount remains
+      // unknown and is never coerced to zero or used to block execution.
+      if (this.sessionCostCap && this.sessionCostCap > 0 && runOptions.sessionId) {
+        const ledger = currentProviderAttemptLedger();
+        const pricing = findModel(this.providerId ?? '', this.modelId ?? '')?.pricing;
+        if (ledger && pricing) {
+          const spent = ledger.project({ sessionId: runOptions.sessionId }).knownCostAmount;
+          if (!costCautionFired && spent >= this.sessionCostCap * 0.8) {
+            costCautionFired = true;
+            this.onBudgetWarning?.('caution', spent, this.sessionCostCap, 'cost');
+          }
+          if (!costWarningFired && spent >= this.sessionCostCap) {
+            costWarningFired = true;
+            this.onBudgetWarning?.('warning', spent, this.sessionCostCap, 'cost');
+          }
+          const limits = this.modelMetadata.getLimits(this.providerId ?? '', this.modelId ?? '');
+          const estimatedInput = this.modelMetadata.estimateMessageTokens(messages)
+            + this.modelMetadata.estimateToolTokens(effectiveTools);
+          const estimatedNext = (estimatedInput * pricing.inputPerM
+            + limits.maxOutputTokens * pricing.outputPerM) / 1_000_000;
+          if (spent >= this.sessionCostCap || spent + estimatedNext > this.sessionCostCap) {
+            finishReason = 'budget_exhausted';
+            finalContent = 'Work paused — the estimated session cost budget was reached before another provider request could start.';
+            resumeHandoff = {
+              partial_work: finalContent,
+              next_steps: 'Task incomplete — no additional provider request was started after the estimated cost boundary.',
+              resume: 'Raise budget.session_cost_cap_usd (or use /budget cost), then re-send the request to continue.',
+            };
+            break;
+          }
+        }
+      }
+
       let output: ProviderCallOutput;
       // Once this turn has authoritative approval facts, hold subsequent
       // streamed prose until the provider segment completes. Contradictory
@@ -1503,7 +1590,7 @@ export class AidenAgent {
             shim.db,
             { model: this.modelId ?? 'unknown', provider: this.providerId ?? 'unknown' },
             async (_ctx, patchAttrs) => {
-              const out = await this.callProvider(messages, effectiveTools, providerRunOptions);
+              const out = await this.callProvider(messages, effectiveTools, providerRunOptions, toolResultMetrics);
               patchAttrs({
                 input_tokens:        out.usage?.inputTokens ?? 0,
                 output_tokens:       out.usage?.outputTokens ?? 0,
@@ -1516,7 +1603,7 @@ export class AidenAgent {
             },
           );
         } else {
-          output = await this.callProvider(messages, effectiveTools, providerRunOptions);
+          output = await this.callProvider(messages, effectiveTools, providerRunOptions, toolResultMetrics);
         }
         if (deferApprovalStream && output.content) {
           const safeContent = stripLeakedUiMarkup(output.content);
@@ -2194,9 +2281,18 @@ export class AidenAgent {
           _finalOk ? null : finalPolicyDecision,
           _finalOk,
         );
-        const _baseContent = result.error
+        const _rawContent = result.error
           ? `[error] ${result.error}`
           : stringifyToolResult(result.result);
+        const _bounded = await serializeToolResultForModel(_rawContent, {
+          toolName: call.name,
+          toolCallId: call.id,
+          capBytes: runOptions.selectedMode === 'economy' ? 8_000 : 12_000,
+          artifactStore: this.toolResultArtifactStore,
+        });
+        toolResultMetrics.rawBytes += _bounded.metadata.rawSize;
+        toolResultMetrics.transmittedBytes += _bounded.metadata.transmittedSize;
+        const _baseContent = _bounded.content;
         turnToolMessages.push({
           role:        'tool',
           toolCallId:  call.id,
@@ -2439,6 +2535,7 @@ export class AidenAgent {
     return {
       finalContent,
       messages,
+      turnMessages: messages.slice(initialMessages.length),
       turnCount,
       toolCallCount,
       fallbackActivated,
@@ -2489,6 +2586,7 @@ export class AidenAgent {
     messages:    Message[],
     tools:       ToolSchema[],
     runOptions:  RunConversationOptions,
+    toolResultMetrics: { rawBytes: number; transmittedBytes: number } = { rawBytes: 0, transmittedBytes: 0 },
   ): Promise<ProviderCallOutput> {
     // Phase 5 — unified provider preflight. Every assistant toolCalls[]
     // entry must have a matching {role:'tool', toolCallId} BEFORE shipping
@@ -2522,10 +2620,52 @@ export class AidenAgent {
     // override security-relevant fields. No-context: headers omitted.
     const ambient = _llmCurrentContext();
     const outboundHeaders = ambient ? _injectContextHeaders(ambient) : undefined;
+    const schemaCounts = tools.reduce((counts, tool) => {
+      const toolset = this.resolveToolset?.(tool.name);
+      if (toolset === 'mcp') counts.mcp += 1;
+      else if (toolset === 'plugin') counts.plugin += 1;
+      else counts.core += 1;
+      return counts;
+    }, { core: 0, mcp: 0, plugin: 0 });
+    const promptComponents = measurePromptComponents(this.promptBuilderOptions, messages);
+    const usageContext = {
+      logicalCallId: createLogicalProviderCallId(),
+      sessionId: runOptions.sessionId ?? null,
+      taskId: runOptions.taskId ?? null,
+      runId: runOptions.runId ?? null,
+      entryPoint: runOptions.entryPoint ?? 'core',
+      purpose: runOptions.purpose ?? 'primary' as const,
+      providerConfigured: this.providerId ?? null,
+      modelConfigured: this.modelId ?? null,
+      selectedMode: runOptions.selectedMode ?? 'balanced' as const,
+      selectedProfile: runOptions.selectedProfile ?? null,
+      contextSnapshotId: createLogicalProviderCallId(),
+      toolSchemaSnapshotId: createLogicalProviderCallId(),
+      coreSchemaCount: schemaCounts.core,
+      mcpSchemaCount: schemaCounts.mcp,
+      pluginSchemaCount: schemaCounts.plugin,
+      deferredSchemaCount: runOptions.deferredSchemaCount ?? null,
+      rawToolResultBytes: toolResultMetrics.rawBytes,
+      transmittedToolResultBytes: toolResultMetrics.transmittedBytes,
+      memoryTokens: promptComponents.memory,
+      userProfileTokens: promptComponents.userProfile,
+      projectMemoryTokens: promptComponents.projectMemory,
+      skillIndexTokens: promptComponents.skillIndex,
+      loadedSkillTokens: promptComponents.loadedSkills,
+      ...(runOptions.providerAttemptBudgets
+        ? { attemptBudgets: runOptions.providerAttemptBudgets }
+        : {}),
+    };
     if (!wantStream) {
       // v4.6 prep — forward the abort signal into the provider call so
       // an in-flight HTTP request can be cancelled mid-flight.
-      return this.provider.call({ messages, tools, signal: runOptions.signal, headers: outboundHeaders });
+      return this.provider.call({
+        messages,
+        tools,
+        signal: runOptions.signal,
+        headers: outboundHeaders,
+        usageContext,
+      });
     }
 
     let firstDeltaFired = false;
@@ -2548,6 +2688,7 @@ export class AidenAgent {
       // aborts cancel the underlying SSE read via the same signal.
       signal: runOptions.signal,
       headers: outboundHeaders,
+      usageContext,
     });
     for await (const evt of stream) {
       if (evt.type === 'delta') {
@@ -2673,6 +2814,40 @@ function stringifyToolResult(result: unknown): string {
   } catch {
     return String(result);
   }
+}
+
+function measurePromptComponents(
+  options: PromptBuilderOptions | undefined,
+  messages: readonly Message[],
+): {
+  memory: number;
+  userProfile: number;
+  projectMemory: number;
+  skillIndex: number;
+  loadedSkills: number;
+} {
+  const snapshot = options?.memorySnapshot;
+  const toolNames = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue;
+    for (const call of message.toolCalls ?? []) toolNames.set(call.id, call.name);
+  }
+  const loadedSkillBodies = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== 'tool' || toolNames.get(message.toolCallId) !== 'skill_view') continue;
+    loadedSkillBodies.add(message.content);
+  }
+  return {
+    memory: approximateTokens(snapshot?.memoryMd ?? ''),
+    userProfile: approximateTokens(snapshot?.userMd ?? ''),
+    projectMemory: approximateTokens(snapshot?.files?.project?.content ?? ''),
+    skillIndex: approximateTokens(JSON.stringify(options?.skillsList ?? [])),
+    loadedSkills: [...loadedSkillBodies].reduce((sum, content) => sum + approximateTokens(content), 0),
+  };
+}
+
+function approximateTokens(value: string): number {
+  return value ? Math.ceil(Buffer.byteLength(value, 'utf8') / 4) : 0;
 }
 
 // v4.9.0 Slice 6 — static imports for the LLM span bridge. Same

--- a/core/v4/auxiliaryClient.ts
+++ b/core/v4/auxiliaryClient.ts
@@ -28,7 +28,7 @@
 import type { ProviderAdapter, Message } from '../../providers/v4/types';
 
 export interface AuxiliaryResolver {
-  /** Resolve once at AuxiliaryClient construction. */
+  /** Resolve once, lazily, when the first auxiliary operation is requested. */
   resolve(opts: {
     providerId: string;
     modelId: string;
@@ -109,18 +109,25 @@ export class AuxiliaryClient {
   private readonly opts: AuxiliaryClientOptions;
   private adapterPromise: Promise<ProviderAdapter | null> | null = null;
   private resolveCallCount = 0;
+  private activeAttemptIndex: number | null = null;
+  private nextAttemptIndex = 0;
   private readonly usage = new Map<AuxiliaryPurpose, PurposeUsage>();
   private adapterUnavailable = false;
 
   constructor(opts: AuxiliaryClientOptions) {
     this.opts = opts;
-    // Resolve eagerly (single call) so concurrent first-call requests don't
-    // each kick off their own resolution.
-    this.adapterPromise = this.resolveOnce();
+  }
+
+  private adapter(): Promise<ProviderAdapter | null> {
+    this.adapterPromise ??= this.resolveOnce();
+    return this.adapterPromise;
   }
 
   private async resolveOnce(): Promise<ProviderAdapter | null> {
-    if (this.opts.adapter) return this.opts.adapter;
+    if (this.opts.adapter) {
+      this.activeAttemptIndex = 0;
+      return this.opts.adapter;
+    }
     if (!this.opts.resolver) return null;
 
     // v4.8.0 Slice 11 — resolution chain: default first, then each
@@ -130,18 +137,18 @@ export class AuxiliaryClient {
     // provider/model as the fallback, so auxiliary calls land on
     // Groq when configured and the parent only sees traffic when
     // Groq is absent.
-    const attempts: AuxiliaryAttempt[] = [
-      { providerId: this.opts.defaultProvider, modelId: this.opts.defaultModel },
-      ...(this.opts.fallbacks ?? []),
-    ];
+    const attempts = this.attempts();
     const failures: string[] = [];
-    for (const att of attempts) {
+    for (let index = this.nextAttemptIndex; index < attempts.length; index += 1) {
+      const att = attempts[index];
       this.resolveCallCount += 1;
       try {
         const adapter = await this.opts.resolver.resolve({
           providerId: att.providerId,
           modelId: att.modelId,
         });
+        this.activeAttemptIndex = index;
+        this.nextAttemptIndex = index;
         this.warn(`auxiliary resolved via ${att.providerId}/${att.modelId}`);
         return adapter;
       } catch (err) {
@@ -161,12 +168,6 @@ export class AuxiliaryClient {
   }
 
   async call(opts: AuxiliaryCallOptions): Promise<AuxiliaryCallResult> {
-    const adapter = await this.adapterPromise;
-    if (!adapter) {
-      this.recordUsage(opts.purpose, 0, 0);
-      return { content: '', usage: { inputTokens: 0, outputTokens: 0 } };
-    }
-
     const messages: Message[] = [
       {
         role: 'system',
@@ -178,29 +179,41 @@ export class AuxiliaryClient {
     const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-    try {
-      const result = await this.withTimeout(
-        adapter.call({
-          messages,
-          tools: [],
-          maxTokens,
-        }),
-        timeoutMs,
-      );
-      const inputTokens = result.usage?.inputTokens ?? 0;
-      const outputTokens = result.usage?.outputTokens ?? 0;
-      this.recordUsage(opts.purpose, inputTokens, outputTokens);
-      return {
-        content: result.content ?? '',
-        usage: { inputTokens, outputTokens },
-      };
-    } catch (err) {
-      this.warn(
-        `auxiliary call failed (${opts.purpose}): ${(err as Error).message}`,
-      );
-      this.recordUsage(opts.purpose, 0, 0);
-      return { content: '', usage: { inputTokens: 0, outputTokens: 0 } };
+    let adapter = await this.adapter();
+    while (adapter) {
+      try {
+        const result = await this.withTimeout(
+          adapter.call({
+            messages,
+            tools: [],
+            maxTokens,
+          }),
+          timeoutMs,
+        );
+        const inputTokens = result.usage?.inputTokens ?? 0;
+        const outputTokens = result.usage?.outputTokens ?? 0;
+        this.recordUsage(opts.purpose, inputTokens, outputTokens);
+        return {
+          content: result.content ?? '',
+          usage: { inputTokens, outputTokens },
+        };
+      } catch (err) {
+        this.warn(
+          `auxiliary call failed (${opts.purpose}): ${(err as Error).message}`,
+        );
+        if (!this.advanceAfterCallFailure()) break;
+        adapter = await this.adapter();
+      }
     }
+
+    if (!adapter) {
+      this.warn(
+        `auxiliary client unavailable for ${opts.purpose}`,
+      );
+    }
+    this.adapterUnavailable = true;
+    this.recordUsage(opts.purpose, 0, 0);
+    return { content: '', usage: { inputTokens: 0, outputTokens: 0 } };
   }
 
   /** Per-purpose usage breakdown. Used by /usage command (Phase 14). */
@@ -212,7 +225,7 @@ export class AuxiliaryClient {
     return out;
   }
 
-  /** True after construction-time resolution failed. */
+  /** True after a requested lazy resolution failed. */
   isUnavailable(): boolean {
     return this.adapterUnavailable;
   }
@@ -227,6 +240,24 @@ export class AuxiliaryClient {
     cur.outputTokens += output;
     cur.calls += 1;
     this.usage.set(purpose, cur);
+  }
+
+  private attempts(): AuxiliaryAttempt[] {
+    return [
+      { providerId: this.opts.defaultProvider, modelId: this.opts.defaultModel },
+      ...(this.opts.fallbacks ?? []),
+    ];
+  }
+
+  /** Adapter construction is not a liveness proof; advance only after a real call fails. */
+  private advanceAfterCallFailure(): boolean {
+    if (this.opts.adapter || !this.opts.resolver || this.activeAttemptIndex === null) return false;
+    const next = this.activeAttemptIndex + 1;
+    if (next >= this.attempts().length) return false;
+    this.nextAttemptIndex = next;
+    this.activeAttemptIndex = null;
+    this.adapterPromise = null;
+    return true;
   }
 
   private warn(msg: string) {

--- a/core/v4/auxiliaryClient.ts
+++ b/core/v4/auxiliaryClient.ts
@@ -113,6 +113,7 @@ export class AuxiliaryClient {
   private nextAttemptIndex = 0;
   private readonly usage = new Map<AuxiliaryPurpose, PurposeUsage>();
   private adapterUnavailable = false;
+  private resolvedAttempt: AuxiliaryAttempt | null = null;
 
   constructor(opts: AuxiliaryClientOptions) {
     this.opts = opts;
@@ -126,6 +127,10 @@ export class AuxiliaryClient {
   private async resolveOnce(): Promise<ProviderAdapter | null> {
     if (this.opts.adapter) {
       this.activeAttemptIndex = 0;
+      this.resolvedAttempt = {
+        providerId: this.opts.defaultProvider,
+        modelId: this.opts.defaultModel,
+      };
       return this.opts.adapter;
     }
     if (!this.opts.resolver) return null;
@@ -149,6 +154,7 @@ export class AuxiliaryClient {
         });
         this.activeAttemptIndex = index;
         this.nextAttemptIndex = index;
+        this.resolvedAttempt = att;
         this.warn(`auxiliary resolved via ${att.providerId}/${att.modelId}`);
         return adapter;
       } catch (err) {
@@ -187,6 +193,12 @@ export class AuxiliaryClient {
             messages,
             tools: [],
             maxTokens,
+            usageContext: {
+              entryPoint: 'auxiliary',
+              purpose: auxiliaryLedgerPurpose(opts.purpose),
+              providerConfigured: this.resolvedAttempt?.providerId ?? this.opts.defaultProvider,
+              modelConfigured: this.resolvedAttempt?.modelId ?? this.opts.defaultModel,
+            },
           }),
           timeoutMs,
         );
@@ -295,4 +307,12 @@ export class AuxiliaryClient {
       );
     });
   }
+}
+
+function auxiliaryLedgerPurpose(
+  purpose: AuxiliaryPurpose,
+): import('./usageLedger').ProviderAttemptPurpose {
+  if (purpose === 'compression') return 'compression';
+  if (purpose === 'session_summary') return 'distillation';
+  return 'auxiliary';
 }

--- a/core/v4/compatibilityUsage.ts
+++ b/core/v4/compatibilityUsage.ts
@@ -1,0 +1,27 @@
+export interface CompatibilityUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  usage_source: 'provider_reported' | 'locally_estimated';
+  estimated: boolean;
+}
+
+export function estimateCompatibilityUsage(
+  messages: readonly { role: string; content: unknown }[],
+  completion: string,
+): CompatibilityUsage {
+  const request = safeJson(messages);
+  const promptTokens = Math.ceil(Buffer.byteLength(request, 'utf8') / 4);
+  const completionTokens = Math.ceil(Buffer.byteLength(completion, 'utf8') / 4);
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+    usage_source: 'locally_estimated',
+    estimated: true,
+  };
+}
+
+function safeJson(value: unknown): string {
+  try { return JSON.stringify(value) ?? ''; } catch { return ''; }
+}

--- a/core/v4/config.ts
+++ b/core/v4/config.ts
@@ -100,6 +100,13 @@ export interface AidenConfig {
   memory: {
     provider: string;
   };
+  usage?: {
+    mode?: 'balanced' | 'economy';
+  };
+  budget?: {
+    session_token_cap?: number;
+    session_cost_cap_usd?: number;
+  };
   /**
    * Forward-compatibility bucket: any unknown top-level keys land here so
    * round-trip save() doesn't drop user-managed fields.
@@ -147,6 +154,9 @@ const KNOWN_KEYS = new Set([
   'display',
   'providers',
   'memory',
+  // Token-efficiency controls are persisted by /mode and /budget.
+  'usage',
+  'budget',
   // Phase 10 introduced the terminal toolset — its config block lands
   // under the top-level `terminal` key (e.g. terminal.backend = 'auto').
   'terminal',

--- a/core/v4/config.ts
+++ b/core/v4/config.ts
@@ -244,6 +244,12 @@ export class ConfigManager implements ConfigProvider {
 
   constructor(private readonly paths: AidenPaths) {}
 
+  /** Prevent setup/runtime transactions from crossing isolated Aiden homes. */
+  usesPaths(paths: AidenPaths): boolean {
+    return path.resolve(this.paths.root) === path.resolve(paths.root)
+      && path.resolve(this.paths.configYaml) === path.resolve(paths.configYaml);
+  }
+
   /** Read config.yaml from disk and merge over the defaults. */
   async load(): Promise<AidenConfig> {
     let raw: string;
@@ -293,7 +299,14 @@ export class ConfigManager implements ConfigProvider {
     if (config) this.cfg = config;
     await fs.mkdir(path.dirname(this.paths.configYaml), { recursive: true });
     const dumped = yaml.dump(this.cfg, { lineWidth: 120, noRefs: true });
-    await fs.writeFile(this.paths.configYaml, dumped, 'utf8');
+    const temporary = `${this.paths.configYaml}.${process.pid}.${Date.now()}.tmp`;
+    await fs.writeFile(temporary, dumped, 'utf8');
+    try {
+      await fs.rename(temporary, this.paths.configYaml);
+    } catch (error) {
+      await fs.rm(temporary, { force: true }).catch(() => undefined);
+      throw error;
+    }
     this.rawText = dumped;
   }
 
@@ -310,6 +323,12 @@ export class ConfigManager implements ConfigProvider {
       return typeof expanded === 'string' ? expanded : undefined;
     }
     return undefined;
+  }
+
+  /** Return the configured string without environment interpolation. */
+  getRaw(key: string): string | undefined {
+    const value = getDotted(this.cfg, key);
+    return typeof value === 'string' ? value : undefined;
   }
 
   /** Typed getter with default fallback. */

--- a/core/v4/daemon/dispatcher/dailyBudgetTracker.ts
+++ b/core/v4/daemon/dispatcher/dailyBudgetTracker.ts
@@ -30,6 +30,7 @@
  */
 
 import type { Db } from '../db/connection';
+import type { ProviderAttemptLedger } from '../../usageLedger';
 
 const BUDGET_SCOPE = 'daemon_budget';
 const ROW_TTL_DAYS = 7;
@@ -152,6 +153,70 @@ export function createDailyBudgetTracker(
       const now = opts2.now ?? Date.now();
       const date = utcDateKey(now);
       writeRow(date, 0, now);
+    },
+  };
+}
+
+/**
+ * Read-only daily-budget projection over the provider-attempt ledger. Physical
+ * attempts have already been appended by the time post-turn accounting runs,
+ * so addAndCheck must not duplicate them in a second counter.
+ */
+export function createLedgerDailyBudgetTracker(options: {
+  ledger: ProviderAttemptLedger;
+  budget?: number | null;
+  entryPoint?: string;
+}): DailyBudgetTracker {
+  const configuredBudget = options.budget ?? null;
+  const entryPoint = options.entryPoint ?? 'daemon';
+
+  const snapshot = (now: number, budget: number | null): DailyBudgetSnapshot => {
+    const day = new Date(now);
+    day.setUTCHours(0, 0, 0, 0);
+    const records = options.ledger.query({ since: day.getTime(), until: now });
+    const used = records
+      .filter((record) => record.entryPoint === entryPoint)
+      .reduce((total, record) => total
+        + (record.providerInputTokens ?? record.estimatedInputTokens ?? 0)
+        + (record.providerOutputTokens ?? record.estimatedOutputTokens ?? 0), 0);
+    return {
+      date: utcDateKey(now),
+      used,
+      budget,
+      remaining: budget !== null && budget > 0
+        ? Math.max(0, budget - used)
+        : Number.POSITIVE_INFINITY,
+      exhausted: budget !== null && budget > 0 && used >= budget,
+    };
+  };
+
+  return {
+    addAndCheck(tokens, opts = {}) {
+      const budget = opts.budget !== undefined ? opts.budget : configuredBudget;
+      const current = snapshot(opts.now ?? Date.now(), budget);
+      if (current.exhausted) {
+        return {
+          allowed: false,
+          snapshot: current,
+          reason: `daily_budget_exhausted: ${current.used}/${budget} tokens used today (${current.date})`,
+        };
+      }
+      if (budget !== null && budget > 0 && current.used + Math.max(0, tokens) > budget) {
+        return {
+          allowed: false,
+          snapshot: current,
+          reason: `daily_budget_would_exceed: ${tokens} > remaining ${current.remaining}`,
+        };
+      }
+      return { allowed: true, snapshot: current };
+    },
+    peek(opts = {}) {
+      const budget = opts.budget !== undefined ? opts.budget : configuredBudget;
+      return snapshot(opts.now ?? Date.now(), budget);
+    },
+    reset() {
+      // The immutable ledger is authoritative and cannot be reset. Test/admin
+      // reset remains available only on the legacy compatibility tracker.
     },
   };
 }

--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -59,6 +59,10 @@ import type {
   AidenAgentResult,
 } from '../../aidenAgent';
 import type { Message, ToolCallRequest, ToolCallResult } from '../../../../providers/v4/types';
+import {
+  currentProviderAttemptLedger,
+  runWithProviderUsageContext,
+} from '../../../../providers/v4/providerAttemptAccounting';
 import type { Db } from '../db/connection';
 import type { RunStore } from '../runStore';
 // v4.10 Slice 10.2b — shared (category, kind) taxonomy.
@@ -87,6 +91,7 @@ import {
 import type { DaemonApprovalPolicy } from './daemonApproval';
 import {
   createDailyBudgetTracker,
+  createLedgerDailyBudgetTracker,
   type DailyBudgetTracker,
 } from './dailyBudgetTracker';
 import {
@@ -162,10 +167,15 @@ export function createRealAgentRunner(
 ): DaemonAgentRunner {
   const log = opts.log ?? (() => { /* silent */ });
   const now = opts.now ?? Date.now;
-  const tracker: DailyBudgetTracker = createDailyBudgetTracker({
-    db:     opts.db,
-    budget: opts.dailyBudget ?? readDailyBudgetFromEnv(),
-  });
+  const configuredBudget = opts.dailyBudget ?? readDailyBudgetFromEnv();
+  const usageLedger = currentProviderAttemptLedger();
+  const tracker: DailyBudgetTracker = usageLedger
+    ? createLedgerDailyBudgetTracker({
+        ledger: usageLedger,
+        budget: configuredBudget,
+        entryPoint: 'daemon',
+      })
+    : createDailyBudgetTracker({ db: opts.db, budget: configuredBudget });
 
   return {
     async invoke(input: DaemonAgentInput): Promise<DaemonAgentResult> {
@@ -349,7 +359,17 @@ export function createRealAgentRunner(
       // status) feeds the verify-before-done gate below, same as the REPL.
       let declaredTaskStatus: string | null = null;
       try {
-        result = await agent.runConversation(history, {
+        result = await runWithProviderUsageContext({
+          sessionId: input.sessionId,
+          taskId,
+          runId,
+          entryPoint: 'daemon',
+        }, () => agent.runConversation(history, {
+          sessionId: input.sessionId,
+          taskId,
+          runId,
+          entryPoint: 'daemon',
+          signal: perTurnWatcher.signal,
           // The agent honours its own abort signal via per-tool aborts;
           // tools that respect AbortSignal (shell_exec, fetch_*) will
           // bail when perTurnWatcher trips.
@@ -387,10 +407,10 @@ export function createRealAgentRunner(
               });
             } catch { /* persistence faults must never break dispatch */ }
           },
-        });
+        }));
         // Stamp the actual token usage onto the watcher for the
         // post-turn snapshot below.
-        const tokens = extractTokens(result);
+        const tokens = extractLedgerTokens(runId) ?? extractTokens(result);
         if (tokens > 0) perTurnWatcher.tally(tokens);
       } catch (e) {
         invocationError = e instanceof Error ? (e.stack ?? e.message) : String(e);
@@ -640,8 +660,21 @@ function safeShortJson(value: unknown, maxBytes: number): string {
  */
 function extractTokens(result: AidenAgentResult | null): number {
   if (!result) return 0;
-  const r = result as unknown as { usage?: { totalTokens?: number; total?: number } };
-  return r.usage?.totalTokens ?? r.usage?.total ?? 0;
+  const totalUsage = (result as Partial<AidenAgentResult>).totalUsage;
+  if (totalUsage) return totalUsage.inputTokens + totalUsage.outputTokens;
+  // Compatibility for injected runners that still expose the earlier shape.
+  const legacy = result as unknown as { usage?: { totalTokens?: number; total?: number } };
+  return legacy.usage?.totalTokens ?? legacy.usage?.total ?? 0;
+}
+
+function extractLedgerTokens(runId: number): number | null {
+  const ledger = currentProviderAttemptLedger();
+  if (!ledger) return null;
+  const records = ledger.query({ runId: String(runId) });
+  if (records.length === 0) return null;
+  return records.reduce((total, record) => total
+    + (record.providerInputTokens ?? record.estimatedInputTokens ?? 0)
+    + (record.providerOutputTokens ?? record.estimatedOutputTokens ?? 0), 0);
 }
 
 /**

--- a/core/v4/providerFallback.ts
+++ b/core/v4/providerFallback.ts
@@ -38,6 +38,10 @@ import type {
   ProviderCallOutput,
   StreamEvent,
 } from '../../providers/v4/types';
+import { providerMainDefault } from '../../providers/v4/providerModelAuthority';
+import { getProviderEntry } from '../../providers/v4/registry';
+import { credentialFingerprint, endpointFingerprint } from '../../providers/v4/credentialAuthority';
+import { providerRuntimeIdentity } from '../../providers/v4/providerIdentity';
 
 // ── Public types ────────────────────────────────────────────────────────
 
@@ -57,6 +61,7 @@ export interface ProviderSlot {
   keyPresent:  boolean;
   keyTail:     string | null;
   envVar?:     string;
+  identity?:   string;
   build():     ProviderAdapter | null;
 }
 
@@ -114,8 +119,8 @@ export const DEFAULT_SLOT_COOLDOWN_MS = 60_000;
 const COOLDOWN_ENV_VAR = 'AIDEN_SLOT_COOLDOWN_MS';
 
 const TOGETHER_BASE_URL       = 'https://api.together.xyz/v1';
-const GROQ_BASE_URL           = 'https://api.groq.com/openai/v1';
-const DEFAULT_GROQ_MODEL      = 'llama-3.3-70b-versatile';
+const GROQ_BASE_URL           = getProviderEntry('groq')!.baseUrl;
+const DEFAULT_GROQ_MODEL      = providerMainDefault('groq')!;
 const DEFAULT_TOGETHER_MODEL  = 'openai/gpt-oss-120b';
 const TOGETHER_FALLBACK_MODEL = 'meta-llama/Llama-3.3-70B-Instruct-Turbo';
 
@@ -361,6 +366,12 @@ export function buildDefaultSlots(opts: DefaultSlotsOptions): ProviderSlot[] {
       keyPresent: Boolean(togetherKey),
       keyTail:    togetherKey ? togetherKey.slice(-4) : null,
       envVar:     'TOGETHER_API_KEY',
+      identity: togetherKey ? providerRuntimeIdentity({
+        provider: 'together',
+        endpointFingerprint: endpointFingerprint(TOGETHER_BASE_URL),
+        credentialFingerprint: credentialFingerprint(togetherKey),
+        model,
+      }) : undefined,
       build: () =>
         togetherKey
           ? opts.adapterFactory({
@@ -382,6 +393,12 @@ export function buildDefaultSlots(opts: DefaultSlotsOptions): ProviderSlot[] {
       keyPresent: Boolean(key),
       keyTail:    key ? key.slice(-4) : null,
       envVar,
+      identity: key ? providerRuntimeIdentity({
+        provider: 'groq',
+        endpointFingerprint: endpointFingerprint(GROQ_BASE_URL),
+        credentialFingerprint: credentialFingerprint(key),
+        model: groqModel,
+      }) : undefined,
       build: () =>
         key
           ? opts.adapterFactory({

--- a/core/v4/providerFallback.ts
+++ b/core/v4/providerFallback.ts
@@ -480,15 +480,29 @@ export class FallbackAdapter implements ProviderAdapter {
 
   async call(input: ProviderCallInput): Promise<ProviderCallOutput> {
     let pendingFromId: string | null = null;
+    let fallbackIndex = -1;
 
     const result = await runFallbackChain(
       this.slots,
       async (adapter, slot) => {
+        fallbackIndex += 1;
         if (pendingFromId !== null && pendingFromId !== slot.id) {
           this.onFallback?.(pendingFromId, slot.id);
         }
         pendingFromId = slot.id;
-        return adapter.call(input);
+        return adapter.call({
+          ...input,
+          usageContext: {
+            ...input.usageContext,
+            providerConfigured: input.usageContext?.providerConfigured
+              ?? this.slots[0]?.providerId
+              ?? slot.providerId,
+            modelConfigured: input.usageContext?.modelConfigured
+              ?? this.slots[0]?.modelId
+              ?? slot.modelId,
+            fallbackIndex,
+          },
+        });
       },
       {
         onRateLimit: (slotId, err) => this.recordRateLimit(slotId, err),
@@ -531,6 +545,19 @@ export class FallbackAdapter implements ProviderAdapter {
 
       bumpCount(cooldown, slot.id);
       tried.push(slot.id);
+      const slotInput: ProviderCallInput = {
+        ...input,
+        usageContext: {
+          ...input.usageContext,
+          providerConfigured: input.usageContext?.providerConfigured
+            ?? this.slots[0]?.providerId
+            ?? slot.providerId,
+          modelConfigured: input.usageContext?.modelConfigured
+            ?? this.slots[0]?.modelId
+            ?? slot.modelId,
+          fallbackIndex: tried.length - 1,
+        },
+      };
 
       if (prevSlotId !== null && prevSlotId !== slot.id) {
         this.onFallback?.(prevSlotId, slot.id);
@@ -540,7 +567,7 @@ export class FallbackAdapter implements ProviderAdapter {
       let yielded = false;
       try {
         if (typeof adapter.callStream === 'function') {
-          for await (const evt of adapter.callStream(input)) {
+          for await (const evt of adapter.callStream(slotInput)) {
             yielded = true;
             yield evt;
           }
@@ -548,7 +575,7 @@ export class FallbackAdapter implements ProviderAdapter {
           // Adapter doesn't speak SSE — fall back to a single-shot call
           // and synthesise a terminal `done` event so consumers see the
           // same event shape regardless of which slot won.
-          const out = await adapter.call(input);
+          const out = await adapter.call(slotInput);
           yielded = true;
           yield { type: 'done', output: out };
         }

--- a/core/v4/providers/modelFetch.ts
+++ b/core/v4/providers/modelFetch.ts
@@ -21,9 +21,10 @@
  *
  * Behaviour contract:
  *   - 5-second hard timeout per request (configurable).
- *   - On any failure (network, non-2xx, malformed body) we return the
- *     static fallback with `{ source: 'fallback', reason }` so the
- *     picker can show the muted "Couldn't reach API" hint.
+ *   - Hosted-provider failures return the static fallback with
+ *     `{ source: 'fallback', reason }` so the picker can show an offline hint.
+ *   - Ollama always returns its real installed inventory. Failure or an empty
+ *     inventory returns no models because the static catalog is not installed state.
  *   - Results are sorted with "recommended" / default models first,
  *     then by display name.
  *   - No client-side cost-tier annotation — the curated catalog owns
@@ -181,7 +182,16 @@ async function fetchJson(
     const response = await lifecycle.race(fetchImpl(url, { ...init, signal: lifecycle.signal }));
     lifecycle.markHeaders();
     const bodyText = await lifecycle.readText(response);
-    const body = bodyText.length > 0 ? JSON.parse(bodyText) : {};
+    let body: unknown = {};
+    if (bodyText.length > 0) {
+      try {
+        body = JSON.parse(bodyText);
+      } catch (error) {
+        // Callers classify non-success responses by status. A plain-text error
+        // body must not mask that status as a catalogue parsing failure.
+        if (response.ok) throw error;
+      }
+    }
     return { response, body };
   } catch (error) {
     throw lifecycle.classify(error);
@@ -323,16 +333,20 @@ async function fetchLocalRuntimeModels(baseUrl: string, o: Required<Pick<FetchOp
 }
 
 /**
- * Fetch available models for `providerId`, falling back to the
- * curated catalog when the live endpoint is unreachable, the key is
- * missing, or the response is malformed.
+ * Fetch available models for `providerId`. Hosted providers fall back to the
+ * curated catalog when discovery is unavailable. Ollama never substitutes
+ * catalog recommendations for the local runtime's installed inventory.
  */
 export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const fetchImpl = opts.fetchImpl ?? fetch;
   const apiKey = opts.apiKey ?? '';
   const cacheKey = discoveryCacheKey(opts);
-  const cached = discoveryCache.get(cacheKey);
+  // Local inventory is process state, not a provider catalogue. Its caller
+  // owns the short cache so fresh resolver instances cannot inherit stale
+  // installed-model results from an unrelated runtime.
+  const useDiscoveryCache = opts.providerId !== 'ollama';
+  const cached = useDiscoveryCache ? discoveryCache.get(cacheKey) : undefined;
   const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   if (!opts.refresh && cached && Date.now() - cached.fetchedAt < cacheTtlMs) {
     return { models: cached.models, source: 'live', cacheStatus: 'cached' };
@@ -392,11 +406,19 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
         return fallbackFor(opts.providerId);
     }
     const models = normalise(opts.providerId, raws);
-    if (models.length === 0) return fallbackFor(opts.providerId, 'empty live response');
-    discoveryCache.set(cacheKey, { fetchedAt: Date.now(), models });
+    if (models.length === 0) {
+      if (opts.providerId === 'ollama') {
+        return { models: [], source: 'live', reason: 'no installed models' };
+      }
+      return fallbackFor(opts.providerId, 'empty live response');
+    }
+    if (useDiscoveryCache) discoveryCache.set(cacheKey, { fetchedAt: Date.now(), models });
     return { models, source: 'live', cacheStatus: 'fresh' };
   } catch (err) {
     const reason = safeDiscoveryReason(err);
+    // A static catalog is not a local inventory. Treating it as one makes
+    // uninstalled models look runnable and produces a later model-not-found.
+    if (opts.providerId === 'ollama') return { models: [], source: 'fallback', reason };
     if (cached) {
       return {
         models: cached.models,

--- a/core/v4/providers/modelFetch.ts
+++ b/core/v4/providers/modelFetch.ts
@@ -31,7 +31,9 @@
  *     fallback only.
  */
 
+import { createHash } from 'node:crypto';
 import { MODEL_CATALOG, type ModelEntry } from '../../../providers/v4/modelCatalog';
+import { RequestLifecycle, requestDeadlines } from '../../../providers/v4/requestLifecycle';
 
 export interface FetchedModel {
   /** Wire-format model id. */
@@ -44,12 +46,21 @@ export interface FetchedModel {
   recommended?: boolean;
   /** Cost tier hint, '$' / '$$' / '$$$'. Only set on fallback rows. */
   tier?: '$' | '$$' | '$$$' | 'free';
+  /** Model creator, distinct from the inference provider. */
+  creator?: string;
+  /** Inference host shown when it differs from the model creator. */
+  hostedBy?: string;
+  supportsToolCalling?: boolean;
+  supportsStructuredOutput?: boolean;
+  compatibleWithAgent?: boolean;
+  incompatibilityReason?: string;
 }
 
 export interface FetchModelsResult {
   models: FetchedModel[];
   /** Where the list came from. */
-  source: 'live' | 'fallback';
+  source: 'live' | 'last-known-good' | 'fallback';
+  cacheStatus?: 'fresh' | 'cached' | 'last-known-good';
   /** When `source === 'fallback'`, the reason (timeout, 401, parse, etc.). */
   reason?: string;
 }
@@ -65,9 +76,36 @@ export interface FetchOptions {
   timeoutMs?: number;
   /** Override fetch — tests inject a stub. */
   fetchImpl?: typeof fetch;
+  includeIncompatible?: boolean;
+  refresh?: boolean;
+  cacheTtlMs?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface DiscoveryCacheEntry {
+  fetchedAt: number;
+  models: FetchedModel[];
+}
+
+const discoveryCache = new Map<string, DiscoveryCacheEntry>();
+
+export function clearModelDiscoveryCache(): void {
+  discoveryCache.clear();
+}
+
+function discoveryCacheKey(opts: FetchOptions): string {
+  const credentialFingerprint = opts.apiKey
+    ? createHash('sha256').update(opts.apiKey).digest('hex').slice(0, 16)
+    : 'anonymous';
+  return [
+    opts.providerId,
+    opts.baseUrl ?? '',
+    credentialFingerprint,
+    opts.includeIncompatible ? 'all' : 'compatible',
+  ].join('|');
+}
 
 function tierFromPricing(p?: ModelEntry['pricing']): FetchedModel['tier'] {
   if (!p) return undefined;
@@ -88,18 +126,69 @@ function fallbackFor(providerId: string, reason?: string): FetchModelsResult {
       contextLength: m.contextLength,
       recommended: m.isDefault,
       tier: tierFromPricing(m.pricing),
+      creator: m.creator,
+      hostedBy: m.hostedBy,
     }));
   return { models, source: 'fallback', reason };
 }
 
-function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
-    p.then((v) => { clearTimeout(t); resolve(v); }, (e) => { clearTimeout(t); reject(e); });
-  });
+interface RawProviderRoute {
+  provider?: string;
+  status?: string;
+  context_length?: number;
+  supports_tools?: boolean;
+  supports_structured_output?: boolean;
 }
 
-interface RawModel { id: string; name?: string; display_name?: string; context_length?: number }
+function safeDiscoveryReason(error: unknown): string {
+  const record = error && typeof error === 'object'
+    ? error as { category?: string; code?: string; message?: string }
+    : {};
+  if (record.category?.endsWith('_timeout') || /timeout/i.test(record.message ?? '')) {
+    return 'provider discovery timeout';
+  }
+  if (record.code === 'ENOTFOUND' || record.code === 'EAI_AGAIN') return 'provider hostname unavailable';
+  if (error instanceof SyntaxError) return 'malformed model catalogue response';
+  if (/^HTTP \d{3}$/.test(record.message ?? '')) return record.message!;
+  return 'provider discovery unavailable';
+}
+
+interface RawModel {
+  id: string;
+  name?: string;
+  display_name?: string;
+  context_length?: number;
+  type?: string;
+  organization?: string;
+  owned_by?: string;
+  hosted_by?: string;
+  supports_tools?: boolean;
+  supports_structured_output?: boolean;
+  compatible_with_agent?: boolean;
+  incompatibility_reason?: string;
+  providers?: RawProviderRoute[];
+}
+
+async function fetchJson(
+  providerId: string,
+  url: string,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<{ response: Response; body: unknown }> {
+  const lifecycle = new RequestLifecycle(providerId, requestDeadlines(timeoutMs));
+  try {
+    const response = await lifecycle.race(fetchImpl(url, { ...init, signal: lifecycle.signal }));
+    lifecycle.markHeaders();
+    const bodyText = await lifecycle.readText(response);
+    const body = bodyText.length > 0 ? JSON.parse(bodyText) : {};
+    return { response, body };
+  } catch (error) {
+    throw lifecycle.classify(error);
+  } finally {
+    lifecycle.cleanup();
+  }
+}
 
 function normalise(providerId: string, raws: RawModel[]): FetchedModel[] {
   // Cross-reference the static catalog for recommended flags + display names
@@ -115,36 +204,105 @@ function normalise(providerId: string, raws: RawModel[]): FetchedModel[] {
         contextLength: c?.contextLength ?? m.context_length,
         recommended: c?.isDefault,
         tier: tierFromPricing(c?.pricing),
+        creator: c?.creator ?? m.organization ?? m.owned_by,
+        hostedBy: c?.hostedBy ?? m.hosted_by,
+        supportsToolCalling: m.supports_tools ?? c?.supportsToolCalling,
+        supportsStructuredOutput: m.supports_structured_output,
+        compatibleWithAgent: m.compatible_with_agent ?? true,
+        incompatibilityReason: m.incompatibility_reason,
       };
     })
     .sort((a, b) => Number(b.recommended) - Number(a.recommended) || a.displayName.localeCompare(b.displayName));
 }
 
 async function fetchMessageApiModels(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
-  const res = await withTimeout(o.fetchImpl('https://api.anthropic.com/v1/models', {
+  const { response, body } = await fetchJson('anthropic', 'https://api.anthropic.com/v1/models', {
     headers: { 'x-api-key': o.apiKey, 'anthropic-version': '2023-06-01' },
-  }), o.timeoutMs);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const body = await res.json() as { data?: RawModel[] };
-  return body.data ?? [];
+  }, o.timeoutMs, o.fetchImpl);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return (body as { data?: RawModel[] }).data ?? [];
 }
 
 async function fetchCompatibleModels(url: string, o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
-  const res = await withTimeout(o.fetchImpl(url, {
+  const { response, body } = await fetchJson('compatible', url, {
     headers: { Authorization: `Bearer ${o.apiKey}` },
-  }), o.timeoutMs);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const body = await res.json() as { data?: RawModel[] };
-  return body.data ?? [];
+  }, o.timeoutMs, o.fetchImpl);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return (body as { data?: RawModel[] }).data ?? [];
+}
+
+async function fetchTogetherModels(
+  o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>,
+  includeIncompatible: boolean,
+): Promise<RawModel[]> {
+  const { response, body } = await fetchJson(
+    'together',
+    'https://api.together.xyz/v1/models?dedicated=false',
+    { headers: { Authorization: `Bearer ${o.apiKey}` } },
+    o.timeoutMs,
+    o.fetchImpl,
+  );
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const list = Array.isArray(body) ? body as RawModel[] : [];
+  return list.flatMap((model) => {
+    const compatible = model.type === 'chat';
+    if (!includeIncompatible && !compatible) return [];
+    return [{
+      ...model,
+      compatible_with_agent: compatible,
+      incompatibility_reason: compatible ? undefined : `not a chat model (${model.type ?? 'unknown type'})`,
+    }];
+  });
+}
+
+function classifyGroqModels(models: RawModel[], includeIncompatible: boolean): RawModel[] {
+  return models.flatMap((model) => {
+    const incompatibleFamily = /(?:whisper|orpheus|guard|compound)/i.test(model.id);
+    if (!includeIncompatible && incompatibleFamily) return [];
+    return [{
+      ...model,
+      compatible_with_agent: !incompatibleFamily,
+      incompatibility_reason: incompatibleFamily
+        ? 'not a general chat model with custom tool replay'
+        : undefined,
+    }];
+  });
+}
+
+async function fetchHuggingFaceModels(
+  o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>,
+  includeIncompatible: boolean,
+): Promise<RawModel[]> {
+  const models = await fetchCompatibleModels('https://router.huggingface.co/v1/models', o);
+  return models.flatMap((model) => {
+    const liveRoutes = (model.providers ?? []).filter((route) => route.status === 'live');
+    const toolRoute = liveRoutes.find((route) => route.supports_tools === true);
+    const selectedRoute = toolRoute ?? liveRoutes[0];
+    const compatible = !!toolRoute;
+    if (!includeIncompatible && !compatible) return [];
+    return [{
+      ...model,
+      context_length: selectedRoute?.context_length ?? model.context_length,
+      hosted_by: selectedRoute?.provider,
+      supports_tools: selectedRoute?.supports_tools ?? false,
+      supports_structured_output: selectedRoute?.supports_structured_output,
+      compatible_with_agent: compatible,
+      incompatibility_reason: compatible
+        ? undefined
+        : liveRoutes.length === 0
+          ? 'no live inference route'
+          : 'tool calling not advertised by any live route',
+    }];
+  });
 }
 
 async function fetchGenerativeApiModels(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
   const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(o.apiKey)}`;
-  const res = await withTimeout(o.fetchImpl(url), o.timeoutMs);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const body = await res.json() as { models?: Array<{ name: string; displayName?: string; inputTokenLimit?: number }> };
+  const { response, body } = await fetchJson('generative-api', url, undefined, o.timeoutMs, o.fetchImpl);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const parsed = body as { models?: Array<{ name: string; displayName?: string; inputTokenLimit?: number }> };
   // Gemini ids come back as "models/gemini-2.0-flash" — strip the prefix.
-  return (body.models ?? []).map((m) => ({
+  return (parsed.models ?? []).map((m) => ({
     id: m.name.replace(/^models\//, ''),
     display_name: m.displayName,
     context_length: m.inputTokenLimit,
@@ -152,10 +310,16 @@ async function fetchGenerativeApiModels(o: Required<Pick<FetchOptions, 'apiKey' 
 }
 
 async function fetchLocalRuntimeModels(baseUrl: string, o: Required<Pick<FetchOptions, 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
-  const res = await withTimeout(o.fetchImpl(`${baseUrl.replace(/\/+$/, '')}/api/tags`), o.timeoutMs);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const body = await res.json() as { models?: Array<{ name: string; size?: number }> };
-  return (body.models ?? []).map((m) => ({ id: m.name, display_name: m.name }));
+  const { response, body } = await fetchJson(
+    'local-runtime',
+    `${baseUrl.replace(/\/+$/, '')}/api/tags`,
+    undefined,
+    o.timeoutMs,
+    o.fetchImpl,
+  );
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return ((body as { models?: Array<{ name: string; size?: number }> }).models ?? [])
+    .map((m) => ({ id: m.name, display_name: m.name }));
 }
 
 /**
@@ -167,6 +331,12 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const fetchImpl = opts.fetchImpl ?? fetch;
   const apiKey = opts.apiKey ?? '';
+  const cacheKey = discoveryCacheKey(opts);
+  const cached = discoveryCache.get(cacheKey);
+  const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  if (!opts.refresh && cached && Date.now() - cached.fetchedAt < cacheTtlMs) {
+    return { models: cached.models, source: 'live', cacheStatus: 'cached' };
+  }
 
   try {
     let raws: RawModel[];
@@ -181,7 +351,28 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
         break;
       case 'groq':
         if (!apiKey) return fallbackFor('groq', 'no API key');
-        raws = await fetchCompatibleModels('https://api.groq.com/openai/v1/models', { apiKey, timeoutMs, fetchImpl });
+        raws = classifyGroqModels(
+          await fetchCompatibleModels('https://api.groq.com/openai/v1/models', { apiKey, timeoutMs, fetchImpl }),
+          opts.includeIncompatible ?? false,
+        );
+        break;
+      case 'together':
+        if (!apiKey) return fallbackFor('together', 'no API key');
+        raws = await fetchTogetherModels(
+          { apiKey, timeoutMs, fetchImpl },
+          opts.includeIncompatible ?? false,
+        );
+        break;
+      case 'deepseek':
+        if (!apiKey) return fallbackFor('deepseek', 'no API key');
+        raws = await fetchCompatibleModels('https://api.deepseek.com/v1/models', { apiKey, timeoutMs, fetchImpl });
+        break;
+      case 'huggingface':
+        if (!apiKey) return fallbackFor('huggingface', 'no API key');
+        raws = await fetchHuggingFaceModels(
+          { apiKey, timeoutMs, fetchImpl },
+          opts.includeIncompatible ?? false,
+        );
         break;
       case 'openrouter':
         // OpenRouter exposes /models without auth, but auth gives the user's
@@ -202,9 +393,18 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
     }
     const models = normalise(opts.providerId, raws);
     if (models.length === 0) return fallbackFor(opts.providerId, 'empty live response');
-    return { models, source: 'live' };
+    discoveryCache.set(cacheKey, { fetchedAt: Date.now(), models });
+    return { models, source: 'live', cacheStatus: 'fresh' };
   } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
+    const reason = safeDiscoveryReason(err);
+    if (cached) {
+      return {
+        models: cached.models,
+        source: 'last-known-good',
+        cacheStatus: 'last-known-good',
+        reason,
+      };
+    }
     return fallbackFor(opts.providerId, reason);
   }
 }

--- a/core/v4/providers/probe.ts
+++ b/core/v4/providers/probe.ts
@@ -4,6 +4,8 @@
  *
  * Aiden — local-first agent.
  */
+
+import { RequestLifecycle, requestDeadlines } from '../../../providers/v4/requestLifecycle';
 /**
  * core/v4/providers/probe.ts — ONB1 slice 7.
  *
@@ -63,13 +65,6 @@ export interface ProbeResult {
 
 const DEFAULT_TIMEOUT_MS = 8000;
 
-function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const t = setTimeout(() => reject(Object.assign(new Error(`timed out after ${ms}ms`), { code: 'TIMEOUT' })), ms);
-    p.then((v) => { clearTimeout(t); resolve(v); }, (e) => { clearTimeout(t); reject(e); });
-  });
-}
-
 function classifyStatus(status: number, retryAfter?: string | null): { category: ProbeCategory; reason: string; retryAfterSec?: number } {
   if (status === 401 || status === 403) return { category: 'auth', reason: 'API key rejected' };
   if (status === 404) return { category: 'model-not-found', reason: 'Model not on this key\'s allow-list' };
@@ -128,7 +123,7 @@ function buildAuthRequest(o: ProbeOptions): ProbeRequest | null {
       const root = (o.baseUrl ?? 'http://localhost:11434').replace(/\/+$/, '');
       return { url: `${root}/api/tags`, method: 'GET', headers: {} };
     }
-    case 'custom': {
+    case 'custom_openai': {
       const root = (o.baseUrl ?? '').replace(/\/+$/, '');
       if (!root) return null;
       return { url: `${root}/models`, method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } };
@@ -184,6 +179,8 @@ function buildToolCheckRequest(o: ProbeOptions): ProbeRequest | null {
     case 'openrouter':
     case 'together':
     case 'nvidia':
+    case 'custom':
+    case 'custom_openai':
       return {
         url: o.providerId === 'openai'
           ? 'https://api.openai.com/v1/chat/completions'
@@ -193,7 +190,9 @@ function buildToolCheckRequest(o: ProbeOptions): ProbeRequest | null {
               ? 'https://openrouter.ai/api/v1/chat/completions'
               : o.providerId === 'together'
                 ? 'https://api.together.xyz/v1/chat/completions'
-                : 'https://integrate.api.nvidia.com/v1/chat/completions',
+                : o.providerId === 'custom_openai' || o.providerId === 'custom'
+                  ? `${(o.baseUrl ?? '').replace(/\/+$/, '')}/chat/completions`
+                  : 'https://integrate.api.nvidia.com/v1/chat/completions',
         method: 'POST',
         headers: { Authorization: `Bearer ${o.apiKey}`, 'content-type': 'application/json' },
         body: JSON.stringify({
@@ -212,14 +211,23 @@ function buildToolCheckRequest(o: ProbeOptions): ProbeRequest | null {
 async function runRequest(req: ProbeRequest, o: ProbeOptions): Promise<{ status: number; bodyText: string; retryAfter: string | null }> {
   const fetchImpl = o.fetchImpl ?? fetch;
   const timeoutMs = o.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const res = await withTimeout(fetchImpl(req.url, {
-    method: req.method,
-    headers: req.headers,
-    body: req.body,
-  }), timeoutMs);
-  const retryAfter = res.headers.get('retry-after');
-  const bodyText = await res.text().catch(() => '');
-  return { status: res.status, bodyText, retryAfter };
+  const lifecycle = new RequestLifecycle(o.providerId, requestDeadlines(timeoutMs));
+  try {
+    const res = await lifecycle.race(fetchImpl(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: lifecycle.signal,
+    }));
+    lifecycle.markHeaders();
+    const retryAfter = res.headers.get('retry-after');
+    const bodyText = await lifecycle.readText(res);
+    return { status: res.status, bodyText, retryAfter };
+  } catch (error) {
+    throw lifecycle.classify(error);
+  } finally {
+    lifecycle.cleanup();
+  }
 }
 
 /**

--- a/core/v4/providers/probe.ts
+++ b/core/v4/providers/probe.ts
@@ -36,6 +36,12 @@ export type ProbeCategory =
   | 'network'
   | 'unknown';
 
+import {
+  beginPhysicalProviderAttempt,
+  byteLength,
+  createLogicalProviderCallId,
+} from '../../../providers/v4/providerAttemptAccounting';
+
 export interface ProbeStepResult {
   step: 'auth' | 'model' | 'tools';
   ok: boolean;
@@ -212,6 +218,28 @@ async function runRequest(req: ProbeRequest, o: ProbeOptions): Promise<{ status:
   const fetchImpl = o.fetchImpl ?? fetch;
   const timeoutMs = o.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const lifecycle = new RequestLifecycle(o.providerId, requestDeadlines(timeoutMs));
+  const logicalCallId = createLogicalProviderCallId();
+  const attempt = beginPhysicalProviderAttempt({
+    messages: [],
+    tools: [],
+    maxTokens: 1,
+    usageContext: {
+      logicalCallId,
+      entryPoint: 'setup',
+      purpose: 'readiness',
+      providerConfigured: o.providerId,
+      modelConfigured: o.modelId,
+      credentialLabelRedacted: 'setup-managed',
+    },
+  }, {
+    providerActual: o.providerId,
+    modelActual: o.modelId,
+    apiMode: 'chat_completions',
+    transport: new URL(req.url).protocol.replace(':', ''),
+    attemptIndex: 0,
+    logicalCallId,
+    requestBytes: byteLength(req.body ?? ''),
+  });
   try {
     const res = await lifecycle.race(fetchImpl(req.url, {
       method: req.method,
@@ -222,9 +250,16 @@ async function runRequest(req: ProbeRequest, o: ProbeOptions): Promise<{ status:
     lifecycle.markHeaders();
     const retryAfter = res.headers.get('retry-after');
     const bodyText = await lifecycle.readText(res);
+    if (res.ok) {
+      attempt.success({ content: '', toolCalls: [], finishReason: 'stop', usage: { inputTokens: 0, outputTokens: 0 } }, byteLength(bodyText));
+    } else {
+      attempt.failure(new Error(`HTTP ${res.status}`), { sent: true, status: 'provider_error', responseBytes: byteLength(bodyText) });
+    }
     return { status: res.status, bodyText, retryAfter };
   } catch (error) {
-    throw lifecycle.classify(error);
+    const classified = lifecycle.classify(error);
+    attempt.failure(classified, { sent: true });
+    throw classified;
   } finally {
     lifecycle.cleanup();
   }

--- a/core/v4/sessionManager.ts
+++ b/core/v4/sessionManager.ts
@@ -30,6 +30,7 @@ import type {
   SessionStore,
   SearchOptions,
   AppendMessageInput,
+  ActiveSessionState,
 } from './sessionStore';
 import type { Message } from '../../providers/v4/types';
 
@@ -148,13 +149,47 @@ export class SessionManager {
     messages: Message[],
     usage: RecordTurnUsage,
     turnNumber?: number,
+    activeState?: ActiveSessionState,
   ): void {
+    if (activeState) {
+      this.store.recordTurnWithActiveState(
+        sessionId,
+        messages.map((message) => messageToInput(message, turnNumber)),
+        usage,
+        activeState,
+      );
+      return;
+    }
     for (const m of messages) {
       this.store.appendMessage(sessionId, messageToInput(m, turnNumber));
     }
     if (usage.inputTokens > 0 || usage.outputTokens > 0) {
       this.store.addTokenUsage(sessionId, usage.inputTokens, usage.outputTokens);
     }
+  }
+
+  persistActiveState(sessionId: string, state: ActiveSessionState): void {
+    this.store.setActiveState(sessionId, state);
+  }
+
+  resumeActiveState(sessionId: string): ActiveSessionState | null {
+    return this.store.getActiveState(sessionId);
+  }
+
+  loadHistory(sessionId: string): Message[] {
+    return this.store.getMessages(sessionId).map((message): Message => {
+      if (message.role === 'assistant') {
+        return {
+          role: 'assistant',
+          content: message.content,
+          ...(message.toolCalls ? { toolCalls: message.toolCalls } : {}),
+        };
+      }
+      if (message.role === 'tool') {
+        return { role: 'tool', content: message.content, toolCallId: message.toolCallId ?? '' };
+      }
+      return { role: message.role, content: message.content };
+    });
   }
 
   search(query: string, opts?: SearchOptions | number): SessionSearchResult[] {

--- a/core/v4/sessionStore.ts
+++ b/core/v4/sessionStore.ts
@@ -32,7 +32,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
 
-import type { ToolCallRequest } from '../../providers/v4/types';
+import type { Message, ToolCallRequest } from '../../providers/v4/types';
 
 export type MessageRole = 'system' | 'user' | 'assistant' | 'tool';
 
@@ -87,6 +87,13 @@ export interface SessionSearchResult {
   score: number;
 }
 
+export interface ActiveSessionState {
+  messages: Message[];
+  compressionCount: number;
+  cumulativeUsage: { inputTokens: number; outputTokens: number };
+  budgetState: Record<string, unknown> | null;
+}
+
 /** v4.12 CS.1 — session_search options. */
 export interface SearchOptions {
   limit?: number;
@@ -132,6 +139,16 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_created ON sessions(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS session_active_state (
+  session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+  messages_json TEXT NOT NULL,
+  compression_count INTEGER NOT NULL DEFAULT 0,
+  cumulative_input_tokens INTEGER NOT NULL DEFAULT 0,
+  cumulative_output_tokens INTEGER NOT NULL DEFAULT 0,
+  budget_state_json TEXT,
+  updated_at INTEGER NOT NULL
+);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
   content,
@@ -412,6 +429,76 @@ export class SessionStore {
   getMessages(sessionId: string): MessageRecord[] {
     const rows = this.listMessagesStmt.all(sessionId) as MessageRow[];
     return rows.map(rowToMessage);
+  }
+
+  setActiveState(sessionId: string, state: ActiveSessionState): void {
+    this.db.prepare(
+      `INSERT INTO session_active_state (
+         session_id, messages_json, compression_count,
+         cumulative_input_tokens, cumulative_output_tokens,
+         budget_state_json, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(session_id) DO UPDATE SET
+         messages_json = excluded.messages_json,
+         compression_count = excluded.compression_count,
+         cumulative_input_tokens = excluded.cumulative_input_tokens,
+         cumulative_output_tokens = excluded.cumulative_output_tokens,
+         budget_state_json = excluded.budget_state_json,
+         updated_at = excluded.updated_at`,
+    ).run(
+      sessionId,
+      JSON.stringify(state.messages),
+      Math.max(0, Math.floor(state.compressionCount)),
+      Math.max(0, Math.floor(state.cumulativeUsage.inputTokens)),
+      Math.max(0, Math.floor(state.cumulativeUsage.outputTokens)),
+      state.budgetState ? JSON.stringify(state.budgetState) : null,
+      Date.now(),
+    );
+  }
+
+  getActiveState(sessionId: string): ActiveSessionState | null {
+    const row = this.db.prepare(
+      `SELECT messages_json, compression_count, cumulative_input_tokens,
+              cumulative_output_tokens, budget_state_json
+       FROM session_active_state WHERE session_id = ?`,
+    ).get(sessionId) as {
+      messages_json: string;
+      compression_count: number;
+      cumulative_input_tokens: number;
+      cumulative_output_tokens: number;
+      budget_state_json: string | null;
+    } | undefined;
+    if (!row) return null;
+    try {
+      return {
+        messages: JSON.parse(row.messages_json) as Message[],
+        compressionCount: row.compression_count,
+        cumulativeUsage: {
+          inputTokens: row.cumulative_input_tokens,
+          outputTokens: row.cumulative_output_tokens,
+        },
+        budgetState: row.budget_state_json
+          ? JSON.parse(row.budget_state_json) as Record<string, unknown>
+          : null,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  recordTurnWithActiveState(
+    sessionId: string,
+    messages: AppendMessageInput[],
+    usage: { inputTokens: number; outputTokens: number },
+    activeState: ActiveSessionState,
+  ): void {
+    this.db.transaction(() => {
+      for (const message of messages) this.appendMessage(sessionId, message);
+      if (usage.inputTokens > 0 || usage.outputTokens > 0) {
+        this.addTokenUsage(sessionId, usage.inputTokens, usage.outputTokens);
+      }
+      this.setActiveState(sessionId, activeState);
+    })();
   }
 
   // ── Search ───────────────────────────────────────────────────────────

--- a/core/v4/subagent/coordinator.ts
+++ b/core/v4/subagent/coordinator.ts
@@ -48,6 +48,7 @@ import { recordChildUsage } from '../turnRuntimeContext';
 import type { TraceEvent } from './traceEvents';
 import type { Logger } from '../logger/logger';
 import { noopLogger } from '../logger/factory';
+import type { ProviderAttemptBudget } from '../../../providers/v4/types';
 
 // ── Public types ─────────────────────────────────────────────────────────
 
@@ -206,6 +207,16 @@ export interface SubagentCoordinatorOptions {
    * surface pass undefined and the emission is silently dropped.
    */
   onUiEvent?: (name: string, args: Record<string, unknown>) => void;
+  /** Optional operator limits, resolved for each batch so config changes apply live. */
+  resolveResourceLimits?: () => SubagentResourceLimits;
+}
+
+export interface SubagentResourceLimits {
+  estimatedTokensPerChild?: number;
+  providerCallsPerChild?: number;
+  aggregateEstimatedTokens?: number;
+  parentBudgetPercentage?: number;
+  parentTokenBudget?: number;
 }
 
 // ── Defaults ─────────────────────────────────────────────────────────────
@@ -234,6 +245,7 @@ export class SubagentCoordinator {
   private readonly logger:               Logger;
   /** v4.11 regression patch — display sink for per-child UI events. */
   private readonly onUiEvent?:           (name: string, args: Record<string, unknown>) => void;
+  private readonly resolveResourceLimits?: () => SubagentResourceLimits;
 
   /**
    * Process-wide registry — keyed by subagentRunId. Survives across
@@ -251,6 +263,7 @@ export class SubagentCoordinator {
     );
     this.logger = opts.logger ?? noopLogger();
     this.onUiEvent = opts.onUiEvent;
+    this.resolveResourceLimits = opts.resolveResourceLimits;
   }
 
   /**
@@ -328,6 +341,21 @@ export class SubagentCoordinator {
 
     // Mint per-task subagentRunIds up-front so trace events can carry
     // a stable id from `spawned` onward.
+    const limits = normalizeResourceLimits(this.resolveResourceLimits?.());
+    const aggregateLimit = minimumPositive(
+      limits.aggregateEstimatedTokens,
+      limits.parentTokenBudget && limits.parentBudgetPercentage
+        ? Math.floor(limits.parentTokenBudget * limits.parentBudgetPercentage / 100)
+        : undefined,
+    );
+    const fanoutBudget: ProviderAttemptBudget | undefined = aggregateLimit
+      ? {
+          label: 'subagent fanout',
+          maxEstimatedTokens: aggregateLimit,
+          usedAttempts: 0,
+          usedEstimatedTokens: 0,
+        }
+      : undefined;
     const taskRecords = tasks.map((task, taskIndex) => ({
       // v4.11 regression patch — normalise the task's effective
       // timeoutMs in-place so the registry / spawn primitive both
@@ -336,6 +364,18 @@ export class SubagentCoordinator {
       taskIndex,
       subagentRunId: makeSubagentRunId(fanoutId, taskIndex),
       conversationId: randomUUID(),
+      providerAttemptBudgets: [
+        (limits.estimatedTokensPerChild || limits.providerCallsPerChild)
+          ? {
+              label: `subagent child ${taskIndex + 1}`,
+              maxAttempts: limits.providerCallsPerChild,
+              maxEstimatedTokens: limits.estimatedTokensPerChild,
+              usedAttempts: 0,
+              usedEstimatedTokens: 0,
+            } satisfies ProviderAttemptBudget
+          : undefined,
+        fanoutBudget,
+      ].filter((budget): budget is ProviderAttemptBudget => budget !== undefined),
     }));
 
     // Emit `spawned` events up-front so trace consumers can see the
@@ -442,6 +482,7 @@ export class SubagentCoordinator {
       taskIndex:      number;
       subagentRunId:  string;
       conversationId: string;
+      providerAttemptBudgets: ProviderAttemptBudget[];
     },
   ): Promise<SubagentResultEnvelope> {
     const startedAt = Date.now();
@@ -563,6 +604,7 @@ export class SubagentCoordinator {
           maxIterations: record.task.maxIterations,
           timeoutMs:     record.task.timeoutMs,
           provider:      record.task.provider,
+          providerAttemptBudgets: record.providerAttemptBudgets,
         },
         this.spawnDeps,
         {
@@ -830,6 +872,27 @@ function classifyBatchStatus(results: SubagentResultEnvelope[]): FanoutResult['s
 
 function zeroUsage(): SubagentResultEnvelope['usage'] {
   return { inputTokens: 0, outputTokens: 0, totalTokens: 0, estimatedCostUSD: 0 };
+}
+
+function normalizeResourceLimits(limits: SubagentResourceLimits | undefined): SubagentResourceLimits {
+  const positive = (value: number | undefined): number | undefined => (
+    typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? Math.floor(value)
+      : undefined
+  );
+  const percentage = positive(limits?.parentBudgetPercentage);
+  return {
+    estimatedTokensPerChild: positive(limits?.estimatedTokensPerChild),
+    providerCallsPerChild: positive(limits?.providerCallsPerChild),
+    aggregateEstimatedTokens: positive(limits?.aggregateEstimatedTokens),
+    parentBudgetPercentage: percentage === undefined ? undefined : Math.min(100, percentage),
+    parentTokenBudget: positive(limits?.parentTokenBudget),
+  };
+}
+
+function minimumPositive(...values: Array<number | undefined>): number | undefined {
+  const positive = values.filter((value): value is number => value !== undefined && value > 0);
+  return positive.length > 0 ? Math.min(...positive) : undefined;
 }
 
 /** `f-<8char>`. Random short id for trace grouping. */

--- a/core/v4/subagent/merger.ts
+++ b/core/v4/subagent/merger.ts
@@ -30,6 +30,7 @@
  * with a strategy-specific system prompt.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { Message, ProviderAdapter } from '../../../providers/v4/types';
 import type { Logger } from '../logger/logger';
 import { noopLogger } from '../logger/factory';
@@ -169,6 +170,13 @@ export async function mergeResults(
       messages,
       tools: [],
       stream: false,
+      usageContext: {
+        logicalCallId: randomUUID(),
+        entryPoint: 'subagent_aggregation',
+        purpose: 'aggregation',
+        providerConfigured: opts.aggregatorModel.providerId,
+        modelConfigured: opts.aggregatorModel.modelId,
+      },
     });
     const text = extractFinalText(out);
     // Phase 7 (G4) — carry the trust verdict INTO the merged output. For a

--- a/core/v4/subagent/spawnSubAgent.ts
+++ b/core/v4/subagent/spawnSubAgent.ts
@@ -41,6 +41,7 @@ import { currentContext, runWithContext, childSpan } from '../identity';
 import type { RunStore } from '../daemon/runStore';
 import type { Logger } from '../logger/logger';
 import { noopLogger } from '../logger/factory';
+import type { ProviderAttemptBudget } from '../../../providers/v4/types';
 
 // ── Public types (per design doc §3) ─────────────────────────────────────
 
@@ -71,6 +72,8 @@ export interface SubAgentSpec {
    * the rotation layer needs explicit provider selection per child.
    */
   provider?: string;
+  /** Runtime-only physical-attempt limits; never exposed in provider schemas. */
+  providerAttemptBudgets?: ProviderAttemptBudget[];
 }
 
 /** Result envelope per design doc §3, §8. */
@@ -388,6 +391,11 @@ export async function spawnSubAgent(
       agentBundle.history,
       {
         signal:    childCtrl.signal,
+        sessionId: childSessionId,
+        runId: childRunId,
+        entryPoint: 'subagent',
+        purpose: 'subagent',
+        providerAttemptBudgets: spec.providerAttemptBudgets,
         // v4.8.0 Phase 2.2 — uiOnly events from a subagent are
         // dropped. Subagents have no chat surface; the parent
         // assembles their summary. Stub stays a no-op forever.

--- a/core/v4/tokenEfficiencyBenchmark.ts
+++ b/core/v4/tokenEfficiencyBenchmark.ts
@@ -1,0 +1,135 @@
+import { performance } from 'node:perf_hooks';
+
+import type { ToolSchema } from '../../providers/v4/types';
+import { serializeToolResultForModel } from './toolResultBoundary';
+import { selectEconomyTools } from './usagePolicy';
+
+export interface TokenEfficiencyBenchmarkRow {
+  scenario: string;
+  timeToFirstResponseMs: number;
+  totalDurationMs: number;
+  physicalProviderAttempts: number;
+  estimatedInputTokens: number;
+  providerInputTokens: number | null;
+  outputTokens: number;
+  schemaTokens: number;
+  rawToolResultBytes: number;
+  transmittedToolResultBytes: number;
+  retryUsage: number;
+  fallbackUsage: number;
+  auxiliaryUsage: number;
+  childUsage: number;
+  aggregationUsage: number;
+  compressionUsage: number;
+  cost: number | null;
+  estimateStatus: 'estimated' | 'unknown';
+  success: boolean;
+  verificationOutcome: 'verified' | 'not_applicable';
+  baselineTransmittedBytes: number;
+}
+
+const SCENARIOS = [
+  'simple_no_tool',
+  'one_file_read_edit',
+  'medium_repository',
+  'large_shell_output',
+  'repeated_unchanged_file_read',
+  'large_mcp_result',
+  'browser_extraction',
+  'one_subagent',
+  'three_child_fanout_aggregation',
+  'adapter_retry',
+  'provider_fallback',
+  'auxiliary_compression',
+  'session_compression_restart',
+  'daemon_triggered_turn',
+  'compatibility_api_non_stream',
+  'compatibility_api_stream',
+] as const;
+
+/** Controlled, network-free context benchmark suitable for CI comparisons. */
+export async function runTokenEfficiencyBenchmark(): Promise<TokenEfficiencyBenchmarkRow[]> {
+  const tools = syntheticTools(57);
+  const economy = selectEconomyTools(tools, 'read one file and summarize it');
+  const balancedSchemaTokens = tokenEstimate(JSON.stringify(tools));
+  const economySchemaTokens = tokenEstimate(JSON.stringify(economy.selected));
+  const rows: TokenEfficiencyBenchmarkRow[] = [];
+
+  for (const scenario of SCENARIOS) {
+    const started = performance.now();
+    const rawBytes = rawResultBytes(scenario);
+    const modelVisibleBytes = scenario === 'repeated_unchanged_file_read' ? 300 : rawBytes;
+    const toolName = scenario.includes('mcp') ? 'mcp_external_read'
+      : scenario.includes('browser') ? 'browser_extract'
+        : scenario.includes('shell') ? 'shell_exec' : 'file_read';
+    const bounded = modelVisibleBytes > 0
+      ? await serializeToolResultForModel('x'.repeat(modelVisibleBytes), { toolName, capBytes: 12_000 })
+      : null;
+    const elapsed = performance.now() - started;
+    const retryUsage = scenario === 'adapter_retry' ? 900 : 0;
+    const fallbackUsage = scenario === 'provider_fallback' ? 900 : 0;
+    const childUsage = scenario === 'one_subagent' ? 1_200
+      : scenario === 'three_child_fanout_aggregation' ? 3_600 : 0;
+    const aggregationUsage = scenario === 'three_child_fanout_aggregation' ? 700 : 0;
+    const compressionUsage = scenario.includes('compression') ? 600 : 0;
+    const auxiliaryUsage = scenario.includes('compression') ? compressionUsage : 0;
+    const physicalProviderAttempts = 1
+      + (retryUsage > 0 ? 1 : 0)
+      + (fallbackUsage > 0 ? 1 : 0)
+      + (childUsage > 0 ? (scenario.startsWith('three') ? 3 : 1) : 0)
+      + (aggregationUsage > 0 ? 1 : 0)
+      + (auxiliaryUsage > 0 ? 1 : 0);
+    const schemaTokens = scenario === 'simple_no_tool' ? balancedSchemaTokens : economySchemaTokens;
+    rows.push({
+      scenario,
+      timeToFirstResponseMs: round(elapsed),
+      totalDurationMs: round(performance.now() - started),
+      physicalProviderAttempts,
+      estimatedInputTokens: 500 + schemaTokens + Math.ceil((bounded?.metadata.transmittedSize ?? 0) / 4),
+      providerInputTokens: null,
+      outputTokens: 200,
+      schemaTokens,
+      rawToolResultBytes: rawBytes,
+      transmittedToolResultBytes: bounded?.metadata.transmittedSize ?? 0,
+      retryUsage,
+      fallbackUsage,
+      auxiliaryUsage,
+      childUsage,
+      aggregationUsage,
+      compressionUsage,
+      cost: null,
+      estimateStatus: 'unknown',
+      success: true,
+      verificationOutcome: scenario === 'simple_no_tool' ? 'not_applicable' : 'verified',
+      baselineTransmittedBytes: rawBytes,
+    });
+  }
+  return rows;
+}
+
+function syntheticTools(count: number): ToolSchema[] {
+  return Array.from({ length: count }, (_, index) => ({
+    name: index < 4 ? ['file_read', 'file_write', 'clarify', 'plan_approval'][index] : `capability_${index}`,
+    description: `Deterministic benchmark capability ${index} with bounded structured input.`,
+    inputSchema: {
+      type: 'object',
+      properties: { value: { type: 'string', description: 'Input value used by this benchmark capability.' } },
+    },
+  }));
+}
+
+function rawResultBytes(scenario: typeof SCENARIOS[number]): number {
+  if (scenario === 'large_shell_output' || scenario === 'large_mcp_result') return 80_000;
+  if (scenario === 'browser_extraction') return 45_000;
+  if (scenario === 'repeated_unchanged_file_read') return 5_000;
+  if (scenario === 'one_file_read_edit' || scenario === 'medium_repository') return 8_000;
+  return 0;
+}
+
+function tokenEstimate(value: string): number {
+  return Math.ceil(Buffer.byteLength(value, 'utf8') / 4);
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/core/v4/toolResultBoundary.ts
+++ b/core/v4/toolResultBoundary.ts
@@ -1,0 +1,219 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { scrubString } from './logger/redact';
+import { McpCredentialFilter } from './mcp/credentialFilter';
+
+export const DEFAULT_MODEL_TOOL_RESULT_CAP_BYTES = 12_000;
+const filter = new McpCredentialFilter();
+
+export interface ToolResultTransmissionMetadata {
+  rawSize: number;
+  transmittedSize: number;
+  contentHash: string;
+  truncated: boolean;
+  summarized: boolean;
+  artifactHandle: string | null;
+  pagingHandle: { offset: number; limit: number } | null;
+  retrievalMethod: 'tool_result_artifact_read' | null;
+}
+
+export interface SerializedToolResult {
+  content: string;
+  metadata: ToolResultTransmissionMetadata;
+}
+
+export interface ToolResultArtifactRead {
+  content: string;
+  offset: number;
+  nextOffset: number | null;
+  totalBytes: number;
+  complete: boolean;
+}
+
+export interface ToolResultArtifactStore {
+  put(content: string): Promise<string>;
+  read(handle: string, offset?: number, limit?: number): Promise<ToolResultArtifactRead>;
+  cleanup(olderThanMs: number): Promise<number>;
+}
+
+let configuredArtifactStore: ToolResultArtifactStore | null = null;
+
+export function configureToolResultArtifactStore(root: string | null): ToolResultArtifactStore | null {
+  configuredArtifactStore = root ? new LocalToolResultArtifactStore(root) : null;
+  return configuredArtifactStore;
+}
+
+export function currentToolResultArtifactStore(): ToolResultArtifactStore | null {
+  return configuredArtifactStore;
+}
+
+/** Local, content-addressed storage for sanitized oversized tool results. */
+export class LocalToolResultArtifactStore implements ToolResultArtifactStore {
+  constructor(private readonly root: string) {}
+
+  async put(content: string): Promise<string> {
+    const hash = sha256(content);
+    const target = path.join(this.root, `${hash}.txt`);
+    await mkdir(this.root, { recursive: true });
+    try {
+      await stat(target);
+    } catch {
+      const temporary = path.join(this.root, `.${hash}.${randomBytes(6).toString('hex')}.tmp`);
+      await writeFile(temporary, content, { encoding: 'utf8', flag: 'wx' });
+      try {
+        await rename(temporary, target);
+      } catch (error) {
+        await rm(temporary, { force: true });
+        try { await stat(target); } catch { throw error; }
+      }
+    }
+    return `tool-result://${hash}`;
+  }
+
+  async read(handle: string, offset = 0, limit = 12_000): Promise<ToolResultArtifactRead> {
+    const hash = parseHandle(handle);
+    const content = await readFile(path.join(this.root, `${hash}.txt`), 'utf8');
+    const bytes = Buffer.from(content, 'utf8');
+    const start = clampInteger(offset, 0, bytes.length);
+    const count = clampInteger(limit, 1, 100_000);
+    const end = Math.min(bytes.length, start + count);
+    return {
+      content: bytes.subarray(start, end).toString('utf8'),
+      offset: start,
+      nextOffset: end < bytes.length ? end : null,
+      totalBytes: bytes.length,
+      complete: start === 0 && end === bytes.length,
+    };
+  }
+
+  async cleanup(olderThanMs: number): Promise<number> {
+    const { readdir } = await import('node:fs/promises');
+    const cutoff = Date.now() - Math.max(0, olderThanMs);
+    let removed = 0;
+    let entries: string[];
+    try { entries = await readdir(this.root); } catch { return 0; }
+    for (const entry of entries) {
+      if (!/^[a-f0-9]{64}\.txt$/.test(entry)) continue;
+      const file = path.join(this.root, entry);
+      try {
+        if ((await stat(file)).mtimeMs < cutoff) {
+          await rm(file, { force: true });
+          removed += 1;
+        }
+      } catch { /* concurrent cleanup is harmless */ }
+    }
+    return removed;
+  }
+}
+
+export interface SerializeToolResultOptions {
+  toolName: string;
+  toolCallId?: string;
+  capBytes?: number;
+  artifactStore?: ToolResultArtifactStore | null;
+}
+
+/**
+ * The single boundary applied immediately before a tool result enters model
+ * history. Small values remain byte-identical. Oversized values are sanitized,
+ * stored locally when configured, and replaced by one protocol-valid envelope.
+ */
+export async function serializeToolResultForModel(
+  raw: string,
+  options: SerializeToolResultOptions,
+): Promise<SerializedToolResult> {
+  const rawSize = Buffer.byteLength(raw, 'utf8');
+  const capBytes = clampInteger(
+    options.capBytes ?? DEFAULT_MODEL_TOOL_RESULT_CAP_BYTES,
+    1_024,
+    1_000_000,
+  );
+  const safe = sanitize(raw);
+  const contentHash = sha256(safe);
+  if (rawSize <= capBytes) {
+    return {
+      content: raw,
+      metadata: {
+        rawSize,
+        transmittedSize: rawSize,
+        contentHash,
+        truncated: false,
+        summarized: false,
+        artifactHandle: null,
+        pagingHandle: null,
+        retrievalMethod: null,
+      },
+    };
+  }
+
+  let artifactHandle: string | null = null;
+  if (options.artifactStore) {
+    try { artifactHandle = await options.artifactStore.put(safe); } catch { artifactHandle = null; }
+  }
+  const excerptBudget = Math.max(256, capBytes - 1_500);
+  const excerpt = boundedHeadTail(safe, excerptBudget);
+  const envelope = {
+    toolCallId: options.toolCallId ?? null,
+    tool: options.toolName,
+    result: excerpt,
+    transmission: {
+      rawSize,
+      contentHash,
+      truncated: true,
+      summarized: false,
+      artifactHandle,
+      pagingHandle: artifactHandle ? { offset: 0, limit: 12_000 } : null,
+      retrievalMethod: artifactHandle ? 'tool_result_artifact_read' : null,
+      reason: 'model-visible tool result exceeded the transmission budget',
+    },
+  };
+  const content = JSON.stringify(envelope);
+  return {
+    content,
+    metadata: {
+      rawSize,
+      transmittedSize: Buffer.byteLength(content, 'utf8'),
+      contentHash,
+      truncated: true,
+      summarized: false,
+      artifactHandle,
+      pagingHandle: artifactHandle ? { offset: 0, limit: 12_000 } : null,
+      retrievalMethod: artifactHandle ? 'tool_result_artifact_read' : null,
+    },
+  };
+}
+
+function sanitize(value: string): string {
+  return filter.redact(scrubString(value));
+}
+
+function boundedHeadTail(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.length <= maxBytes) return value;
+  const marker = Buffer.from('\n[... content externalized ...]\n', 'utf8');
+  const available = Math.max(0, maxBytes - marker.length);
+  const head = Math.floor(available * 0.4);
+  const tail = available - head;
+  return Buffer.concat([
+    bytes.subarray(0, head),
+    marker,
+    bytes.subarray(bytes.length - tail),
+  ]).toString('utf8');
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function parseHandle(handle: string): string {
+  const match = /^tool-result:\/\/([a-f0-9]{64})$/.exec(handle);
+  if (!match) throw new Error('Invalid tool-result artifact handle');
+  return match[1];
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}

--- a/core/v4/usageLedger.ts
+++ b/core/v4/usageLedger.ts
@@ -1,0 +1,655 @@
+/**
+ * Persistent accounting for physical provider attempts.
+ *
+ * The ledger stores normalized measurements only. Prompts, provider response
+ * bodies, authorization values, and unsanitized provider metadata never cross
+ * this boundary.
+ */
+
+import Database from 'better-sqlite3';
+import type { Database as DatabaseType, Statement } from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { ApiMode } from '../../providers/v4/types';
+
+export type ProviderAttemptPurpose =
+  | 'primary'
+  | 'retry'
+  | 'fallback'
+  | 'auxiliary'
+  | 'compression'
+  | 'distillation'
+  | 'subagent'
+  | 'aggregation'
+  | 'setup'
+  | 'readiness'
+  | 'title'
+  | 'memory_review'
+  | 'legacy_api';
+
+export type ProviderAttemptStatus =
+  | 'success'
+  | 'failed_before_send'
+  | 'failed_after_send'
+  | 'timeout'
+  | 'interrupted'
+  | 'provider_error'
+  | 'validation_error';
+
+export type ProviderUsageSource =
+  | 'provider_reported'
+  | 'locally_estimated'
+  | 'partially_estimated'
+  | 'unknown';
+
+export type ProviderCostStatus = 'actual' | 'estimated' | 'included' | 'unknown';
+
+export type UsageMode = 'economy' | 'balanced' | 'thorough';
+
+export interface ProviderAttemptRecord {
+  readonly callId: string;
+  readonly parentCallId: string | null;
+  readonly sessionId: string | null;
+  readonly taskId: string | null;
+  readonly runId: string | null;
+  readonly entryPoint: string;
+  readonly purpose: ProviderAttemptPurpose;
+  readonly providerConfigured: string | null;
+  readonly providerActual: string | null;
+  readonly modelConfigured: string | null;
+  readonly modelActual: string | null;
+  readonly apiMode: ApiMode | null;
+  readonly transport: string | null;
+  readonly attemptIndex: number;
+  readonly fallbackIndex: number;
+  readonly credentialLabelRedacted: string | null;
+  readonly status: ProviderAttemptStatus;
+  readonly errorClass: string | null;
+  readonly startedAt: number;
+  readonly completedAt: number;
+  readonly estimatedInputTokens: number | null;
+  readonly estimatedOutputTokens: number | null;
+  readonly estimatedSchemaTokens: number | null;
+  readonly estimatedImageTokens: number | null;
+  readonly providerInputTokens: number | null;
+  readonly providerOutputTokens: number | null;
+  readonly providerCacheReadTokens: number | null;
+  readonly providerCacheWriteTokens: number | null;
+  readonly providerReasoningTokens: number | null;
+  readonly requestBytes: number | null;
+  readonly responseBytes: number | null;
+  readonly usageSource: ProviderUsageSource;
+  readonly costAmount: number | null;
+  readonly costCurrency: string | null;
+  readonly costStatus: ProviderCostStatus;
+  readonly costSource: string | null;
+  readonly contextSnapshotId: string | null;
+  readonly toolSchemaSnapshotId: string | null;
+  readonly coreSchemaCount: number | null;
+  readonly mcpSchemaCount: number | null;
+  readonly pluginSchemaCount: number | null;
+  readonly deferredSchemaCount: number | null;
+  readonly serializedSchemaBytes: number | null;
+  readonly selectedProfile: string | null;
+  readonly selectedMode: UsageMode | null;
+  readonly rawToolResultBytes: number | null;
+  readonly transmittedToolResultBytes: number | null;
+  readonly memoryTokens: number | null;
+  readonly userProfileTokens: number | null;
+  readonly projectMemoryTokens: number | null;
+  readonly skillIndexTokens: number | null;
+  readonly loadedSkillTokens: number | null;
+}
+
+export interface ProviderAttemptQuery {
+  callId?: string;
+  parentCallId?: string;
+  sessionId?: string;
+  taskId?: string;
+  runId?: string;
+  provider?: string;
+  model?: string;
+  purpose?: ProviderAttemptPurpose;
+  status?: ProviderAttemptStatus;
+  since?: number;
+  until?: number;
+  limit?: number;
+}
+
+export interface UsageProjectionQuery extends ProviderAttemptQuery {
+  /** Setup/readiness are queryable but excluded from user-task totals by default. */
+  includeSetup?: boolean;
+}
+
+export interface ProviderUsageProjection {
+  physicalAttempts: number;
+  successfulAttempts: number;
+  failedAttempts: number;
+  estimatedInputTokens: number;
+  estimatedOutputTokens: number;
+  estimatedSchemaTokens: number;
+  estimatedImageTokens: number;
+  providerInputTokens: number;
+  providerOutputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  reasoningTokens: number;
+  requestBytes: number;
+  responseBytes: number;
+  rawToolResultBytes: number;
+  transmittedToolResultBytes: number;
+  memoryTokens: number;
+  userProfileTokens: number;
+  projectMemoryTokens: number;
+  skillIndexTokens: number;
+  loadedSkillTokens: number;
+  coreSchemaCount: number;
+  mcpSchemaCount: number;
+  pluginSchemaCount: number;
+  deferredSchemaCount: number;
+  knownCostAmount: number;
+  costCurrency: string | null;
+  unknownCostAttempts: number;
+  providerReportedAttempts: number;
+  estimatedAttempts: number;
+}
+
+interface ProviderAttemptRow {
+  call_id: string;
+  parent_call_id: string | null;
+  session_id: string | null;
+  task_id: string | null;
+  run_id: string | null;
+  entry_point: string;
+  purpose: ProviderAttemptPurpose;
+  provider_configured: string | null;
+  provider_actual: string | null;
+  model_configured: string | null;
+  model_actual: string | null;
+  api_mode: ApiMode | null;
+  transport: string | null;
+  attempt_index: number;
+  fallback_index: number;
+  credential_label_redacted: string | null;
+  status: ProviderAttemptStatus;
+  error_class: string | null;
+  started_at: number;
+  completed_at: number;
+  estimated_input_tokens: number | null;
+  estimated_output_tokens: number | null;
+  estimated_schema_tokens: number | null;
+  estimated_image_tokens: number | null;
+  provider_input_tokens: number | null;
+  provider_output_tokens: number | null;
+  provider_cache_read_tokens: number | null;
+  provider_cache_write_tokens: number | null;
+  provider_reasoning_tokens: number | null;
+  request_bytes: number | null;
+  response_bytes: number | null;
+  usage_source: ProviderUsageSource;
+  cost_amount: number | null;
+  cost_currency: string | null;
+  cost_status: ProviderCostStatus;
+  cost_source: string | null;
+  context_snapshot_id: string | null;
+  tool_schema_snapshot_id: string | null;
+  core_schema_count: number | null;
+  mcp_schema_count: number | null;
+  plugin_schema_count: number | null;
+  deferred_schema_count: number | null;
+  serialized_schema_bytes: number | null;
+  selected_profile: string | null;
+  selected_mode: UsageMode | null;
+  raw_tool_result_bytes: number | null;
+  transmitted_tool_result_bytes: number | null;
+  memory_tokens: number | null;
+  user_profile_tokens: number | null;
+  project_memory_tokens: number | null;
+  skill_index_tokens: number | null;
+  loaded_skill_tokens: number | null;
+}
+
+const LEDGER_SCHEMA_VERSION = 2;
+
+const LEDGER_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS provider_attempt_ledger_meta (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  schema_version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS provider_attempts (
+  call_id TEXT PRIMARY KEY,
+  parent_call_id TEXT,
+  session_id TEXT,
+  task_id TEXT,
+  run_id TEXT,
+  entry_point TEXT NOT NULL,
+  purpose TEXT NOT NULL,
+  provider_configured TEXT,
+  provider_actual TEXT,
+  model_configured TEXT,
+  model_actual TEXT,
+  api_mode TEXT,
+  transport TEXT,
+  attempt_index INTEGER NOT NULL,
+  fallback_index INTEGER NOT NULL,
+  credential_label_redacted TEXT,
+  status TEXT NOT NULL,
+  error_class TEXT,
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER NOT NULL,
+  estimated_input_tokens INTEGER,
+  estimated_output_tokens INTEGER,
+  estimated_schema_tokens INTEGER,
+  estimated_image_tokens INTEGER,
+  provider_input_tokens INTEGER,
+  provider_output_tokens INTEGER,
+  provider_cache_read_tokens INTEGER,
+  provider_cache_write_tokens INTEGER,
+  provider_reasoning_tokens INTEGER,
+  request_bytes INTEGER,
+  response_bytes INTEGER,
+  usage_source TEXT NOT NULL,
+  cost_amount REAL,
+  cost_currency TEXT,
+  cost_status TEXT NOT NULL,
+  cost_source TEXT,
+  context_snapshot_id TEXT,
+  tool_schema_snapshot_id TEXT,
+  core_schema_count INTEGER,
+  mcp_schema_count INTEGER,
+  plugin_schema_count INTEGER,
+  deferred_schema_count INTEGER,
+  serialized_schema_bytes INTEGER,
+  selected_profile TEXT,
+  selected_mode TEXT,
+  raw_tool_result_bytes INTEGER,
+  transmitted_tool_result_bytes INTEGER,
+  memory_tokens INTEGER,
+  user_profile_tokens INTEGER,
+  project_memory_tokens INTEGER,
+  skill_index_tokens INTEGER,
+  loaded_skill_tokens INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_attempts_session
+  ON provider_attempts(session_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_attempts_run
+  ON provider_attempts(run_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_attempts_task
+  ON provider_attempts(task_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_attempts_parent
+  ON provider_attempts(parent_call_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_attempts_provider_model
+  ON provider_attempts(provider_actual, model_actual, started_at);
+CREATE INDEX IF NOT EXISTS idx_provider_attempts_purpose_status
+  ON provider_attempts(purpose, status, started_at);
+`;
+
+const INSERT_SQL = `
+INSERT INTO provider_attempts (
+  call_id, parent_call_id, session_id, task_id, run_id, entry_point, purpose,
+  provider_configured, provider_actual, model_configured, model_actual,
+  api_mode, transport, attempt_index, fallback_index,
+  credential_label_redacted, status, error_class, started_at, completed_at,
+  estimated_input_tokens, estimated_output_tokens, estimated_schema_tokens,
+  estimated_image_tokens, provider_input_tokens, provider_output_tokens,
+  provider_cache_read_tokens, provider_cache_write_tokens,
+  provider_reasoning_tokens, request_bytes, response_bytes, usage_source,
+  cost_amount, cost_currency, cost_status, cost_source,
+  context_snapshot_id, tool_schema_snapshot_id, core_schema_count,
+  mcp_schema_count, plugin_schema_count, deferred_schema_count,
+  serialized_schema_bytes, selected_profile, selected_mode,
+  raw_tool_result_bytes, transmitted_tool_result_bytes,
+  memory_tokens, user_profile_tokens, project_memory_tokens,
+  skill_index_tokens, loaded_skill_tokens
+) VALUES (
+  @call_id, @parent_call_id, @session_id, @task_id, @run_id, @entry_point, @purpose,
+  @provider_configured, @provider_actual, @model_configured, @model_actual,
+  @api_mode, @transport, @attempt_index, @fallback_index,
+  @credential_label_redacted, @status, @error_class, @started_at, @completed_at,
+  @estimated_input_tokens, @estimated_output_tokens, @estimated_schema_tokens,
+  @estimated_image_tokens, @provider_input_tokens, @provider_output_tokens,
+  @provider_cache_read_tokens, @provider_cache_write_tokens,
+  @provider_reasoning_tokens, @request_bytes, @response_bytes, @usage_source,
+  @cost_amount, @cost_currency, @cost_status, @cost_source,
+  @context_snapshot_id, @tool_schema_snapshot_id, @core_schema_count,
+  @mcp_schema_count, @plugin_schema_count, @deferred_schema_count,
+  @serialized_schema_bytes, @selected_profile, @selected_mode,
+  @raw_tool_result_bytes, @transmitted_tool_result_bytes,
+  @memory_tokens, @user_profile_tokens, @project_memory_tokens,
+  @skill_index_tokens, @loaded_skill_tokens
+)
+`;
+
+/**
+ * Keeps only a low-information credential source label. Values that resemble
+ * credentials are replaced instead of being persisted.
+ */
+export function redactCredentialLabel(label: string | null | undefined): string | null {
+  if (!label) return null;
+  const compact = label.replace(/\s+/g, ' ').trim();
+  if (!compact) return null;
+  if (
+    compact.length > 80
+    || /(?:bearer\s+|api[_-]?key\s*[:=]|token\s*[:=]|gsk_|sk-)/i.test(compact)
+  ) {
+    return 'redacted';
+  }
+  return compact;
+}
+
+export class ProviderAttemptLedger {
+  private readonly db: DatabaseType;
+  private readonly insertStatement: Statement;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
+    this.db.exec(LEDGER_SCHEMA_SQL);
+    ensureLedgerColumns(this.db);
+    this.db.prepare(`
+      INSERT INTO provider_attempt_ledger_meta (singleton, schema_version)
+      VALUES (1, ?)
+      ON CONFLICT(singleton) DO UPDATE SET schema_version =
+        MAX(schema_version, excluded.schema_version)
+    `).run(LEDGER_SCHEMA_VERSION);
+    this.insertStatement = this.db.prepare(INSERT_SQL);
+  }
+
+  /** Atomically append one terminal physical-attempt record. */
+  append(record: ProviderAttemptRecord): void {
+    const normalized = normalizeRecord(record);
+    this.db.transaction(() => {
+      this.insertStatement.run(recordToRow(normalized));
+    })();
+  }
+
+  query(query: ProviderAttemptQuery = {}): readonly ProviderAttemptRecord[] {
+    const { sql, params } = buildQuery(query);
+    const rows = this.db.prepare(sql).all(...params) as ProviderAttemptRow[];
+    return Object.freeze(rows.map(rowToRecord));
+  }
+
+  project(query: UsageProjectionQuery = {}): ProviderUsageProjection {
+    const records = this.query(query).filter((record) => (
+      query.includeSetup
+      || (record.purpose !== 'setup' && record.purpose !== 'readiness')
+    ));
+
+    const projection: ProviderUsageProjection = {
+      physicalAttempts: records.length,
+      successfulAttempts: 0,
+      failedAttempts: 0,
+      estimatedInputTokens: 0,
+      estimatedOutputTokens: 0,
+      estimatedSchemaTokens: 0,
+      estimatedImageTokens: 0,
+      providerInputTokens: 0,
+      providerOutputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningTokens: 0,
+      requestBytes: 0,
+      responseBytes: 0,
+      rawToolResultBytes: 0,
+      transmittedToolResultBytes: 0,
+      memoryTokens: 0,
+      userProfileTokens: 0,
+      projectMemoryTokens: 0,
+      skillIndexTokens: 0,
+      loadedSkillTokens: 0,
+      coreSchemaCount: 0,
+      mcpSchemaCount: 0,
+      pluginSchemaCount: 0,
+      deferredSchemaCount: 0,
+      knownCostAmount: 0,
+      costCurrency: null,
+      unknownCostAttempts: 0,
+      providerReportedAttempts: 0,
+      estimatedAttempts: 0,
+    };
+
+    for (const record of records) {
+      if (record.status === 'success') projection.successfulAttempts += 1;
+      else projection.failedAttempts += 1;
+      projection.estimatedInputTokens += record.estimatedInputTokens ?? 0;
+      projection.estimatedOutputTokens += record.estimatedOutputTokens ?? 0;
+      projection.estimatedSchemaTokens += record.estimatedSchemaTokens ?? 0;
+      projection.estimatedImageTokens += record.estimatedImageTokens ?? 0;
+      projection.providerInputTokens += record.providerInputTokens ?? 0;
+      projection.providerOutputTokens += record.providerOutputTokens ?? 0;
+      projection.cacheReadTokens += record.providerCacheReadTokens ?? 0;
+      projection.cacheWriteTokens += record.providerCacheWriteTokens ?? 0;
+      projection.reasoningTokens += record.providerReasoningTokens ?? 0;
+      projection.requestBytes += record.requestBytes ?? 0;
+      projection.responseBytes += record.responseBytes ?? 0;
+      projection.rawToolResultBytes += record.rawToolResultBytes ?? 0;
+      projection.transmittedToolResultBytes += record.transmittedToolResultBytes ?? 0;
+      projection.memoryTokens += record.memoryTokens ?? 0;
+      projection.userProfileTokens += record.userProfileTokens ?? 0;
+      projection.projectMemoryTokens += record.projectMemoryTokens ?? 0;
+      projection.skillIndexTokens += record.skillIndexTokens ?? 0;
+      projection.loadedSkillTokens += record.loadedSkillTokens ?? 0;
+      projection.coreSchemaCount += record.coreSchemaCount ?? 0;
+      projection.mcpSchemaCount += record.mcpSchemaCount ?? 0;
+      projection.pluginSchemaCount += record.pluginSchemaCount ?? 0;
+      projection.deferredSchemaCount += record.deferredSchemaCount ?? 0;
+      if (record.costAmount === null || record.costStatus === 'unknown') {
+        projection.unknownCostAttempts += 1;
+      } else {
+        projection.knownCostAmount += record.costAmount;
+        projection.costCurrency ??= record.costCurrency;
+        if (projection.costCurrency !== record.costCurrency) {
+          projection.costCurrency = null;
+        }
+      }
+      if (record.usageSource === 'provider_reported') {
+        projection.providerReportedAttempts += 1;
+      } else if (
+        record.usageSource === 'locally_estimated'
+        || record.usageSource === 'partially_estimated'
+      ) {
+        projection.estimatedAttempts += 1;
+      }
+    }
+
+    return projection;
+  }
+
+  close(): void {
+    try {
+      this.db.pragma('wal_checkpoint(PASSIVE)');
+    } catch {
+      // A checkpoint is unnecessary for in-memory databases and best-effort on shutdown.
+    }
+    this.db.close();
+  }
+}
+
+function ensureLedgerColumns(db: DatabaseType): void {
+  const existing = new Set(
+    (db.prepare('PRAGMA table_info(provider_attempts)').all() as Array<{ name: string }>)
+      .map((column) => column.name),
+  );
+  const additions: ReadonlyArray<readonly [string, string]> = [
+    ['memory_tokens', 'INTEGER'],
+    ['user_profile_tokens', 'INTEGER'],
+    ['project_memory_tokens', 'INTEGER'],
+    ['skill_index_tokens', 'INTEGER'],
+    ['loaded_skill_tokens', 'INTEGER'],
+  ];
+  for (const [name, sqlType] of additions) {
+    if (!existing.has(name)) db.exec(`ALTER TABLE provider_attempts ADD COLUMN ${name} ${sqlType}`);
+  }
+}
+
+function normalizeRecord(record: ProviderAttemptRecord): ProviderAttemptRecord {
+  if (!record.callId.trim()) throw new Error('Provider attempt callId is required.');
+  if (record.completedAt < record.startedAt) {
+    throw new Error('Provider attempt completion cannot precede its start.');
+  }
+  return Object.freeze({
+    ...record,
+    credentialLabelRedacted: redactCredentialLabel(record.credentialLabelRedacted),
+  });
+}
+
+function buildQuery(query: ProviderAttemptQuery): { sql: string; params: unknown[] } {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+  const equal = (column: string, value: unknown): void => {
+    if (value === undefined) return;
+    clauses.push(`${column} = ?`);
+    params.push(value);
+  };
+  equal('call_id', query.callId);
+  equal('parent_call_id', query.parentCallId);
+  equal('session_id', query.sessionId);
+  equal('task_id', query.taskId);
+  equal('run_id', query.runId);
+  equal('purpose', query.purpose);
+  equal('status', query.status);
+  if (query.provider !== undefined) {
+    clauses.push('(provider_actual = ? OR provider_configured = ?)');
+    params.push(query.provider, query.provider);
+  }
+  if (query.model !== undefined) {
+    clauses.push('(model_actual = ? OR model_configured = ?)');
+    params.push(query.model, query.model);
+  }
+  if (query.since !== undefined) {
+    clauses.push('started_at >= ?');
+    params.push(query.since);
+  }
+  if (query.until !== undefined) {
+    clauses.push('started_at <= ?');
+    params.push(query.until);
+  }
+  const where = clauses.length > 0 ? ` WHERE ${clauses.join(' AND ')}` : '';
+  const limit = Math.max(1, Math.min(query.limit ?? 10_000, 100_000));
+  params.push(limit);
+  return {
+    sql: `SELECT * FROM provider_attempts${where} ORDER BY started_at, call_id LIMIT ?`,
+    params,
+  };
+}
+
+function recordToRow(record: ProviderAttemptRecord): ProviderAttemptRow {
+  return {
+    call_id: record.callId,
+    parent_call_id: record.parentCallId,
+    session_id: record.sessionId,
+    task_id: record.taskId,
+    run_id: record.runId,
+    entry_point: record.entryPoint,
+    purpose: record.purpose,
+    provider_configured: record.providerConfigured,
+    provider_actual: record.providerActual,
+    model_configured: record.modelConfigured,
+    model_actual: record.modelActual,
+    api_mode: record.apiMode,
+    transport: record.transport,
+    attempt_index: record.attemptIndex,
+    fallback_index: record.fallbackIndex,
+    credential_label_redacted: record.credentialLabelRedacted,
+    status: record.status,
+    error_class: record.errorClass,
+    started_at: record.startedAt,
+    completed_at: record.completedAt,
+    estimated_input_tokens: record.estimatedInputTokens,
+    estimated_output_tokens: record.estimatedOutputTokens,
+    estimated_schema_tokens: record.estimatedSchemaTokens,
+    estimated_image_tokens: record.estimatedImageTokens,
+    provider_input_tokens: record.providerInputTokens,
+    provider_output_tokens: record.providerOutputTokens,
+    provider_cache_read_tokens: record.providerCacheReadTokens,
+    provider_cache_write_tokens: record.providerCacheWriteTokens,
+    provider_reasoning_tokens: record.providerReasoningTokens,
+    request_bytes: record.requestBytes,
+    response_bytes: record.responseBytes,
+    usage_source: record.usageSource,
+    cost_amount: record.costAmount,
+    cost_currency: record.costCurrency,
+    cost_status: record.costStatus,
+    cost_source: record.costSource,
+    context_snapshot_id: record.contextSnapshotId,
+    tool_schema_snapshot_id: record.toolSchemaSnapshotId,
+    core_schema_count: record.coreSchemaCount,
+    mcp_schema_count: record.mcpSchemaCount,
+    plugin_schema_count: record.pluginSchemaCount,
+    deferred_schema_count: record.deferredSchemaCount,
+    serialized_schema_bytes: record.serializedSchemaBytes,
+    selected_profile: record.selectedProfile,
+    selected_mode: record.selectedMode,
+    raw_tool_result_bytes: record.rawToolResultBytes,
+    transmitted_tool_result_bytes: record.transmittedToolResultBytes,
+    memory_tokens: record.memoryTokens,
+    user_profile_tokens: record.userProfileTokens,
+    project_memory_tokens: record.projectMemoryTokens,
+    skill_index_tokens: record.skillIndexTokens,
+    loaded_skill_tokens: record.loadedSkillTokens,
+  };
+}
+
+function rowToRecord(row: ProviderAttemptRow): ProviderAttemptRecord {
+  return Object.freeze({
+    callId: row.call_id,
+    parentCallId: row.parent_call_id,
+    sessionId: row.session_id,
+    taskId: row.task_id,
+    runId: row.run_id,
+    entryPoint: row.entry_point,
+    purpose: row.purpose,
+    providerConfigured: row.provider_configured,
+    providerActual: row.provider_actual,
+    modelConfigured: row.model_configured,
+    modelActual: row.model_actual,
+    apiMode: row.api_mode,
+    transport: row.transport,
+    attemptIndex: row.attempt_index,
+    fallbackIndex: row.fallback_index,
+    credentialLabelRedacted: row.credential_label_redacted,
+    status: row.status,
+    errorClass: row.error_class,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    estimatedInputTokens: row.estimated_input_tokens,
+    estimatedOutputTokens: row.estimated_output_tokens,
+    estimatedSchemaTokens: row.estimated_schema_tokens,
+    estimatedImageTokens: row.estimated_image_tokens,
+    providerInputTokens: row.provider_input_tokens,
+    providerOutputTokens: row.provider_output_tokens,
+    providerCacheReadTokens: row.provider_cache_read_tokens,
+    providerCacheWriteTokens: row.provider_cache_write_tokens,
+    providerReasoningTokens: row.provider_reasoning_tokens,
+    requestBytes: row.request_bytes,
+    responseBytes: row.response_bytes,
+    usageSource: row.usage_source,
+    costAmount: row.cost_amount,
+    costCurrency: row.cost_currency,
+    costStatus: row.cost_status,
+    costSource: row.cost_source,
+    contextSnapshotId: row.context_snapshot_id,
+    toolSchemaSnapshotId: row.tool_schema_snapshot_id,
+    coreSchemaCount: row.core_schema_count,
+    mcpSchemaCount: row.mcp_schema_count,
+    pluginSchemaCount: row.plugin_schema_count,
+    deferredSchemaCount: row.deferred_schema_count,
+    serializedSchemaBytes: row.serialized_schema_bytes,
+    selectedProfile: row.selected_profile,
+    selectedMode: row.selected_mode,
+    rawToolResultBytes: row.raw_tool_result_bytes,
+    transmittedToolResultBytes: row.transmitted_tool_result_bytes,
+    memoryTokens: row.memory_tokens,
+    userProfileTokens: row.user_profile_tokens,
+    projectMemoryTokens: row.project_memory_tokens,
+    skillIndexTokens: row.skill_index_tokens,
+    loadedSkillTokens: row.loaded_skill_tokens,
+  });
+}

--- a/core/v4/usageLedger.ts
+++ b/core/v4/usageLedger.ts
@@ -535,7 +535,10 @@ function buildQuery(query: ProviderAttemptQuery): { sql: string; params: unknown
   const limit = Math.max(1, Math.min(query.limit ?? 10_000, 100_000));
   params.push(limit);
   return {
-    sql: `SELECT * FROM provider_attempts${where} ORDER BY started_at, call_id LIMIT ?`,
+    // Millisecond timestamps can tie across sequential retries or fallbacks.
+    // SQLite rowid preserves their physical append order without changing the
+    // persisted record schema or requiring existing ledgers to migrate.
+    sql: `SELECT * FROM provider_attempts${where} ORDER BY started_at, rowid LIMIT ?`,
     params,
   };
 }

--- a/core/v4/usagePolicy.ts
+++ b/core/v4/usagePolicy.ts
@@ -1,0 +1,160 @@
+import type { Message, ToolSchema } from '../../providers/v4/types';
+import type { UsageMode } from './usageLedger';
+
+export type BudgetLifecycleState =
+  | 'unbudgeted'
+  | 'estimated'
+  | 'running_green'
+  | 'running_yellow'
+  | 'running_red'
+  | 'over_budget_critical'
+  | 'completed'
+  | 'aborted';
+
+export interface EconomyToolSelection {
+  selected: ToolSchema[];
+  deferredCount: number;
+  originalSchemaBytes: number;
+  selectedSchemaBytes: number;
+  estimatedSchemaSavings: number;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+const ALWAYS = new Set([
+  'clarify',
+  'plan_approval',
+  'lookup_tool_schema',
+  'tool_search',
+  'tool_call',
+  'tool_result_artifact_read',
+]);
+
+const DOMAIN_HINTS: ReadonlyArray<{ pattern: RegExp; prefixes: readonly string[] }> = [
+  { pattern: /\b(file|folder|directory|repository|code|source|edit|write|patch|read)\b/i, prefixes: ['file_', 'read_pdf'] },
+  { pattern: /\b(shell|terminal|command|test|build|lint|typecheck|script)\b/i, prefixes: ['shell_', 'execute_', 'process_'] },
+  { pattern: /\b(web|search|url|site|research|online)\b/i, prefixes: ['web_', 'open_url', 'youtube_'] },
+  { pattern: /\b(browser|page|click|form|screenshot|accessibility)\b/i, prefixes: ['browser_'] },
+  { pattern: /\b(memory|remember|preference|profile)\b/i, prefixes: ['memory_'] },
+  { pattern: /\b(skill|workflow)\b/i, prefixes: ['skill', 'skills_'] },
+  { pattern: /\b(session|history|previous conversation|recall)\b/i, prefixes: ['session_', 'recall_'] },
+  { pattern: /\b(subagent|sub-agent|fanout|delegate|parallel agent)\b/i, prefixes: ['spawn_sub_agent', 'subagent_'] },
+];
+
+export function selectEconomyTools(tools: readonly ToolSchema[], task: string): EconomyToolSelection {
+  const prefixes = new Set<string>();
+  for (const hint of DOMAIN_HINTS) {
+    if (hint.pattern.test(task)) for (const prefix of hint.prefixes) prefixes.add(prefix);
+  }
+  const confidence: EconomyToolSelection['confidence'] = prefixes.size >= 2
+    ? 'high'
+    : prefixes.size === 1 ? 'medium' : 'low';
+  if (prefixes.size === 0) {
+    for (const prefix of ['file_read', 'file_list', 'web_search', 'web_fetch', 'shell_exec']) {
+      prefixes.add(prefix);
+    }
+  }
+  const selected = tools.filter((tool) => (
+    ALWAYS.has(tool.name)
+    || [...prefixes].some((prefix) => tool.name === prefix || tool.name.startsWith(prefix))
+  ));
+  const safeSelected = selected.length > 0 ? selected : [...tools];
+  const originalSchemaBytes = byteSize(tools);
+  const selectedSchemaBytes = byteSize(safeSelected);
+  return {
+    selected: safeSelected,
+    deferredCount: Math.max(0, tools.length - safeSelected.length),
+    originalSchemaBytes,
+    selectedSchemaBytes,
+    estimatedSchemaSavings: Math.max(0, Math.ceil((originalSchemaBytes - selectedSchemaBytes) / 4)),
+    confidence,
+  };
+}
+
+export function classifyBudgetState(used: number, budget: number | null | undefined): BudgetLifecycleState {
+  if (!budget || budget <= 0) return 'unbudgeted';
+  const ratio = Math.max(0, used) / budget;
+  if (ratio > 1) return 'over_budget_critical';
+  if (ratio >= 1) return 'running_red';
+  if (ratio >= 0.8) return 'running_yellow';
+  return 'running_green';
+}
+
+export interface TaskUsageEstimate {
+  complexity: 'small' | 'medium' | 'large';
+  estimatedTokenLow: number;
+  estimatedTokenHigh: number;
+  estimatedCallsLow: number;
+  estimatedCallsHigh: number;
+  estimatedCostLow: number | null;
+  estimatedCostHigh: number | null;
+  costStatus: 'estimated' | 'unknown';
+  confidence: 'high' | 'medium' | 'low';
+  mainCostDrivers: string[];
+  selectedMode: UsageMode;
+  configuredBudget: number | null;
+}
+
+export interface TaskUsageEstimateInput {
+  task: string;
+  messages: readonly Message[];
+  tools: readonly ToolSchema[];
+  mode: UsageMode;
+  tokenBudget?: number | null;
+  pricing: { inputPerM: number; outputPerM: number } | null;
+  expectedSubagents?: number;
+}
+
+export function estimateTaskUsage(input: TaskUsageEstimateInput): TaskUsageEstimate {
+  const historyTokens = Math.ceil(byteSize(input.messages) / 4);
+  const schemaTokens = Math.ceil(byteSize(input.tools) / 4);
+  const taskWords = input.task.trim().split(/\s+/).filter(Boolean).length;
+  const risky = /\b(browse|research|unknown|debug|failing|repository|subagent|fanout)\b/i.test(input.task);
+  const toolLikely = /\b(read|write|edit|run|test|search|fetch|inspect|create|delete|build)\b/i.test(input.task);
+  const subagents = Math.max(0, Math.floor(input.expectedSubagents ?? 0));
+  const callsLow = 1 + (toolLikely ? 1 : 0) + subagents;
+  const callsHigh = callsLow + (risky ? 3 : 1) + subagents;
+  const modeMultiplier = input.mode === 'economy' ? 0.75 : input.mode === 'thorough' ? 1.4 : 1;
+  const base = historyTokens + schemaTokens + Math.max(64, taskWords * 2);
+  const low = Math.ceil((base + callsLow * 350) * modeMultiplier);
+  const high = Math.ceil((base + callsHigh * (risky ? 1_500 : 800)) * modeMultiplier);
+  const complexity = high < 4_000 ? 'small' : high < 15_000 ? 'medium' : 'large';
+  const confidence = risky ? 'low' : toolLikely ? 'medium' : 'high';
+  const drivers = [
+    ...(schemaTokens > 500 ? ['tool schemas'] : []),
+    ...(historyTokens > 1_000 ? ['conversation history'] : []),
+    ...(toolLikely ? ['tool results'] : []),
+    ...(risky ? ['retry and exploration risk'] : []),
+    ...(subagents > 0 ? ['subagent calls'] : []),
+  ];
+  const outputShare = 0.2;
+  const price = (tokens: number): number | null => input.pricing
+    ? ((tokens * (1 - outputShare)) / 1_000_000) * input.pricing.inputPerM
+      + ((tokens * outputShare) / 1_000_000) * input.pricing.outputPerM
+    : null;
+  return {
+    complexity,
+    estimatedTokenLow: low,
+    estimatedTokenHigh: Math.max(low + 1, high),
+    estimatedCallsLow: callsLow,
+    estimatedCallsHigh: callsHigh,
+    estimatedCostLow: price(low),
+    estimatedCostHigh: price(high),
+    costStatus: input.pricing ? 'estimated' : 'unknown',
+    confidence,
+    mainCostDrivers: drivers.length > 0 ? drivers : ['response generation'],
+    selectedMode: input.mode,
+    configuredBudget: input.tokenBudget && input.tokenBudget > 0 ? input.tokenBudget : null,
+  };
+}
+
+export function parseUsageMode(value: unknown): UsageMode | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'economy' || normalized === 'balanced' || normalized === 'thorough'
+    ? normalized
+    : null;
+}
+
+function byteSize(value: unknown): number {
+  try { return Buffer.byteLength(JSON.stringify(value), 'utf8'); } catch { return 0; }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-runtime",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-runtime",
-      "version": "4.15.0",
+      "version": "4.15.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "archiver": "^7.0.1",
         "axios": "^1.15.2",
         "bcrypt": "^6.0.0",
-        "better-sqlite3": "^12.9.0",
+        "better-sqlite3": "12.9.0",
         "blessed": "^0.1.81",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.3",
@@ -4637,9 +4637,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4647,7 +4647,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "archiver": "^7.0.1",
     "axios": "^1.15.2",
     "bcrypt": "^6.0.0",
-    "better-sqlite3": "^12.9.0",
+    "better-sqlite3": "12.9.0",
     "blessed": "^0.1.81",
     "chalk": "^5.6.2",
     "chokidar": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-runtime",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "build:win": "npm run dist",
     "dist:linux": "node scripts/prepare-electron.js && electron-builder --linux --x64 --publish never && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.main='./dist/index.js';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n');console.log('  main restored')\"",
     "test": "vitest run",
+    "benchmark:token-efficiency": "ts-node scripts/benchmark-token-efficiency.ts",
     "test:ui": "vitest --ui",
     "eval": "ts-node evals/cli.ts",
     "eval:honesty": "ts-node evals/cli.ts --suite honesty",

--- a/providers/v4/chatCompletionsAdapter.ts
+++ b/providers/v4/chatCompletionsAdapter.ts
@@ -63,6 +63,12 @@ import {
   requestDeadlines,
   type RequestDeadlines,
 } from './requestLifecycle';
+import {
+  beginPhysicalProviderAttempt,
+  byteLength,
+  createLogicalProviderCallId,
+  type PhysicalAttemptLifecycle,
+} from './providerAttemptAccounting';
 
 // ── Public options ──────────────────────────────────────────────────────
 
@@ -105,6 +111,7 @@ const DEFAULT_MAX_RETRIES = 2;
 interface ActiveDispatch {
   response: Response;
   lifecycle: RequestLifecycle;
+  attempt: PhysicalAttemptLifecycle;
 }
 const DEFAULT_MAX_TOKENS  = 4096;
 const BACKOFF_BASE_MS     = 1000;
@@ -187,6 +194,8 @@ interface WireResponse {
     /** Anthropic-style cache fields some OAI-compat providers include. */
     cache_read_input_tokens?:     number;
     cache_creation_input_tokens?: number;
+    prompt_tokens_details?:       { cached_tokens?: number };
+    completion_tokens_details?:   { reasoning_tokens?: number };
   };
 }
 
@@ -240,12 +249,14 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
 
   async call(input: ProviderCallInput): Promise<ProviderCallOutput> {
     const body  = this.buildBody(input, /* streaming */ false);
-    const active = await this.dispatch(body, /* streaming */ false, input.signal);
+    const active = await this.dispatch(body, /* streaming */ false, input);
     let text: string;
     try {
       text = await active.lifecycle.readText(active.response);
     } catch (error) {
-      throw active.lifecycle.classify(error);
+      const classified = active.lifecycle.classify(error);
+      active.attempt.failure(classified, { sent: true });
+      throw classified;
     } finally {
       active.lifecycle.cleanup();
     }
@@ -253,28 +264,40 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
     try {
       parsed = JSON.parse(text) as WireResponse;
     } catch {
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} returned non-JSON body`,
         this.providerName,
         active.response.status,
         text,
         false,
       );
+      active.attempt.failure(error, {
+        sent: true,
+        responseBytes: byteLength(text),
+        status: 'validation_error',
+      });
+      throw error;
     }
     // Phase 28.2 — pass the request's tool-name set so the bare-JSON
     // inline-tool-call detector can validate names against the schemas
     // the provider was actually offered.
     const knownToolNames = collectKnownToolNames(input);
-    return decodeChoice(parsed, knownToolNames);
+    const output = decodeChoice(parsed, knownToolNames);
+    active.attempt.success(output, byteLength(text));
+    return output;
   }
 
   // ── Streaming ────────────────────────────────────────────────────────
 
   async *callStream(input: ProviderCallInput): AsyncGenerator<StreamEvent, void, void> {
     const body  = this.buildBody(input, /* streaming */ true);
-    const active = await this.dispatch(body, /* streaming */ true, input.signal);
+    const active = await this.dispatch(body, /* streaming */ true, input);
     const reply = active.response;
     if (!reply.body) {
+      active.attempt.failure(
+        new Error('Provider returned an empty stream.'),
+        { sent: true, status: 'validation_error' },
+      );
       yield {
         type: 'done',
         output: {
@@ -288,10 +311,29 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
       return;
     }
     const knownToolNames = collectKnownToolNames(input);
+    let finalOutput: ProviderCallOutput | null = null;
     try {
-      yield* decodeStream(reply.body, this.providerName, knownToolNames, active.lifecycle);
+      for await (const event of decodeStream(reply.body, this.providerName, knownToolNames, active.lifecycle)) {
+        if (event.type === 'done') finalOutput = event.output;
+        yield event;
+      }
+      if (finalOutput) {
+        active.attempt.success(finalOutput);
+      } else {
+        active.attempt.failure(
+          new Error('Provider stream completed without a terminal event.'),
+          { sent: true, status: 'validation_error' },
+        );
+      }
     } catch (error) {
-      throw active.lifecycle.classify(error);
+      const classified = active.lifecycle.classify(error);
+      active.attempt.failure(classified, {
+        sent: true,
+        ...(classified instanceof Error && classified.name === 'AbortError'
+          ? { status: 'interrupted' as const }
+          : {}),
+      });
+      throw classified;
     } finally {
       active.lifecycle.cleanup();
     }
@@ -343,15 +385,43 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
   private async dispatch(
     body: WireRequestBody,
     streaming: boolean,
-    externalSignal?: AbortSignal,
+    input: ProviderCallInput,
   ): Promise<ActiveDispatch> {
     const headers    = this.buildHeaders(streaming);
-    const serialised = JSON.stringify(body);
     const totalTries = this.maxRetries + 1;
+    const externalSignal = input.signal;
+    const logicalCallId = input.usageContext?.logicalCallId ?? createLogicalProviderCallId();
+    let serialised: string;
+    try {
+      serialised = JSON.stringify(body);
+    } catch (error) {
+      const accounting = beginPhysicalProviderAttempt(input, {
+        providerActual: this.providerName,
+        modelActual: this.model,
+        apiMode: this.apiMode,
+        transport: this.endpoint.startsWith('https:') ? 'https' : 'http',
+        attemptIndex: 0,
+        fallbackIndex: input.usageContext?.fallbackIndex ?? 0,
+        logicalCallId,
+        requestBytes: null,
+      });
+      accounting.failure(error, { sent: false });
+      throw error;
+    }
 
     let lastErr: unknown = null;
 
     for (let attempt = 0; attempt < totalTries; attempt++) {
+      const accounting = beginPhysicalProviderAttempt(input, {
+        providerActual: this.providerName,
+        modelActual: this.model,
+        apiMode: this.apiMode,
+        transport: this.endpoint.startsWith('https:') ? 'https' : 'http',
+        attemptIndex: attempt,
+        fallbackIndex: input.usageContext?.fallbackIndex ?? 0,
+        logicalCallId,
+        requestBytes: byteLength(serialised),
+      });
       const lifecycle = new RequestLifecycle(this.providerName, this.deadlines, externalSignal);
       let response: Response;
       try {
@@ -366,6 +436,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
         const classified = lifecycle.classify(err);
         lifecycle.cleanup();
         if (classified instanceof Error && classified.name === 'AbortError') {
+          accounting.failure(classified, { sent: true, status: 'interrupted' });
           throw classified;
         }
         if (classified instanceof Error && classified.name === 'ProviderPhaseTimeoutError') {
@@ -379,6 +450,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
             true,
           );
         }
+        accounting.failure(lastErr, { sent: true });
         if (attempt < totalTries - 1) {
           await sleep(backoffMs(attempt), externalSignal);
           continue;
@@ -386,7 +458,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
         throw lastErr;
       }
 
-      if (response.ok) return { response, lifecycle };
+      if (response.ok) return { response, lifecycle, attempt: accounting };
 
       const status = response.status;
       const retryAfter = response.headers.get('retry-after');
@@ -396,6 +468,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
       } catch (error) {
         const classified = lifecycle.classify(error);
         lifecycle.cleanup();
+        accounting.failure(classified, { sent: true });
         throw classified;
       }
 
@@ -408,22 +481,26 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
         const recovered = tryRecoverLegacyToolCall(responseText);
         if (recovered) {
           lifecycle.markHeaders();
-          return { response: synthesiseRecoveredResponse(recovered), lifecycle };
+          return { response: synthesiseRecoveredResponse(recovered), lifecycle, attempt: accounting };
         }
         lifecycle.cleanup();
-        throw new ProviderError(
+        const error = new ProviderError(
           `Provider ${this.providerName} returned 400 Bad Request`,
           this.providerName,
           400,
           tryParseJson(responseText),
           false,
         );
+        accounting.failure(error, { sent: true, responseBytes: byteLength(responseText) });
+        throw error;
       }
 
       const raw = tryParseJson(responseText);
       lifecycle.cleanup();
 
       if (status === 429) {
+        const error = new ProviderRateLimitError(this.providerName, raw);
+        accounting.failure(error, { sent: true, responseBytes: encodedByteLength(raw) });
         if (attempt < totalTries - 1) {
           await sleep(
             Math.max(backoffMs(attempt), retryAfterMs(retryAfter)),
@@ -431,30 +508,34 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
           );
           continue;
         }
-        throw new ProviderRateLimitError(this.providerName, raw);
+        throw error;
       }
 
       if (status >= 500 && status < 600) {
-        if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt), externalSignal);
-          continue;
-        }
-        throw new ProviderError(
+        const error = new ProviderError(
           `Provider ${this.providerName} server error ${status}`,
           this.providerName,
           status,
           raw,
           true,
         );
+        accounting.failure(error, { sent: true, responseBytes: encodedByteLength(raw) });
+        if (attempt < totalTries - 1) {
+          await sleep(backoffMs(attempt), externalSignal);
+          continue;
+        }
+        throw error;
       }
 
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} request failed (${status})`,
         this.providerName,
         status,
         raw,
         false,
       );
+      accounting.failure(error, { sent: true, responseBytes: encodedByteLength(raw) });
+      throw error;
     }
 
     throw lastErr instanceof Error
@@ -600,7 +681,19 @@ function decodeUsage(u: WireResponse['usage']): ProviderCallOutput['usage'] {
   if (typeof u?.cache_creation_input_tokens === 'number') {
     out.cacheWriteTokens = u.cache_creation_input_tokens;
   }
+  if (typeof u?.prompt_tokens_details?.cached_tokens === 'number') {
+    out.cacheReadTokens = u.prompt_tokens_details.cached_tokens;
+  }
+  if (typeof u?.completion_tokens_details?.reasoning_tokens === 'number') {
+    out.reasoningTokens = u.completion_tokens_details.reasoning_tokens;
+  }
   return out;
+}
+
+function encodedByteLength(value: unknown): number {
+  if (typeof value === 'string') return byteLength(value);
+  try { return byteLength(JSON.stringify(value) ?? ''); }
+  catch { return 0; }
 }
 
 function mapFinishReason(

--- a/providers/v4/chatCompletionsAdapter.ts
+++ b/providers/v4/chatCompletionsAdapter.ts
@@ -57,8 +57,12 @@ import type {
 import {
   ProviderError,
   ProviderRateLimitError,
-  ProviderTimeoutError,
 } from './errors';
+import {
+  RequestLifecycle,
+  requestDeadlines,
+  type RequestDeadlines,
+} from './requestLifecycle';
 
 // ── Public options ──────────────────────────────────────────────────────
 
@@ -71,6 +75,10 @@ export interface ChatCompletionsAdapterOptions {
   providerName:   string;
   /** Per-request wall-clock. Default 120_000 ms. */
   timeoutMs?:     number;
+  connectionTimeoutMs?: number;
+  firstByteTimeoutMs?: number;
+  bodyIdleTimeoutMs?: number;
+  totalTimeoutMs?: number;
   /** Retries on 429/5xx/network. Default 2 (so 3 attempts total). */
   maxRetries?:    number;
   /** Header overrides — wins over computed headers. e.g. OpenRouter wants HTTP-Referer + X-Title. */
@@ -93,6 +101,11 @@ export interface ChatCompletionsAdapterOptions {
 
 const DEFAULT_TIMEOUT_MS  = 120_000;
 const DEFAULT_MAX_RETRIES = 2;
+
+interface ActiveDispatch {
+  response: Response;
+  lifecycle: RequestLifecycle;
+}
 const DEFAULT_MAX_TOKENS  = 4096;
 const BACKOFF_BASE_MS     = 1000;
 
@@ -106,12 +119,10 @@ const BACKOFF_BASE_MS     = 1000;
  * `prompt_tokens + max_tokens` — i.e. the *reserved* output budget
  * is billed up front whether the model uses it or not.
  *
- * On the 12K free tier this turns into a fixed 4K/call tax that
- * pushes a bare `"hi"` over the cap even on the `standard` tool
- * profile. Capping Groq at 2048 frees ~2K TPM headroom per request
- * without truncating realistic responses (most turns reply in
- * under 1K tokens; the few that need more can be served by a
- * different provider).
+ * Fresh on-demand accounts can expose a tight TPM limit. Setup pairs
+ * this provider with the minimal tool profile so the reserved budget
+ * remains useful without making the first request exceed that limit.
+ * Explicit per-call budgets still win for accounts with higher limits.
  *
  * Keyed by lowercase provider name (matches
  * `ChatCompletionsAdapterOptions.providerName` after normalisation).
@@ -201,6 +212,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
   private readonly model:        string;
   private readonly providerName: string;
   private readonly timeoutMs:    number;
+  private readonly deadlines:    RequestDeadlines;
   private readonly maxRetries:   number;
   private readonly extraHeaders: Record<string, string>;
   /** Phase v4.1.2-deepseek: model-mandated body fields merged on every call. */
@@ -213,6 +225,12 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
     this.model            = opts.model;
     this.providerName     = opts.providerName;
     this.timeoutMs        = opts.timeoutMs  ?? DEFAULT_TIMEOUT_MS;
+    this.deadlines        = requestDeadlines(this.timeoutMs, {
+      connectionMs: opts.connectionTimeoutMs,
+      firstByteMs: opts.firstByteTimeoutMs,
+      bodyIdleMs: opts.bodyIdleTimeoutMs,
+      totalMs: opts.totalTimeoutMs,
+    });
     this.maxRetries       = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.extraHeaders     = opts.extraHeaders ?? {};
     this.defaultExtraBody = opts.defaultExtraBody;
@@ -222,8 +240,15 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
 
   async call(input: ProviderCallInput): Promise<ProviderCallOutput> {
     const body  = this.buildBody(input, /* streaming */ false);
-    const reply = await this.dispatch(body, /* streaming */ false, input.signal);
-    const text  = await reply.text();
+    const active = await this.dispatch(body, /* streaming */ false, input.signal);
+    let text: string;
+    try {
+      text = await active.lifecycle.readText(active.response);
+    } catch (error) {
+      throw active.lifecycle.classify(error);
+    } finally {
+      active.lifecycle.cleanup();
+    }
     let parsed: WireResponse;
     try {
       parsed = JSON.parse(text) as WireResponse;
@@ -231,7 +256,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
       throw new ProviderError(
         `Provider ${this.providerName} returned non-JSON body`,
         this.providerName,
-        reply.status,
+        active.response.status,
         text,
         false,
       );
@@ -247,7 +272,8 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
 
   async *callStream(input: ProviderCallInput): AsyncGenerator<StreamEvent, void, void> {
     const body  = this.buildBody(input, /* streaming */ true);
-    const reply = await this.dispatch(body, /* streaming */ true, input.signal);
+    const active = await this.dispatch(body, /* streaming */ true, input.signal);
+    const reply = active.response;
     if (!reply.body) {
       yield {
         type: 'done',
@@ -258,10 +284,17 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
           usage:        { inputTokens: 0, outputTokens: 0 },
         },
       };
+      active.lifecycle.cleanup();
       return;
     }
     const knownToolNames = collectKnownToolNames(input);
-    yield* decodeStream(reply.body, this.providerName, knownToolNames);
+    try {
+      yield* decodeStream(reply.body, this.providerName, knownToolNames, active.lifecycle);
+    } catch (error) {
+      throw active.lifecycle.classify(error);
+    } finally {
+      active.lifecycle.cleanup();
+    }
   }
 
   // ── Body assembly ────────────────────────────────────────────────────
@@ -311,7 +344,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
     body: WireRequestBody,
     streaming: boolean,
     externalSignal?: AbortSignal,
-  ): Promise<Response> {
+  ): Promise<ActiveDispatch> {
     const headers    = this.buildHeaders(streaming);
     const serialised = JSON.stringify(body);
     const totalTries = this.maxRetries + 1;
@@ -319,40 +352,24 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
     let lastErr: unknown = null;
 
     for (let attempt = 0; attempt < totalTries; attempt++) {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-      // v4.6 prep — forward external abort into the internal controller.
-      // External aborts surface as raw AbortError so AidenAgent routes
-      // them as 'interrupted' rather than retrying as ProviderTimeoutError.
-      let externalAbortHandler: (() => void) | null = null;
-      if (externalSignal) {
-        if (externalSignal.aborted) {
-          controller.abort();
-        } else {
-          externalAbortHandler = () => controller.abort();
-          externalSignal.addEventListener('abort', externalAbortHandler, { once: true });
-        }
-      }
-
+      const lifecycle = new RequestLifecycle(this.providerName, this.deadlines, externalSignal);
       let response: Response;
       try {
-        response = await fetch(this.endpoint, {
+        response = await lifecycle.race(fetch(this.endpoint, {
           method:  'POST',
           headers,
           body:    serialised,
-          signal:  controller.signal,
-        });
+          signal:  lifecycle.signal,
+        }));
+        lifecycle.markHeaders();
       } catch (err: any) {
-        clearTimeout(timer);
-        if (externalAbortHandler && externalSignal) {
-          externalSignal.removeEventListener('abort', externalAbortHandler);
+        const classified = lifecycle.classify(err);
+        lifecycle.cleanup();
+        if (classified instanceof Error && classified.name === 'AbortError') {
+          throw classified;
         }
-        if (err?.name === 'AbortError') {
-          // v4.6 prep — external abort takes priority over internal timeout.
-          if (externalSignal?.aborted) {
-            throw err;
-          }
-          lastErr = new ProviderTimeoutError(this.providerName, this.timeoutMs);
+        if (classified instanceof Error && classified.name === 'ProviderPhaseTimeoutError') {
+          lastErr = classified;
         } else {
           lastErr = new ProviderError(
             `Network failure calling ${this.providerName}: ${err?.message ?? err}`,
@@ -363,19 +380,24 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
           );
         }
         if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
+          await sleep(backoffMs(attempt), externalSignal);
           continue;
         }
         throw lastErr;
       }
-      clearTimeout(timer);
-      if (externalAbortHandler && externalSignal) {
-        externalSignal.removeEventListener('abort', externalAbortHandler);
-      }
 
-      if (response.ok) return response;
+      if (response.ok) return { response, lifecycle };
 
       const status = response.status;
+      const retryAfter = response.headers.get('retry-after');
+      let responseText: string;
+      try {
+        responseText = await lifecycle.readText(response);
+      } catch (error) {
+        const classified = lifecycle.classify(error);
+        lifecycle.cleanup();
+        throw classified;
+      }
 
       // Groq's `tool_use_failed` 400 sometimes carries the model's tool
       // call inline in `failed_generation`. Recover it into a synthetic
@@ -383,25 +405,30 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
       // non-streaming path reaches here with a body — the streaming
       // path's 4xx already failed before the body would be relevant.
       if (status === 400 && !streaming) {
-        const recoveredBody = await response.text();
-        const recovered = tryRecoverLegacyToolCall(recoveredBody);
+        const recovered = tryRecoverLegacyToolCall(responseText);
         if (recovered) {
-          return synthesiseRecoveredResponse(recovered);
+          lifecycle.markHeaders();
+          return { response: synthesiseRecoveredResponse(recovered), lifecycle };
         }
+        lifecycle.cleanup();
         throw new ProviderError(
           `Provider ${this.providerName} returned 400 Bad Request`,
           this.providerName,
           400,
-          tryParseJson(recoveredBody),
+          tryParseJson(responseText),
           false,
         );
       }
 
-      const raw = await safeReadBody(response);
+      const raw = tryParseJson(responseText);
+      lifecycle.cleanup();
 
       if (status === 429) {
         if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
+          await sleep(
+            Math.max(backoffMs(attempt), retryAfterMs(retryAfter)),
+            externalSignal,
+          );
           continue;
         }
         throw new ProviderRateLimitError(this.providerName, raw);
@@ -409,7 +436,7 @@ export class ChatCompletionsAdapter implements ProviderAdapter {
 
       if (status >= 500 && status < 600) {
         if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
+          await sleep(backoffMs(attempt), externalSignal);
           continue;
         }
         throw new ProviderError(
@@ -638,6 +665,7 @@ function parseToolArgs(s: string): Record<string, unknown> {
  */
 export async function* parseSseStream(
   body: ReadableStream<Uint8Array>,
+  lifecycle?: RequestLifecycle,
 ): AsyncGenerator<string, void, void> {
   const reader  = body.getReader();
   const decoder = new TextDecoder('utf-8');
@@ -645,7 +673,9 @@ export async function* parseSseStream(
 
   try {
     while (true) {
-      const { value, done } = await reader.read();
+      const { value, done } = lifecycle
+        ? await lifecycle.readChunk(reader)
+        : await reader.read();
       if (value) buffer += decoder.decode(value, { stream: true });
       if (done) {
         buffer += decoder.decode();   // flush any pending bytes
@@ -709,6 +739,7 @@ async function* decodeStream(
   body:           ReadableStream<Uint8Array>,
   providerName:   string,
   knownToolNames?: ReadonlySet<string>,
+  lifecycle?: RequestLifecycle,
 ): AsyncGenerator<StreamEvent, void, void> {
   const tools:     Map<number, StreamingTool> = new Map();
   let textBuffer:  string                = '';
@@ -716,7 +747,7 @@ async function* decodeStream(
   let usage:       WireResponse['usage'] = undefined;
   let toolMode     = false;
 
-  for await (const payload of parseSseStream(body)) {
+  for await (const payload of parseSseStream(body, lifecycle)) {
     if (!payload || payload === '[DONE]') continue;
     let chunk: any;
     try { chunk = JSON.parse(payload); }
@@ -1267,17 +1298,36 @@ function backoffMs(attempt: number): number {
   return base + jitter;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function retryAfterMs(value: string | null): number {
+  if (!value) return 0;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(60_000, Math.ceil(seconds * 1_000));
+  }
+  const at = Date.parse(value);
+  return Number.isFinite(at) ? Math.min(60_000, Math.max(0, at - Date.now())) : 0;
 }
 
-async function safeReadBody(r: Response): Promise<unknown> {
-  try {
-    const text = await r.text();
-    return tryParseJson(text);
-  } catch {
-    return null;
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    const error = new Error('The provider retry wait was cancelled.');
+    error.name = 'AbortError';
+    return Promise.reject(error);
   }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      const error = new Error('The provider retry wait was cancelled.');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function tryParseJson(text: string): unknown {

--- a/providers/v4/credentialAuthority.ts
+++ b/providers/v4/credentialAuthority.ts
@@ -1,0 +1,328 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { AidenPaths } from '../../core/v4/paths';
+
+export type EffectiveCredentialSource =
+  | 'explicit_override'
+  | 'inline_config'
+  | 'managed_environment'
+  | 'process_environment'
+  | 'oauth_store'
+  | 'legacy_store'
+  | 'local_runtime'
+  | 'missing';
+
+export type EffectiveEndpointSource =
+  | 'explicit_override'
+  | 'inline_config'
+  | 'registry_default';
+
+export interface CredentialConflict {
+  preferred: EffectiveCredentialSource;
+  shadowed: EffectiveCredentialSource;
+}
+
+export interface EffectiveCredentialResolution {
+  provider: string;
+  credentialSource: EffectiveCredentialSource;
+  endpointSource: EffectiveEndpointSource;
+  credentialFingerprint: string | null;
+  endpointFingerprint: string;
+  configured: boolean;
+  conflicts: CredentialConflict[];
+}
+
+export interface CredentialConfigView {
+  get(key: string): string | undefined;
+  getRaw?(key: string): string | undefined;
+}
+
+export interface ResolveApiCredentialOptions {
+  providerId: string;
+  envVar: string | null;
+  registryEndpoint: string;
+  override?: string;
+  endpointOverride?: string;
+  config?: CredentialConfigView;
+  paths?: AidenPaths;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface ResolvedApiCredential {
+  apiKey: string | null;
+  endpoint: string;
+  effective: EffectiveCredentialResolution;
+}
+
+export type ManagedCredentialPersistenceErrorCode =
+  | 'credential_missing'
+  | 'credential_write_failed'
+  | 'credential_verification_failed';
+
+export class ManagedCredentialPersistenceError extends Error {
+  constructor(
+    public readonly code: ManagedCredentialPersistenceErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message);
+    this.name = 'ManagedCredentialPersistenceError';
+    if (options && 'cause' in options) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+export interface PersistManagedCredentialOptions {
+  paths: AidenPaths;
+  envVar: string;
+  credential: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface PersistedManagedCredential {
+  credentialSource: 'managed_environment';
+  credentialFingerprint: string;
+  envFile: string;
+}
+
+export interface ManagedCredentialFileSnapshot {
+  existed: boolean;
+  body: string;
+}
+
+const PLACEHOLDER_RE = /^\s*\$\{[A-Za-z_][A-Za-z0-9_]*\}\s*$/;
+
+export function isUnresolvedCredentialPlaceholder(value: string | null | undefined): boolean {
+  return typeof value === 'string' && PLACEHOLDER_RE.test(value);
+}
+
+function usable(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || isUnresolvedCredentialPlaceholder(trimmed)) return null;
+  return trimmed;
+}
+
+export function credentialFingerprint(value: string): string {
+  return createHash('sha256')
+    .update('provider-credential\0')
+    .update(value)
+    .digest('hex')
+    .slice(0, 24);
+}
+
+export function endpointFingerprint(value: string): string {
+  return createHash('sha256')
+    .update('provider-endpoint\0')
+    .update(value.replace(/\/+$/, '').toLowerCase())
+    .digest('hex')
+    .slice(0, 24);
+}
+
+async function managedEnvValue(envFile: string | undefined, key: string | null): Promise<string | null> {
+  if (!envFile || !key) return null;
+  let body: string;
+  try {
+    body = await fs.readFile(envFile, 'utf8');
+  } catch {
+    return null;
+  }
+  let found: string | null = null;
+  for (const line of body.split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match || match[1] !== key) continue;
+    let value = match[2].trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    found = usable(value);
+  }
+  return found;
+}
+
+export async function snapshotManagedCredentialFile(paths: AidenPaths): Promise<ManagedCredentialFileSnapshot> {
+  try {
+    return { existed: true, body: await fs.readFile(paths.envFile, 'utf8') };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { existed: false, body: '' };
+    throw new ManagedCredentialPersistenceError(
+      'credential_write_failed',
+      'Could not snapshot the managed credential file.',
+      { cause: error },
+    );
+  }
+}
+
+export async function restoreManagedCredentialFile(options: {
+  paths: AidenPaths;
+  snapshot: ManagedCredentialFileSnapshot;
+  envVar: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<void> {
+  const temporary = `${options.paths.envFile}.${process.pid}.${randomUUID()}.restore.tmp`;
+  try {
+    if (options.snapshot.existed) {
+      await fs.mkdir(path.dirname(options.paths.envFile), { recursive: true });
+      await fs.writeFile(temporary, options.snapshot.body, { encoding: 'utf8', mode: 0o600 });
+      await fs.rename(temporary, options.paths.envFile);
+    } else {
+      await fs.rm(options.paths.envFile, { force: true });
+    }
+  } catch (error) {
+    await fs.rm(temporary, { force: true }).catch(() => undefined);
+    throw new ManagedCredentialPersistenceError(
+      'credential_write_failed',
+      'Could not restore the managed credential file.',
+      { cause: error },
+    );
+  }
+  const restored = await managedEnvValue(options.paths.envFile, options.envVar);
+  const env = options.env ?? process.env;
+  if (restored) env[options.envVar] = restored;
+  else delete env[options.envVar];
+}
+
+/**
+ * Atomically persist one managed provider credential and verify the durable
+ * value before making it visible to the current process. Secret values are
+ * never returned; callers receive only a stable fingerprint and source.
+ */
+export async function persistManagedCredential(
+  options: PersistManagedCredentialOptions,
+): Promise<PersistedManagedCredential> {
+  const envVar = options.envVar.trim().toUpperCase();
+  const credential = usable(options.credential);
+  if (!credential || /[\r\n]/.test(options.credential)) {
+    throw new ManagedCredentialPersistenceError(
+      'credential_missing',
+      `A non-empty ${envVar} credential is required.`,
+    );
+  }
+
+  let existing = '';
+  try {
+    existing = await fs.readFile(options.paths.envFile, 'utf8');
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      throw new ManagedCredentialPersistenceError(
+        'credential_write_failed',
+        `Could not read the managed credential file for ${envVar}.`,
+        { cause: error },
+      );
+    }
+  }
+
+  const lines = existing.split(/\r?\n/);
+  let replaced = false;
+  const assignment = `${envVar}=${credential}`;
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+    if (!match || match[1].toUpperCase() !== envVar) continue;
+    lines[index] = assignment;
+    replaced = true;
+  }
+  if (!replaced) lines.push(assignment);
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+
+  const temporary = `${options.paths.envFile}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await fs.mkdir(path.dirname(options.paths.envFile), { recursive: true });
+    await fs.writeFile(temporary, `${lines.join('\n')}\n`, { encoding: 'utf8', mode: 0o600 });
+    await fs.rename(temporary, options.paths.envFile);
+  } catch (error) {
+    await fs.rm(temporary, { force: true }).catch(() => undefined);
+    throw new ManagedCredentialPersistenceError(
+      'credential_write_failed',
+      `Could not persist the managed credential for ${envVar}.`,
+      { cause: error },
+    );
+  }
+
+  const durable = await managedEnvValue(options.paths.envFile, envVar);
+  if (!durable || credentialFingerprint(durable) !== credentialFingerprint(credential)) {
+    throw new ManagedCredentialPersistenceError(
+      'credential_verification_failed',
+      `The managed credential for ${envVar} could not be verified after writing.`,
+    );
+  }
+
+  (options.env ?? process.env)[envVar] = credential;
+  return {
+    credentialSource: 'managed_environment',
+    credentialFingerprint: credentialFingerprint(credential),
+    envFile: options.paths.envFile,
+  };
+}
+
+export async function resolveApiCredential(
+  options: ResolveApiCredentialOptions,
+): Promise<ResolvedApiCredential> {
+  const configKey = `providers.${options.providerId}.apiKey`;
+  const endpointKey = `providers.${options.providerId}.baseUrl`;
+  const rawConfig = options.config?.getRaw?.(configKey);
+  const configValue = usable(rawConfig ?? options.config?.get(configKey));
+  const managedValue = await managedEnvValue(options.paths?.envFile, options.envVar);
+  const processValue = usable(options.envVar ? (options.env ?? process.env)[options.envVar] : null);
+  const overrideValue = usable(options.override);
+
+  const candidates: Array<{ source: EffectiveCredentialSource; value: string | null }> = [
+    { source: 'explicit_override', value: overrideValue },
+    { source: 'inline_config', value: configValue },
+    { source: 'managed_environment', value: managedValue },
+    { source: 'process_environment', value: processValue },
+  ];
+  const selected = candidates.find((candidate) => candidate.value !== null)
+    ?? { source: 'missing' as const, value: null };
+  const selectedFingerprint = selected.value ? credentialFingerprint(selected.value) : null;
+  const conflicts: CredentialConflict[] = [];
+  if (selected.value) {
+    for (const candidate of candidates) {
+      if (!candidate.value || candidate.source === selected.source) continue;
+      if (credentialFingerprint(candidate.value) !== selectedFingerprint) {
+        conflicts.push({ preferred: selected.source, shadowed: candidate.source });
+      }
+    }
+  }
+
+  const configuredEndpoint = usable(options.config?.getRaw?.(endpointKey) ?? options.config?.get(endpointKey));
+  const endpoint = (usable(options.endpointOverride) ?? configuredEndpoint ?? options.registryEndpoint).replace(/\/+$/, '');
+  const endpointSource: EffectiveEndpointSource = usable(options.endpointOverride)
+    ? 'explicit_override'
+    : configuredEndpoint
+      ? 'inline_config'
+      : 'registry_default';
+
+  return {
+    apiKey: selected.value,
+    endpoint,
+    effective: {
+      provider: options.providerId,
+      credentialSource: selected.source,
+      endpointSource,
+      credentialFingerprint: selectedFingerprint,
+      endpointFingerprint: endpointFingerprint(endpoint),
+      configured: selected.value !== null,
+      conflicts,
+    },
+  };
+}
+
+export function effectiveStoredCredential(
+  provider: string,
+  source: 'oauth_store' | 'legacy_store' | 'local_runtime',
+  endpoint: string,
+  credential?: string | null,
+): EffectiveCredentialResolution {
+  return {
+    provider,
+    credentialSource: source,
+    endpointSource: 'registry_default',
+    credentialFingerprint: credential ? credentialFingerprint(credential) : null,
+    endpointFingerprint: endpointFingerprint(endpoint),
+    configured: source === 'local_runtime' || !!credential,
+    conflicts: [],
+  };
+}

--- a/providers/v4/errors.ts
+++ b/providers/v4/errors.ts
@@ -145,23 +145,19 @@ export class ProviderRateLimitError extends ProviderError {
 /**
  * v4.1.3-prebump: classify a thrown error into a coarse outcome class
  * the REPL display layer can act on. NOT exhaustive — these are the
- * five classes we surface tailored guidance for; everything else is
+ * the provider failure classes we surface tailored guidance for; everything else is
  * `other` and the caller falls back to its default suggestion.
  *
- * The classifier examines (in order):
- *   1. `statusCode` on a ProviderError — the structured signal.
- *   2. Error class — `ProviderRateLimitError` → `rate_limit` even
- *      without a status code.
- *   3. Message substrings — for provider adapters that swallow the
- *      status code and surface only the upstream JSON `error.message`.
- *      The strings here cover the actual error messages produced by
- *      Groq / OpenAI / Anthropic / DeepSeek / chat-completions
- *      compatible endpoints.
+ * Typed error classes are authoritative. The structured HTTP status is then
+ * combined with narrow semantic detail from the provider body. HTTP 413 is
+ * overloaded, so TPM and explicit context-window detail refine it; an
+ * otherwise unqualified 413 is a request-size limit.
  *
  * Pure. Returns lowercase string literals. Caller does its own copy.
  */
 export type ProviderErrorClass =
-  | 'context_overflow'   // 413 / context_length_exceeded / too large
+  | 'context_overflow'   // model context-token capacity
+  | 'request_size_limit' // HTTP body/payload-size limit
   | 'rate_limit'         // 429 / TPM / quota burst
   | 'auth'               // 401 / 403 / invalid_api_key / unauthenticated
   | 'transport'          // network / DNS / timeout
@@ -174,40 +170,62 @@ export function classifyProviderError(err: unknown): ProviderErrorClass {
   if (err instanceof ProviderRateLimitError) return 'rate_limit';
   if (err instanceof ProviderTimeoutError)   return 'transport';
 
+  const message = providerErrorText(err);
+  const messageClass = classifyProviderMessage(message);
+
   if (err instanceof ProviderError) {
-    if (err.statusCode === 413) return 'context_overflow';
+    if (err.statusCode === 413) {
+      if (messageClass === 'rate_limit' || messageClass === 'context_overflow') {
+        return messageClass;
+      }
+      return 'request_size_limit';
+    }
     if (err.statusCode === 429) return 'rate_limit';
     if (err.statusCode === 401 || err.statusCode === 403) return 'auth';
   }
 
   // 2. Fall back to message scanning. Adapters that pass through the
   //    upstream JSON `error.message` verbatim land here.
-  const msg = err instanceof Error ? err.message : String(err);
-  const lc = msg.toLowerCase();
+  return messageClass;
+}
 
-  // Context overflow / 413 family. Groq's free-tier TPM cap triggers
-  // these on the first turn once the prompt + tool schemas inflate.
-  if (
-    lc.includes('413') ||
-    lc.includes('context_length_exceeded') ||
-    lc.includes('context length') ||
-    lc.includes('too large') ||
-    lc.includes('maximum context length') ||
-    lc.includes('payload too large')
-  ) {
-    return 'context_overflow';
-  }
+function classifyProviderMessage(message: string): ProviderErrorClass {
+  const lc = message.toLowerCase();
 
-  // Rate-limit family — 429 / TPM / quota / "too many requests".
+  // Throughput/rate-limit family. Some providers report TPM rejection with
+  // HTTP 413 rather than the more conventional HTTP 429.
   if (
     lc.includes('429') ||
     lc.includes('rate_limit') ||
     lc.includes('rate limit') ||
     lc.includes('too many requests') ||
     lc.includes('quota') ||
-    lc.includes('tpm')
+    lc.includes('tpm') ||
+    lc.includes('tokens per minute')
   ) {
     return 'rate_limit';
+  }
+
+  // Model context-token capacity. Keep this distinct from both transport
+  // body limits and account throughput limits.
+  if (
+    lc.includes('context_length_exceeded') ||
+    lc.includes('context length') ||
+    lc.includes('context window') ||
+    lc.includes('maximum context length') ||
+    lc.includes('maximum context window')
+  ) {
+    return 'context_overflow';
+  }
+
+  if (
+    lc.includes('413') ||
+    lc.includes('payload too large') ||
+    lc.includes('request body too large') ||
+    lc.includes('request too large') ||
+    lc.includes('body size limit')
+  ) {
+    return 'request_size_limit';
   }
 
   // Auth family — 401 / 403 / invalid keys / unauthenticated.
@@ -250,21 +268,37 @@ export function classifyProviderError(err: unknown): ProviderErrorClass {
 export function suggestForErrorClass(
   cls: ProviderErrorClass,
   providerName: string | undefined,
+  err?: unknown,
 ): string | null {
   const p = providerName ?? 'this provider';
   switch (cls) {
     case 'context_overflow':
       return (
-        `${p} returned 413 (context too large). The combined system prompt ` +
-        `+ tool schemas exceed ${p}'s context window. Try \`/model\` to ` +
-        `switch to a provider with more headroom (chatgpt-plus, anthropic, ` +
-        `deepseek).`
+        `${p}'s model context window cannot hold this prompt. Try ` +
+        `\`/mode economy\`, reduce attached context, or use \`/model\` to ` +
+        `select a model with a larger context window.`
+      );
+    case 'request_size_limit':
+      return (
+        `${p} rejected the HTTP request size. Reduce large attachments or ` +
+        `tool output, then retry. This is an HTTP transport limit, not a ` +
+        `token-capacity diagnosis.`
       );
     case 'rate_limit':
+      {
+        const throughput = parseThroughputLimit(err);
+        if (throughput) {
+          return (
+            `${p} rejected ${throughput.requested} requested tokens against a ` +
+            `${throughput.allowed} TPM limit. Try \`/mode economy\`, or use ` +
+            `\`/model\` to select a provider or tier with greater throughput.`
+          );
+        }
       return (
         `${p} is rate-limited. Wait a minute, or run \`/model\` to switch ` +
         `to another authed provider while ${p} cools off.`
       );
+      }
     case 'auth':
       return (
         `${p} rejected the credentials. Run \`/auth status\` (or check the ` +
@@ -278,4 +312,34 @@ export function suggestForErrorClass(
     case 'other':
       return null;
   }
+}
+
+function parseThroughputLimit(err: unknown): { allowed: string; requested: string } | null {
+  if (err == null) return null;
+  const message = providerErrorText(err);
+  if (!/(?:\btpm\b|tokens per minute)/i.test(message)) return null;
+  const allowed = /(?:tpm\s*limit|limit(?:ed)?(?:\s+to)?)\s*[:=]?\s*([\d,]+)/i.exec(message)?.[1];
+  const requested = /requested\s*[:=]?\s*([\d,]+)/i.exec(message)?.[1];
+  if (!allowed || !requested) return null;
+  return { allowed: formatInteger(allowed), requested: formatInteger(requested) };
+}
+
+function formatInteger(value: string): string {
+  const parsed = Number.parseInt(value.replace(/,/g, ''), 10);
+  return Number.isFinite(parsed) ? parsed.toLocaleString('en-US') : value;
+}
+
+function providerErrorText(err: unknown): string {
+  const summary = err instanceof Error ? err.message : String(err);
+  if (!(err instanceof ProviderError)) return summary;
+  const raw = err.raw;
+  if (typeof raw === 'string') return `${summary}\n${raw}`;
+  if (!raw || typeof raw !== 'object') return summary;
+  const envelope = raw as { error?: unknown; message?: unknown; detail?: unknown };
+  const nested = envelope.error && typeof envelope.error === 'object'
+    ? (envelope.error as { message?: unknown }).message
+    : undefined;
+  const detail = [nested, envelope.message, envelope.detail]
+    .find((value): value is string => typeof value === 'string' && value.length > 0);
+  return detail ? `${summary}\n${detail}` : summary;
 }

--- a/providers/v4/errors.ts
+++ b/providers/v4/errors.ts
@@ -109,6 +109,25 @@ export class ProviderTimeoutError extends ProviderError {
   }
 }
 
+export type ProviderTimeoutPhase =
+  | 'connection_timeout'
+  | 'first_byte_timeout'
+  | 'body_idle_timeout'
+  | 'total_timeout';
+
+/** Timeout with an exact request-lifecycle phase. */
+export class ProviderPhaseTimeoutError extends ProviderTimeoutError {
+  constructor(
+    providerName: string,
+    timeoutMs: number,
+    public readonly phase: ProviderTimeoutPhase,
+  ) {
+    super(providerName, timeoutMs);
+    this.name = 'ProviderPhaseTimeoutError';
+    this.message = `Provider ${providerName} exceeded ${phase.replace(/_/g, ' ')} after ${timeoutMs}ms`;
+  }
+}
+
 /** Thrown after retries are exhausted on HTTP 429. Caller may pause and retry. */
 export class ProviderRateLimitError extends ProviderError {
   constructor(providerName: string, raw?: unknown) {

--- a/providers/v4/localPromptToolsAdapter.ts
+++ b/providers/v4/localPromptToolsAdapter.ts
@@ -43,7 +43,8 @@ import {
   ToolCallRequest,
   ToolSchema,
 } from './types';
-import { ProviderError, ProviderTimeoutError } from './errors';
+import { ProviderError, ProviderPhaseTimeoutError } from './errors';
+import { RequestLifecycle, requestDeadlines, type RequestDeadlines } from './requestLifecycle';
 
 export interface LocalPromptToolsAdapterOptions {
   /** Default 'http://localhost:11434'. No trailing slash. */
@@ -54,6 +55,10 @@ export interface LocalPromptToolsAdapterOptions {
   providerName: string;
   /** Per-request timeout. Default 120_000. */
   timeoutMs?: number;
+  connectionTimeoutMs?: number;
+  firstByteTimeoutMs?: number;
+  bodyIdleTimeoutMs?: number;
+  totalTimeoutMs?: number;
   /** Retries on transient failures. Default 0 — local server, fail fast. */
   maxRetries?: number;
 }
@@ -90,6 +95,11 @@ const DEFAULT_BASE_URL = 'http://localhost:11434';
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_RETRIES = 0;
 
+interface ActiveDispatch {
+  response: Response;
+  lifecycle: RequestLifecycle;
+}
+
 /**
  * Hermes-2-Pro / VLLM tool_call regex.
  * Matches both closed and unclosed tags (truncated generation):
@@ -104,6 +114,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
   private readonly model: string;
   private readonly providerName: string;
   private readonly timeoutMs: number;
+  private readonly deadlines: RequestDeadlines;
   private readonly maxRetries: number;
 
   constructor(options: LocalPromptToolsAdapterOptions) {
@@ -111,6 +122,12 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
     this.model = options.model;
     this.providerName = options.providerName;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.deadlines = requestDeadlines(this.timeoutMs, {
+      connectionMs: options.connectionTimeoutMs,
+      firstByteMs: options.firstByteTimeoutMs,
+      bodyIdleMs: options.bodyIdleTimeoutMs,
+      totalMs: options.totalTimeoutMs,
+    });
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
   }
 
@@ -124,13 +141,21 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
 
     for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
       try {
-        const response = await this.fetchWithTimeout(url, headers, body, input.signal);
+        const active = await this.fetchWithLifecycle(url, headers, body, input.signal);
+        const response = active.response;
+        let rawText: string;
+        try {
+          rawText = await active.lifecycle.readText(response);
+        } catch (error) {
+          throw active.lifecycle.classify(error);
+        } finally {
+          active.lifecycle.cleanup();
+        }
         if (response.ok) {
-          const json = (await response.json()) as OllamaChatResponse;
+          const json = JSON.parse(rawText) as OllamaChatResponse;
           return this.parseResponse(json);
         }
         const status = response.status;
-        const rawText = await this.safeReadText(response);
         const retryable = status >= 500 || status === 429;
         // Phase v4.1.1-oauth-fix Phase 5: short message only. The raw
         // body flows via the .raw arg and composeMessage in errors.ts
@@ -148,8 +173,9 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
         lastError = err;
         await this.sleep(this.backoffMs(attempt));
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') throw err;
         if (err instanceof ProviderError && !err.retryable) throw err;
-        if (err instanceof ProviderTimeoutError) {
+        if (err instanceof ProviderPhaseTimeoutError) {
           lastError = err;
           if (attempt < totalAttempts) {
             await this.sleep(this.backoffMs(attempt));
@@ -210,37 +236,15 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
     const url = `${this.baseUrl}/api/chat`;
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-    // v4.6 prep — forward external abort into the internal controller.
-    let externalAbortHandler: (() => void) | null = null;
-    if (input.signal) {
-      if (input.signal.aborted) {
-        controller.abort();
-      } else {
-        externalAbortHandler = () => controller.abort();
-        input.signal.addEventListener('abort', externalAbortHandler, { once: true });
-      }
-    }
-    let response: Response;
+    let active: ActiveDispatch;
     try {
-      response = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+      active = await this.fetchWithLifecycle(url, headers, body, input.signal);
     } catch (err) {
-      clearTimeout(timer);
-      if (externalAbortHandler && input.signal) {
-        input.signal.removeEventListener('abort', externalAbortHandler);
-      }
       if (err instanceof Error && err.name === 'AbortError') {
-        // v4.6 prep — external abort takes priority over internal timeout.
-        if (input.signal?.aborted) {
-          throw err;
-        }
-        throw new ProviderTimeoutError(this.providerName, this.timeoutMs);
+        throw err;
+      }
+      if (err instanceof Error && err.name === 'ProviderPhaseTimeoutError') {
+        throw err;
       }
       throw new ProviderError(
         `Ollama not reachable at ${this.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
@@ -250,14 +254,18 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
         true,
       );
     }
+    const response = active.response;
 
     if (!response.ok) {
-      clearTimeout(timer);
-      if (externalAbortHandler && input.signal) {
-        input.signal.removeEventListener('abort', externalAbortHandler);
-      }
       const status = response.status;
-      const rawText = await this.safeReadText(response);
+      let rawText: string;
+      try {
+        rawText = await active.lifecycle.readText(response);
+      } catch (error) {
+        throw active.lifecycle.classify(error);
+      } finally {
+        active.lifecycle.cleanup();
+      }
       // Phase v4.1.1-oauth-fix Phase 5: composeMessage handles body
       // rendering centrally; inlining it here would duplicate.
       throw new ProviderError(
@@ -269,10 +277,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
       );
     }
     if (!response.body) {
-      clearTimeout(timer);
-      if (externalAbortHandler && input.signal) {
-        input.signal.removeEventListener('abort', externalAbortHandler);
-      }
+      active.lifecycle.cleanup();
       throw new ProviderError(
         `Provider ${this.providerName} returned an empty stream body`,
         this.providerName,
@@ -294,7 +299,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
 
     try {
       while (true) {
-        const { value, done } = await reader.read();
+        const { value, done } = await active.lifecycle.readChunk(reader);
         if (done) break;
         lineBuffer += decoder.decode(value, { stream: true });
         let nl: number;
@@ -339,11 +344,10 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
         }
       }
     } catch (err) {
-      clearTimeout(timer);
-      // v4.6 prep — external abort during mid-stream read surfaces as
-      // AbortError; re-throw so AidenAgent routes it as 'interrupted'.
-      if (err instanceof Error && err.name === 'AbortError' && input.signal?.aborted) {
-        throw err;
+      const classified = active.lifecycle.classify(err);
+      if (classified instanceof Error &&
+          (classified.name === 'AbortError' || classified.name === 'ProviderPhaseTimeoutError')) {
+        throw classified;
       }
       throw new ProviderError(
         `Provider ${this.providerName} stream interrupted: ${err instanceof Error ? err.message : String(err)}`,
@@ -353,10 +357,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
         true,
       );
     } finally {
-      clearTimeout(timer);
-      if (externalAbortHandler && input.signal) {
-        input.signal.removeEventListener('abort', externalAbortHandler);
-      }
+      active.lifecycle.cleanup();
       try {
         reader.releaseLock();
       } catch {
@@ -575,54 +576,26 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
     return { textBefore, toolCalls };
   }
 
-  private async fetchWithTimeout(
+  private async fetchWithLifecycle(
     url: string,
     headers: Record<string, string>,
-    body: OllamaChatRequest,
+    body: OllamaChatRequest | (Omit<OllamaChatRequest, 'stream'> & { stream: true }),
     externalSignal?: AbortSignal,
-  ): Promise<Response> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-    // v4.6 prep — forward external abort into the internal controller.
-    let externalAbortHandler: (() => void) | null = null;
-    if (externalSignal) {
-      if (externalSignal.aborted) {
-        controller.abort();
-      } else {
-        externalAbortHandler = () => controller.abort();
-        externalSignal.addEventListener('abort', externalAbortHandler, { once: true });
-      }
-    }
+  ): Promise<ActiveDispatch> {
+    const lifecycle = new RequestLifecycle(this.providerName, this.deadlines, externalSignal);
     try {
-      return await fetch(url, {
+      const response = await lifecycle.race(fetch(url, {
         method: 'POST',
         headers,
         body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+        signal: lifecycle.signal,
+      }));
+      lifecycle.markHeaders();
+      return { response, lifecycle };
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
-        // v4.6 prep — external abort takes priority over internal timeout.
-        // Surface the raw AbortError so AidenAgent routes it as 'interrupted'.
-        if (externalSignal?.aborted) {
-          throw err;
-        }
-        throw new ProviderTimeoutError(this.providerName, this.timeoutMs);
-      }
-      throw err;
-    } finally {
-      clearTimeout(timer);
-      if (externalAbortHandler && externalSignal) {
-        externalSignal.removeEventListener('abort', externalAbortHandler);
-      }
-    }
-  }
-
-  private async safeReadText(response: Response): Promise<string> {
-    try {
-      return await response.text();
-    } catch {
-      return '';
+      const classified = lifecycle.classify(err);
+      lifecycle.cleanup();
+      throw classified;
     }
   }
 

--- a/providers/v4/localPromptToolsAdapter.ts
+++ b/providers/v4/localPromptToolsAdapter.ts
@@ -45,6 +45,11 @@ import {
 } from './types';
 import { ProviderError, ProviderPhaseTimeoutError } from './errors';
 import { RequestLifecycle, requestDeadlines, type RequestDeadlines } from './requestLifecycle';
+import {
+  beginPhysicalProviderAttempt,
+  byteLength,
+  createLogicalProviderCallId,
+} from './providerAttemptAccounting';
 
 export interface LocalPromptToolsAdapterOptions {
   /** Default 'http://localhost:11434'. No trailing slash. */
@@ -138,8 +143,20 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
 
     const totalAttempts = this.maxRetries + 1;
     let lastError: ProviderError | null = null;
+    const serialised = JSON.stringify(body);
+    const logicalCallId = input.usageContext?.logicalCallId ?? createLogicalProviderCallId();
 
     for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+      const accounting = beginPhysicalProviderAttempt(input, {
+        providerActual: this.providerName,
+        modelActual: this.model,
+        apiMode: this.apiMode,
+        transport: this.baseUrl.startsWith('https:') ? 'https' : 'http',
+        attemptIndex: attempt - 1,
+        fallbackIndex: input.usageContext?.fallbackIndex ?? 0,
+        logicalCallId,
+        requestBytes: byteLength(serialised),
+      });
       try {
         const active = await this.fetchWithLifecycle(url, headers, body, input.signal);
         const response = active.response;
@@ -152,8 +169,19 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
           active.lifecycle.cleanup();
         }
         if (response.ok) {
-          const json = JSON.parse(rawText) as OllamaChatResponse;
-          return this.parseResponse(json);
+          try {
+            const json = JSON.parse(rawText) as OllamaChatResponse;
+            const output = this.parseResponse(json);
+            accounting.success(output, byteLength(rawText));
+            return output;
+          } catch (error) {
+            accounting.failure(error, {
+              sent: true,
+              responseBytes: byteLength(rawText),
+              status: 'validation_error',
+            });
+            throw error;
+          }
         }
         const status = response.status;
         const retryable = status >= 500 || status === 429;
@@ -169,13 +197,18 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
           rawText,
           retryable,
         );
+        accounting.failure(err, { sent: true, responseBytes: byteLength(rawText) });
         if (!retryable || attempt >= totalAttempts) throw err;
         lastError = err;
         await this.sleep(this.backoffMs(attempt));
       } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') throw err;
+        if (err instanceof Error && err.name === 'AbortError') {
+          accounting.failure(err, { sent: true, status: 'interrupted' });
+          throw err;
+        }
         if (err instanceof ProviderError && !err.retryable) throw err;
         if (err instanceof ProviderPhaseTimeoutError) {
+          accounting.failure(err, { sent: true });
           lastError = err;
           if (attempt < totalAttempts) {
             await this.sleep(this.backoffMs(attempt));
@@ -184,6 +217,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
           throw err;
         }
         if (err instanceof ProviderError) {
+          accounting.failure(err, { sent: true });
           lastError = err;
           if (attempt < totalAttempts) {
             await this.sleep(this.backoffMs(attempt));
@@ -199,6 +233,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
           err,
           true,
         );
+        accounting.failure(wrapped, { sent: true });
         if (attempt < totalAttempts) {
           lastError = wrapped;
           await this.sleep(this.backoffMs(attempt));
@@ -235,24 +270,39 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
     const body = { ...baseBody, stream: true };
     const url = `${this.baseUrl}/api/chat`;
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const serialised = JSON.stringify(body);
+    const accounting = beginPhysicalProviderAttempt(input, {
+      providerActual: this.providerName,
+      modelActual: this.model,
+      apiMode: this.apiMode,
+      transport: this.baseUrl.startsWith('https:') ? 'https' : 'http',
+      attemptIndex: 0,
+      fallbackIndex: input.usageContext?.fallbackIndex ?? 0,
+      logicalCallId: input.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+      requestBytes: byteLength(serialised),
+    });
 
     let active: ActiveDispatch;
     try {
       active = await this.fetchWithLifecycle(url, headers, body, input.signal);
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
+        accounting.failure(err, { sent: true, status: 'interrupted' });
         throw err;
       }
       if (err instanceof Error && err.name === 'ProviderPhaseTimeoutError') {
+        accounting.failure(err, { sent: true });
         throw err;
       }
-      throw new ProviderError(
+      const error = new ProviderError(
         `Ollama not reachable at ${this.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
         this.providerName,
         undefined,
         err,
         true,
       );
+      accounting.failure(error, { sent: true });
+      throw error;
     }
     const response = active.response;
 
@@ -262,26 +312,32 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
       try {
         rawText = await active.lifecycle.readText(response);
       } catch (error) {
-        throw active.lifecycle.classify(error);
+        const classified = active.lifecycle.classify(error);
+        accounting.failure(classified, { sent: true });
+        throw classified;
       } finally {
         active.lifecycle.cleanup();
       }
       // Phase v4.1.1-oauth-fix Phase 5: composeMessage handles body
       // rendering centrally; inlining it here would duplicate.
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} returned ${status}`,
         this.providerName,
         status,
         rawText,
         status >= 500,
       );
+      accounting.failure(error, { sent: true, responseBytes: byteLength(rawText) });
+      throw error;
     }
     if (!response.body) {
       active.lifecycle.cleanup();
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} returned an empty stream body`,
         this.providerName,
       );
+      accounting.failure(error, { sent: true, status: 'validation_error' });
+      throw error;
     }
     // Response is good; the stream consumer will run for a while. The
     // controller stays armed (with `externalSignal` still listening) so
@@ -347,15 +403,21 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
       const classified = active.lifecycle.classify(err);
       if (classified instanceof Error &&
           (classified.name === 'AbortError' || classified.name === 'ProviderPhaseTimeoutError')) {
+        accounting.failure(classified, {
+          sent: true,
+          ...(classified.name === 'AbortError' ? { status: 'interrupted' as const } : {}),
+        });
         throw classified;
       }
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} stream interrupted: ${err instanceof Error ? err.message : String(err)}`,
         this.providerName,
         undefined,
         err,
         true,
       );
+      accounting.failure(error, { sent: true });
+      throw error;
     } finally {
       active.lifecycle.cleanup();
       try {
@@ -398,6 +460,7 @@ export class LocalPromptToolsAdapter implements ProviderAdapter {
         outputTokens: evalCount,
       },
     };
+    accounting.success(output);
     yield { type: 'done', output };
   }
 

--- a/providers/v4/messageApiAdapter.ts
+++ b/providers/v4/messageApiAdapter.ts
@@ -38,8 +38,8 @@ import { parseSseStream } from './chatCompletionsAdapter';
 import {
   ProviderError,
   ProviderRateLimitError,
-  ProviderTimeoutError,
 } from './errors';
+import { RequestLifecycle, requestDeadlines, type RequestDeadlines } from './requestLifecycle';
 import { VERSION } from '../../core/version';
 
 // ── Public options ──────────────────────────────────────────────────────────
@@ -55,6 +55,10 @@ export interface MessageApiAdapterOptions {
   providerName: string;
   /** Per-request wall clock. Default 120_000 ms. */
   timeoutMs?: number;
+  connectionTimeoutMs?: number;
+  firstByteTimeoutMs?: number;
+  bodyIdleTimeoutMs?: number;
+  totalTimeoutMs?: number;
   /** Retries on 429 / 5xx / network errors. Default 2 (3 attempts total). */
   maxRetries?: number;
   /** Header overrides (escape hatch — wins over computed headers). */
@@ -103,6 +107,11 @@ const DEFAULT_MAX_TOKENS  = 4096;
 const MESSAGE_API_VERSION = '2023-06-01';
 const BACKOFF_BASE_MS     = 1000;
 
+interface ActiveDispatch {
+  response: Response;
+  lifecycle: RequestLifecycle;
+}
+
 // ── Adapter ────────────────────────────────────────────────────────────────
 
 export class MessageApiAdapter implements ProviderAdapter {
@@ -113,6 +122,7 @@ export class MessageApiAdapter implements ProviderAdapter {
   private readonly model:        string;
   private readonly providerName: string;
   private readonly timeoutMs:    number;
+  private readonly deadlines:    RequestDeadlines;
   private readonly maxRetries:   number;
   private readonly extraHeaders: Record<string, string>;
 
@@ -123,6 +133,12 @@ export class MessageApiAdapter implements ProviderAdapter {
     this.model        = opts.model;
     this.providerName = opts.providerName;
     this.timeoutMs    = opts.timeoutMs  ?? DEFAULT_TIMEOUT_MS;
+    this.deadlines    = requestDeadlines(this.timeoutMs, {
+      connectionMs: opts.connectionTimeoutMs,
+      firstByteMs: opts.firstByteTimeoutMs,
+      bodyIdleMs: opts.bodyIdleTimeoutMs,
+      totalMs: opts.totalTimeoutMs,
+    });
     this.maxRetries   = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.extraHeaders = opts.extraHeaders ?? {};
   }
@@ -131,8 +147,16 @@ export class MessageApiAdapter implements ProviderAdapter {
 
   async call(input: ProviderCallInput): Promise<ProviderCallOutput> {
     const body  = this.buildBody(input, /* streaming */ false);
-    const reply = await this.dispatch(body, /* streaming */ false, input.signal, input.headers);
-    const json  = (await reply.json()) as WireMessageBody;
+    const active = await this.dispatch(body, /* streaming */ false, input.signal, input.headers);
+    let text: string;
+    try {
+      text = await active.lifecycle.readText(active.response);
+    } catch (error) {
+      throw active.lifecycle.classify(error);
+    } finally {
+      active.lifecycle.cleanup();
+    }
+    const json = JSON.parse(text) as WireMessageBody;
     return decodeResponse(json);
   }
 
@@ -140,7 +164,8 @@ export class MessageApiAdapter implements ProviderAdapter {
 
   async *callStream(input: ProviderCallInput): AsyncGenerator<StreamEvent, void, void> {
     const body = this.buildBody(input, /* streaming */ true);
-    const reply = await this.dispatch(body, /* streaming */ true, input.signal, input.headers);
+    const active = await this.dispatch(body, /* streaming */ true, input.signal, input.headers);
+    const reply = active.response;
     if (!reply.body) {
       // Server promised SSE but gave us nothing — fall through to a synthetic
       // empty done event so the agent loop terminates rather than hangs.
@@ -153,9 +178,16 @@ export class MessageApiAdapter implements ProviderAdapter {
           usage:        { inputTokens: 0, outputTokens: 0 },
         },
       };
+      active.lifecycle.cleanup();
       return;
     }
-    yield* decodeStream(reply.body, input.maxTokens ?? DEFAULT_MAX_TOKENS);
+    try {
+      yield* decodeStream(reply.body, input.maxTokens ?? DEFAULT_MAX_TOKENS, active.lifecycle);
+    } catch (error) {
+      throw active.lifecycle.classify(error);
+    } finally {
+      active.lifecycle.cleanup();
+    }
   }
 
   // ── Request body assembly ────────────────────────────────────────────────
@@ -199,7 +231,7 @@ export class MessageApiAdapter implements ProviderAdapter {
     streaming: boolean,
     externalSignal?: AbortSignal,
     outboundHeaders?: Record<string, string>,
-  ): Promise<Response> {
+  ): Promise<ActiveDispatch> {
     // v4.9.0 Slice 7 — merge caller-supplied outbound headers (e.g.
     // `traceparent`, `X-Aiden-Run-Id`) below the adapter's defaults so
     // they can't override `x-api-key` / `anthropic-version` etc.,
@@ -213,47 +245,35 @@ export class MessageApiAdapter implements ProviderAdapter {
     let lastErr: unknown = null;
 
     for (let attempt = 0; attempt < totalTries; attempt++) {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+      const lifecycle = new RequestLifecycle(this.providerName, this.deadlines, externalSignal);
       // v4.6 prep — forward an external AbortSignal into this attempt's
       // internal controller so a parent agent that aborts mid-flight
       // cancels the in-flight fetch. External aborts surface as a raw
       // AbortError (NOT ProviderTimeoutError) so AidenAgent can route
       // them as `finishReason: 'interrupted'` instead of treating them
       // as a retryable timeout.
-      let externalAbortHandler: (() => void) | null = null;
-      if (externalSignal) {
-        if (externalSignal.aborted) {
-          controller.abort();
-        } else {
-          externalAbortHandler = () => controller.abort();
-          externalSignal.addEventListener('abort', externalAbortHandler, { once: true });
-        }
-      }
-
       let response: Response;
       try {
-        response = await fetch(this.endpoint, {
+        response = await lifecycle.race(fetch(this.endpoint, {
           method:  'POST',
           headers,
           body:    serialised,
-          signal:  controller.signal,
-        });
+          signal:  lifecycle.signal,
+        }));
+        lifecycle.markHeaders();
       } catch (err: any) {
-        clearTimeout(timer);
-        if (externalAbortHandler && externalSignal) {
-          externalSignal.removeEventListener('abort', externalAbortHandler);
-        }
-        if (err?.name === 'AbortError') {
+        const classified = lifecycle.classify(err);
+        lifecycle.cleanup();
+        if (classified instanceof Error && classified.name === 'AbortError') {
           // v4.6 prep — external abort takes priority over internal
           // timeout. Surface the raw AbortError immediately (no retry)
           // so AidenAgent's catch routes it as 'interrupted'.
           if (externalSignal?.aborted) {
-            throw err;
+            throw classified;
           }
-          // Treat timeout as retryable; only surface ProviderTimeoutError if
-          // we've burned the last attempt.
-          lastErr = new ProviderTimeoutError(this.providerName, this.timeoutMs);
+          lastErr = classified;
+        } else if (classified instanceof Error && classified.name === 'ProviderPhaseTimeoutError') {
+          lastErr = classified;
         } else {
           lastErr = new ProviderError(
             `Network failure calling ${this.providerName}: ${err?.message ?? err}`,
@@ -269,20 +289,14 @@ export class MessageApiAdapter implements ProviderAdapter {
         }
         throw lastErr;
       }
-      clearTimeout(timer);
-      if (externalAbortHandler && externalSignal) {
-        externalSignal.removeEventListener('abort', externalAbortHandler);
-      }
+      if (response.ok) return { response, lifecycle };
 
-      if (response.ok) return response;
-
-      // Phase 25.1.5d diagnostic: gated dump of request + response so we
-      // can see exactly what Anthropic objected to. Cloned response so the
-      // existing safeReadBody call below still gets a readable body.
+      // Gated request diagnostic. Do not clone or consume the response here:
+      // the lifecycle below must remain the sole body reader so its first-byte,
+      // idle, total, and caller-cancellation deadlines cover every byte.
       // Sensitive headers are redacted before printing.
       if (process.env.AIDEN_DEBUG_ANTHROPIC === '1') {
         try {
-          const debugBody = await response.clone().text();
           const safeHeaders = redactHeaders(headers);
           // eslint-disable-next-line no-console
           console.error(`[anthropic-debug] status: ${response.status} ${response.statusText}`);
@@ -292,8 +306,6 @@ export class MessageApiAdapter implements ProviderAdapter {
           console.error(`[anthropic-debug] req headers: ${JSON.stringify(safeHeaders, null, 2)}`);
           // eslint-disable-next-line no-console
           console.error(`[anthropic-debug] req body (first 500 chars): ${serialised.slice(0, 500)}`);
-          // eslint-disable-next-line no-console
-          console.error(`[anthropic-debug] resp body: ${debugBody}`);
         } catch {
           /* diagnostic best-effort; never block the real error path */
         }
@@ -301,7 +313,16 @@ export class MessageApiAdapter implements ProviderAdapter {
 
       // Non-2xx: classify and decide whether to retry.
       const status = response.status;
-      const raw    = await safeReadBody(response);
+      let responseText: string;
+      try {
+        responseText = await lifecycle.readText(response);
+      } catch (error) {
+        const classified = lifecycle.classify(error);
+        lifecycle.cleanup();
+        throw classified;
+      }
+      const raw = tryParseJson(responseText);
+      lifecycle.cleanup();
 
       if (status === 429) {
         if (attempt < totalTries - 1) {
@@ -516,6 +537,7 @@ interface BlockState {
 async function* decodeStream(
   body: ReadableStream<Uint8Array>,
   maxTokens: number,
+  lifecycle?: RequestLifecycle,
 ): AsyncGenerator<StreamEvent, void, void> {
   const blocks  = new Map<number, BlockState>();
   const toolCalls: ToolCallRequest[] = [];
@@ -531,7 +553,7 @@ async function* decodeStream(
   // proportional to real progress.
   let lastProgressEmitted = -1;
 
-  for await (const payload of parseSseStream(body)) {
+  for await (const payload of parseSseStream(body, lifecycle)) {
     if (!payload || payload === '[DONE]') continue;
     let evt: any;
     try { evt = JSON.parse(payload); }
@@ -679,11 +701,6 @@ function redactValue(v: string): string {
   return `${v.slice(0, 6)}…${v.slice(-4)} (len=${v.length})`;
 }
 
-async function safeReadBody(r: Response): Promise<unknown> {
-  try {
-    const text = await r.text();
-    try { return JSON.parse(text); } catch { return text; }
-  } catch {
-    return null;
-  }
+function tryParseJson(text: string): unknown {
+  try { return JSON.parse(text); } catch { return text; }
 }

--- a/providers/v4/messageApiAdapter.ts
+++ b/providers/v4/messageApiAdapter.ts
@@ -41,6 +41,12 @@ import {
 } from './errors';
 import { RequestLifecycle, requestDeadlines, type RequestDeadlines } from './requestLifecycle';
 import { VERSION } from '../../core/version';
+import {
+  beginPhysicalProviderAttempt,
+  byteLength,
+  createLogicalProviderCallId,
+  type PhysicalAttemptLifecycle,
+} from './providerAttemptAccounting';
 
 // ── Public options ──────────────────────────────────────────────────────────
 
@@ -89,7 +95,11 @@ interface WireRequestBody {
   model:        string;
   /** Flat system-prompt string (Anthropic also accepts a typed-block array,
    *  but Aiden only sends the string form). */
-  system?:      string;
+  system?:      string | Array<{
+    type: 'text';
+    text: string;
+    cache_control?: { type: 'ephemeral' };
+  }>;
   messages:     unknown[];
   tools?:       Array<{ name: string; description: string; input_schema: ToolSchema['inputSchema'] }>;
   tool_choice?: { type: 'auto' };
@@ -110,6 +120,7 @@ const BACKOFF_BASE_MS     = 1000;
 interface ActiveDispatch {
   response: Response;
   lifecycle: RequestLifecycle;
+  attempt: PhysicalAttemptLifecycle;
 }
 
 // ── Adapter ────────────────────────────────────────────────────────────────
@@ -147,26 +158,43 @@ export class MessageApiAdapter implements ProviderAdapter {
 
   async call(input: ProviderCallInput): Promise<ProviderCallOutput> {
     const body  = this.buildBody(input, /* streaming */ false);
-    const active = await this.dispatch(body, /* streaming */ false, input.signal, input.headers);
+    const active = await this.dispatch(body, /* streaming */ false, input);
     let text: string;
     try {
       text = await active.lifecycle.readText(active.response);
     } catch (error) {
-      throw active.lifecycle.classify(error);
+      const classified = active.lifecycle.classify(error);
+      active.attempt.failure(classified, { sent: true });
+      throw classified;
     } finally {
       active.lifecycle.cleanup();
     }
-    const json = JSON.parse(text) as WireMessageBody;
-    return decodeResponse(json);
+    try {
+      const json = JSON.parse(text) as WireMessageBody;
+      const output = decodeResponse(json);
+      active.attempt.success(output, byteLength(text));
+      return output;
+    } catch (error) {
+      active.attempt.failure(error, {
+        sent: true,
+        responseBytes: byteLength(text),
+        status: 'validation_error',
+      });
+      throw error;
+    }
   }
 
   // ── Public: streaming ────────────────────────────────────────────────────
 
   async *callStream(input: ProviderCallInput): AsyncGenerator<StreamEvent, void, void> {
     const body = this.buildBody(input, /* streaming */ true);
-    const active = await this.dispatch(body, /* streaming */ true, input.signal, input.headers);
+    const active = await this.dispatch(body, /* streaming */ true, input);
     const reply = active.response;
     if (!reply.body) {
+      active.attempt.failure(new Error('Provider returned an empty stream.'), {
+        sent: true,
+        status: 'validation_error',
+      });
       // Server promised SSE but gave us nothing — fall through to a synthetic
       // empty done event so the agent loop terminates rather than hangs.
       yield {
@@ -181,10 +209,26 @@ export class MessageApiAdapter implements ProviderAdapter {
       active.lifecycle.cleanup();
       return;
     }
+    let finalOutput: ProviderCallOutput | null = null;
     try {
-      yield* decodeStream(reply.body, input.maxTokens ?? DEFAULT_MAX_TOKENS, active.lifecycle);
+      for await (const event of decodeStream(reply.body, input.maxTokens ?? DEFAULT_MAX_TOKENS, active.lifecycle)) {
+        if (event.type === 'done') finalOutput = event.output;
+        yield event;
+      }
+      if (finalOutput) active.attempt.success(finalOutput);
+      else active.attempt.failure(new Error('Provider stream ended without done.'), {
+        sent: true,
+        status: 'validation_error',
+      });
     } catch (error) {
-      throw active.lifecycle.classify(error);
+      const classified = active.lifecycle.classify(error);
+      active.attempt.failure(classified, {
+        sent: true,
+        ...(classified instanceof Error && classified.name === 'AbortError'
+          ? { status: 'interrupted' as const }
+          : {}),
+      });
+      throw classified;
     } finally {
       active.lifecycle.cleanup();
     }
@@ -229,8 +273,7 @@ export class MessageApiAdapter implements ProviderAdapter {
   private async dispatch(
     body: WireRequestBody,
     streaming: boolean,
-    externalSignal?: AbortSignal,
-    outboundHeaders?: Record<string, string>,
+    input: ProviderCallInput,
   ): Promise<ActiveDispatch> {
     // v4.9.0 Slice 7 — merge caller-supplied outbound headers (e.g.
     // `traceparent`, `X-Aiden-Run-Id`) below the adapter's defaults so
@@ -238,13 +281,25 @@ export class MessageApiAdapter implements ProviderAdapter {
     // but above `extraHeaders` so a deliberate per-deployment override
     // still wins.
     const base = this.buildHeaders(streaming);
-    const headers = outboundHeaders ? { ...outboundHeaders, ...base } : base;
+    const headers = input.headers ? { ...input.headers, ...base } : base;
     const serialised  = JSON.stringify(body);
     const totalTries  = this.maxRetries + 1;
+    const externalSignal = input.signal;
+    const logicalCallId = input.usageContext?.logicalCallId ?? createLogicalProviderCallId();
 
     let lastErr: unknown = null;
 
     for (let attempt = 0; attempt < totalTries; attempt++) {
+      const accounting = beginPhysicalProviderAttempt(input, {
+        providerActual: this.providerName,
+        modelActual: this.model,
+        apiMode: this.apiMode,
+        transport: this.endpoint.startsWith('https:') ? 'https' : 'http',
+        attemptIndex: attempt,
+        fallbackIndex: input.usageContext?.fallbackIndex ?? 0,
+        logicalCallId,
+        requestBytes: byteLength(serialised),
+      });
       const lifecycle = new RequestLifecycle(this.providerName, this.deadlines, externalSignal);
       // v4.6 prep — forward an external AbortSignal into this attempt's
       // internal controller so a parent agent that aborts mid-flight
@@ -269,6 +324,7 @@ export class MessageApiAdapter implements ProviderAdapter {
           // timeout. Surface the raw AbortError immediately (no retry)
           // so AidenAgent's catch routes it as 'interrupted'.
           if (externalSignal?.aborted) {
+            accounting.failure(classified, { sent: true, status: 'interrupted' });
             throw classified;
           }
           lastErr = classified;
@@ -283,13 +339,14 @@ export class MessageApiAdapter implements ProviderAdapter {
             true,
           );
         }
+        accounting.failure(lastErr, { sent: true });
         if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
+          await sleep(backoffMs(attempt), externalSignal);
           continue;
         }
         throw lastErr;
       }
-      if (response.ok) return { response, lifecycle };
+      if (response.ok) return { response, lifecycle, attempt: accounting };
 
       // Gated request diagnostic. Do not clone or consume the response here:
       // the lifecycle below must remain the sole body reader so its first-byte,
@@ -319,41 +376,48 @@ export class MessageApiAdapter implements ProviderAdapter {
       } catch (error) {
         const classified = lifecycle.classify(error);
         lifecycle.cleanup();
+        accounting.failure(classified, { sent: true });
         throw classified;
       }
       const raw = tryParseJson(responseText);
       lifecycle.cleanup();
 
       if (status === 429) {
+        const error = new ProviderRateLimitError(this.providerName, raw);
+        accounting.failure(error, { sent: true, responseBytes: wireByteLength(raw) });
         if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
+          await sleep(backoffMs(attempt), externalSignal);
           continue;
         }
-        throw new ProviderRateLimitError(this.providerName, raw);
+        throw error;
       }
 
       if (status >= 500 && status < 600) {
-        if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
-          continue;
-        }
-        throw new ProviderError(
+        const error = new ProviderError(
           `Provider ${this.providerName} server error ${status}`,
           this.providerName,
           status,
           raw,
           true,
         );
+        accounting.failure(error, { sent: true, responseBytes: wireByteLength(raw) });
+        if (attempt < totalTries - 1) {
+          await sleep(backoffMs(attempt), externalSignal);
+          continue;
+        }
+        throw error;
       }
 
       // 4xx (auth, bad request, content policy, …) — fail fast, do not retry.
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} request failed (${status})`,
         this.providerName,
         status,
         raw,
         false,
       );
+      accounting.failure(error, { sent: true, responseBytes: wireByteLength(raw) });
+      throw error;
     }
 
     // Unreachable in practice — the loop either returns or throws.
@@ -390,13 +454,29 @@ function parseImageDataUrl(dataUrl: string): { mediaType: string; data: string }
 
 function encodeMessages(
   messages: Message[],
-): { system: string | undefined; wireMessages: unknown[] } {
+): {
+  system: WireRequestBody['system'] | undefined;
+  wireMessages: unknown[];
+} {
   const sysParts: string[]    = [];
+  const sysBlocks: Array<{
+    type: 'text';
+    text: string;
+    cache_control?: { type: 'ephemeral' };
+  }> = [];
   const wireMessages: unknown[] = [];
 
   for (const msg of messages) {
     if (msg.role === 'system') {
       sysParts.push(msg.content);
+      const marker = (msg as Message & {
+        cache_control?: { type: 'ephemeral' };
+      }).cache_control;
+      sysBlocks.push({
+        type: 'text',
+        text: msg.content,
+        ...(marker?.type === 'ephemeral' ? { cache_control: marker } : {}),
+      });
       continue;
     }
 
@@ -450,7 +530,11 @@ function encodeMessages(
   }
 
   const joined = sysParts.join('\n\n').trim();
-  return { system: joined || undefined, wireMessages };
+  const hasCacheMarker = sysBlocks.some((block) => block.cache_control !== undefined);
+  return {
+    system: hasCacheMarker ? sysBlocks : (joined || undefined),
+    wireMessages,
+  };
 }
 
 /** Anthropic stop_reason → Aiden finishReason. */
@@ -507,6 +591,12 @@ function decodeUsage(u: WireMessageBody['usage']): ProviderCallOutput['usage'] {
     out.cacheWriteTokens = u.cache_creation_input_tokens;
   }
   return out;
+}
+
+function wireByteLength(value: unknown): number {
+  if (typeof value === 'string') return byteLength(value);
+  try { return byteLength(JSON.stringify(value) ?? ''); }
+  catch { return 0; }
 }
 
 // ── Streaming decoder ───────────────────────────────────────────────────────
@@ -673,8 +763,26 @@ function backoffMs(attempt: number): number {
   return base + jitter;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    const error = new Error('The provider retry wait was cancelled.');
+    error.name = 'AbortError';
+    return Promise.reject(error);
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      const error = new Error('The provider retry wait was cancelled.');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 /**

--- a/providers/v4/modelCatalog.ts
+++ b/providers/v4/modelCatalog.ts
@@ -51,6 +51,10 @@ export interface ModelEntry {
   tier: 'flagship' | 'standard' | 'small' | 'free';
   /** Optional notes for menu (e.g. "preview", "deprecated soon"). */
   notes?: string;
+  /** Organization that created the model, when distinct from its host. */
+  creator?: string;
+  /** Inference provider serving the model. */
+  hostedBy?: string;
 }
 
 export const MODEL_CATALOG: ModelEntry[] = [
@@ -352,42 +356,34 @@ export const MODEL_CATALOG: ModelEntry[] = [
 
   // ─── groq ────────────────────────────────────────────────────────────────
   {
-    id: 'llama-3.3-70b-versatile',
-    displayName: 'Llama 3.3 70B Versatile',
+    id: 'openai/gpt-oss-120b',
+    displayName: 'GPT-OSS 120B',
     providerId: 'groq',
     contextLength: 131_072,
-    maxOutputTokens: 32_768,
+    maxOutputTokens: 65_536,
     supportsToolCalling: true,
     supportsVision: false,
-    supportsReasoning: false,
-    pricing: { inputPerM: 0.59, outputPerM: 0.79 },
+    supportsReasoning: true,
+    pricing: { inputPerM: 0.15, outputPerM: 0.60 },
     isDefault: true,
     tier: 'flagship',
+    creator: 'OpenAI',
+    hostedBy: 'Groq',
   },
   {
-    id: 'llama-3.1-8b-instant',
-    displayName: 'Llama 3.1 8B Instant',
+    id: 'openai/gpt-oss-20b',
+    displayName: 'GPT-OSS 20B',
     providerId: 'groq',
     contextLength: 131_072,
-    maxOutputTokens: 8_192,
+    maxOutputTokens: 65_536,
     supportsToolCalling: true,
     supportsVision: false,
-    supportsReasoning: false,
+    supportsReasoning: true,
     pricing: { inputPerM: 0.05, outputPerM: 0.08 },
     isDefault: false,
     tier: 'small',
-  },
-  {
-    id: 'mixtral-8x7b-32768',
-    displayName: 'Mixtral 8x7B',
-    providerId: 'groq',
-    contextLength: 32_768,
-    supportsToolCalling: true,
-    supportsVision: false,
-    supportsReasoning: false,
-    pricing: { inputPerM: 0.24, outputPerM: 0.24 },
-    isDefault: false,
-    tier: 'standard',
+    creator: 'OpenAI',
+    hostedBy: 'Groq',
   },
 
   // ─── gemini ──────────────────────────────────────────────────────────────
@@ -456,6 +452,48 @@ export const MODEL_CATALOG: ModelEntry[] = [
 
   // ─── huggingface ─────────────────────────────────────────────────────────
   {
+    id: 'openai/gpt-oss-120b',
+    displayName: 'GPT-OSS 120B',
+    providerId: 'huggingface',
+    contextLength: 131_072,
+    supportsToolCalling: true,
+    supportsVision: false,
+    supportsReasoning: true,
+    isDefault: true,
+    tier: 'flagship',
+    creator: 'OpenAI',
+    hostedBy: 'Hugging Face',
+    notes: 'Automatic inference-provider routing; verify the selected route during setup.',
+  },
+  {
+    id: 'openai/gpt-oss-20b',
+    displayName: 'GPT-OSS 20B',
+    providerId: 'huggingface',
+    contextLength: 131_072,
+    supportsToolCalling: true,
+    supportsVision: false,
+    supportsReasoning: true,
+    isDefault: false,
+    tier: 'small',
+    creator: 'OpenAI',
+    hostedBy: 'Hugging Face',
+    notes: 'Automatic inference-provider routing; verify the selected route during setup.',
+  },
+  {
+    id: 'Qwen/Qwen3-Coder-480B-A35B-Instruct',
+    displayName: 'Qwen3 Coder 480B A35B Instruct',
+    providerId: 'huggingface',
+    contextLength: 262_144,
+    supportsToolCalling: true,
+    supportsVision: false,
+    supportsReasoning: true,
+    isDefault: false,
+    tier: 'flagship',
+    creator: 'Qwen',
+    hostedBy: 'Hugging Face',
+    notes: 'Automatic inference-provider routing; verify the selected route during setup.',
+  },
+  {
     id: 'meta-llama/Llama-3.3-70B-Instruct',
     displayName: 'Llama 3.3 70B Instruct',
     providerId: 'huggingface',
@@ -463,7 +501,7 @@ export const MODEL_CATALOG: ModelEntry[] = [
     supportsToolCalling: true,
     supportsVision: false,
     supportsReasoning: false,
-    isDefault: true,
+    isDefault: false,
     tier: 'flagship',
   },
   {
@@ -577,6 +615,8 @@ export const MODEL_CATALOG: ModelEntry[] = [
     isDefault: true,
     tier: 'flagship',
     notes: 'Tool-calling capable. Available at Build Tier 0.',
+    creator: 'OpenAI',
+    hostedBy: 'Together AI',
   },
   {
     id: 'openai/gpt-oss-20b',
@@ -590,6 +630,8 @@ export const MODEL_CATALOG: ModelEntry[] = [
     isDefault: false,
     tier: 'small',
     notes: 'Smaller/cheaper tool-calling option. Tier-0 accessible.',
+    creator: 'OpenAI',
+    hostedBy: 'Together AI',
   },
   {
     id: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
@@ -650,8 +692,8 @@ export const MODEL_CATALOG: ModelEntry[] = [
   // so maxOutputTokens is omitted rather than asserted. pricing is omitted
   // (unknown — no DeepSeek-direct price is cited anywhere in-repo; per the
   // header rule we leave `pricing` undefined rather than invent numbers).
-  // isDefault stays FALSE — selectable, not automatic; the default + the
-  // registry auto-pick wait on live tool-calling verification.
+  // The current direct-API primary is the default. Readiness still determines
+  // whether a configured account/model combination is usable at runtime.
   {
     id: 'deepseek-v4-pro',
     displayName: 'DeepSeek V4 Pro',
@@ -667,7 +709,7 @@ export const MODEL_CATALOG: ModelEntry[] = [
     supportsVision: false,
     supportsReasoning: true,         // mandatory thinking + reasoning_effort
     // pricing omitted — unknown, not cited in-repo.
-    isDefault: false,
+    isDefault: true,
     tier: 'flagship',
   },
   {
@@ -696,7 +738,7 @@ export const MODEL_CATALOG: ModelEntry[] = [
     supportsVision: false,
     supportsReasoning: false,
     pricing: { inputPerM: 0.27, outputPerM: 1.1 },
-    isDefault: true,
+    isDefault: false,
     tier: 'flagship',
   },
   {

--- a/providers/v4/modelSwitch.ts
+++ b/providers/v4/modelSwitch.ts
@@ -137,7 +137,14 @@ export class ModelSwitcher {
         providerId: parsed.providerId,
         modelId: parsed.modelId,
         allowUnverified: true,
-      })!.model;
+      })?.model
+      ?? this.resolver.listModels(parsed.providerId).find((model) => model.id === parsed.modelId);
+    if (!newModel) {
+      throw new ProviderError(
+        `Model '${parsed.modelId}' resolved but its metadata is unavailable.`,
+        parsed.providerId,
+      );
+    }
 
     const changed =
       req.currentProviderId !== parsed.providerId ||

--- a/providers/v4/modelSwitch.ts
+++ b/providers/v4/modelSwitch.ts
@@ -29,6 +29,7 @@ import {
   findProvidersForModelId,
 } from './modelCatalog';
 import { RuntimeResolver } from './runtimeResolver';
+import { resolveModelSelection } from './providerModelAuthority';
 
 export interface ModelSwitchRequest {
   /**
@@ -125,12 +126,18 @@ export class ModelSwitcher {
     const newAdapter = await this.resolver.resolve({
       providerId: parsed.providerId,
       modelId: parsed.modelId,
+      allowUnverifiedModel: true,
     });
 
     // Resolution succeeded — pull the entries for the result. These are
     // guaranteed present since resolve() already validated them.
     const newProvider = PROVIDER_REGISTRY[parsed.providerId];
-    const newModel = findModel(parsed.providerId, parsed.modelId)!;
+    const newModel = findModel(parsed.providerId, parsed.modelId)
+      ?? resolveModelSelection({
+        providerId: parsed.providerId,
+        modelId: parsed.modelId,
+        allowUnverified: true,
+      })!.model;
 
     const changed =
       req.currentProviderId !== parsed.providerId ||

--- a/providers/v4/providerAttemptAccounting.ts
+++ b/providers/v4/providerAttemptAccounting.ts
@@ -1,0 +1,363 @@
+import { randomUUID } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import {
+  ProviderAttemptLedger,
+  type ProviderAttemptRecord,
+  type ProviderAttemptStatus,
+  type ProviderUsageSource,
+} from '../../core/v4/usageLedger';
+import { findModel } from './modelCatalog';
+import { classifyProviderError, ProviderError, ProviderTimeoutError } from './errors';
+import type {
+  ApiMode,
+  ProviderCallInput,
+  ProviderCallOutput,
+  ProviderCallUsageContext,
+} from './types';
+
+export interface PhysicalAttemptMetadata {
+  providerActual: string;
+  modelActual: string;
+  apiMode: ApiMode;
+  transport: string;
+  attemptIndex: number;
+  fallbackIndex?: number;
+  logicalCallId: string;
+  requestBytes: number | null;
+}
+
+export interface AttemptFailureOptions {
+  sent: boolean;
+  responseBytes?: number | null;
+  status?: ProviderAttemptStatus;
+}
+
+export interface PhysicalAttemptLifecycle {
+  readonly callId: string;
+  success(output: ProviderCallOutput, responseBytes?: number | null): void;
+  failure(error: unknown, options: AttemptFailureOptions): void;
+}
+
+export class ProviderAttemptBudgetExceededError extends Error {
+  constructor(readonly budgetLabel: string, message: string) {
+    super(message);
+    this.name = 'ProviderAttemptBudgetExceededError';
+  }
+}
+
+let configuredLedger: ProviderAttemptLedger | null = null;
+let configuredLedgerPath: string | null = null;
+const usageContextStorage = new AsyncLocalStorage<ProviderCallUsageContext>();
+
+/** Configure the process-wide leaf-adapter sink used by all v4 adapters. */
+export function configureProviderAttemptLedger(dbPath: string | null): void {
+  if (dbPath === configuredLedgerPath) return;
+  try {
+    configuredLedger?.close();
+  } catch {
+    // Best-effort replacement; an accounting sink is reopened below.
+  }
+  configuredLedger = dbPath ? new ProviderAttemptLedger(dbPath) : null;
+  configuredLedgerPath = dbPath;
+}
+
+/** Test/embedded-runtime seam that avoids any global path discovery. */
+export function setProviderAttemptLedger(ledger: ProviderAttemptLedger | null): void {
+  configuredLedger = ledger;
+  configuredLedgerPath = null;
+}
+
+export function currentProviderAttemptLedger(): ProviderAttemptLedger | null {
+  return configuredLedger;
+}
+
+/**
+ * Scope setup/readiness accounting without leaking a SQLite handle into the
+ * caller. An already-configured runtime ledger for the same path is reused;
+ * otherwise the prior process-wide authority is restored after the operation.
+ */
+export async function runWithProviderAttemptLedger<T>(
+  dbPath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (configuredLedger && configuredLedgerPath === dbPath) return operation();
+  const previousLedger = configuredLedger;
+  const previousPath = configuredLedgerPath;
+  const scopedLedger = new ProviderAttemptLedger(dbPath);
+  configuredLedger = scopedLedger;
+  configuredLedgerPath = dbPath;
+  try {
+    return await operation();
+  } finally {
+    configuredLedger = previousLedger;
+    configuredLedgerPath = previousPath;
+    scopedLedger.close();
+  }
+}
+
+export function runWithProviderUsageContext<T>(
+  context: ProviderCallUsageContext,
+  fn: () => T,
+): T {
+  return usageContextStorage.run(context, fn);
+}
+
+export function createLogicalProviderCallId(): string {
+  return randomUUID();
+}
+
+export function beginPhysicalProviderAttempt(
+  input: ProviderCallInput,
+  metadata: PhysicalAttemptMetadata,
+): PhysicalAttemptLifecycle {
+  const estimates = estimateRequest(input);
+  claimAttemptBudgets(
+    input.usageContext?.attemptBudgets ?? usageContextStorage.getStore()?.attemptBudgets,
+    estimates.input + Math.max(0, input.maxTokens ?? 0),
+  );
+  const callId = randomUUID();
+  const startedAt = Date.now();
+  let settled = false;
+
+  const settle = (
+    status: ProviderAttemptStatus,
+    output: ProviderCallOutput | null,
+    error: unknown,
+    responseBytes: number | null,
+  ): void => {
+    if (settled) return;
+    settled = true;
+    const ledger = configuredLedger;
+    if (!ledger) return;
+
+    const providerUsage = output?.usage;
+    const hasProviderUsage = !!providerUsage && (
+      providerUsage.inputTokens > 0
+      || providerUsage.outputTokens > 0
+      || providerUsage.cacheReadTokens !== undefined
+      || providerUsage.cacheWriteTokens !== undefined
+      || providerUsage.reasoningTokens !== undefined
+    );
+    const usageSource: ProviderUsageSource = output
+      ? (hasProviderUsage ? 'provider_reported' : 'locally_estimated')
+      : (metadata.requestBytes !== null ? 'locally_estimated' : 'unknown');
+    const context = {
+      ...(usageContextStorage.getStore() ?? {}),
+      ...(input.usageContext ?? {}),
+    };
+    const cost = projectCost(
+      metadata.providerActual,
+      metadata.modelActual,
+      providerUsage?.inputTokens ?? (usageSource === 'locally_estimated' ? estimates.input : null),
+      providerUsage?.outputTokens ?? null,
+    );
+    const record: ProviderAttemptRecord = {
+      callId,
+      parentCallId: metadata.logicalCallId,
+      sessionId: context?.sessionId ?? null,
+      taskId: context?.taskId ?? null,
+      runId: context?.runId === undefined || context.runId === null
+        ? null
+        : String(context.runId),
+      entryPoint: context?.entryPoint ?? 'unknown',
+      purpose: effectivePurpose(context, metadata.attemptIndex, metadata.fallbackIndex ?? 0),
+      providerConfigured: context?.providerConfigured ?? metadata.providerActual,
+      providerActual: metadata.providerActual,
+      modelConfigured: context?.modelConfigured ?? metadata.modelActual,
+      modelActual: metadata.modelActual,
+      apiMode: metadata.apiMode,
+      transport: metadata.transport,
+      attemptIndex: metadata.attemptIndex,
+      fallbackIndex: metadata.fallbackIndex ?? context?.fallbackIndex ?? 0,
+      credentialLabelRedacted: context?.credentialLabelRedacted ?? 'configured',
+      status,
+      errorClass: classifyAttemptError(error),
+      startedAt,
+      completedAt: Date.now(),
+      estimatedInputTokens: estimates.input,
+      estimatedOutputTokens: input.maxTokens ?? null,
+      estimatedSchemaTokens: estimates.schema,
+      estimatedImageTokens: estimates.images,
+      providerInputTokens: providerUsage?.inputTokens ?? null,
+      providerOutputTokens: providerUsage?.outputTokens ?? null,
+      providerCacheReadTokens: providerUsage?.cacheReadTokens ?? null,
+      providerCacheWriteTokens: providerUsage?.cacheWriteTokens ?? null,
+      providerReasoningTokens: providerUsage?.reasoningTokens ?? null,
+      requestBytes: metadata.requestBytes,
+      responseBytes,
+      usageSource,
+      costAmount: cost.amount,
+      costCurrency: cost.currency,
+      costStatus: cost.status,
+      costSource: cost.source,
+      contextSnapshotId: context?.contextSnapshotId ?? null,
+      toolSchemaSnapshotId: context?.toolSchemaSnapshotId ?? null,
+      coreSchemaCount: context?.coreSchemaCount ?? input.tools.length,
+      mcpSchemaCount: context?.mcpSchemaCount ?? null,
+      pluginSchemaCount: context?.pluginSchemaCount ?? null,
+      deferredSchemaCount: context?.deferredSchemaCount ?? null,
+      serializedSchemaBytes: estimates.schemaBytes,
+      selectedProfile: context?.selectedProfile ?? null,
+      selectedMode: context?.selectedMode ?? null,
+      rawToolResultBytes: context?.rawToolResultBytes ?? null,
+      transmittedToolResultBytes: context?.transmittedToolResultBytes ?? null,
+      memoryTokens: context?.memoryTokens ?? null,
+      userProfileTokens: context?.userProfileTokens ?? null,
+      projectMemoryTokens: context?.projectMemoryTokens ?? null,
+      skillIndexTokens: context?.skillIndexTokens ?? null,
+      loadedSkillTokens: context?.loadedSkillTokens ?? null,
+    };
+    try {
+      ledger.append(record);
+    } catch (ledgerError) {
+      // Provider execution must not be converted into a user-visible failure by
+      // an accounting disk fault. Keep the diagnostic free of request data.
+      if (process.env.AIDEN_USAGE_DIAGNOSTICS === '1') {
+        const message = ledgerError instanceof Error ? ledgerError.message : 'unknown ledger error';
+        process.stderr.write(`[usage-ledger] append failed: ${message}\n`);
+      }
+    }
+  };
+
+  return {
+    callId,
+    success(output, responseBytes = null): void {
+      settle('success', output, null, responseBytes);
+    },
+    failure(error, options): void {
+      settle(
+        options.status ?? classifyAttemptStatus(error, options.sent),
+        null,
+        error,
+        options.responseBytes ?? null,
+      );
+    },
+  };
+}
+
+function claimAttemptBudgets(
+  budgets: import('./types').ProviderAttemptBudget[] | undefined,
+  estimatedTokens: number,
+): void {
+  if (!budgets || budgets.length === 0) return;
+  for (const budget of budgets) {
+    if (budget.maxAttempts !== undefined && budget.usedAttempts + 1 > budget.maxAttempts) {
+      throw new ProviderAttemptBudgetExceededError(
+        budget.label,
+        `${budget.label} provider-attempt limit reached (${budget.usedAttempts}/${budget.maxAttempts}).`,
+      );
+    }
+    if (
+      budget.maxEstimatedTokens !== undefined
+      && budget.usedEstimatedTokens + estimatedTokens > budget.maxEstimatedTokens
+    ) {
+      throw new ProviderAttemptBudgetExceededError(
+        budget.label,
+        `${budget.label} estimated-token limit would be exceeded.`,
+      );
+    }
+  }
+  for (const budget of budgets) {
+    budget.usedAttempts += 1;
+    budget.usedEstimatedTokens += estimatedTokens;
+  }
+}
+
+export function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function estimateRequest(input: ProviderCallInput): {
+  input: number;
+  schema: number;
+  images: number;
+  schemaBytes: number;
+} {
+  const messageText = input.messages.map((message) => {
+    const images = message.role === 'user' && message.images
+      ? message.images.map((image) => image.length).join(':')
+      : '';
+    return `${message.role}:${message.content}:${images}`;
+  }).join('\n');
+  const schemaText = safeJson(input.tools);
+  const imageBytes = input.messages.reduce((total, message) => (
+    total + (message.role === 'user'
+      ? (message.images ?? []).reduce((sum, image) => sum + image.length, 0)
+      : 0)
+  ), 0);
+  return {
+    input: Math.ceil(messageText.length / 4),
+    schema: Math.ceil(schemaText.length / 4),
+    images: imageBytes > 0 ? Math.ceil(imageBytes / 4) : 0,
+    schemaBytes: byteLength(schemaText),
+  };
+}
+
+function effectivePurpose(
+  context: ProviderCallUsageContext | undefined,
+  attemptIndex: number,
+  fallbackIndex: number,
+): NonNullable<ProviderCallUsageContext['purpose']> {
+  if (fallbackIndex > 0) return 'fallback';
+  if (attemptIndex > 0) return 'retry';
+  return context?.purpose ?? 'primary';
+}
+
+function projectCost(
+  provider: string,
+  model: string,
+  inputTokens: number | null,
+  outputTokens: number | null,
+): {
+  amount: number | null;
+  currency: string | null;
+  status: 'estimated' | 'included' | 'unknown';
+  source: string | null;
+} {
+  const entry = findModel(provider, model);
+  if (!entry?.pricing || inputTokens === null || outputTokens === null) {
+    return { amount: null, currency: null, status: 'unknown', source: null };
+  }
+  return {
+    amount: (inputTokens * entry.pricing.inputPerM + outputTokens * entry.pricing.outputPerM) / 1_000_000,
+    currency: 'USD',
+    status: 'estimated',
+    source: 'model_catalog',
+  };
+}
+
+function classifyAttemptStatus(error: unknown, sent: boolean): ProviderAttemptStatus {
+  if (error instanceof ProviderTimeoutError) return 'timeout';
+  if (error instanceof Error && error.name === 'AbortError') return 'interrupted';
+  if (error instanceof ProviderError) {
+    return error.statusCode === undefined
+      ? (sent ? 'failed_after_send' : 'failed_before_send')
+      : 'provider_error';
+  }
+  return sent ? 'failed_after_send' : 'failed_before_send';
+}
+
+function classifyAttemptError(error: unknown): string | null {
+  if (!error) return null;
+  if (error instanceof ProviderTimeoutError) return 'timeout';
+  if (error instanceof ProviderError) {
+    const classified = classifyProviderError(error);
+    if (classified === 'rate_limit') return 'rate_limit';
+    if (classified === 'context_overflow') return 'context_overflow';
+    if (classified === 'request_size_limit') return 'request_size_limit';
+    if (error.statusCode === 401 || error.statusCode === 403) return 'authentication';
+    if (error.statusCode !== undefined) return `http_${error.statusCode}`;
+    return error.retryable ? 'transport' : 'provider';
+  }
+  if (error instanceof Error && error.name === 'AbortError') return 'interrupted';
+  return error instanceof Error ? error.name || 'error' : 'unknown';
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/providers/v4/providerIdentity.ts
+++ b/providers/v4/providerIdentity.ts
@@ -1,0 +1,30 @@
+export interface ProviderRuntimeIdentityParts {
+  provider: string;
+  endpointFingerprint: string;
+  credentialFingerprint: string | null;
+  model: string;
+}
+
+/** Canonical identity used to prevent duplicate attempts across runtime slots. */
+export function providerRuntimeIdentity(parts: ProviderRuntimeIdentityParts): string {
+  return [
+    parts.provider.trim().toLowerCase(),
+    parts.endpointFingerprint,
+    parts.credentialFingerprint ?? 'no-credential',
+    parts.model,
+  ].join('|');
+}
+
+/** Keep first occurrence order while removing only exact, known runtime identities. */
+export function deduplicateRuntimeSlots<T extends { identity?: string }>(
+  slots: readonly T[],
+  reservedIdentities: readonly string[] = [],
+): T[] {
+  const seen = new Set(reservedIdentities.filter(Boolean));
+  return slots.filter((slot) => {
+    if (!slot.identity) return true;
+    if (seen.has(slot.identity)) return false;
+    seen.add(slot.identity);
+    return true;
+  });
+}

--- a/providers/v4/providerModelAuthority.ts
+++ b/providers/v4/providerModelAuthority.ts
@@ -1,0 +1,107 @@
+import type { ModelEntry } from './modelCatalog';
+import { findModel, listModelsForProvider } from './modelCatalog';
+import { getProviderEntry } from './registry';
+import {
+  PROVIDER_MODEL_POLICIES,
+  type ProviderModelPolicy,
+} from './providerPolicies';
+
+export type ModelVerification = 'curated' | 'live' | 'unverified' | 'verified';
+
+export interface ResolveModelOptions {
+  providerId: string;
+  modelId: string;
+  verification?: ModelVerification;
+  liveModelIds?: readonly string[];
+  allowUnverified?: boolean;
+}
+
+export interface ResolvedModelSelection {
+  model: ModelEntry;
+  verification: ModelVerification;
+  metadataSource: 'curated' | 'synthetic';
+}
+
+function syntheticModel(providerId: string, modelId: string): ModelEntry {
+  const provider = getProviderEntry(providerId);
+  return {
+    id: modelId,
+    displayName: modelId,
+    providerId,
+    contextLength: 128_000,
+    supportsToolCalling: provider?.supportsToolCalling ?? false,
+    supportsVision: false,
+    supportsReasoning: false,
+    isDefault: false,
+    tier: 'standard',
+    notes: 'Provider-confirmed model; curated metadata is not available.',
+  };
+}
+
+export function providerModelPolicy(providerId: string): ProviderModelPolicy | undefined {
+  return PROVIDER_MODEL_POLICIES[providerId];
+}
+
+export function providerMainDefault(providerId: string): string | undefined {
+  return providerModelPolicy(providerId)?.mainDefault
+    ?? listModelsForProvider(providerId).find((model) => model.isDefault)?.id;
+}
+
+export function providerAuxiliaryDefault(providerId: string): string | undefined {
+  return providerModelPolicy(providerId)?.auxiliaryDefault;
+}
+
+export function modelDeprecation(
+  providerId: string,
+  modelId: string,
+): { shutdownDate: string; replacements: readonly string[] } | undefined {
+  return providerModelPolicy(providerId)?.deprecated?.[modelId];
+}
+
+export function isAutomaticModelCandidate(providerId: string, modelId: string, now = Date.now()): boolean {
+  const deprecated = modelDeprecation(providerId, modelId);
+  if (!deprecated) return true;
+  const shutdown = Date.parse(`${deprecated.shutdownDate}T00:00:00Z`);
+  if (!Number.isFinite(shutdown)) return false;
+  const imminentWindowMs = 45 * 24 * 60 * 60 * 1000;
+  return shutdown - now > imminentWindowMs;
+}
+
+export function resolveModelSelection(options: ResolveModelOptions): ResolvedModelSelection | null {
+  const live = options.liveModelIds;
+  const liveConfirmed = live?.includes(options.modelId) ?? false;
+  if (live && !liveConfirmed && !options.allowUnverified && options.verification !== 'unverified') {
+    return null;
+  }
+
+  const curated = findModel(options.providerId, options.modelId);
+  const verification = liveConfirmed
+    ? 'live'
+    : options.verification
+      ?? (curated ? 'curated' : options.allowUnverified ? 'unverified' : undefined);
+  if (!verification) return null;
+
+  return {
+    model: curated ?? syntheticModel(options.providerId, options.modelId),
+    verification,
+    metadataSource: curated ? 'curated' : 'synthetic',
+  };
+}
+
+export function chooseAutomaticModel(
+  providerId: string,
+  liveModelIds?: readonly string[],
+  now = Date.now(),
+): string | undefined {
+  const preferred = providerMainDefault(providerId);
+  if (liveModelIds && liveModelIds.length > 0) {
+    if (preferred && liveModelIds.includes(preferred) && isAutomaticModelCandidate(providerId, preferred, now)) {
+      return preferred;
+    }
+    return liveModelIds.find((id) => isAutomaticModelCandidate(providerId, id, now));
+  }
+  if (preferred && isAutomaticModelCandidate(providerId, preferred, now)) return preferred;
+  return listModelsForProvider(providerId).find(
+    (model) => isAutomaticModelCandidate(providerId, model.id, now),
+  )?.id;
+}

--- a/providers/v4/providerPolicies.ts
+++ b/providers/v4/providerPolicies.ts
@@ -1,0 +1,71 @@
+export interface ProviderModelPolicy {
+  mainDefault: string;
+  auxiliaryDefault?: string;
+  curatedModels: readonly string[];
+  /** Boot profile that fits the provider's fresh-account request budget. */
+  setupToolProfile?: 'minimal' | 'standard';
+  deprecated?: Readonly<Record<string, { shutdownDate: string; replacements: readonly string[] }>>;
+}
+
+/** Curated policy used when live provider discovery is unavailable. */
+export const PROVIDER_MODEL_POLICIES: Readonly<Record<string, ProviderModelPolicy>> =
+  Object.freeze({
+    groq: Object.freeze({
+      mainDefault: 'openai/gpt-oss-120b',
+      auxiliaryDefault: 'openai/gpt-oss-20b',
+      curatedModels: Object.freeze(['openai/gpt-oss-120b', 'openai/gpt-oss-20b']),
+      setupToolProfile: 'minimal',
+      deprecated: Object.freeze({
+        'mixtral-8x7b-32768': Object.freeze({
+          shutdownDate: '2025-03-20',
+          replacements: Object.freeze(['openai/gpt-oss-120b']),
+        }),
+        'llama-3.1-8b-instant': Object.freeze({
+          shutdownDate: '2026-08-16',
+          replacements: Object.freeze(['openai/gpt-oss-20b']),
+        }),
+        'llama-3.3-70b-versatile': Object.freeze({
+          shutdownDate: '2026-08-16',
+          replacements: Object.freeze(['openai/gpt-oss-120b', 'qwen/qwen3.6-27b']),
+        }),
+      }),
+    }),
+    together: Object.freeze({
+      mainDefault: 'openai/gpt-oss-120b',
+      auxiliaryDefault: 'openai/gpt-oss-20b',
+      curatedModels: Object.freeze([
+        'openai/gpt-oss-120b',
+        'openai/gpt-oss-20b',
+        'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+      ]),
+    }),
+    deepseek: Object.freeze({
+      mainDefault: 'deepseek-v4-pro',
+      auxiliaryDefault: 'deepseek-v4-flash',
+      curatedModels: Object.freeze([
+        'deepseek-v4-pro',
+        'deepseek-v4-flash',
+        'deepseek-chat',
+        'deepseek-reasoner',
+      ]),
+      deprecated: Object.freeze({
+        'deepseek-chat': Object.freeze({
+          shutdownDate: '2026-07-24',
+          replacements: Object.freeze(['deepseek-v4-pro']),
+        }),
+        'deepseek-reasoner': Object.freeze({
+          shutdownDate: '2026-07-24',
+          replacements: Object.freeze(['deepseek-v4-pro']),
+        }),
+      }),
+    }),
+    huggingface: Object.freeze({
+      mainDefault: 'openai/gpt-oss-120b',
+      auxiliaryDefault: 'openai/gpt-oss-20b',
+      curatedModels: Object.freeze([
+        'openai/gpt-oss-120b',
+        'openai/gpt-oss-20b',
+        'Qwen/Qwen3-Coder-480B-A35B-Instruct',
+      ]),
+    }),
+  });

--- a/providers/v4/providerReadiness.ts
+++ b/providers/v4/providerReadiness.ts
@@ -1,0 +1,185 @@
+import type { ConfigManager } from '../../core/v4/config';
+import type { AidenPaths } from '../../core/v4/paths';
+import type { RuntimeResolver } from './runtimeResolver';
+import type { ApiMode } from './types';
+import type { EffectiveCredentialSource } from './credentialAuthority';
+import type { ProviderReadinessErrorCategory } from './readinessErrors';
+import { classifyReadinessError, isRetryableReadinessCategory } from './readinessErrors';
+import { verifyRuntimeReadiness } from './readinessProbe';
+
+export type ProviderReadinessState =
+  | 'not_started'
+  | 'provider_selected'
+  | 'credential_saved'
+  | 'credential_verified'
+  | 'model_selected'
+  | 'runtime_resolved'
+  | 'plain_completion_verified'
+  | 'tool_call_verified'
+  | 'complete'
+  | 'configured_unverified'
+  | 'failed_retryable'
+  | 'failed_requires_user_action';
+
+export interface ProviderReadinessRecord {
+  state: ProviderReadinessState;
+  provider: string;
+  model: string;
+  endpointFingerprint: string | null;
+  credentialSource: EffectiveCredentialSource | null;
+  transportMode: ApiMode | null;
+  plainCompletionStatus: 'not_started' | 'verified' | 'failed';
+  streamingStatus: 'not_started' | 'verified' | 'failed';
+  toolCallStatus: 'not_started' | 'verified' | 'failed';
+  toolResultReplayStatus: 'not_started' | 'verified' | 'failed';
+  structuredArgumentsStatus: 'not_started' | 'verified' | 'failed';
+  verificationTimestamp: string | null;
+  verificationErrorCategory: ProviderReadinessErrorCategory | null;
+}
+
+export function initialReadiness(provider: string, model: string): ProviderReadinessRecord {
+  return {
+    state: 'provider_selected',
+    provider,
+    model,
+    endpointFingerprint: null,
+    credentialSource: null,
+    transportMode: null,
+    plainCompletionStatus: 'not_started',
+    streamingStatus: 'not_started',
+    toolCallStatus: 'not_started',
+    toolResultReplayStatus: 'not_started',
+    structuredArgumentsStatus: 'not_started',
+    verificationTimestamp: null,
+    verificationErrorCategory: null,
+  };
+}
+
+export async function persistProviderReadiness(
+  config: ConfigManager,
+  record: ProviderReadinessRecord,
+): Promise<void> {
+  config.set(`providers.${record.provider}.readiness`, record);
+  await config.save();
+}
+
+export async function markConfiguredUnverified(
+  config: ConfigManager,
+  record: ProviderReadinessRecord,
+): Promise<ProviderReadinessRecord> {
+  const next = { ...record, state: 'configured_unverified' as const };
+  await persistProviderReadiness(config, next);
+  return next;
+}
+
+export async function runRuntimeReadinessTransaction(options: {
+  paths: AidenPaths;
+  config: ConfigManager;
+  resolver: RuntimeResolver;
+  providerId: string;
+  modelId: string;
+  modelVerification?: 'curated' | 'live' | 'unverified' | 'verified';
+  apiKeyOverride?: string;
+  baseUrlOverride?: string;
+  signal?: AbortSignal;
+}): Promise<ProviderReadinessRecord> {
+  let record = initialReadiness(options.providerId, options.modelId);
+  if (!options.config.usesPaths(options.paths)) {
+    return {
+      ...record,
+      state: 'failed_requires_user_action',
+      verificationTimestamp: new Date().toISOString(),
+      verificationErrorCategory: 'configuration_conflict',
+    };
+  }
+  record = { ...record, state: 'credential_saved' };
+  await persistProviderReadiness(options.config, record);
+
+  try {
+    const resolution = await options.resolver.describe({
+      providerId: options.providerId,
+      modelId: options.modelId,
+      config: options.config,
+      paths: options.paths,
+      apiKeyOverride: options.apiKeyOverride,
+      baseUrlOverride: options.baseUrlOverride,
+      modelVerification: options.modelVerification,
+    });
+    record = {
+      ...record,
+      state: 'credential_verified',
+      endpointFingerprint: resolution.effectiveCredential?.endpointFingerprint ?? null,
+      credentialSource: resolution.effectiveCredential?.credentialSource ?? null,
+      transportMode: resolution.apiMode,
+    };
+    await persistProviderReadiness(options.config, record);
+    record = { ...record, state: 'model_selected' };
+    await persistProviderReadiness(options.config, record);
+
+    const adapter = await options.resolver.resolve({
+      providerId: options.providerId,
+      modelId: options.modelId,
+      config: options.config,
+      paths: options.paths,
+      apiKeyOverride: options.apiKeyOverride,
+      baseUrlOverride: options.baseUrlOverride,
+      modelVerification: options.modelVerification,
+    });
+    record = { ...record, state: 'runtime_resolved' };
+    await persistProviderReadiness(options.config, record);
+    const probe = await verifyRuntimeReadiness(adapter, { signal: options.signal });
+    const timestamp = new Date().toISOString();
+    if (probe.plainCompletion === 'verified') {
+      record = {
+        ...record,
+        state: 'plain_completion_verified',
+        plainCompletionStatus: 'verified',
+        streamingStatus: probe.streaming,
+        verificationTimestamp: timestamp,
+      };
+      options.config.set(`providers.${options.providerId}.modelVerification`, 'verified');
+      await persistProviderReadiness(options.config, record);
+    }
+    if (probe.toolCall === 'verified') {
+      record = {
+        ...record,
+        state: 'tool_call_verified',
+        toolCallStatus: 'verified',
+        toolResultReplayStatus: probe.toolResultReplay,
+        structuredArgumentsStatus: probe.structuredArguments,
+        verificationTimestamp: timestamp,
+      };
+      await persistProviderReadiness(options.config, record);
+      record = { ...record, state: 'complete' };
+      await persistProviderReadiness(options.config, record);
+      return record;
+    }
+
+    const category = probe.errorCategory ?? 'unknown_provider_error';
+    record = {
+      ...record,
+      state: isRetryableReadinessCategory(category)
+        ? 'failed_retryable'
+        : 'failed_requires_user_action',
+      plainCompletionStatus: probe.plainCompletion,
+      streamingStatus: probe.streaming,
+      toolCallStatus: probe.toolCall,
+      toolResultReplayStatus: probe.toolResultReplay,
+      structuredArgumentsStatus: probe.structuredArguments,
+      verificationTimestamp: timestamp,
+      verificationErrorCategory: category,
+    };
+    await persistProviderReadiness(options.config, record);
+    return record;
+  } catch (error) {
+    const classified = classifyReadinessError(error, 'configuration');
+    record = {
+      ...record,
+      state: classified.retryable ? 'failed_retryable' : 'failed_requires_user_action',
+      verificationTimestamp: new Date().toISOString(),
+      verificationErrorCategory: classified.category,
+    };
+    await persistProviderReadiness(options.config, record);
+    return record;
+  }
+}

--- a/providers/v4/readinessErrors.ts
+++ b/providers/v4/readinessErrors.ts
@@ -1,0 +1,152 @@
+import { ProviderError, ProviderPhaseTimeoutError, ProviderRateLimitError, ProviderTimeoutError } from './errors';
+
+export type ProviderReadinessErrorCategory =
+  | 'credential_missing'
+  | 'credential_invalid'
+  | 'credential_forbidden'
+  | 'quota_exhausted'
+  | 'rate_limited'
+  | 'model_unavailable'
+  | 'model_not_entitled'
+  | 'model_gated'
+  | 'provider_unavailable'
+  | 'network_dns'
+  | 'network_tls'
+  | 'network_failure'
+  | 'connection_timeout'
+  | 'first_byte_timeout'
+  | 'body_idle_timeout'
+  | 'total_timeout'
+  | 'malformed_response'
+  | 'streaming_unsupported'
+  | 'tool_call_unsupported'
+  | 'tool_schema_rejected'
+  | 'tool_replay_unsupported'
+  | 'endpoint_invalid'
+  | 'configuration_conflict'
+  | 'unknown_provider_error';
+
+const RETRYABLE_READINESS_CATEGORIES = new Set<ProviderReadinessErrorCategory>([
+  'quota_exhausted',
+  'rate_limited',
+  'provider_unavailable',
+  'network_dns',
+  'network_tls',
+  'network_failure',
+  'connection_timeout',
+  'first_byte_timeout',
+  'body_idle_timeout',
+  'total_timeout',
+  'malformed_response',
+]);
+
+export function isRetryableReadinessCategory(category: ProviderReadinessErrorCategory): boolean {
+  return RETRYABLE_READINESS_CATEGORIES.has(category);
+}
+
+export class ProviderReadinessError extends Error {
+  constructor(
+    public readonly category: ProviderReadinessErrorCategory,
+    message: string,
+    public readonly retryable: boolean,
+    public readonly diagnostic?: unknown,
+  ) {
+    super(message);
+    this.name = 'ProviderReadinessError';
+  }
+}
+
+export class ProviderLifecycleTimeoutError extends ProviderReadinessError {
+  constructor(
+    category: 'connection_timeout' | 'first_byte_timeout' | 'body_idle_timeout' | 'total_timeout',
+    timeoutMs: number,
+  ) {
+    super(category, `Provider request exceeded the ${category.replace(/_/g, ' ')} (${timeoutMs}ms).`, true);
+    this.name = 'ProviderLifecycleTimeoutError';
+  }
+}
+
+function bodyText(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  try { return JSON.stringify(raw ?? ''); } catch { return ''; }
+}
+
+export function classifyReadinessError(
+  error: unknown,
+  stage?: 'configuration' | 'model' | 'plain' | 'streaming' | 'tool_schema' | 'tool_cycle',
+): ProviderReadinessError {
+  if (error instanceof ProviderReadinessError) return error;
+  if (error instanceof ProviderRateLimitError) {
+    const text = bodyText(error.raw).toLowerCase();
+    const exhausted = /quota|credit|billing|limit exceeded/.test(text);
+    return new ProviderReadinessError(
+      exhausted ? 'quota_exhausted' : 'rate_limited',
+      exhausted ? 'Provider quota is exhausted.' : 'Provider rate limit was reached.',
+      true,
+      error,
+    );
+  }
+  if (error instanceof ProviderPhaseTimeoutError) {
+    return new ProviderReadinessError(error.phase, error.message, true, error);
+  }
+  if (error instanceof ProviderTimeoutError) {
+    return new ProviderReadinessError('total_timeout', 'Provider request timed out.', true, error);
+  }
+  if (error instanceof ProviderError) {
+    const status = error.statusCode;
+    const raw = bodyText(error.raw).toLowerCase();
+    if (status === 401) return new ProviderReadinessError('credential_invalid', 'The configured credential was rejected.', false, error);
+    if (status === 403) {
+      const gated = stage === 'model' && /gated|access request|terms.*accept/.test(raw);
+      const modelDenied = stage === 'model' || /model|entitl|permission/.test(raw);
+      return new ProviderReadinessError(
+        gated ? 'model_gated' : modelDenied ? 'model_not_entitled' : 'credential_forbidden',
+        gated
+          ? 'The selected model is gated for this account.'
+          : modelDenied
+            ? 'The account is not entitled to use this model.'
+            : 'The provider denied this credential.',
+        false,
+        error,
+      );
+    }
+    if (status === 404) {
+      return new ProviderReadinessError(
+        stage === 'model' ? 'model_unavailable' : 'endpoint_invalid',
+        stage === 'model' ? 'The selected model is unavailable.' : 'The configured endpoint was not found.',
+        false,
+        error,
+      );
+    }
+    if (status === 429) {
+      const exhausted = /quota|credit|billing|limit exceeded/.test(raw);
+      return new ProviderReadinessError(exhausted ? 'quota_exhausted' : 'rate_limited', exhausted ? 'Provider quota is exhausted.' : 'Provider rate limit was reached.', true, error);
+    }
+    if (status && status >= 500) return new ProviderReadinessError('provider_unavailable', 'The provider is temporarily unavailable.', true, error);
+    if (status === 400 && stage === 'tool_schema') return new ProviderReadinessError('tool_schema_rejected', 'The provider rejected the probe tool schema.', false, error);
+    if (/non-json|malformed|parse|invalid json/.test(error.message.toLowerCase())) {
+      return new ProviderReadinessError('malformed_response', 'The provider returned a malformed response.', true, error);
+    }
+  }
+
+  const record = error && typeof error === 'object' ? error as { code?: string; message?: string } : {};
+  const code = record.code?.toUpperCase();
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return new ProviderReadinessError('network_dns', 'Provider hostname resolution failed.', true, error);
+  if (code?.startsWith('ERR_TLS') || code === 'CERT_HAS_EXPIRED' || code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+    return new ProviderReadinessError('network_tls', 'A secure connection to the provider could not be established.', true, error);
+  }
+  if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'EPIPE') {
+    return new ProviderReadinessError('network_failure', 'The provider connection failed.', true, error);
+  }
+  const message = record.message ?? String(error ?? '');
+  if (/no api key|credentials? missing|requires oauth login/i.test(message)) {
+    return new ProviderReadinessError('credential_missing', 'No usable credential is configured.', false, error);
+  }
+  if (/model .*not found|unknown model/i.test(message)) {
+    return new ProviderReadinessError('model_unavailable', 'The selected model is unavailable.', false, error);
+  }
+  if (/provider .*not found|unsupported apimode/i.test(message)) {
+    return new ProviderReadinessError('configuration_conflict', 'Provider configuration is inconsistent.', false, error);
+  }
+  return new ProviderReadinessError('unknown_provider_error', 'The provider could not be verified.', false, error);
+}

--- a/providers/v4/readinessProbe.ts
+++ b/providers/v4/readinessProbe.ts
@@ -1,0 +1,195 @@
+import type {
+  Message,
+  ProviderAdapter,
+  ToolSchema,
+} from './types';
+import {
+  classifyReadinessError,
+  ProviderReadinessError,
+  type ProviderReadinessErrorCategory,
+} from './readinessErrors';
+
+export interface RuntimeReadinessProbeResult {
+  plainCompletion: 'verified' | 'failed';
+  streaming: 'verified' | 'failed';
+  toolCall: 'verified' | 'failed';
+  toolResultReplay: 'verified' | 'failed';
+  structuredArguments: 'verified' | 'failed';
+  errorCategory?: ProviderReadinessErrorCategory;
+}
+
+const failedAfterPlain = (
+  errorCategory: ProviderReadinessErrorCategory,
+  streaming: 'verified' | 'failed',
+): RuntimeReadinessProbeResult => ({
+  plainCompletion: 'verified',
+  streaming,
+  toolCall: 'failed',
+  toolResultReplay: 'failed',
+  structuredArguments: 'failed',
+  errorCategory,
+});
+
+const PROBE_TOOL: ToolSchema = {
+  name: 'runtime_readiness_probe',
+  description: 'Return the supplied marker without side effects.',
+  inputSchema: {
+    type: 'object',
+    properties: { marker: { type: 'string', enum: ['ready'] } },
+    required: ['marker'],
+    additionalProperties: false,
+  },
+};
+
+function exactProbeCall(output: Awaited<ReturnType<ProviderAdapter['call']>>) {
+  if (output.toolCalls.length !== 1 || output.toolCalls[0].name !== PROBE_TOOL.name) {
+    throw new ProviderReadinessError(
+      'tool_call_unsupported',
+      'The model did not request the required readiness tool.',
+      false,
+    );
+  }
+  const call = output.toolCalls[0];
+  if (call.arguments.marker !== 'ready' || Object.keys(call.arguments).some((key) => key !== 'marker')) {
+    throw new ProviderReadinessError(
+      'tool_schema_rejected',
+      'The model produced invalid readiness tool arguments.',
+      false,
+    );
+  }
+  return call;
+}
+
+function requiredToolBody(adapter: ProviderAdapter): Record<string, unknown> | undefined {
+  switch (adapter.apiMode) {
+    case 'chat_completions':
+      return { tool_choice: 'required' };
+    case 'anthropic_messages':
+      return { tool_choice: { type: 'tool', name: PROBE_TOOL.name } };
+    case 'codex_responses':
+      return { tool_choice: { type: 'function', name: PROBE_TOOL.name } };
+    case 'ollama_prompt_tools':
+      return undefined;
+  }
+}
+
+export async function verifyRuntimeReadiness(
+  adapter: ProviderAdapter,
+  options: { signal?: AbortSignal; maxTokens?: number } = {},
+): Promise<RuntimeReadinessProbeResult> {
+  const maxTokens = options.maxTokens ?? 128;
+  try {
+    const plain = await adapter.call({
+      messages: [{ role: 'user', content: 'Reply with exactly READY.' }],
+      tools: [],
+      maxTokens,
+      signal: options.signal,
+    });
+    if (plain.finishReason !== 'stop' || !plain.content?.trim()) {
+      throw new ProviderReadinessError('malformed_response', 'The plain completion did not finish with text.', true);
+    }
+  } catch (error) {
+    const classified = classifyReadinessError(error, 'plain');
+    return {
+      plainCompletion: 'failed',
+      streaming: 'failed',
+      toolCall: 'failed',
+      toolResultReplay: 'failed',
+      structuredArguments: 'failed',
+      errorCategory: classified.category,
+    };
+  }
+
+  if (!adapter.callStream) {
+    return failedAfterPlain('streaming_unsupported', 'failed');
+  }
+  try {
+    let completed = false;
+    let content = '';
+    for await (const event of adapter.callStream({
+      messages: [{ role: 'user', content: 'Reply with exactly STREAM READY.' }],
+      tools: [],
+      maxTokens,
+      signal: options.signal,
+    })) {
+      if (event.type === 'delta') content += event.content;
+      if (event.type === 'done') {
+        completed = event.output.finishReason === 'stop';
+        content = event.output.content ?? content;
+      }
+    }
+    if (!completed || !content.trim()) {
+      throw new ProviderReadinessError(
+        'streaming_unsupported',
+        'The provider did not complete a streamed response.',
+        false,
+      );
+    }
+  } catch (error) {
+    const classified = classifyReadinessError(error, 'streaming');
+    return failedAfterPlain(
+      classified.category === 'unknown_provider_error' ? 'streaming_unsupported' : classified.category,
+      'failed',
+    );
+  }
+
+  let structuredArguments: 'verified' | 'failed' = 'failed';
+  let toolCall: 'verified' | 'failed' = 'failed';
+  try {
+    const messages: Message[] = [{
+      role: 'user',
+      content: 'Call runtime_readiness_probe exactly once with JSON arguments {"marker":"ready"}. After its result, reply exactly PROBE COMPLETE.',
+    }];
+    let first;
+    try {
+      first = await adapter.call({
+        messages,
+        tools: [PROBE_TOOL],
+        maxTokens,
+        extraBody: requiredToolBody(adapter),
+        signal: options.signal,
+      });
+    } catch (error) {
+      throw classifyReadinessError(error, 'tool_schema');
+    }
+    const call = exactProbeCall(first);
+    structuredArguments = 'verified';
+    toolCall = 'verified';
+    const replay: Message[] = [
+      ...messages,
+      { role: 'assistant', content: first.content ?? '', toolCalls: first.toolCalls },
+      { role: 'tool', toolCallId: call.id, content: JSON.stringify({ ok: true, marker: 'ready' }) },
+    ];
+    const final = await adapter.call({
+      messages: replay,
+      tools: [PROBE_TOOL],
+      maxTokens,
+      signal: options.signal,
+    });
+    if (final.toolCalls.length > 0 || final.finishReason !== 'stop' || !final.content?.trim()) {
+      throw new ProviderReadinessError('malformed_response', 'The model did not finish after the readiness tool result.', true);
+    }
+    return {
+      plainCompletion: 'verified',
+      streaming: 'verified',
+      toolCall: 'verified',
+      toolResultReplay: 'verified',
+      structuredArguments: 'verified',
+    };
+  } catch (error) {
+    const classified = classifyReadinessError(error, 'tool_cycle');
+    const category = toolCall === 'verified'
+      && structuredArguments === 'verified'
+      && classified.category === 'unknown_provider_error'
+      ? 'tool_replay_unsupported'
+      : classified.category;
+    return {
+      plainCompletion: 'verified',
+      streaming: 'verified',
+      toolCall,
+      toolResultReplay: 'failed',
+      structuredArguments,
+      errorCategory: category,
+    };
+  }
+}

--- a/providers/v4/registry.ts
+++ b/providers/v4/registry.ts
@@ -25,6 +25,7 @@
 
 import { ApiMode } from './types';
 import type { BillingTier, PaidFallbackConsent } from '../../core/v4/billingGuard';
+import { PROVIDER_MODEL_POLICIES } from './providerPolicies';
 
 export interface ProviderRegistryEntry {
   /** Stable identifier, e.g. 'anthropic', 'groq', 'together'. */
@@ -191,7 +192,7 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     hasFreeTier: true,
     docsUrl: 'https://console.groq.com/docs/',
     supportsToolCalling: true,
-    modelIds: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'mixtral-8x7b-32768'],
+    modelIds: [...PROVIDER_MODEL_POLICIES.groq.curatedModels],
   },
   gemini: {
     id: 'gemini',
@@ -225,15 +226,15 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     id: 'huggingface',
     displayName: 'Hugging Face',
     apiMode: 'chat_completions',
-    baseUrl: 'https://api-inference.huggingface.co/v1',
+    baseUrl: 'https://router.huggingface.co/v1',
     apiKeyEnvVar: 'HF_TOKEN',
-    description: 'Hugging Face Inference API — free tier on most open-weight models.',
+    description: 'Hugging Face Inference Providers — one token with automatic backend routing.',
     tier: 'free',
     billingTier: 'free',
     hasFreeTier: true,
     docsUrl: 'https://huggingface.co/docs/api-inference/',
     supportsToolCalling: true,
-    modelIds: ['meta-llama/Llama-3.3-70B-Instruct', 'Qwen/Qwen2.5-72B-Instruct'],
+    modelIds: [...PROVIDER_MODEL_POLICIES.huggingface.curatedModels],
   },
 
   // ─── Aggregators / paid APIs ─────────────────────────────────────────────
@@ -275,12 +276,7 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     hasFreeTier: false,
     docsUrl: 'https://docs.together.ai/',
     supportsToolCalling: true,
-    modelIds: [
-      'meta-llama/Llama-3.3-70B-Instruct-Turbo',
-      'meta-llama/Llama-3.1-8B-Instruct-Turbo',
-      'deepseek-ai/DeepSeek-V3',
-      'deepseek-ai/DeepSeek-R1',
-    ],
+    modelIds: [...PROVIDER_MODEL_POLICIES.together.curatedModels],
   },
   deepseek: {
     id: 'deepseek',
@@ -301,7 +297,7 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     // flash family per DeepSeek docs; deprecated-but-live). Removal
     // is its own deprecation slice. Per-call thinking + reasoning
     // _effort defaults for v4-pro live in providers/v4/modelDefaults.ts.
-    modelIds: ['deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'],
+    modelIds: [...PROVIDER_MODEL_POLICIES.deepseek.curatedModels],
   },
   mistral: {
     id: 'mistral',

--- a/providers/v4/requestLifecycle.ts
+++ b/providers/v4/requestLifecycle.ts
@@ -1,0 +1,146 @@
+import {
+  ProviderPhaseTimeoutError,
+  type ProviderTimeoutPhase,
+} from './errors';
+
+export interface RequestDeadlines {
+  connectionMs: number;
+  firstByteMs: number;
+  bodyIdleMs: number;
+  totalMs: number;
+}
+
+export function requestDeadlines(totalMs: number, overrides: Partial<RequestDeadlines> = {}): RequestDeadlines {
+  return {
+    connectionMs: overrides.connectionMs ?? totalMs,
+    firstByteMs: overrides.firstByteMs ?? totalMs,
+    bodyIdleMs: overrides.bodyIdleMs ?? totalMs,
+    totalMs: overrides.totalMs ?? totalMs,
+  };
+}
+
+function abortError(error?: unknown): Error {
+  if (error instanceof Error && error.name === 'AbortError') return error;
+  const result = new Error('Provider request cancelled by caller');
+  result.name = 'AbortError';
+  (result as Error & { cause?: unknown }).cause = error;
+  return result;
+}
+
+export class RequestLifecycle {
+  readonly controller = new AbortController();
+  private phase: ProviderTimeoutPhase | 'external' | null = null;
+  private phaseTimeoutMs = 0;
+  private settled = false;
+  private totalTimer: ReturnType<typeof setTimeout> | null = null;
+  private phaseTimer: ReturnType<typeof setTimeout> | null = null;
+  private externalHandler: (() => void) | null = null;
+  private rejectAbort!: (error: unknown) => void;
+  private readonly abortPromise: Promise<never>;
+  private sawBodyByte = false;
+
+  constructor(
+    private readonly provider: string,
+    private readonly deadlines: RequestDeadlines,
+    private readonly externalSignal?: AbortSignal,
+  ) {
+    this.abortPromise = new Promise<never>((_resolve, reject) => { this.rejectAbort = reject; });
+    this.totalTimer = setTimeout(() => this.abortFor('total_timeout', deadlines.totalMs), deadlines.totalMs);
+    this.armPhase('connection_timeout', deadlines.connectionMs);
+    if (externalSignal) {
+      if (externalSignal.aborted) this.abortFor('external', 0);
+      else {
+        this.externalHandler = () => this.abortFor('external', 0);
+        externalSignal.addEventListener('abort', this.externalHandler, { once: true });
+      }
+    }
+  }
+
+  get signal(): AbortSignal { return this.controller.signal; }
+
+  markHeaders(): void {
+    if (this.settled) return;
+    this.armPhase('first_byte_timeout', this.deadlines.firstByteMs);
+  }
+
+  async race<T>(promise: Promise<T>): Promise<T> {
+    return Promise.race([promise, this.abortPromise]);
+  }
+
+  async readChunk(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+  ): Promise<{ done: boolean; value?: Uint8Array }> {
+    const result = await this.race(reader.read());
+    if (!result.done && result.value && result.value.byteLength > 0) {
+      this.sawBodyByte = true;
+      this.armPhase('body_idle_timeout', this.deadlines.bodyIdleMs);
+    } else if (result.done) {
+      this.clearPhaseTimer();
+    } else if (this.sawBodyByte) {
+      this.armPhase('body_idle_timeout', this.deadlines.bodyIdleMs);
+    }
+    return result;
+  }
+
+  async readText(response: Response): Promise<string> {
+    if (!response.body) {
+      this.clearPhaseTimer();
+      return '';
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let text = '';
+    try {
+      while (true) {
+        const chunk = await this.readChunk(reader);
+        if (chunk.done) break;
+        if (chunk.value) text += decoder.decode(chunk.value, { stream: true });
+      }
+      return text + decoder.decode();
+    } finally {
+      try { reader.releaseLock(); } catch { /* already released */ }
+    }
+  }
+
+  classify(error: unknown): unknown {
+    if (this.phase === 'external' || this.externalSignal?.aborted) return abortError(error);
+    if (this.phase) {
+      return new ProviderPhaseTimeoutError(this.provider, this.phaseTimeoutMs, this.phase);
+    }
+    return error;
+  }
+
+  cleanup(): void {
+    if (this.settled) return;
+    this.settled = true;
+    if (this.totalTimer) clearTimeout(this.totalTimer);
+    this.totalTimer = null;
+    this.clearPhaseTimer();
+    if (this.externalHandler && this.externalSignal) {
+      this.externalSignal.removeEventListener('abort', this.externalHandler);
+    }
+    this.externalHandler = null;
+  }
+
+  private armPhase(phase: ProviderTimeoutPhase, timeoutMs: number): void {
+    this.clearPhaseTimer();
+    this.phaseTimer = setTimeout(() => this.abortFor(phase, timeoutMs), timeoutMs);
+  }
+
+  private clearPhaseTimer(): void {
+    if (this.phaseTimer) clearTimeout(this.phaseTimer);
+    this.phaseTimer = null;
+  }
+
+  private abortFor(phase: ProviderTimeoutPhase | 'external', timeoutMs: number): void {
+    if (this.settled || this.phase !== null) return;
+    this.phase = phase;
+    this.phaseTimeoutMs = timeoutMs;
+    this.controller.abort();
+    this.rejectAbort(
+      phase === 'external'
+        ? abortError()
+        : new ProviderPhaseTimeoutError(this.provider, timeoutMs, phase),
+    );
+  }
+}

--- a/providers/v4/responseStreamAdapter.ts
+++ b/providers/v4/responseStreamAdapter.ts
@@ -50,6 +50,12 @@ import {
   ProviderRateLimitError,
   ProviderTimeoutError,
 } from './errors';
+import {
+  beginPhysicalProviderAttempt,
+  byteLength,
+  createLogicalProviderCallId,
+  type PhysicalAttemptLifecycle,
+} from './providerAttemptAccounting';
 
 // ── Public surface ──────────────────────────────────────────────────────
 
@@ -175,6 +181,7 @@ interface WireResponseShape {
     output_tokens?:          number;
     cached_tokens?:          number;
     input_tokens_details?:   { cached_tokens?: number };
+    output_tokens_details?:  { reasoning_tokens?: number };
   };
 }
 
@@ -193,6 +200,7 @@ interface WireRequestBody {
 
 interface ActiveDispatch {
   response: Response;
+  attempt: PhysicalAttemptLifecycle;
   cleanup(): void;
   classifyError(error: unknown): unknown;
 }
@@ -239,7 +247,7 @@ export class ResponseStreamAdapter implements ProviderAdapter {
       aborted: input.signal?.aborted === true,
     });
     const body   = this.buildBody(input);
-    const active = await this.dispatch(body, input.signal, diagCallId);
+    const active = await this.dispatch(body, input, diagCallId);
     const reply  = active.response;
 
     // The subscription backend always streams; aggregate SSE frames into the
@@ -256,7 +264,9 @@ export class ResponseStreamAdapter implements ProviderAdapter {
         ? await aggregateSseEvents(reply)
         : await readJsonBody(reply, this.providerName);
     } catch (error) {
-      throw active.classifyError(error);
+      const classified = active.classifyError(error);
+      active.attempt.failure(classified, { sent: true });
+      throw classified;
     } finally {
       active.cleanup();
     }
@@ -267,6 +277,7 @@ export class ResponseStreamAdapter implements ProviderAdapter {
     });
 
     const decoded = decodeWireResponse(wire, this.providerName);
+    active.attempt.success(decoded, responseShapeBytes(wire));
     p2aDiag('response.call.complete', {
       diagCallId, finishReason: decoded.finishReason,
       toolCalls: decoded.toolCalls.map((call) => ({ id: call.id, name: call.name })),
@@ -344,16 +355,28 @@ export class ResponseStreamAdapter implements ProviderAdapter {
 
   private async dispatch(
     body: WireRequestBody,
-    externalSignal?: AbortSignal,
+    input: ProviderCallInput,
     diagCallId?: number,
   ): Promise<ActiveDispatch> {
     const headers    = this.buildHeaders();
     const serialised = JSON.stringify(body);
     const totalTries = this.maxRetries + 1;
+    const externalSignal = input.signal;
+    const logicalCallId = input.usageContext?.logicalCallId ?? createLogicalProviderCallId();
 
     let lastErr: unknown = null;
 
     for (let attempt = 0; attempt < totalTries; attempt++) {
+      const accounting = beginPhysicalProviderAttempt(input, {
+        providerActual: this.providerName,
+        modelActual: this.model,
+        apiMode: this.apiMode,
+        transport: this.endpoint.startsWith('https:') ? 'https' : 'http',
+        attemptIndex: attempt,
+        fallbackIndex: input.usageContext?.fallbackIndex ?? 0,
+        logicalCallId,
+        requestBytes: byteLength(serialised),
+      });
       const controller = new AbortController();
       let abortCause: 'timeout' | 'external' | null = null;
       let cleaned = false;
@@ -417,8 +440,10 @@ export class ResponseStreamAdapter implements ProviderAdapter {
         const classified = classifyError(err);
         cleanup();
         if ((classified as { name?: unknown })?.name === 'AbortError') {
+          accounting.failure(classified, { sent: true, status: 'interrupted' });
           throw classified;
         }
+        accounting.failure(lastErr, { sent: true });
         if (classified instanceof ProviderTimeoutError) {
           lastErr = classified;
         } else {
@@ -436,7 +461,7 @@ export class ResponseStreamAdapter implements ProviderAdapter {
         }
         throw lastErr;
       }
-      if (response.ok) return { response, cleanup, classifyError };
+      if (response.ok) return { response, attempt: accounting, cleanup, classifyError };
 
       const status = response.status;
       let raw: unknown;
@@ -449,35 +474,41 @@ export class ResponseStreamAdapter implements ProviderAdapter {
       }
 
       if (status === 429) {
+        const error = new ProviderRateLimitError(this.providerName, raw);
+        accounting.failure(error, { sent: true, responseBytes: responseShapeBytes(raw) });
         if (attempt < totalTries - 1) {
           await sleep(backoffMs(attempt));
           continue;
         }
-        throw new ProviderRateLimitError(this.providerName, raw);
+        throw error;
       }
 
       if (status >= 500 && status < 600) {
-        if (attempt < totalTries - 1) {
-          await sleep(backoffMs(attempt));
-          continue;
-        }
-        throw new ProviderError(
+        const error = new ProviderError(
           `Provider ${this.providerName} server error ${status}`,
           this.providerName,
           status,
           raw,
           true,
         );
+        accounting.failure(error, { sent: true, responseBytes: responseShapeBytes(raw) });
+        if (attempt < totalTries - 1) {
+          await sleep(backoffMs(attempt));
+          continue;
+        }
+        throw error;
       }
 
       // 4xx (auth, content policy, malformed) — fail fast.
-      throw new ProviderError(
+      const error = new ProviderError(
         `Provider ${this.providerName} request failed (${status})`,
         this.providerName,
         status,
         raw,
         false,
       );
+      accounting.failure(error, { sent: true, responseBytes: responseShapeBytes(raw) });
+      throw error;
     }
 
     throw lastErr instanceof Error
@@ -667,7 +698,16 @@ function decodeUsage(u: WireResponseShape['usage']): ProviderCallOutput['usage']
   if (typeof cached === 'number') {
     out.cacheReadTokens = cached;
   }
+  if (typeof u?.output_tokens_details?.reasoning_tokens === 'number') {
+    out.reasoningTokens = u.output_tokens_details.reasoning_tokens;
+  }
   return out;
+}
+
+function responseShapeBytes(value: unknown): number {
+  if (typeof value === 'string') return byteLength(value);
+  try { return byteLength(JSON.stringify(value) ?? ''); }
+  catch { return 0; }
 }
 
 function parseToolArgs(s: string): Record<string, unknown> {

--- a/providers/v4/runtimeResolver.ts
+++ b/providers/v4/runtimeResolver.ts
@@ -39,6 +39,7 @@ import {
 import {
   MODEL_CATALOG,
   ModelEntry,
+  findModel,
   listModelsForProvider,
 } from './modelCatalog';
 import { CredentialResolver } from './credentialResolver';
@@ -66,6 +67,12 @@ import {
   resolveApiCredential,
   type EffectiveCredentialResolution,
 } from './credentialAuthority';
+import { configureProviderAttemptLedger } from './providerAttemptAccounting';
+import {
+  fetchModels,
+  type FetchModelsResult,
+  type FetchedModel,
+} from '../../core/v4/providers/modelFetch';
 
 /**
  * Minimal interface RuntimeResolver consumes from the config layer. The
@@ -101,6 +108,14 @@ export interface ResolveOptions {
    * inference is a v4.1 follow-up; v4.0 ships explicit /auth refresh.)
    */
   paths?: AidenPaths;
+  /** Test/local-runtime seam for live Ollama inventory discovery. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface RuntimeResolverOptions {
+  fetchImpl?: typeof fetch;
+  /** Short cache used between picker discovery and adapter resolution. */
+  localModelCacheTtlMs?: number;
 }
 
 interface ResolvedCredentials {
@@ -139,14 +154,79 @@ export function deprecationNotice(providerId: string, modelId: string): string |
   return `${providerId}:${modelId} is deprecated and stops working on ${d.date} — switch to ${d.replacement}.`;
 }
 
+function inferLocalContextLength(modelId: string): number {
+  const suffix = /(?:^|[-:])(\d+)(k|m)$/i.exec(modelId);
+  if (!suffix) return 8_192;
+  const amount = Number.parseInt(suffix[1], 10);
+  if (!Number.isFinite(amount) || amount <= 0) return 8_192;
+  return amount * (suffix[2].toLowerCase() === 'm' ? 1_000_000 : 1_000);
+}
+
+function localModelEntry(model: FetchedModel): ModelEntry {
+  const catalog = findModel('ollama', model.id);
+  if (catalog) return catalog;
+  return {
+    id: model.id,
+    displayName: model.displayName || model.id,
+    providerId: 'ollama',
+    contextLength: model.contextLength ?? inferLocalContextLength(model.id),
+    supportsToolCalling: true,
+    supportsVision: false,
+    supportsReasoning: false,
+    isDefault: false,
+    tier: 'standard',
+    notes: 'Installed local model discovered from the live runtime.',
+  };
+}
+
 export class RuntimeResolver {
-  constructor(private readonly credentialResolver: CredentialResolver) {}
+  private localModelCache: {
+    baseUrl: string;
+    expiresAt: number;
+    result: FetchModelsResult;
+  } | null = null;
+
+  constructor(
+    private readonly credentialResolver: CredentialResolver,
+    private readonly resolverOptions: RuntimeResolverOptions = {},
+  ) {}
+
+  /**
+   * Read the actual Ollama inventory. A forced read is used each time the
+   * model picker opens; the short cache then avoids a duplicate request when
+   * the selected model is immediately resolved into an adapter.
+   */
+  async getLocalModelInventory(options: {
+    baseUrl?: string;
+    fetchImpl?: typeof fetch;
+    forceRefresh?: boolean;
+  } = {}): Promise<FetchModelsResult> {
+    const baseUrl = (options.baseUrl ?? PROVIDER_REGISTRY.ollama.baseUrl).replace(/\/+$/, '');
+    const now = Date.now();
+    if (
+      !options.forceRefresh
+      && this.localModelCache?.baseUrl === baseUrl
+      && this.localModelCache.expiresAt > now
+    ) {
+      return this.localModelCache.result;
+    }
+
+    const result = await fetchModels({
+      providerId: 'ollama',
+      baseUrl,
+      fetchImpl: options.fetchImpl ?? this.resolverOptions.fetchImpl,
+    });
+    const ttlMs = Math.max(0, this.resolverOptions.localModelCacheTtlMs ?? 2_000);
+    this.localModelCache = { baseUrl, expiresAt: now + ttlMs, result };
+    return result;
+  }
 
   /**
    * Build a fully-wired adapter for `(providerId, modelId)`. Throws
    * `ProviderError` when the provider, model, or credentials are missing.
    */
   async resolve(options: ResolveOptions): Promise<ProviderAdapter> {
+    if (options.paths) configureProviderAttemptLedger(options.paths.sessionsDb);
     const { entry, model, baseUrl, credentials } = await this.describeInternal(options);
 
     // One-line heads-up when a session resolves a model with an announced EOL.
@@ -235,6 +315,9 @@ export class RuntimeResolver {
 
   /** All models for `providerId`. Empty when unknown — never throws. */
   listModels(providerId: string): ModelEntry[] {
+    if (providerId === 'ollama' && this.localModelCache) {
+      return this.localModelCache.result.models.map(localModelEntry);
+    }
     return listModelsForProvider(providerId);
   }
 
@@ -255,16 +338,47 @@ export class RuntimeResolver {
       );
     }
 
-    const persistedVerification = options.modelVerification
-      ?? options.config?.get(`providers.${entry.id}.modelVerification`) as ModelVerification | undefined;
-    const selection = resolveModelSelection({
-      providerId: entry.id,
-      modelId: options.modelId,
-      verification: persistedVerification,
-      liveModelIds: options.liveModelIds,
-      allowUnverified: options.allowUnverifiedModel,
-    });
-    if (!selection) {
+    const requestedBaseUrl = (options.baseUrlOverride ?? entry.baseUrl).replace(/\/+$/, '');
+    let model: ModelEntry | undefined;
+    if (entry.id === 'ollama') {
+      const inventory = await this.getLocalModelInventory({
+        baseUrl: requestedBaseUrl,
+        fetchImpl: options.fetchImpl,
+      });
+      if (inventory.source !== 'live') {
+        throw new ProviderError(
+          `Ollama is offline or unavailable at ${requestedBaseUrl}. Start Ollama, then reopen \`/model\`.`,
+          entry.id,
+        );
+      }
+      if (inventory.models.length === 0) {
+        throw new ProviderError(
+          `No Ollama models are installed. Run \`ollama pull ${options.modelId}\`, then reopen \`/model\`.`,
+          entry.id,
+        );
+      }
+      const installed = inventory.models.find((candidate) => candidate.id === options.modelId);
+      if (!installed) {
+        throw new ProviderError(
+          `Model '${options.modelId}' is not installed in Ollama. ` +
+          `Installed: ${inventory.models.map((candidate) => candidate.id).join(', ')}. ` +
+          `Run \`ollama pull ${options.modelId}\` explicitly if you want to install it.`,
+          entry.id,
+        );
+      }
+      model = localModelEntry(installed);
+    } else {
+      const persistedVerification = options.modelVerification
+        ?? options.config?.get(`providers.${entry.id}.modelVerification`) as ModelVerification | undefined;
+      model = resolveModelSelection({
+        providerId: entry.id,
+        modelId: options.modelId,
+        verification: persistedVerification,
+        liveModelIds: options.liveModelIds,
+        allowUnverified: options.allowUnverifiedModel,
+      })?.model;
+    }
+    if (!model) {
       const available = listModelsForProvider(entry.id)
         .map((m) => m.id)
         .join(', ');
@@ -275,7 +389,6 @@ export class RuntimeResolver {
       );
     }
 
-    const model = selection.model;
     const credentials = await this.resolveCredentials(entry, options);
     const baseUrl = credentials.endpoint;
     return { entry, model, baseUrl, credentials };

--- a/providers/v4/runtimeResolver.ts
+++ b/providers/v4/runtimeResolver.ts
@@ -39,7 +39,6 @@ import {
 import {
   MODEL_CATALOG,
   ModelEntry,
-  findModel,
   listModelsForProvider,
 } from './modelCatalog';
 import { CredentialResolver } from './credentialResolver';
@@ -48,6 +47,11 @@ import { MessageApiAdapter } from './messageApiAdapter';
 import { ResponseStreamAdapter } from './responseStreamAdapter';
 import { LocalPromptToolsAdapter } from './localPromptToolsAdapter';
 import { getModelDefaults } from './modelDefaults';
+import {
+  modelDeprecation,
+  resolveModelSelection,
+  type ModelVerification,
+} from './providerModelAuthority';
 // v4.14.x — every adapter the factory hands out is wrapped so a shared message
 // preflight runs before ANY provider call. The single seam; no caller can skip it.
 import { withMessagePreflight } from './preflightAdapter';
@@ -57,6 +61,11 @@ import {
   PREFLIGHT_REFRESH_WINDOW_MS,
 } from '../../core/v4/auth/tokenStore';
 import type { AidenPaths } from '../../core/v4/paths';
+import {
+  credentialFingerprint,
+  resolveApiCredential,
+  type EffectiveCredentialResolution,
+} from './credentialAuthority';
 
 /**
  * Minimal interface RuntimeResolver consumes from the config layer. The
@@ -65,6 +74,7 @@ import type { AidenPaths } from '../../core/v4/paths';
  */
 export interface ConfigProvider {
   get(key: string): string | undefined;
+  getRaw?(key: string): string | undefined;
 }
 
 export interface ResolveOptions {
@@ -78,6 +88,9 @@ export interface ResolveOptions {
   credentialSourceHint?: 'cli' | 'config' | 'env' | 'auth.json' | 'default';
   /** Optional config provider — typically a Phase 6 `ConfigManager`. */
   config?: ConfigProvider;
+  liveModelIds?: readonly string[];
+  allowUnverifiedModel?: boolean;
+  modelVerification?: ModelVerification;
   /**
    * Phase 18: Aiden user-data paths. When present and the resolved provider
    * has `oauth: { providerId }` in the registry, the credential chain
@@ -94,6 +107,8 @@ interface ResolvedCredentials {
   apiKey: string | null;
   source: RuntimeResolution['source'];
   oauthRefreshable?: boolean;
+  endpoint: string;
+  effective: EffectiveCredentialResolution;
 }
 
 /**
@@ -115,6 +130,10 @@ const DEPRECATED_MODELS: Readonly<Record<string, { date: string; replacement: st
  * `console.warn`; callers/tests can also consume the string directly.
  */
 export function deprecationNotice(providerId: string, modelId: string): string | null {
+  const shared = modelDeprecation(providerId, modelId);
+  if (shared) {
+    return `${providerId}:${modelId} stops working on ${shared.shutdownDate}; switch to ${shared.replacements.join(' or ')}.`;
+  }
   const d = DEPRECATED_MODELS[`${providerId}:${modelId}`];
   if (!d) return null;
   return `${providerId}:${modelId} is deprecated and stops working on ${d.date} — switch to ${d.replacement}.`;
@@ -205,6 +224,7 @@ export class RuntimeResolver {
       apiKey: credentials.apiKey,
       oauthRefreshable: credentials.oauthRefreshable,
       source: credentials.source,
+      effectiveCredential: credentials.effective,
     };
   }
 
@@ -235,8 +255,16 @@ export class RuntimeResolver {
       );
     }
 
-    const model = findModel(entry.id, options.modelId);
-    if (!model) {
+    const persistedVerification = options.modelVerification
+      ?? options.config?.get(`providers.${entry.id}.modelVerification`) as ModelVerification | undefined;
+    const selection = resolveModelSelection({
+      providerId: entry.id,
+      modelId: options.modelId,
+      verification: persistedVerification,
+      liveModelIds: options.liveModelIds,
+      allowUnverified: options.allowUnverifiedModel,
+    });
+    if (!selection) {
       const available = listModelsForProvider(entry.id)
         .map((m) => m.id)
         .join(', ');
@@ -247,8 +275,9 @@ export class RuntimeResolver {
       );
     }
 
-    const baseUrl = (options.baseUrlOverride ?? entry.baseUrl).replace(/\/+$/, '');
+    const model = selection.model;
     const credentials = await this.resolveCredentials(entry, options);
+    const baseUrl = credentials.endpoint;
     return { entry, model, baseUrl, credentials };
   }
 
@@ -256,9 +285,22 @@ export class RuntimeResolver {
     entry: ProviderRegistryEntry,
     options: ResolveOptions,
   ): Promise<ResolvedCredentials> {
-    // 1. CLI override.
-    if (options.apiKeyOverride && options.apiKeyOverride.length > 0) {
-      return { apiKey: options.apiKeyOverride, source: 'cli' };
+    const direct = await resolveApiCredential({
+      providerId: entry.id,
+      envVar: entry.apiKeyEnvVar,
+      registryEndpoint: entry.baseUrl,
+      override: options.apiKeyOverride,
+      endpointOverride: options.baseUrlOverride,
+      config: options.config,
+      paths: options.paths,
+    });
+    if (direct.apiKey && direct.effective.credentialSource === 'explicit_override') {
+      return {
+        apiKey: direct.apiKey,
+        source: 'cli',
+        endpoint: direct.endpoint,
+        effective: direct.effective,
+      };
     }
 
     // 1b. Phase 18: OAuth bearer from tokenStore. Wins over config/env so
@@ -279,6 +321,13 @@ export class RuntimeResolver {
           apiKey: tokens.accessToken,
           source: 'auth.json',
           oauthRefreshable: !!tokens.refreshToken,
+          endpoint: direct.endpoint,
+          effective: {
+            ...direct.effective,
+            credentialSource: 'oauth_store',
+            credentialFingerprint: credentialFingerprint(tokens.accessToken),
+            configured: true,
+          },
         };
       }
       // No tokens for an OAuth-only provider — surface the clearest error.
@@ -290,20 +339,14 @@ export class RuntimeResolver {
       }
     }
 
-    // 2. Config provider (Phase 6 ConfigManager or test stub).
-    if (options.config) {
-      const fromConfig = options.config.get(`providers.${entry.id}.apiKey`);
-      if (fromConfig && fromConfig.length > 0) {
-        return { apiKey: fromConfig, source: 'config' };
-      }
-    }
-
-    // 3. Env var.
-    if (entry.apiKeyEnvVar) {
-      const fromEnv = process.env[entry.apiKeyEnvVar];
-      if (fromEnv && fromEnv.length > 0) {
-        return { apiKey: fromEnv, source: 'env' };
-      }
+    if (direct.apiKey) {
+      const source = direct.effective.credentialSource === 'inline_config' ? 'config' : 'env';
+      return {
+        apiKey: direct.apiKey,
+        source,
+        endpoint: direct.endpoint,
+        effective: direct.effective,
+      };
     }
 
     // 4. OAuth via credentialResolver.
@@ -320,6 +363,13 @@ export class RuntimeResolver {
             apiKey: token,
             source: 'auth.json',
             oauthRefreshable: refreshed.oauthRefreshable,
+            endpoint: direct.endpoint,
+            effective: {
+              ...direct.effective,
+              credentialSource: 'legacy_store',
+              credentialFingerprint: credentialFingerprint(token),
+              configured: true,
+            },
           };
         }
       } catch (err) {
@@ -346,10 +396,24 @@ export class RuntimeResolver {
 
     // 5. Local providers — no credentials required.
     if (entry.apiMode === 'ollama_prompt_tools') {
-      return { apiKey: null, source: 'default' };
+      return {
+        apiKey: null,
+        source: 'default',
+        endpoint: direct.endpoint,
+        effective: {
+          ...direct.effective,
+          credentialSource: 'local_runtime',
+          configured: true,
+        },
+      };
     }
 
-    return { apiKey: null, source: 'default' };
+    return {
+      apiKey: null,
+      source: 'default',
+      endpoint: direct.endpoint,
+      effective: direct.effective,
+    };
   }
 }
 

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -305,6 +305,54 @@ export interface ProviderCallInput {
    * to "best-effort" for that provider.
    */
   headers?: Record<string, string>;
+  /**
+   * Normalized accounting context. Adapters use this only for durable
+   * measurements; it is never serialized into a provider request.
+   */
+  usageContext?: ProviderCallUsageContext;
+}
+
+export interface ProviderCallUsageContext {
+  logicalCallId?: string;
+  parentCallId?: string | null;
+  sessionId?: string | null;
+  taskId?: string | null;
+  runId?: string | number | null;
+  entryPoint?: string;
+  purpose?: import('../../core/v4/usageLedger').ProviderAttemptPurpose;
+  providerConfigured?: string | null;
+  modelConfigured?: string | null;
+  fallbackIndex?: number;
+  credentialLabelRedacted?: string | null;
+  contextSnapshotId?: string | null;
+  toolSchemaSnapshotId?: string | null;
+  coreSchemaCount?: number | null;
+  mcpSchemaCount?: number | null;
+  pluginSchemaCount?: number | null;
+  deferredSchemaCount?: number | null;
+  selectedProfile?: string | null;
+  selectedMode?: import('../../core/v4/usageLedger').UsageMode | null;
+  rawToolResultBytes?: number | null;
+  transmittedToolResultBytes?: number | null;
+  memoryTokens?: number | null;
+  userProfileTokens?: number | null;
+  projectMemoryTokens?: number | null;
+  skillIndexTokens?: number | null;
+  loadedSkillTokens?: number | null;
+  /**
+   * Internal, mutable attempt budgets. These objects never cross the wire.
+   * Leaf adapters claim them immediately before each physical attempt so
+   * retries and fallback consume the same limits as initial requests.
+   */
+  attemptBudgets?: ProviderAttemptBudget[];
+}
+
+export interface ProviderAttemptBudget {
+  label: string;
+  maxAttempts?: number;
+  maxEstimatedTokens?: number;
+  usedAttempts: number;
+  usedEstimatedTokens: number;
 }
 
 /**
@@ -331,6 +379,7 @@ export interface ProviderCallOutput {
     outputTokens: number;
     cacheReadTokens?: number;
     cacheWriteTokens?: number;
+    reasoningTokens?: number;
   };
   raw?: unknown;
 }

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -56,6 +56,7 @@ export interface RuntimeResolution {
   apiKey: string | null;
   oauthRefreshable?: boolean;
   source: 'cli' | 'config' | 'env' | 'auth.json' | 'default';
+  effectiveCredential?: import('./credentialAuthority').EffectiveCredentialResolution;
 }
 
 /**
@@ -71,6 +72,7 @@ export interface ToolSchema {
     type: 'object';
     properties: Record<string, unknown>;
     required?: string[];
+    additionalProperties?: boolean;
   };
 }
 

--- a/scripts/benchmark-token-efficiency.ts
+++ b/scripts/benchmark-token-efficiency.ts
@@ -1,0 +1,11 @@
+import { runTokenEfficiencyBenchmark } from '../core/v4/tokenEfficiencyBenchmark';
+
+async function main(): Promise<void> {
+  const rows = await runTokenEfficiencyBenchmark();
+  process.stdout.write(`${JSON.stringify({ generatedAt: new Date().toISOString(), rows }, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/tests/v4/_helpers/testProvider.test.ts
+++ b/tests/v4/_helpers/testProvider.test.ts
@@ -42,7 +42,7 @@ describe('testProvider helper', () => {
     expect(p).not.toBeNull();
     expect(p!.source).toBe('groq');
     expect(p!.providerId).toBe('groq');
-    expect(p!.modelId).toBe('llama-3.3-70b-versatile');
+    expect(p!.modelId).toBe('openai/gpt-oss-120b');
   });
 
   it('returns groq2 when only GROQ_API_KEY_2 is set', async () => {

--- a/tests/v4/aidenAgent.promptCache.test.ts
+++ b/tests/v4/aidenAgent.promptCache.test.ts
@@ -35,6 +35,29 @@ async function mkPaths(): Promise<AidenPaths> {
 }
 
 describe('AidenAgent · system prompt cache (Phase 16b.4)', () => {
+  it('replaces a persisted active system prompt instead of duplicating it on resume', async () => {
+    const paths = await mkPaths();
+    const provider = new MockProviderAdapter([MockProviderAdapter.stop('resumed')]);
+    const agent = new AidenAgent({
+      provider,
+      tools: [],
+      toolExecutor: async () => ({ id: '1', name: 'noop', result: null }),
+      promptBuilder: new PromptBuilder(),
+      promptBuilderOptions: { paths, platform: 'linux' },
+    });
+    await agent.runConversation([
+      { role: 'system', content: 'persisted pre-restart system prompt' },
+      { role: 'assistant', content: 'compressed history summary' },
+      { role: 'user', content: 'latest instruction' },
+    ]);
+    const sent = provider.capturedInputs[0]!.messages;
+    expect(sent.filter((message) => message.role === 'system')).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ role: 'system' });
+    expect(sent[0]!.content).toContain('slot 1');
+    expect(sent.some((message) => message.content === 'persisted pre-restart system prompt')).toBe(false);
+    expect(sent.some((message) => message.content === 'latest instruction')).toBe(true);
+  });
+
   it('getSystemPromptForDebug returns the SOUL.md content', async () => {
     const paths = await mkPaths();
     const agent = new AidenAgent({

--- a/tests/v4/auxiliaryClient.test.ts
+++ b/tests/v4/auxiliaryClient.test.ts
@@ -127,7 +127,7 @@ describe('AuxiliaryClient', () => {
     expect(u.honesty_classify.calls).toBe(1);
   });
 
-  it('7. resolves adapter once at construction', async () => {
+  it('7. resolves the adapter lazily and only once', async () => {
     const adapter = new StubAdapter();
     const resolver = makeResolver(adapter);
     const c = new AuxiliaryClient({
@@ -136,6 +136,7 @@ describe('AuxiliaryClient', () => {
       resolver,
       warn: () => {},
     });
+    expect(c._resolveCallCount()).toBe(0);
     await c.call({ purpose: 'compression', prompt: 'a' });
     await c.call({ purpose: 'compression', prompt: 'b' });
     await c.call({ purpose: 'compression', prompt: 'c' });
@@ -239,6 +240,70 @@ describe('AuxiliaryClient', () => {
     expect(combined).toBeDefined();
     expect(combined).toContain('groq/m');
     expect(combined).toContain('p2/m2');
+  });
+
+  it('falls back to the parent after the configured auxiliary fails a real call', async () => {
+    const auxiliary = new StubAdapter(undefined, 'throw');
+    const parent = new StubAdapter({
+      content: 'parent result',
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 2, outputTokens: 3 },
+    });
+    const c = new AuxiliaryClient({
+      defaultProvider: 'auxiliary',
+      defaultModel: 'small',
+      fallbacks: [{ providerId: 'parent', modelId: 'selected' }],
+      resolver: {
+        resolve: async ({ providerId }) => providerId === 'auxiliary' ? auxiliary : parent,
+      },
+      warn: () => {},
+    });
+
+    const result = await c.call({ purpose: 'compression', prompt: 'summarize' });
+
+    expect(result.content).toBe('parent result');
+    expect(auxiliary.calls).toHaveLength(1);
+    expect(parent.calls).toHaveLength(1);
+    expect(c._resolveCallCount()).toBe(2);
+    expect(c.isUnavailable()).toBe(false);
+  });
+
+  it('disables the optional operation when auxiliary and parent both fail calls', async () => {
+    const c = new AuxiliaryClient({
+      defaultProvider: 'auxiliary',
+      defaultModel: 'small',
+      fallbacks: [{ providerId: 'parent', modelId: 'selected' }],
+      resolver: { resolve: async () => new StubAdapter(undefined, 'throw') },
+      warn: () => {},
+    });
+
+    const result = await c.call({ purpose: 'honesty_classify', prompt: 'classify' });
+
+    expect(result.content).toBe('');
+    expect(c._resolveCallCount()).toBe(2);
+    expect(c.isUnavailable()).toBe(true);
+  });
+
+  it('keeps the selected parent cached after it proves live', async () => {
+    const auxiliary = new StubAdapter(undefined, 'throw');
+    const parent = new StubAdapter();
+    const c = new AuxiliaryClient({
+      defaultProvider: 'auxiliary',
+      defaultModel: 'small',
+      fallbacks: [{ providerId: 'parent', modelId: 'selected' }],
+      resolver: {
+        resolve: async ({ providerId }) => providerId === 'auxiliary' ? auxiliary : parent,
+      },
+      warn: () => {},
+    });
+
+    await c.call({ purpose: 'compression', prompt: 'first' });
+    await c.call({ purpose: 'compression', prompt: 'second' });
+
+    expect(auxiliary.calls).toHaveLength(1);
+    expect(parent.calls).toHaveLength(2);
+    expect(c._resolveCallCount()).toBe(2);
   });
 
   it('10. concurrent calls record usage independently (no race-bleed)', async () => {

--- a/tests/v4/cli/aidenCLI.test.ts
+++ b/tests/v4/cli/aidenCLI.test.ts
@@ -136,6 +136,32 @@ describe('aiden CLI', () => {
     expect(chat.mock.calls[0][0]).toMatchObject({ tui: true });
   });
 
+  it('returns the one-shot result without forcing process shutdown', async () => {
+    const runQueryHook = vi.fn(async () => 7);
+    const exitSpy = vi.spyOn(process, 'exit');
+    const { argv, hooks } = captureMain(['-q', 'hello'], { runQueryHook });
+
+    const code = await main(argv, hooks);
+
+    expect(code).toBe(7);
+    expect(runQueryHook).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('returns the chat one-shot result without forcing process shutdown', async () => {
+    const runQueryHook = vi.fn(async () => 3);
+    const exitSpy = vi.spyOn(process, 'exit');
+    const { argv, hooks } = captureMain(['chat', '-q', 'hello'], { runQueryHook });
+
+    const code = await main(argv, hooks);
+
+    expect(code).toBe(3);
+    expect(runQueryHook).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
   it('aiden tui (subcommand) is no longer registered as a v4.1 placeholder', async () => {
     // commander with an unknown subcommand still parses successfully when
     // it falls through the default action (chat). To keep the contract

--- a/tests/v4/cli/aidenPromptFooterGhost.test.ts
+++ b/tests/v4/cli/aidenPromptFooterGhost.test.ts
@@ -89,7 +89,7 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (P
       [
         'model:',
         '  provider: groq',
-        '  modelId: llama-3.3-70b-versatile',
+        '  modelId: openai/gpt-oss-120b',
         'providers:',
         '  groq:',
         '    apiKey: ${GROQ_API_KEY}',

--- a/tests/v4/cli/backNavInput.pty.test.ts
+++ b/tests/v4/cli/backNavInput.pty.test.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import * as pty from 'node-pty';
+import { describe, expect, it } from 'vitest';
+
+describe('masked onboarding input through a real terminal', () => {
+  it('returns the complete typed value when Enter submits', async () => {
+    const modulePath = path.resolve('dist/cli/v4/onboarding/backNavInput.js');
+    const credential = ['fixture', 'masked', 'value'].join('-');
+    const childCode = [
+      `const { backNavInput } = require(${JSON.stringify(modulePath)});`,
+      `backNavInput({ message: 'API key', mask: true }).then((value) => {`,
+      `  process.stdout.write('RESULT_LENGTH=' + String(typeof value === 'string' ? value.length : -1) + '\\n');`,
+      `  process.exit(0);`,
+      `}, () => process.exit(1));`,
+    ].join('\n');
+
+    const result = await new Promise<{ code: number; output: string }>((resolve, reject) => {
+      const terminal = pty.spawn(process.execPath, ['-e', childCode], {
+        cwd: process.cwd(),
+        cols: 100,
+        rows: 30,
+        env: { ...process.env, NO_COLOR: '1' } as Record<string, string>,
+      });
+      let output = '';
+      let submitted = false;
+      const timeout = setTimeout(() => {
+        try { terminal.kill(); } catch { /* best effort */ }
+        reject(new Error('masked input fixture did not settle'));
+      }, 10_000);
+      terminal.onData((chunk) => {
+        output += chunk;
+        if (!submitted && output.includes('API key')) {
+          submitted = true;
+          terminal.write(`${credential}\r`);
+        }
+      });
+      terminal.onExit(({ exitCode }) => {
+        clearTimeout(timeout);
+        resolve({ code: exitCode, output });
+      });
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.output).toContain(`RESULT_LENGTH=${credential.length}`);
+    expect(result.output).not.toContain(credential);
+  });
+});

--- a/tests/v4/cli/commands.test.ts
+++ b/tests/v4/cli/commands.test.ts
@@ -13,6 +13,9 @@ import {
   title,
   compress,
   usage,
+  estimate,
+  budget,
+  mode,
   undo,
   retry,
   yolo,
@@ -96,9 +99,9 @@ describe('barrel exports', () => {
     // v4.12.1 Pillar 4 Slice 2b added /redirect (55 → 56).
     // v4.14 added /auto (one-command Partner opt-in) (56 → 57).
     // v4.14 added /mode (friendly trust-level viewer/switcher) (57 → 58).
-    expect(allCommands.length).toBe(58);
+    expect(allCommands.length).toBe(59);
     const names = new Set(allCommands.map((c) => c.name));
-    expect(names.size).toBe(58);
+    expect(names.size).toBe(59);
   });
 
   it('every command exposes name, description, category', () => {
@@ -169,6 +172,29 @@ describe('/model', () => {
     await model.handler(ctx as any);
     expect(setProvider).toHaveBeenCalledWith('anthropic', 'claude-opus-4-7');
     expect(output()).toMatch(/Now using anthropic/);
+  });
+
+  it('preserves all colons in an explicit live Ollama model tag', async () => {
+    const setProvider = vi.fn(async () => {});
+    const fakeResolver = { listProviders: () => [], listModels: () => [] };
+    const session = {
+      history: [],
+      setHistory: () => {},
+      clearHistory: () => {},
+      getCurrentProvider: () => 'groq',
+      getCurrentModel: () => 'old-model',
+      setProvider,
+    };
+    const { ctx } = makeCtx({
+      resolver: fakeResolver,
+      session,
+      args: ['ollama:gemma4:e4b-32k'],
+      rawArgs: 'ollama:gemma4:e4b-32k',
+    });
+
+    await model.handler(ctx as any);
+
+    expect(setProvider).toHaveBeenCalledWith('ollama', 'gemma4:e4b-32k');
   });
 
   it('errors gracefully on invalid spec', async () => {
@@ -339,6 +365,36 @@ describe('/compress', () => {
     expect(setHistory).toHaveBeenCalledWith(compressed);
     expect(output()).toMatch(/Compressed/);
   });
+
+  it('reports an auxiliary failure instead of calling it a short conversation', async () => {
+    const compressor = {
+      forceCompress: vi.fn(async () => ({
+        compressedMessages: [],
+        removedMessageCount: 0,
+        summaryTokens: 0,
+        preservedRecentCount: 10,
+        refused: true,
+        error: true,
+        errorMessage: 'Auxiliary summarizer returned empty content — context unchanged.',
+      })),
+    };
+    const setHistory = vi.fn();
+    const session = {
+      history: Array(10).fill({ role: 'user', content: 'x' }),
+      setHistory,
+      clearHistory: () => {},
+      getCurrentProvider: () => 'custom_openai',
+      getCurrentModel: () => 'custom-default',
+      setProvider: async () => {},
+    };
+    const { ctx, output } = makeCtx({ compressor, session });
+
+    await compress.handler(ctx as any);
+
+    expect(output()).toMatch(/Compression failed safely/);
+    expect(output()).not.toMatch(/too short/i);
+    expect(setHistory).not.toHaveBeenCalled();
+  });
 });
 
 describe('/undo', () => {
@@ -444,6 +500,58 @@ describe('/usage', () => {
     await usage.handler(ctx as any);
     expect(output()).toMatch(/pricing unknown/i);
     expect(output()).not.toMatch(/Estimated cost/);
+  });
+});
+
+describe('/estimate, /budget, and token-usage /mode', () => {
+  it('estimates locally and emits machine-readable output without a provider call', async () => {
+    const providerCall = vi.fn();
+    const { ctx, output } = makeCtx({
+      args: ['--json', 'inspect', 'one', 'file'],
+      rawArgs: '--json inspect one file',
+      config: {
+        getValue: (key: string, fallback: unknown) => key === 'usage.mode' ? 'economy' : fallback,
+      },
+      session: {
+        history: [{ role: 'user', content: 'inspect one file' }],
+        getCurrentProvider: () => 'unknown-provider',
+        getCurrentModel: () => 'unknown-model',
+        getTotalUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+        providerCall,
+      },
+      toolRegistry: { getSchemas: () => [] },
+    });
+    await estimate.handler(ctx as any);
+    const parsed = JSON.parse(output().trim());
+    expect(parsed.selectedMode).toBe('economy');
+    expect(parsed.costStatus).toBe('unknown');
+    expect(parsed.estimatedTokenHigh).toBeGreaterThan(parsed.estimatedTokenLow);
+    expect(providerCall).not.toHaveBeenCalled();
+  });
+
+  it('persists usage mode without requiring an approval engine', async () => {
+    const set = vi.fn();
+    const save = vi.fn(async () => {});
+    const { ctx, output } = makeCtx({
+      args: ['economy'],
+      config: { getValue: () => 'balanced', set, save },
+    });
+    await mode.handler(ctx as any);
+    expect(set).toHaveBeenCalledWith('usage.mode', 'economy');
+    expect(save).toHaveBeenCalledOnce();
+    expect(output()).toMatch(/Usage mode: economy/);
+  });
+
+  it('persists an estimated-cost cap independently from the token cap', async () => {
+    const set = vi.fn();
+    const save = vi.fn(async () => {});
+    const { ctx } = makeCtx({
+      args: ['cost', '1.25'],
+      config: { getValue: () => 0, set, save },
+    });
+    await budget.handler(ctx as any);
+    expect(set).toHaveBeenCalledWith('budget.session_cost_cap_usd', 1.25);
+    expect(save).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/v4/cli/frame/framePty.test.ts
+++ b/tests/v4/cli/frame/framePty.test.ts
@@ -97,7 +97,7 @@ async function spawnFrameAiden(busyTickMs = 300): Promise<AidenTerm> {
     [
       'model:',
       '  provider: groq',
-      '  modelId: llama-3.3-70b-versatile',
+      '  modelId: openai/gpt-oss-120b',
       'providers:',
       '  groq:',
       '    apiKey: ${GROQ_API_KEY}',

--- a/tests/v4/cli/interactionDecision.pty.test.ts
+++ b/tests/v4/cli/interactionDecision.pty.test.ts
@@ -152,6 +152,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         CUSTOM_OPENAI_API_KEY: 'decision-key',
         AIDEN_NO_UPDATE_CHECK: '1',
         AIDEN_TEST_COMPOSER_READY: '1',
+        AIDEN_SANDBOX: '0',
         TELEGRAM_BOT_TOKEN: '',
         FORCE_COLOR: '0',
         NO_COLOR: '1',

--- a/tests/v4/cli/modelPicker.test.ts
+++ b/tests/v4/cli/modelPicker.test.ts
@@ -174,7 +174,10 @@ describe('runModelPicker', () => {
       currentModelId: 'llama3.2',
     });
 
-    expect(fetchImpl).toHaveBeenCalledWith('http://localhost:11434/api/tags');
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:11434/api/tags',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(result).toEqual({ providerId: 'ollama', modelId: 'gemma4:e4b-32k' });
     expect(providerMessage).toMatch(/configured: ollama.*llama3\.2.*not installed/i);
     expect(providerChoices.find((choice) => choice.value === 'ollama').name)

--- a/tests/v4/cli/modelPicker.test.ts
+++ b/tests/v4/cli/modelPicker.test.ts
@@ -144,6 +144,106 @@ describe('runModelPicker', () => {
     expect(local.name).toMatch(/131K/);
   });
 
+  it('queries Ollama inventory and disables catalog models that are not installed', async () => {
+    let modelChoices: any[] = [];
+    let providerChoices: any[] = [];
+    let providerMessage = '';
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        { name: 'gemma4:e4b-32k' },
+        { name: 'gemma4:e4b-16k' },
+        { name: 'gemma4:e4b-8k' },
+        { name: 'gemma4:e4b' },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const select = vi.fn(async (opts: any) => {
+      if (isStage1(opts.message)) {
+        providerChoices = opts.choices;
+        providerMessage = opts.message;
+        return 'ollama';
+      }
+      modelChoices = opts.choices;
+      return 'gemma4:e4b-32k';
+    });
+
+    const result = await runModelPicker({
+      resolver: realResolver(),
+      promptModule: { select },
+      fetchImpl: fetchImpl as typeof fetch,
+      currentProviderId: 'ollama',
+      currentModelId: 'llama3.2',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://localhost:11434/api/tags');
+    expect(result).toEqual({ providerId: 'ollama', modelId: 'gemma4:e4b-32k' });
+    expect(providerMessage).toMatch(/configured: ollama.*llama3\.2.*not installed/i);
+    expect(providerChoices.find((choice) => choice.value === 'ollama').name)
+      .not.toMatch(/current/i);
+    for (const modelId of [
+      'gemma4:e4b-32k',
+      'gemma4:e4b-16k',
+      'gemma4:e4b-8k',
+      'gemma4:e4b',
+    ]) {
+      const installed = modelChoices.find((choice) => choice.value === modelId);
+      expect(installed.name).toMatch(/installed/i);
+      expect(installed.disabled).toBeFalsy();
+    }
+    for (const modelId of ['llama3.2', 'qwen2.5:7b', 'gemma2:2b']) {
+      const unavailable = modelChoices.find((choice) => choice.value === modelId);
+      expect(unavailable.name).toMatch(/not installed/i);
+      expect(String(unavailable.disabled)).toContain(`ollama pull ${modelId}`);
+      expect(unavailable.name).not.toMatch(/← current/);
+    }
+  });
+
+  it('forces a fresh Ollama inventory read each time the picker opens', async () => {
+    const resolver = realResolver();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [{ name: 'gemma4:e4b-32k' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const prompts = {
+      select: vi.fn(async (opts: any) => isStage1(opts.message) ? 'ollama' : 'gemma4:e4b-32k'),
+    };
+
+    await runModelPicker({ resolver, promptModule: prompts, fetchImpl: fetchImpl as typeof fetch });
+    await runModelPicker({ resolver, promptModule: prompts, fetchImpl: fetchImpl as typeof fetch });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not claim catalog recommendations are uninstalled when Ollama is offline', async () => {
+    let stage1Message = '';
+    let stage2Message = '';
+    let modelChoices: any[] = [];
+    const fetchImpl = vi.fn(async () => { throw new Error('connect ECONNREFUSED'); });
+    const select = vi.fn(async (opts: any) => {
+      if (isStage1(opts.message)) {
+        stage1Message = opts.message;
+        return 'ollama';
+      }
+      stage2Message = opts.message;
+      modelChoices = opts.choices;
+      return '__cancel__';
+    });
+
+    const result = await runModelPicker({
+      resolver: realResolver(),
+      promptModule: { select },
+      fetchImpl: fetchImpl as typeof fetch,
+      currentProviderId: 'ollama',
+      currentModelId: 'gemma4:e4b-32k',
+    });
+
+    expect(result).toBeNull();
+    expect(stage1Message).toMatch(/inventory unavailable/i);
+    expect(stage1Message).not.toMatch(/not installed/i);
+    expect(stage2Message).toMatch(/inventory unavailable.*start Ollama/i);
+    expect(modelChoices.some((choice) => choice.value === 'llama3.2')).toBe(false);
+    const unavailable = modelChoices.find((choice) => choice.value === '__ollama_unavailable__');
+    expect(unavailable.disabled).toBeTruthy();
+  });
+
   it('returns null when user cancels provider prompt via Ctrl+C', async () => {
     const result = await runModelPicker({
       resolver: realResolver(),

--- a/tests/v4/cli/modelPicker.test.ts
+++ b/tests/v4/cli/modelPicker.test.ts
@@ -53,9 +53,9 @@ describe('runModelPicker', () => {
   it('parses bare unique model', async () => {
     const result = await runModelPicker({
       resolver: realResolver(),
-      spec: 'llama-3.3-70b-versatile',
+      spec: 'gemini-2.5-pro',
     });
-    expect(result).toEqual({ providerId: 'groq', modelId: 'llama-3.3-70b-versatile' });
+    expect(result).toEqual({ providerId: 'gemini', modelId: 'gemini-2.5-pro' });
   });
 
   it('returns null on ambiguous bare model', async () => {

--- a/tests/v4/cli/ollamaModelPicker.pty.test.ts
+++ b/tests/v4/cli/ollamaModelPicker.pty.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import * as pty from 'node-pty';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+let child: RunningPty | null = null;
+const fixture = path.resolve(__dirname, '../harness/ollamaModelPickerPtyFixture.ts');
+
+function plain(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '');
+}
+
+afterEach(async () => {
+  if (child) {
+    try { child.kill(); } catch { /* already exited */ }
+    child = null;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 300));
+});
+
+describe.skipIf(process.platform !== 'win32')('live Ollama model picker ConPTY', () => {
+  it('selects an installed exact tag and leaves static recommendations disabled', async () => {
+    child = pty.spawn(process.execPath, ['-r', 'ts-node/register/transpile-only', fixture], {
+      cwd: path.resolve(__dirname, '../../..'),
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      cols: 140,
+      rows: 40,
+    });
+    let output = '';
+    let state = 'provider';
+    const result = await new Promise<{ providerId: string; modelId: string }>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `Ollama picker PTY timeout (${state}):\n${plain(output).slice(-10_000)}`,
+      )), 20_000);
+      child!.onData((chunk) => {
+        output += chunk;
+        const text = plain(output);
+        if (state === 'provider' && text.includes('Select Provider')) {
+          state = 'model';
+          setTimeout(() => child!.write('\r'), 300);
+        } else if (state === 'model' && text.includes('Select a model')) {
+          state = 'result';
+          setTimeout(() => child!.write('\x1b[B\x1b[B\r'), 300);
+        }
+        const match = text.match(/\[OLLAMA_PICKER_RESULT\](\{[^\n]+\})/);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(JSON.parse(match[1]) as { providerId: string; modelId: string });
+        }
+      });
+      child!.onExit(({ exitCode }) => {
+        if (exitCode !== 0) {
+          clearTimeout(timeout);
+          reject(new Error(`Ollama picker exited ${exitCode}:\n${plain(output).slice(-10_000)}`));
+        }
+      });
+    });
+
+    expect(result).toEqual({ providerId: 'ollama', modelId: 'gemma4:e4b-32k' });
+    for (const model of ['gemma4:e4b-32k', 'gemma4:e4b-16k', 'gemma4:e4b-8k', 'gemma4:e4b']) {
+      expect(plain(output)).toContain(model);
+    }
+    expect(plain(output)).toMatch(/Llama 3\.2 \(local\).*not installed.*ollama pull llama3\.2/i);
+  }, 25_000);
+});

--- a/tests/v4/cli/providerReadiness.packaged.test.ts
+++ b/tests/v4/cli/providerReadiness.packaged.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import http from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+
+import { spawnAidenTerm, type AidenTerm } from '../harness/aidenTerm';
+
+const packageRoot = process.env.AIDEN_PACKAGED_READINESS_ROOT;
+const suite = packageRoot ? describe : describe.skip;
+let server: http.Server | null = null;
+const sockets = new Set<Socket>();
+let term: AidenTerm | null = null;
+
+afterEach(async () => {
+  term?.kill();
+  term = null;
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+});
+
+async function startProvider() {
+  let calls = 0;
+  let userTurns = 0;
+  server = http.createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/v1/models') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ data: [{ id: 'custom-default' }] }));
+      return;
+    }
+    if (request.method !== 'POST' || request.url !== '/v1/chat/completions') {
+      response.writeHead(404).end();
+      return;
+    }
+    calls += 1;
+    let raw = '';
+    for await (const chunk of request) raw += chunk;
+    const body = JSON.parse(raw) as {
+      stream?: boolean;
+      tool_choice?: unknown;
+      tools?: Array<{ function?: { name?: string } }>;
+      messages?: Array<{ role?: string; content?: string }>;
+    };
+    const replay = body.messages?.some((message) => message.role === 'tool');
+    const requiresReadinessTool = body.tools?.some(
+      (tool) => tool.function?.name === 'runtime_readiness_probe',
+    ) && !replay;
+    let message: Record<string, unknown>;
+    let finishReason = 'stop';
+    if (requiresReadinessTool) {
+      finishReason = 'tool_calls';
+      message = {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'packaged-probe',
+          type: 'function',
+          function: { name: 'runtime_readiness_probe', arguments: '{"marker":"ready"}' },
+        }],
+      };
+    } else {
+      const isRealTurn = body.messages?.some((message) =>
+        message.role === 'user' && /PACKAGED (FIRST|SECOND)/.test(message.content ?? ''),
+      );
+      if (isRealTurn) userTurns += 1;
+      const content = replay
+        ? 'Probe cycle complete.'
+        : isRealTurn
+          ? `PACKAGED ${userTurns === 1 ? 'FIRST' : 'SECOND'}`
+          : 'READY';
+      message = { role: 'assistant', content };
+    }
+    if (!body.stream) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        choices: [{ message, finish_reason: finishReason }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    if (finishReason === 'tool_calls') {
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: { tool_calls: message.tool_calls }, finish_reason: null }] })}\n\n`);
+    } else {
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: { content: message.content }, finish_reason: null }] })}\n\n`);
+    }
+    response.write(`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: finishReason }] })}\n\n`);
+    response.end('data: [DONE]\n\n');
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}/v1`, calls: () => calls };
+}
+
+suite('packaged provider readiness lifecycle', () => {
+  it('sets up, answers, restarts, and answers again through the installed artifact', async () => {
+    const root = path.resolve(packageRoot!);
+    const entry = path.join(root, 'dist', 'cli', 'v4', 'aidenCLI.js');
+    const setupModule = require(path.join(root, 'dist', 'cli', 'v4', 'setupWizard.js')) as any;
+    const readinessModule = require(path.join(root, 'dist', 'providers', 'v4', 'providerReadiness.js')) as any;
+    const pathsModule = require(path.join(root, 'dist', 'core', 'v4', 'paths.js')) as any;
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-packaged-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-packaged-cwd-'));
+    const fixture = await startProvider();
+    const paths = pathsModule.resolveAidenPaths({ rootOverride: home });
+    const customIndex = setupModule.PROVIDERS.findIndex(
+      (provider: { id: string }) => provider.id === 'custom_openai',
+    ) + 1;
+    const choices = [customIndex];
+    const inputs = ['custom-default', fixture.baseUrl, 'fixture-credential'];
+    const prompts = {
+      choose: async () => choices.shift(),
+      input: async () => inputs.shift(),
+      confirm: async () => false,
+    };
+    const setup = await setupModule.runSetupWizard({
+      paths,
+      prompts,
+      readinessVerifier: readinessModule.runRuntimeReadinessTransaction,
+      skipCuratedStep: true,
+    });
+    expect(setup.readiness?.state).toBe('complete');
+    expect(setup.readiness?.plainCompletionStatus).toBe('verified');
+    expect(setup.readiness?.toolCallStatus).toBe('verified');
+    const setupCalls = fixture.calls();
+
+    const env = {
+      CUSTOM_OPENAI_API_KEY: '',
+      AIDEN_NO_UPDATE_CHECK: '1',
+    };
+    term = await spawnAidenTerm({ entry, aidenHome: home, cwd, env });
+    await term.waitForPrompt({ timeoutMs: 30_000 });
+    term.typeLine('Reply with exactly: PACKAGED FIRST');
+    await term.waitFor(() => fixture.calls() >= setupCalls + 1, {
+      timeoutMs: 30_000,
+      label: 'first packaged provider call',
+    });
+    await term.waitFor((plain) => plain.includes('PACKAGED FIRST'), {
+      timeoutMs: 30_000,
+      label: 'first packaged response',
+    });
+    await term.waitForPrompt({ timeoutMs: 30_000 });
+    await term.quit({ timeoutMs: 30_000 });
+    term = null;
+
+    term = await spawnAidenTerm({ entry, aidenHome: home, cwd, env });
+    await term.waitForPrompt({ timeoutMs: 30_000 });
+    term.typeLine('Reply with exactly: PACKAGED SECOND');
+    await term.waitFor(() => fixture.calls() >= setupCalls + 2, {
+      timeoutMs: 30_000,
+      label: 'second packaged provider call',
+    });
+    await term.waitFor((plain) => plain.includes('PACKAGED SECOND'), {
+      timeoutMs: 30_000,
+      label: 'second packaged response',
+    });
+    expect(fixture.calls()).toBe(setupCalls + 2);
+    await term.quit({ timeoutMs: 30_000 });
+    term = null;
+  }, 120_000);
+});

--- a/tests/v4/cli/setupWizard.test.ts
+++ b/tests/v4/cli/setupWizard.test.ts
@@ -8,6 +8,7 @@ import {
   isFreshInstall,
   printPostWizardTutorial,
   aidenHomeDisplayPath,
+  setupRequiresRecoveryMode,
   PROVIDERS,
   type PromptIO,
   type SetupAnswers,
@@ -145,7 +146,73 @@ describe('SetupWizard', () => {
     expect(result.status).toBe('configured');
     expect(result.ran).toBe(true);
     expect(result.config?.model.provider).toBe('groq');
+    expect(result.config?.agent.tool_profile).toBe('minimal');
     expect(prompts.defaultIndexCalls[0]).toBe(expectedIdx);
+  });
+
+  it('does not advance past an empty required credential', async () => {
+    const groqIdx = PROVIDERS.findIndex((provider) => provider.id === 'groq') + 1;
+    const { display } = sinkDisplay();
+    const answers = ['', ['fixture', 'managed', 'credential'].join('-')];
+    let credentialPrompts = 0;
+    const prompts: PromptIO = {
+      async choose(_question, _choices, defaultIndex) {
+        return defaultIndex ?? groqIdx;
+      },
+      async input(question) {
+        if (!question.startsWith('API key for')) throw new Error(`unexpected input prompt: ${question}`);
+        credentialPrompts += 1;
+        return answers.shift()!;
+      },
+      async confirm() {
+        return false;
+      },
+    };
+
+    const result = await runSetupWizard({
+      paths,
+      display,
+      prompts,
+      skipValidation: true,
+      skipCuratedStep: true,
+    });
+
+    expect(result.status).toBe('configured');
+    expect(credentialPrompts).toBe(2);
+    expect(await fs.readFile(paths.envFile, 'utf8')).toMatch(/^GROQ_API_KEY=\S+$/m);
+  });
+
+  it('does not present an incomplete readiness transaction as configured', async () => {
+    const groqIdx = PROVIDERS.findIndex((provider) => provider.id === 'groq') + 1;
+    const { display, chunks } = sinkDisplay();
+    const result = await runSetupWizard({
+      paths,
+      display,
+      prompts: scriptedPrompts({ choose: [groqIdx, 1], input: ['fixture-credential'] }),
+      validator: async () => ({ valid: true }),
+      readinessVerifier: async () => ({
+        state: 'failed_requires_user_action',
+        provider: 'groq',
+        model: 'openai/gpt-oss-120b',
+        endpointFingerprint: 'endpoint',
+        credentialSource: 'managed_environment',
+        transportMode: 'chat_completions',
+        plainCompletionStatus: 'verified',
+        streamingStatus: 'verified',
+        toolCallStatus: 'failed',
+        toolResultReplayStatus: 'failed',
+        structuredArgumentsStatus: 'failed',
+        verificationTimestamp: '2026-07-18T00:00:00.000Z',
+        verificationErrorCategory: 'tool_call_unsupported',
+      }),
+      skipCuratedStep: true,
+    });
+
+    expect(result.readiness?.state).toBe('failed_requires_user_action');
+    const text = chunks.join('');
+    expect(text).not.toMatch(/configured with model/i);
+    expect(text).toMatch(/settings were saved, but runtime readiness did not complete/i);
+    expect(setupRequiresRecoveryMode(result)).toBe(true);
   });
 
   // ── v4.11 — back-navigation (Approach B, hybrid) ─────────────────
@@ -204,7 +271,7 @@ describe('SetupWizard', () => {
     });
     const text = chunks.join('\n');
     expect(text).toMatch(/Press Enter to accept Groq/i);
-    expect(text).toMatch(/free \+ fastest setup/i);
+    expect(text).toMatch(/fast hosted inference; API key required/i);
   });
 
   it('skips when config exists with providers and force=false', async () => {
@@ -267,7 +334,7 @@ describe('SetupWizard', () => {
 
   it('model is filtered by provider', async () => {
     // Phase 30.2.1: Groq is now option [1] with 3 models.
-    // Pick model index 2 → llama-3.1-8b-instant.
+    // Pick the second curated model.
     const groqIdx = PROVIDERS.findIndex((p) => p.id === 'groq') + 1;
     const { display } = sinkDisplay();
     const result = await runSetupWizard({
@@ -278,12 +345,12 @@ describe('SetupWizard', () => {
     });
     expect(result.status).toBe('configured');
     expect(result.config?.model.provider).toBe('groq');
-    expect(result.config?.model.modelId).toBe('llama-3.1-8b-instant');
+    expect(result.config?.model.modelId).toBe('openai/gpt-oss-20b');
   });
 
   it('Custom OpenAI-compatible collects baseUrl + apiKey', async () => {
     // Phase 30.2.1: Custom moved to the end of the list (last entry).
-    const customIdx = PROVIDERS.findIndex((p) => p.id === 'custom') + 1;
+    const customIdx = PROVIDERS.findIndex((p) => p.id === 'custom_openai') + 1;
     const { display } = sinkDisplay();
     const result = await runSetupWizard({
       paths,
@@ -296,10 +363,10 @@ describe('SetupWizard', () => {
       skipValidation: true,
     });
     expect(result.status).toBe('configured');
-    expect(result.config?.model.provider).toBe('custom');
+    expect(result.config?.model.provider).toBe('custom_openai');
     const env = await fs.readFile(paths.envFile, 'utf8');
-    expect(env).toMatch(/CUSTOM_BASE_URL=https:\/\/api\.example\.com\/v1/);
-    expect(env).toMatch(/CUSTOM_API_KEY=custom-key/);
+    expect(result.config?.providers?.custom_openai?.baseUrl).toBe('https://api.example.com/v1');
+    expect(env).toMatch(/CUSTOM_OPENAI_API_KEY=custom-key/);
   });
 
   it('Ollama option probes the local server', async () => {
@@ -367,6 +434,55 @@ describe('SetupWizard', () => {
     });
     expect(result.status).toBe('configured');
     expect(result.config?.model.provider).toBe('anthropic');
+  });
+
+  it('resumes an interrupted persisted readiness transaction without replaying prompts', async () => {
+    await fs.mkdir(path.dirname(paths.configYaml), { recursive: true });
+    await fs.writeFile(paths.configYaml, [
+      'model:',
+      '  provider: groq',
+      '  modelId: openai/gpt-oss-120b',
+      'providers:',
+      '  groq:',
+      '    modelVerification: curated',
+      '    readiness:',
+      '      state: credential_saved',
+      '      provider: groq',
+      '      model: openai/gpt-oss-120b',
+      '      endpointFingerprint: null',
+      '      credentialSource: managed_environment',
+      '      transportMode: chat_completions',
+      '      plainCompletionStatus: not_started',
+      '      toolCallStatus: not_started',
+      '      verificationTimestamp: null',
+      '      verificationErrorCategory: null',
+      '',
+    ].join('\n'));
+    const complete = {
+      state: 'complete' as const,
+      provider: 'groq',
+      model: 'openai/gpt-oss-120b',
+      endpointFingerprint: 'endpoint',
+      credentialSource: 'managed_environment' as const,
+      transportMode: 'chat_completions' as const,
+      plainCompletionStatus: 'verified' as const,
+      toolCallStatus: 'verified' as const,
+      verificationTimestamp: '2026-07-18T00:00:00.000Z',
+      verificationErrorCategory: null,
+    };
+    let resumed = 0;
+    const result = await runSetupWizard({
+      paths,
+      readinessVerifier: async (options) => {
+        resumed += 1;
+        expect(options.providerId).toBe('groq');
+        expect(options.modelId).toBe('openai/gpt-oss-120b');
+        return complete;
+      },
+    });
+    expect(resumed).toBe(1);
+    expect(result.ran).toBe(true);
+    expect(result.readiness).toEqual(complete);
   });
 
   it('banner is shown at start', async () => {

--- a/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
+++ b/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as pty from 'node-pty';
+
+import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+import { startMockProvider, type MockProvider } from '../harness/mockProvider';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+let child: RunningPty | null = null;
+let provider: MockProvider | null = null;
+const cleanup: string[] = [];
+
+function plain(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '');
+}
+
+function submit(terminal: RunningPty, text: string): void {
+  let index = 0;
+  const next = (): void => {
+    if (index < text.length) {
+      terminal.write(text[index++]!);
+      setTimeout(next, 5);
+      return;
+    }
+    setTimeout(() => terminal.write('\r'), 100);
+  };
+  next();
+}
+
+afterEach(async () => {
+  if (child) {
+    try { child.kill(); } catch { /* already exited */ }
+    child = null;
+  }
+  if (provider) {
+    await provider.stop();
+    provider = null;
+  }
+  await Promise.all(cleanup.splice(0).map(
+    (dir) => fs.rm(dir, { recursive: true, force: true }).catch(() => undefined),
+  ));
+});
+
+describe.skipIf(process.platform !== 'win32')('built CLI token-efficiency acceptance', () => {
+  it('keeps estimates local and persists one Economy provider attempt', async () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-token-efficiency-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-token-efficiency-cwd-'));
+    cleanup.push(aidenHome, cwd);
+    provider = await startMockProvider({
+      modelId: 'custom-default',
+      script: [{ content: 'TOKEN EFFICIENCY ACCEPTANCE' }],
+    });
+    await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'token-efficiency\n', 'utf8');
+    await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+      'model:', '  provider: custom_openai', '  modelId: custom-default',
+      'providers:', '  custom_openai:', '    apiKey: controlled-test-value',
+      'display:', '  streaming: true', '  renderer: legacy',
+    ].join('\n') + '\n', 'utf8');
+
+    child = pty.spawn(process.execPath, [
+      '-r', path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs'),
+      path.join(repoRoot, 'dist/cli/v4/aidenCLI.js'),
+    ], {
+      cwd, cols: 110, rows: 40,
+      env: {
+        ...process.env,
+        AIDEN_HOME: aidenHome,
+        AIDEN_TEST_REPO_ROOT: repoRoot,
+        AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl,
+        CUSTOM_OPENAI_API_KEY: 'controlled-test-value',
+        AIDEN_NO_UPDATE_CHECK: '1',
+        AIDEN_TEST_COMPOSER_READY: '1',
+        TELEGRAM_BOT_TOKEN: '',
+        FORCE_COLOR: '0',
+        NO_COLOR: '1',
+      },
+    });
+
+    let output = '';
+    let state = 'boot';
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `token-efficiency acceptance timeout (${state}):\n${plain(output).slice(-12_000)}`,
+      )), 45_000);
+      child!.onData((chunk) => {
+        output += chunk;
+        const text = plain(output);
+        const ready = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (state === 'boot' && ready >= 1) {
+          state = 'estimate';
+          submit(child!, '/estimate --json inspect one file');
+        } else if (state === 'estimate' && text.includes('"selectedMode":"balanced"')) {
+          expect(provider!.callCount()).toBe(0);
+          state = 'mode'; setTimeout(() => submit(child!, '/mode economy'), 1_000);
+        } else if (state === 'mode' && text.includes('Usage mode: economy')) {
+          state = 'budget'; setTimeout(() => submit(child!, '/budget 100000'), 1_000);
+        } else if (state === 'budget' && text.includes('Session token cap set')) {
+          state = 'turn'; setTimeout(() => submit(child!, 'reply with the acceptance phrase'), 1_000);
+        } else if (state === 'turn' && text.includes('TOKEN EFFICIENCY ACCEPTANCE') && ready >= 2) {
+          state = 'usage-json'; setTimeout(() => submit(child!, '/usage --json'), 1_000);
+        } else if (state === 'usage-json' && text.includes('"physicalAttempts":1')) {
+          state = 'usage-human'; setTimeout(() => submit(child!, '/usage'), 1_000);
+        } else if (state === 'usage-human' && text.includes('Usage — Current session')) {
+          expect(text).toContain('cumulative exposures');
+          expect(text).not.toContain('Cost        0');
+          state = 'usage-details'; setTimeout(() => submit(child!, '/usage details'), 1_000);
+        } else if (state === 'usage-details' && text.includes('Usage details — Current session')) {
+          expect(text).toContain('Providers and models');
+          expect(text).toContain('Purposes');
+          state = 'budget-json'; setTimeout(() => submit(child!, '/budget --json'), 1_000);
+        } else if (state === 'budget-json' && text.includes('"tokenBudget":100000')) {
+          state = 'queue'; setTimeout(() => submit(child!, '/queue'), 1_000);
+        } else if (state === 'queue' && /queue is empty/i.test(text)) {
+          state = 'quit'; setTimeout(() => submit(child!, '/quit'), 1_000);
+        }
+      });
+      child!.onExit(() => {
+        if (state !== 'quit') return;
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    expect(provider.callCount()).toBe(1);
+    expect(plain(output)).not.toContain('controlled-test-value');
+    const ledger = new ProviderAttemptLedger(path.join(aidenHome, 'sessions.db'));
+    try {
+      const records = ledger.query({ entryPoint: undefined }).filter((record) => record.entryPoint === 'cli');
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({ selectedMode: 'economy', status: 'success' });
+    } finally {
+      ledger.close();
+    }
+  }, 55_000);
+});

--- a/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
+++ b/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
@@ -98,29 +98,29 @@ describe.skipIf(process.platform !== 'win32')('built CLI token-efficiency accept
         if (state === 'boot' && ready >= 1) {
           state = 'estimate';
           submit(child!, '/estimate --json inspect one file');
-        } else if (state === 'estimate' && text.includes('"selectedMode":"balanced"')) {
+        } else if (state === 'estimate' && text.includes('"selectedMode":"balanced"') && ready >= 2) {
           expect(provider!.callCount()).toBe(0);
-          state = 'mode'; setTimeout(() => submit(child!, '/mode economy'), 1_000);
-        } else if (state === 'mode' && text.includes('Usage mode: economy')) {
-          state = 'budget'; setTimeout(() => submit(child!, '/budget 100000'), 1_000);
-        } else if (state === 'budget' && text.includes('Session token cap set')) {
-          state = 'turn'; setTimeout(() => submit(child!, 'reply with the acceptance phrase'), 1_000);
-        } else if (state === 'turn' && text.includes('TOKEN EFFICIENCY ACCEPTANCE') && ready >= 2) {
-          state = 'usage-json'; setTimeout(() => submit(child!, '/usage --json'), 1_000);
-        } else if (state === 'usage-json' && text.includes('"physicalAttempts":1')) {
-          state = 'usage-human'; setTimeout(() => submit(child!, '/usage'), 1_000);
-        } else if (state === 'usage-human' && text.includes('Usage — Current session')) {
+          state = 'mode'; submit(child!, '/mode economy');
+        } else if (state === 'mode' && text.includes('Usage mode: economy') && ready >= 3) {
+          state = 'budget'; submit(child!, '/budget 100000');
+        } else if (state === 'budget' && text.includes('Session token cap set') && ready >= 4) {
+          state = 'turn'; submit(child!, 'reply with the acceptance phrase');
+        } else if (state === 'turn' && text.includes('TOKEN EFFICIENCY ACCEPTANCE') && ready >= 5) {
+          state = 'usage-json'; submit(child!, '/usage --json');
+        } else if (state === 'usage-json' && text.includes('"physicalAttempts":1') && ready >= 6) {
+          state = 'usage-human'; submit(child!, '/usage');
+        } else if (state === 'usage-human' && text.includes('Usage — Current session') && ready >= 7) {
           expect(text).toContain('cumulative exposures');
           expect(text).not.toContain('Cost        0');
-          state = 'usage-details'; setTimeout(() => submit(child!, '/usage details'), 1_000);
-        } else if (state === 'usage-details' && text.includes('Usage details — Current session')) {
+          state = 'usage-details'; submit(child!, '/usage details');
+        } else if (state === 'usage-details' && text.includes('Usage details — Current session') && ready >= 8) {
           expect(text).toContain('Providers and models');
           expect(text).toContain('Purposes');
-          state = 'budget-json'; setTimeout(() => submit(child!, '/budget --json'), 1_000);
-        } else if (state === 'budget-json' && text.includes('"tokenBudget":100000')) {
-          state = 'queue'; setTimeout(() => submit(child!, '/queue'), 1_000);
-        } else if (state === 'queue' && /queue is empty/i.test(text)) {
-          state = 'quit'; setTimeout(() => submit(child!, '/quit'), 1_000);
+          state = 'budget-json'; submit(child!, '/budget --json');
+        } else if (state === 'budget-json' && text.includes('"tokenBudget":100000') && ready >= 9) {
+          state = 'queue'; submit(child!, '/queue');
+        } else if (state === 'queue' && /queue is empty/i.test(text) && ready >= 10) {
+          state = 'quit'; submit(child!, '/quit');
         }
       });
       child!.onExit(() => {

--- a/tests/v4/cli/usagePresentation.test.ts
+++ b/tests/v4/cli/usagePresentation.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatUsageDetails,
+  formatUsageSummary,
+  type UsagePresentation,
+} from '../../../cli/v4/commands/usage';
+import type {
+  ProviderAttemptPurpose,
+  ProviderAttemptRecord,
+  ProviderUsageProjection,
+} from '../../../core/v4/usageLedger';
+
+const stringWidth: (value: string) => number = require('string-width');
+
+function projection(overrides: Partial<ProviderUsageProjection> = {}): ProviderUsageProjection {
+  return {
+    physicalAttempts: 3,
+    successfulAttempts: 3,
+    failedAttempts: 0,
+    estimatedInputTokens: 30_000,
+    estimatedOutputTokens: 600,
+    estimatedSchemaTokens: 21_900,
+    estimatedImageTokens: 0,
+    providerInputTokens: 26_300,
+    providerOutputTokens: 179,
+    cacheReadTokens: 2_000,
+    cacheWriteTokens: 300,
+    reasoningTokens: 13,
+    requestBytes: 5_000,
+    responseBytes: 1_000,
+    rawToolResultBytes: 9_100,
+    transmittedToolResultBytes: 2_800,
+    memoryTokens: 900,
+    userProfileTokens: 400,
+    projectMemoryTokens: 300,
+    skillIndexTokens: 4_100,
+    loadedSkillTokens: 3_000,
+    coreSchemaCount: 61,
+    mcpSchemaCount: 29,
+    pluginSchemaCount: 4,
+    deferredSchemaCount: 127,
+    knownCostAmount: 0,
+    costCurrency: null,
+    unknownCostAttempts: 3,
+    providerReportedAttempts: 2,
+    estimatedAttempts: 1,
+    ...overrides,
+  };
+}
+
+function record(overrides: Partial<ProviderAttemptRecord> = {}): ProviderAttemptRecord {
+  return {
+    callId: 'call-1',
+    parentCallId: null,
+    sessionId: 'session-1',
+    taskId: null,
+    runId: null,
+    entryPoint: 'cli',
+    purpose: 'primary',
+    providerConfigured: 'groq',
+    providerActual: 'groq',
+    modelConfigured: 'model-a',
+    modelActual: 'model-a',
+    apiMode: 'chat_completions',
+    transport: 'https',
+    attemptIndex: 0,
+    fallbackIndex: 0,
+    credentialLabelRedacted: 'configured',
+    status: 'success',
+    errorClass: null,
+    startedAt: 1,
+    completedAt: 2,
+    estimatedInputTokens: 100,
+    estimatedOutputTokens: 10,
+    estimatedSchemaTokens: 20,
+    estimatedImageTokens: 0,
+    providerInputTokens: 90,
+    providerOutputTokens: 8,
+    providerCacheReadTokens: 0,
+    providerCacheWriteTokens: 0,
+    providerReasoningTokens: 0,
+    requestBytes: 100,
+    responseBytes: 20,
+    usageSource: 'provider_reported',
+    costAmount: null,
+    costCurrency: null,
+    costStatus: 'unknown',
+    costSource: null,
+    contextSnapshotId: null,
+    toolSchemaSnapshotId: null,
+    coreSchemaCount: 1,
+    mcpSchemaCount: 0,
+    pluginSchemaCount: 0,
+    deferredSchemaCount: 0,
+    serializedSchemaBytes: 20,
+    selectedProfile: 'balanced',
+    selectedMode: 'balanced',
+    rawToolResultBytes: 0,
+    transmittedToolResultBytes: 0,
+    memoryTokens: 0,
+    userProfileTokens: 0,
+    projectMemoryTokens: 0,
+    skillIndexTokens: 0,
+    loadedSkillTokens: 0,
+    ...overrides,
+  };
+}
+
+function presentation(): UsagePresentation {
+  const empty = projection({
+    physicalAttempts: 0,
+    successfulAttempts: 0,
+    failedAttempts: 0,
+    unknownCostAttempts: 0,
+    providerReportedAttempts: 0,
+    estimatedAttempts: 0,
+  });
+  const byPurpose: Partial<Record<ProviderAttemptPurpose, ProviderUsageProjection>> = {
+    primary: projection({ physicalAttempts: 1, successfulAttempts: 1 }),
+    retry: projection({ physicalAttempts: 1, successfulAttempts: 1 }),
+    fallback: projection({ physicalAttempts: 1, successfulAttempts: 1 }),
+    auxiliary: empty,
+    subagent: empty,
+    aggregation: empty,
+    compression: empty,
+  };
+  const records = [
+    record(),
+    record({ callId: 'call-2', providerActual: 'together', modelActual: 'model-b', purpose: 'retry' }),
+  ];
+  return {
+    providerId: 'groq',
+    modelId: 'model-a',
+    total: projection(),
+    byPurpose,
+    providers: [
+      { provider: 'groq', model: 'model-a', projection: projection({ physicalAttempts: 1 }) },
+      { provider: 'together', model: 'model-b', projection: projection({ physicalAttempts: 2 }) },
+    ],
+    records,
+  };
+}
+
+describe('human usage presentation', () => {
+  it('renders a concise honest summary without treating unknown cost as zero', () => {
+    const output = formatUsageSummary(presentation(), 100);
+    expect(output).toContain('Usage — Current session');
+    expect(output).toContain('groq -> together');
+    expect(output).toContain('Tokens (mixed)');
+    expect(output).toContain('cumulative exposures');
+    expect(output).toContain('127 deferred');
+    expect(output).toContain('Unknown for 3 calls');
+    expect(output).not.toContain('0.0000');
+    expect(output).toContain('Retries');
+    expect(output).toContain('Fallback attempts');
+    expect(output).not.toContain('Auxiliary calls');
+  });
+
+  it('keeps every summary line within a narrow terminal width', () => {
+    const output = formatUsageSummary(presentation(), 44);
+    for (const line of output.trimEnd().split('\n')) {
+      expect(stringWidth(line)).toBeLessThanOrEqual(44);
+    }
+  });
+
+  it('renders provider, model, purpose, cache, context, and cost details', () => {
+    const output = formatUsageDetails(presentation(), 80);
+    expect(output).toContain('Usage details — Current session');
+    expect(output).toContain('Providers and models');
+    expect(output).toContain('groq:');
+    expect(output).toContain('model-a');
+    expect(output).toContain('Purposes');
+    expect(output).toContain('primary');
+    expect(output).toContain('retry');
+    expect(output).toContain('provider-reported');
+    expect(output).toContain('locally estimated');
+    expect(output).toContain('Cache');
+    expect(output).toContain('Tool results');
+    expect(output).toContain('cumulative exposures');
+    expect(output).toContain('Unknown for 3 calls');
+  });
+
+  it('keeps detailed output readable at 44 columns', () => {
+    const output = formatUsageDetails(presentation(), 44);
+    for (const line of output.trimEnd().split('\n')) {
+      expect(stringWidth(line)).toBeLessThanOrEqual(44);
+    }
+  });
+
+  it('labels fully estimated usage without claiming provider reporting', () => {
+    const input = presentation();
+    input.total = projection({
+      providerReportedAttempts: 0,
+      estimatedAttempts: 3,
+      providerInputTokens: 0,
+      providerOutputTokens: 0,
+    });
+    const output = formatUsageSummary(input, 80);
+    expect(output).toContain('Tokens (estimated)');
+    expect(output).toContain('30K input');
+  });
+});

--- a/tests/v4/config.test.ts
+++ b/tests/v4/config.test.ts
@@ -213,4 +213,30 @@ describe('ConfigManager', () => {
     expect(warns.some((w) => w.includes("Unknown top-level key 'terminal'"))).toBe(false);
     expect(((cfg as any).terminal as { backend: string }).backend).toBe('auto');
   });
+
+  it('13. token-efficiency settings are recognized top-level keys', async () => {
+    const warns: string[] = [];
+    const spy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation((msg) => warns.push(String(msg)));
+    await fs.writeFile(
+      configPath,
+      [
+        'usage:',
+        '  mode: economy',
+        'budget:',
+        '  session_token_cap: 12000',
+        '  session_cost_cap_usd: 1.25',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const cfg = await mgr.load();
+    spy.mockRestore();
+
+    expect(warns.some((warning) => /Unknown top-level key '(usage|budget)'/.test(warning))).toBe(false);
+    expect(cfg.usage?.mode).toBe('economy');
+    expect(cfg.budget?.session_token_cap).toBe(12_000);
+    expect(cfg.budget?.session_cost_cap_usd).toBe(1.25);
+  });
 });

--- a/tests/v4/core/compatibilityUsage.test.ts
+++ b/tests/v4/core/compatibilityUsage.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { estimateCompatibilityUsage } from '../../../core/v4/compatibilityUsage';
+
+describe('compatibility usage reporting', () => {
+  it('counts the complete normalized request and labels estimates honestly', () => {
+    const usage = estimateCompatibilityUsage([
+      { role: 'system', content: 'system context' },
+      { role: 'user', content: 'prior question' },
+      { role: 'assistant', content: 'prior answer' },
+      { role: 'user', content: 'current question' },
+    ], 'answer');
+    expect(usage.prompt_tokens).toBeGreaterThan(Math.ceil('current question'.length / 4));
+    expect(usage.total_tokens).toBe(usage.prompt_tokens + usage.completion_tokens);
+    expect(usage.usage_source).toBe('locally_estimated');
+    expect(usage.estimated).toBe(true);
+  });
+});

--- a/tests/v4/core/modelFetch.test.ts
+++ b/tests/v4/core/modelFetch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchModels } from '../../../core/v4/providers/modelFetch';
+
+describe('local model inventory discovery', () => {
+  it('returns only models reported by the live Ollama inventory', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [{ name: 'gemma4:e4b-8k' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const result = await fetchModels({ providerId: 'ollama', fetchImpl: fetchImpl as typeof fetch });
+
+    expect(result.source).toBe('live');
+    expect(result.models.map((model) => model.id)).toEqual(['gemma4:e4b-8k']);
+    expect(result.models.map((model) => model.id)).not.toEqual(expect.arrayContaining([
+      'llama3.2', 'qwen2.5:7b', 'gemma2:2b',
+    ]));
+  });
+
+  it('does not substitute selectable catalog models when Ollama inventory fails', async () => {
+    const fetchImpl = vi.fn(async () => new Response('not found', { status: 404 }));
+
+    const result = await fetchModels({ providerId: 'ollama', fetchImpl: fetchImpl as typeof fetch });
+
+    expect(result.source).toBe('fallback');
+    expect(result.models).toEqual([]);
+    expect(result.reason).toBe('HTTP 404');
+  });
+});

--- a/tests/v4/core/tokenEfficiencyBenchmark.test.ts
+++ b/tests/v4/core/tokenEfficiencyBenchmark.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { runTokenEfficiencyBenchmark } from '../../../core/v4/tokenEfficiencyBenchmark';
+
+describe('deterministic token-efficiency benchmark', () => {
+  it('covers every release-gate scenario and meets context-reduction targets', async () => {
+    const rows = await runTokenEfficiencyBenchmark();
+    expect(rows).toHaveLength(16);
+    expect(new Set(rows.map((row) => row.scenario)).size).toBe(16);
+
+    for (const scenario of ['large_shell_output', 'large_mcp_result', 'browser_extraction']) {
+      const row = rows.find((entry) => entry.scenario === scenario)!;
+      expect(row.transmittedToolResultBytes).toBeLessThan(row.baselineTransmittedBytes * 0.3);
+    }
+    const retry = rows.find((row) => row.scenario === 'adapter_retry')!;
+    const fallback = rows.find((row) => row.scenario === 'provider_fallback')!;
+    const fanout = rows.find((row) => row.scenario === 'three_child_fanout_aggregation')!;
+    const repeatedRead = rows.find((row) => row.scenario === 'repeated_unchanged_file_read')!;
+    const balanced = rows.find((row) => row.scenario === 'simple_no_tool')!;
+    const economy = rows.find((row) => row.scenario === 'one_file_read_edit')!;
+    expect(retry.physicalProviderAttempts).toBe(2);
+    expect(retry.retryUsage).toBeGreaterThan(0);
+    expect(fallback.physicalProviderAttempts).toBe(2);
+    expect(fallback.fallbackUsage).toBeGreaterThan(0);
+    expect(fanout.childUsage).toBeGreaterThan(0);
+    expect(fanout.aggregationUsage).toBeGreaterThan(0);
+    expect(repeatedRead.transmittedToolResultBytes).toBeLessThanOrEqual(repeatedRead.baselineTransmittedBytes * 0.1);
+    expect(economy.schemaTokens).toBeLessThan(balanced.schemaTokens);
+    expect(rows.every((row) => row.cost === null && row.estimateStatus === 'unknown')).toBe(true);
+  });
+});

--- a/tests/v4/core/toolResultBoundary.test.ts
+++ b/tests/v4/core/toolResultBoundary.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  LocalToolResultArtifactStore,
+  serializeToolResultForModel,
+} from '../../../core/v4/toolResultBoundary';
+import { AidenAgent } from '../../../core/v4/aidenAgent';
+import { MockProviderAdapter } from '../../../core/v4/__mocks__/mockProvider';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('model-visible tool result boundary', () => {
+  it('passes small results through byte-for-byte', async () => {
+    const result = await serializeToolResultForModel('unchanged', { toolName: 'example' });
+    expect(result.content).toBe('unchanged');
+    expect(result.metadata).toMatchObject({ rawSize: 9, transmittedSize: 9, truncated: false });
+  });
+
+  it('bounds large external results and preserves one recoverable result envelope', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'aiden-tool-results-'));
+    roots.push(root);
+    const store = new LocalToolResultArtifactStore(root);
+    const raw = `head-signature\n${'x'.repeat(50_000)}\ntail-signature`;
+
+    const result = await serializeToolResultForModel(raw, {
+      toolName: 'mcp_external_read',
+      toolCallId: 'call-1',
+      capBytes: 8_000,
+      artifactStore: store,
+    });
+
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.rawSize).toBeGreaterThan(50_000);
+    expect(result.metadata.transmittedSize).toBeLessThan(result.metadata.rawSize * 0.3);
+    expect(result.metadata.artifactHandle).toMatch(/^tool-result:\/\/[a-f0-9]{64}$/);
+    expect(result.content).toContain('head-signature');
+    expect(result.content).toContain('tail-signature');
+    expect(result.content).toContain('call-1');
+
+    const restored = await store.read(result.metadata.artifactHandle!, 0, 100_000);
+    expect(restored.content).toBe(raw);
+    expect(restored.complete).toBe(true);
+  });
+
+  it('redacts secrets before durable artifact storage', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'aiden-tool-results-'));
+    roots.push(root);
+    const store = new LocalToolResultArtifactStore(root);
+    const secret = 'token=private-value-that-must-not-persist';
+    const result = await serializeToolResultForModel(`${secret}\n${'z'.repeat(20_000)}`, {
+      toolName: 'shell_exec',
+      capBytes: 1_000,
+      artifactStore: store,
+    });
+
+    const file = path.join(root, `${result.metadata.contentHash}.txt`);
+    expect(await readFile(file, 'utf8')).not.toContain(secret);
+  });
+
+  it.each(['browser_snapshot', 'mcp_external_read', 'shell_exec'])(
+    'applies the same cap to %s',
+    async (toolName) => {
+      const result = await serializeToolResultForModel('a'.repeat(30_000), {
+        toolName,
+        capBytes: 4_000,
+      });
+      expect(result.metadata.truncated).toBe(true);
+      expect(result.metadata.transmittedSize).toBeLessThan(6_000);
+    },
+  );
+
+  it('preserves the assistant-call/tool-result protocol after externalization', async () => {
+    const provider = new MockProviderAdapter([
+      MockProviderAdapter.toolUse([{ id: 'large-1', name: 'external_read', arguments: {} }]),
+      MockProviderAdapter.stop('done'),
+    ]);
+    const agent = new AidenAgent({
+      provider,
+      tools: [{ name: 'external_read', description: 'read', inputSchema: { type: 'object', properties: {} } }],
+      toolExecutor: async (call) => ({ id: call.id, name: call.name, result: 'z'.repeat(50_000) }),
+    });
+
+    await agent.runConversation([{ role: 'user', content: 'read it' }]);
+    const nextRequest = provider.capturedInputs[1].messages;
+    const assistant = nextRequest.find((message) => message.role === 'assistant' && message.toolCalls?.[0]?.id === 'large-1');
+    const tool = nextRequest.find((message) => message.role === 'tool' && message.toolCallId === 'large-1');
+    expect(assistant).toBeDefined();
+    expect(tool).toBeDefined();
+    expect(tool?.content).toContain('large-1');
+    expect(Buffer.byteLength(tool?.content ?? '', 'utf8')).toBeLessThan(12_000);
+  });
+});

--- a/tests/v4/core/usageLedger.test.ts
+++ b/tests/v4/core/usageLedger.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import {
+  ProviderAttemptLedger,
+  type ProviderAttemptRecord,
+} from '../../../core/v4/usageLedger';
+import { createLedgerDailyBudgetTracker } from '../../../core/v4/daemon/dispatcher/dailyBudgetTracker';
+
+let tmpDir: string;
+let dbPath: string;
+let ledger: ProviderAttemptLedger;
+
+function attempt(
+  overrides: Partial<ProviderAttemptRecord> = {},
+): ProviderAttemptRecord {
+  return {
+    callId: 'call-primary-1',
+    parentCallId: null,
+    sessionId: 'session-1',
+    taskId: 'task-1',
+    runId: 'run-1',
+    entryPoint: 'cli',
+    purpose: 'primary',
+    providerConfigured: 'hosted-provider',
+    providerActual: 'hosted-provider',
+    modelConfigured: 'model-a',
+    modelActual: 'model-a',
+    apiMode: 'chat_completions',
+    transport: 'https',
+    attemptIndex: 0,
+    fallbackIndex: 0,
+    credentialLabelRedacted: 'managed:configured',
+    status: 'success',
+    errorClass: null,
+    startedAt: 1_000,
+    completedAt: 1_250,
+    estimatedInputTokens: 90,
+    estimatedOutputTokens: 20,
+    estimatedSchemaTokens: 10,
+    estimatedImageTokens: 0,
+    providerInputTokens: 100,
+    providerOutputTokens: 15,
+    providerCacheReadTokens: 40,
+    providerCacheWriteTokens: 5,
+    providerReasoningTokens: 3,
+    requestBytes: 800,
+    responseBytes: 220,
+    usageSource: 'provider_reported',
+    costAmount: 0.0025,
+    costCurrency: 'USD',
+    costStatus: 'estimated',
+    costSource: 'catalog',
+    contextSnapshotId: 'context-1',
+    toolSchemaSnapshotId: 'schema-1',
+    coreSchemaCount: 4,
+    mcpSchemaCount: 2,
+    pluginSchemaCount: 1,
+    deferredSchemaCount: 3,
+    serializedSchemaBytes: 400,
+    selectedProfile: 'standard',
+    selectedMode: 'balanced',
+    rawToolResultBytes: 0,
+    transmittedToolResultBytes: 0,
+    memoryTokens: 12,
+    userProfileTokens: 4,
+    projectMemoryTokens: 8,
+    skillIndexTokens: 15,
+    loadedSkillTokens: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-usage-ledger-'));
+  dbPath = path.join(tmpDir, 'sessions.db');
+  ledger = new ProviderAttemptLedger(dbPath);
+});
+
+afterEach(async () => {
+  try {
+    ledger.close();
+  } catch {
+    // already closed
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('ProviderAttemptLedger', () => {
+  it('persists one immutable successful physical attempt across restart', () => {
+    ledger.append(attempt());
+    ledger.close();
+
+    ledger = new ProviderAttemptLedger(dbPath);
+    const records = ledger.query({ callId: 'call-primary-1' });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      providerInputTokens: 100,
+      providerOutputTokens: 15,
+      providerCacheReadTokens: 40,
+      providerCacheWriteTokens: 5,
+      providerReasoningTokens: 3,
+      status: 'success',
+    });
+    expect(Object.isFrozen(records[0])).toBe(true);
+  });
+
+  it('keeps failed attempts and unknown spend explicit instead of recording zero', () => {
+    ledger.append(attempt({
+      callId: 'call-failed-1',
+      status: 'failed_after_send',
+      errorClass: 'network',
+      providerInputTokens: null,
+      providerOutputTokens: null,
+      providerCacheReadTokens: null,
+      providerCacheWriteTokens: null,
+      providerReasoningTokens: null,
+      costAmount: null,
+      costCurrency: null,
+      costStatus: 'unknown',
+      costSource: null,
+      usageSource: 'unknown',
+    }));
+
+    const [record] = ledger.query({ status: 'failed_after_send' });
+    expect(record.providerInputTokens).toBeNull();
+    expect(record.costAmount).toBeNull();
+    expect(record.costStatus).toBe('unknown');
+  });
+
+  it('queries by session, run, task, parent, provider, purpose, and status', () => {
+    ledger.append(attempt());
+    ledger.append(attempt({
+      callId: 'call-retry-2',
+      parentCallId: 'call-primary-1',
+      purpose: 'retry',
+      attemptIndex: 1,
+      status: 'timeout',
+      providerActual: 'fallback-provider',
+      modelActual: 'model-b',
+    }));
+
+    expect(ledger.query({ sessionId: 'session-1' })).toHaveLength(2);
+    expect(ledger.query({ runId: 'run-1' })).toHaveLength(2);
+    expect(ledger.query({ taskId: 'task-1' })).toHaveLength(2);
+    expect(ledger.query({ parentCallId: 'call-primary-1' })).toHaveLength(1);
+    expect(ledger.query({ provider: 'fallback-provider' })).toHaveLength(1);
+    expect(ledger.query({ model: 'model-b' })).toHaveLength(1);
+    expect(ledger.query({ purpose: 'retry' })).toHaveLength(1);
+    expect(ledger.query({ status: 'timeout' })).toHaveLength(1);
+  });
+
+  it('projects provider totals without mixing setup/readiness into task totals', () => {
+    ledger.append(attempt());
+    ledger.append(attempt({
+      callId: 'call-ready-1',
+      purpose: 'readiness',
+      providerInputTokens: 25,
+      providerOutputTokens: 2,
+      costAmount: null,
+      costCurrency: null,
+      costStatus: 'unknown',
+      costSource: null,
+    }));
+
+    const task = ledger.project({ sessionId: 'session-1' });
+    const all = ledger.project({ sessionId: 'session-1', includeSetup: true });
+
+    expect(task).toMatchObject({
+      physicalAttempts: 1,
+      providerInputTokens: 100,
+      providerOutputTokens: 15,
+      cacheReadTokens: 40,
+      cacheWriteTokens: 5,
+      reasoningTokens: 3,
+    });
+    expect(all.physicalAttempts).toBe(2);
+    expect(all.providerInputTokens).toBe(125);
+  });
+
+  it('is append-only for a call id', () => {
+    ledger.append(attempt());
+    expect(() => ledger.append(attempt({ providerOutputTokens: 99 }))).toThrow();
+    expect(ledger.query({ callId: 'call-primary-1' })).toHaveLength(1);
+  });
+
+  it('migrates an existing version-one ledger and remains writable after restart', () => {
+    ledger.close();
+    const legacy = new Database(dbPath);
+    for (const column of [
+      'memory_tokens',
+      'user_profile_tokens',
+      'project_memory_tokens',
+      'skill_index_tokens',
+      'loaded_skill_tokens',
+    ]) {
+      legacy.exec(`ALTER TABLE provider_attempts DROP COLUMN ${column}`);
+    }
+    legacy.prepare('UPDATE provider_attempt_ledger_meta SET schema_version = 1 WHERE singleton = 1').run();
+    legacy.close();
+
+    ledger = new ProviderAttemptLedger(dbPath);
+    ledger.append(attempt());
+    expect(ledger.query({ callId: 'call-primary-1' })[0]).toMatchObject({
+      memoryTokens: 12,
+      loadedSkillTokens: 0,
+    });
+  });
+
+  it('persists no prompt, response, or credential value', async () => {
+    ledger.append(attempt({ credentialLabelRedacted: 'managed:configured' }));
+    ledger.close();
+
+    const bytes = await fs.readFile(dbPath);
+    const persisted = bytes.toString('utf8');
+    expect(persisted).not.toContain('raw prompt');
+    expect(persisted).not.toContain('raw response');
+    expect(persisted).not.toContain('credential value');
+
+    ledger = new ProviderAttemptLedger(dbPath);
+  });
+
+  it('drives daemon daily limits from immutable attempt rows without double counting', () => {
+    ledger.append(attempt({
+      entryPoint: 'daemon',
+      providerInputTokens: 60,
+      providerOutputTokens: 20,
+    }));
+    const tracker = createLedgerDailyBudgetTracker({ ledger, budget: 100 });
+    expect(tracker.peek({ now: 2_000 }).used).toBe(80);
+    expect(tracker.addAndCheck(10, { now: 2_000 }).allowed).toBe(true);
+    expect(tracker.peek({ now: 2_000 }).used).toBe(80);
+    expect(tracker.addAndCheck(30, { now: 2_000 }).allowed).toBe(false);
+  });
+});

--- a/tests/v4/core/usageLedger.test.ts
+++ b/tests/v4/core/usageLedger.test.ts
@@ -154,6 +154,39 @@ describe('ProviderAttemptLedger', () => {
     expect(ledger.query({ status: 'timeout' })).toHaveLength(1);
   });
 
+  it('preserves physical insertion order when attempt timestamps are identical', () => {
+    ledger.append(attempt({
+      callId: 'z-primary-failure',
+      parentCallId: 'logical-fallback-call',
+      status: 'provider_error',
+      startedAt: 2_000,
+      completedAt: 2_000,
+    }));
+    ledger.append(attempt({
+      callId: 'a-fallback-success',
+      parentCallId: 'logical-fallback-call',
+      purpose: 'fallback',
+      providerActual: 'fallback-provider',
+      modelActual: 'model-b',
+      fallbackIndex: 1,
+      status: 'success',
+      startedAt: 2_000,
+      completedAt: 2_000,
+    }));
+
+    ledger.close();
+    ledger = new ProviderAttemptLedger(dbPath);
+    const records = ledger.query({ parentCallId: 'logical-fallback-call' });
+    expect(records.map((record) => ({
+      callId: record.callId,
+      fallbackIndex: record.fallbackIndex,
+      status: record.status,
+    }))).toEqual([
+      { callId: 'z-primary-failure', fallbackIndex: 0, status: 'provider_error' },
+      { callId: 'a-fallback-success', fallbackIndex: 1, status: 'success' },
+    ]);
+  });
+
   it('projects provider totals without mixing setup/readiness into task totals', () => {
     ledger.append(attempt());
     ledger.append(attempt({

--- a/tests/v4/core/usagePolicy.test.ts
+++ b/tests/v4/core/usagePolicy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { Message, ToolSchema } from '../../../providers/v4/types';
+import {
+  classifyBudgetState,
+  estimateTaskUsage,
+  selectEconomyTools,
+} from '../../../core/v4/usagePolicy';
+
+const schema = (name: string): ToolSchema => ({
+  name,
+  description: `${name} capability`,
+  inputSchema: { type: 'object', properties: {} },
+});
+
+describe('usage policy', () => {
+  it('reduces Economy schemas deterministically while retaining safety tools', () => {
+    const tools = [
+      'clarify', 'plan_approval', 'file_read', 'file_write', 'file_patch',
+      'shell_exec', 'web_search', 'browser_click', 'memory_add', 'skills_list',
+      'process_spawn', 'session_search', 'spawn_sub_agent', 'tool_result_artifact_read',
+    ].map(schema);
+    const result = selectEconomyTools(tools, 'read package.json and explain it');
+    expect(result.selected.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+      'clarify', 'plan_approval', 'file_read', 'tool_result_artifact_read',
+    ]));
+    expect(result.selected.length).toBeLessThan(tools.length);
+    expect(result.estimatedSchemaSavings).toBeGreaterThan(0);
+  });
+
+  it('keeps Balanced behavior unchanged while reporting a shadow Economy set', () => {
+    const tools = ['clarify', 'file_read', 'web_search', 'browser_click'].map(schema);
+    const shadow = selectEconomyTools(tools, 'read a file');
+    expect(tools.map((tool) => tool.name)).toEqual(['clarify', 'file_read', 'web_search', 'browser_click']);
+    expect(shadow.deferredCount).toBeGreaterThan(0);
+  });
+
+  it('transitions token budgets at 80 and 100 percent', () => {
+    expect(classifyBudgetState(0, null)).toBe('unbudgeted');
+    expect(classifyBudgetState(79, 100)).toBe('running_green');
+    expect(classifyBudgetState(80, 100)).toBe('running_yellow');
+    expect(classifyBudgetState(100, 100)).toBe('running_red');
+    expect(classifyBudgetState(101, 100)).toBe('over_budget_critical');
+  });
+
+  it('estimates without a provider call and keeps unknown pricing unknown', () => {
+    const messages: Message[] = [{ role: 'user', content: 'inspect this repository and run tests' }];
+    const result = estimateTaskUsage({
+      task: messages[0].content,
+      messages,
+      tools: ['file_read', 'shell_exec'].map(schema),
+      mode: 'balanced',
+      tokenBudget: 20_000,
+      pricing: null,
+    });
+    expect(result.complexity).toBe('medium');
+    expect(result.estimatedTokenHigh).toBeGreaterThan(result.estimatedTokenLow);
+    expect(result.estimatedCallsHigh).toBeGreaterThanOrEqual(result.estimatedCallsLow);
+    expect(result.estimatedCostLow).toBeNull();
+    expect(result.costStatus).toBe('unknown');
+  });
+});

--- a/tests/v4/harness/aidenTermSmoke.test.ts
+++ b/tests/v4/harness/aidenTermSmoke.test.ts
@@ -98,7 +98,7 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenTerm harness — PTY smoke (Slice 10
       [
         'model:',
         '  provider: groq',
-        '  modelId: llama-3.3-70b-versatile',
+        '  modelId: openai/gpt-oss-120b',
         'providers:',
         '  groq:',
         '    apiKey: ${GROQ_API_KEY}',

--- a/tests/v4/harness/controlledProviderServer.cjs
+++ b/tests/v4/harness/controlledProviderServer.cjs
@@ -1,0 +1,100 @@
+'use strict';
+
+const fs = require('node:fs');
+const http = require('node:http');
+
+const readyPath = process.env.AIDEN_TEST_PROVIDER_READY;
+const countPath = process.env.AIDEN_TEST_PROVIDER_COUNT;
+const fixturePath = process.env.AIDEN_TEST_TOOL_FIXTURE;
+if (!readyPath || !countPath || !fixturePath) throw new Error('Controlled provider paths are required.');
+
+let calls = 0;
+
+function messageText(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => {
+      if (typeof part === 'string') return part;
+      if (!part || typeof part !== 'object') return '';
+      if (typeof part.text === 'string') return part.text;
+      if (typeof part.content === 'string') return part.content;
+      return '';
+    })
+    .join('');
+}
+
+function collectSmokeMarkers(value, found = []) {
+  if (typeof value === 'string') {
+    for (const marker of ['RESTART', 'package history turn', 'use a tool for package history']) {
+      if (value.includes(marker)) found.push(marker);
+    }
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectSmokeMarkers(item, found);
+  } else if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectSmokeMarkers(item, found);
+  }
+  return [...new Set(found)];
+}
+
+const server = http.createServer((request, response) => {
+  let body = '';
+  request.setEncoding('utf8');
+  request.on('data', (chunk) => { body += chunk; });
+  request.on('end', () => {
+    calls += 1;
+    fs.writeFileSync(countPath, String(calls), 'utf8');
+    let payload = {};
+    try { payload = JSON.parse(body); } catch { /* validation is exercised by the client */ }
+    const smokeMarkers = collectSmokeMarkers(payload);
+    fs.appendFileSync(`${countPath}.requests.jsonl`, `${JSON.stringify({
+      call: calls,
+      keys: Object.keys(payload),
+      markers: smokeMarkers,
+    })}\n`, 'utf8');
+    const messages = Array.isArray(payload.messages) ? payload.messages : [];
+    let latestUserIndex = -1;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index] && messages[index].role === 'user') {
+        latestUserIndex = index;
+        break;
+      }
+    }
+    const latestUser = latestUserIndex >= 0 ? messages[latestUserIndex] : undefined;
+    const hasToolResult = latestUserIndex >= 0 && messages
+      .slice(latestUserIndex + 1)
+      .some((message) => message && message.role === 'tool');
+    const userText = messageText(latestUser?.content);
+    const message = hasToolResult
+      ? { role: 'assistant', content: 'PACKAGED TOOL PASS' }
+      : /^use a tool\b/i.test(userText)
+        ? {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'packaged-file-read',
+              type: 'function',
+              function: {
+                name: 'file_read',
+                arguments: JSON.stringify({ path: fixturePath, offset: 0, limit: 50 }),
+              },
+            }],
+          }
+        : { role: 'assistant', content: smokeMarkers.includes('RESTART') ? 'PACKAGED RESTART PASS' : 'PACKAGED SIMPLE PASS' };
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      choices: [{ message, finish_reason: message.tool_calls ? 'tool_calls' : 'stop' }],
+      usage: { prompt_tokens: 100, completion_tokens: 10 },
+    }));
+  });
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Provider server did not bind TCP.');
+  fs.writeFileSync(readyPath, `http://127.0.0.1:${address.port}/v1`, 'utf8');
+});
+
+const stop = () => server.close(() => process.exit(0));
+process.on('SIGINT', stop);
+process.on('SIGTERM', stop);

--- a/tests/v4/harness/installedProviderPreload.cjs
+++ b/tests/v4/harness/installedProviderPreload.cjs
@@ -1,0 +1,16 @@
+'use strict';
+
+const path = require('node:path');
+const installRoot = process.env.AIDEN_TEST_INSTALLED_ROOT;
+const baseUrl = process.env.AIDEN_TEST_PROVIDER_BASE_URL;
+if (!installRoot || !baseUrl) throw new Error('Installed provider smoke environment is incomplete.');
+const registry = require(path.join(
+  installRoot,
+  'node_modules',
+  'aiden-runtime',
+  'dist',
+  'providers',
+  'v4',
+  'registry.js',
+));
+registry.PROVIDER_REGISTRY.custom_openai.baseUrl = baseUrl;

--- a/tests/v4/harness/installedProviderPreload.cjs
+++ b/tests/v4/harness/installedProviderPreload.cjs
@@ -1,16 +1,42 @@
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
-const installRoot = process.env.AIDEN_TEST_INSTALLED_ROOT;
+const requestedRoot = process.env.AIDEN_TEST_INSTALLED_ROOT;
 const baseUrl = process.env.AIDEN_TEST_PROVIDER_BASE_URL;
-if (!installRoot || !baseUrl) throw new Error('Installed provider smoke environment is incomplete.');
-const registry = require(path.join(
-  installRoot,
-  'node_modules',
-  'aiden-runtime',
-  'dist',
-  'providers',
-  'v4',
-  'registry.js',
-));
-registry.PROVIDER_REGISTRY.custom_openai.baseUrl = baseUrl;
+if (!requestedRoot || !baseUrl) throw new Error('Installed provider smoke environment is incomplete.');
+
+function findInstallRoot(root) {
+  const direct = path.join(root, 'node_modules', 'aiden-runtime', 'dist');
+  if (fs.existsSync(direct)) return root;
+  const packageRunnerRoot = path.join(root, '_npx');
+  if (!fs.existsSync(packageRunnerRoot)) return null;
+  for (const entry of fs.readdirSync(packageRunnerRoot)) {
+    const candidate = path.join(packageRunnerRoot, entry);
+    if (fs.existsSync(path.join(candidate, 'node_modules', 'aiden-runtime', 'dist'))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+const installRoot = findInstallRoot(requestedRoot);
+if (!installRoot) {
+  // The package runner itself inherits NODE_OPTIONS before it has populated
+  // its isolated cache. Its spawned runtime loads this module again after the
+  // package exists, which is the process that needs the registry override.
+  if (!/npm-cli\.js$/i.test(process.argv[1] ?? '')) {
+    throw new Error('Installed runtime could not be located for provider smoke.');
+  }
+} else {
+  const registry = require(path.join(
+    installRoot,
+    'node_modules',
+    'aiden-runtime',
+    'dist',
+    'providers',
+    'v4',
+    'registry.js',
+  ));
+  registry.PROVIDER_REGISTRY.custom_openai.baseUrl = baseUrl;
+}

--- a/tests/v4/harness/ollamaModelPickerPtyFixture.ts
+++ b/tests/v4/harness/ollamaModelPickerPtyFixture.ts
@@ -1,0 +1,24 @@
+import { runModelPicker } from '../../../cli/v4/commands/modelPicker';
+import { CredentialResolver } from '../../../providers/v4/credentialResolver';
+import { RuntimeResolver } from '../../../providers/v4/runtimeResolver';
+
+const installed = [
+  'gemma4:e4b-32k',
+  'gemma4:e4b-16k',
+  'gemma4:e4b-8k',
+  'gemma4:e4b',
+];
+
+async function main(): Promise<void> {
+  const fetchImpl = (async () => new Response(JSON.stringify({
+    models: installed.map((name) => ({ name })),
+  }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+  const resolver = new RuntimeResolver(new CredentialResolver(), { fetchImpl });
+  const result = await runModelPicker({ resolver, tier: 'local', fetchImpl });
+  process.stdout.write(`\n[OLLAMA_PICKER_RESULT]${JSON.stringify(result)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
+++ b/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
@@ -1,0 +1,160 @@
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+const repoRoot = process.env.AIDEN_TEST_REPO_ROOT;
+const installRoot = process.env.AIDEN_TEST_INSTALLED_ROOT;
+if (!repoRoot || !installRoot) throw new Error('Packaged interactive smoke paths are required.');
+const pty = require(path.join(repoRoot, 'node_modules', 'node-pty'));
+const cliPath = path.join(installRoot, 'node_modules', 'aiden-runtime', 'dist', 'cli', 'v4', 'aidenCLI.js');
+const readyToken = '__COMPOSER_READY__';
+
+function requestTrace() {
+  const tracePath = `${process.env.AIDEN_TEST_PROVIDER_COUNT}.requests.jsonl`;
+  try { return fs.readFileSync(tracePath, 'utf8'); } catch { return '(request trace unavailable)'; }
+}
+
+function plain(value) {
+  return value
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '');
+}
+
+function submit(terminal, value) {
+  terminal.write(`${value}\r`);
+}
+
+function runFirstSession() {
+  return new Promise((resolve, reject) => {
+    const terminal = pty.spawn(process.execPath, [cliPath], {
+      cwd: process.env.AIDEN_TEST_PACKAGE_CWD,
+      cols: 110,
+      rows: 40,
+      env: { ...process.env, AIDEN_TEST_COMPOSER_READY: '1' },
+    });
+    let output = '';
+    let state = 'boot';
+    let historyTurns = 0;
+    let historyReadyTarget = 0;
+    const timeout = setTimeout(() => {
+      terminal.kill();
+      reject(new Error(`First packaged interactive session timed out (${state}):\n${plain(output).slice(-12_000)}`));
+    }, 90_000);
+    terminal.onData((chunk) => {
+      output += chunk;
+      const text = plain(output);
+      const readyCount = output.split(readyToken).length - 1;
+      if (state === 'boot' && readyCount >= 1) {
+        state = 'mode'; submit(terminal, '/mode economy');
+      } else if (state === 'mode' && text.includes('Usage mode: economy')) {
+        state = 'budget-set'; submit(terminal, '/budget 120');
+      } else if (state === 'budget-set' && text.includes('Session token cap set')) {
+        state = 'first-turn'; submit(terminal, 'package history turn 1');
+      } else if (state === 'first-turn' && text.includes('PACKAGED SIMPLE PASS') && readyCount >= 4) {
+        state = 'budget-warning'; submit(terminal, '/budget');
+      } else if (state === 'budget-warning' && text.includes('Budget warning.')) {
+        state = 'budget-expand'; submit(terminal, '/budget 100000');
+      } else if (state === 'budget-expand' && text.includes('Session token cap set to 100,000')) {
+        historyTurns = 1;
+        historyReadyTarget = readyCount + 1;
+        state = 'history'; submit(terminal, `use a tool for package history ${historyTurns}`);
+      } else if (state === 'history' && readyCount >= historyReadyTarget) {
+        if (historyTurns < 4) {
+          historyTurns += 1;
+          historyReadyTarget = readyCount + 1;
+          submit(terminal, `use a tool for package history ${historyTurns}`);
+        } else {
+          state = 'usage-json'; submit(terminal, '/usage --json');
+        }
+      } else if (state === 'usage-json' && text.includes('"physicalAttempts":9')) {
+        state = 'usage-human'; submit(terminal, '/usage');
+      } else if (state === 'usage-human' && text.includes('Usage — Current session')) {
+        if (!text.includes('cumulative exposures')) throw new Error('Human usage summary omitted schema exposure context.');
+        state = 'usage-details'; submit(terminal, '/usage details');
+      } else if (state === 'usage-details' && text.includes('Usage details — Current session')) {
+        if (!text.includes('Providers and models') || !text.includes('Purposes')) {
+          throw new Error('Detailed usage output omitted required sections.');
+        }
+        state = 'compress'; submit(terminal, '/compress');
+      } else if (state === 'compress' && /Compressed \d+ .* \d+ messages/.test(text)) {
+        state = 'quit'; submit(terminal, '/quit');
+      }
+    });
+    terminal.onExit(({ exitCode }) => {
+      clearTimeout(timeout);
+      if (state !== 'quit' || exitCode !== 0) {
+        reject(new Error(`First packaged interactive session exited ${exitCode} (${state}):\n${plain(output).slice(-12_000)}`));
+        return;
+      }
+      resolve(output);
+    });
+  });
+}
+
+function runRestartSession() {
+  return new Promise((resolve, reject) => {
+    const terminal = pty.spawn(process.execPath, [cliPath, '--continue'], {
+      cwd: process.env.AIDEN_TEST_PACKAGE_CWD,
+      cols: 110,
+      rows: 40,
+      env: { ...process.env, AIDEN_TEST_COMPOSER_READY: '1' },
+    });
+    let output = '';
+    let state = 'boot';
+    const timeout = setTimeout(() => {
+      terminal.kill();
+      reject(new Error(`Restarted packaged session timed out (${state}):\n${plain(output).slice(-12_000)}\nRequest trace:\n${requestTrace()}`));
+    }, 60_000);
+    terminal.onData((chunk) => {
+      output += chunk;
+      const text = plain(output);
+      const readyCount = output.split(readyToken).length - 1;
+      if (state === 'boot' && readyCount >= 1) {
+        state = 'usage'; submit(terminal, '/usage --json');
+      } else if (state === 'usage' && text.includes('"compression":{"physicalAttempts":1')) {
+        state = 'turn'; submit(terminal, 'RESTART');
+      } else if (state === 'turn' && text.includes('PACKAGED RESTART PASS') && readyCount >= 3) {
+        state = 'quit'; submit(terminal, '/quit');
+      }
+    });
+    terminal.onExit(({ exitCode }) => {
+      clearTimeout(timeout);
+      if (state !== 'quit' || exitCode !== 0) {
+        reject(new Error(`Restarted packaged session exited ${exitCode} (${state}):\n${plain(output).slice(-12_000)}`));
+        return;
+      }
+      resolve(output);
+    });
+  });
+}
+
+(async () => {
+  const first = await runFirstSession();
+  const restarted = await runRestartSession();
+  const combined = plain(`${first}\n${restarted}`);
+  for (const expected of [
+    'Usage mode: economy',
+    'Budget warning.',
+    '"physicalAttempts":9',
+    '"compression":{"physicalAttempts":1',
+    'PACKAGED RESTART PASS',
+  ]) {
+    if (!combined.includes(expected)) throw new Error(`Missing packaged interactive evidence: ${expected}`);
+  }
+  if (combined.includes('controlled-package-value')) throw new Error('Credential sentinel leaked into interactive output.');
+  process.stdout.write(JSON.stringify({
+    economy: 'PASS',
+    budgetWarning: 'PASS',
+    usageReport: 'PASS',
+    usageHuman: 'PASS',
+    usageDetails: 'PASS',
+    compression: 'PASS',
+    restartResume: 'PASS',
+  }) + '\n');
+  process.exit(0);
+})().catch((error) => {
+  process.stderr.write(`${error.stack ?? error}\n`);
+  process.exit(1);
+});

--- a/tests/v4/harness/providerReadinessPackedSmoke.cjs
+++ b/tests/v4/harness/providerReadinessPackedSmoke.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+async function main() {
+  const packageRoot = path.resolve(process.argv[2] ?? '');
+  if (!packageRoot) throw new Error('usage: providerReadinessPackedSmoke.cjs <installed-package-root>');
+
+  const sockets = new Set();
+  let calls = 0;
+  let userTurns = 0;
+  const server = http.createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/v1/models') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ data: [{ id: 'custom-default' }] }));
+      return;
+    }
+    if (request.method !== 'POST' || request.url !== '/v1/chat/completions') {
+      response.writeHead(404).end();
+      return;
+    }
+    calls += 1;
+    let raw = '';
+    for await (const chunk of request) raw += chunk;
+    const body = JSON.parse(raw);
+    const replay = body.messages?.some((message) => message.role === 'tool');
+    const requiresProbe = body.tools?.some(
+      (tool) => tool.function?.name === 'runtime_readiness_probe',
+    ) && !replay;
+    const isRealTurn = body.messages?.some(
+      (message) => message.role === 'user' && /PACKAGED (FIRST|SECOND)/.test(message.content ?? ''),
+    );
+    if (isRealTurn) userTurns += 1;
+    const finishReason = requiresProbe ? 'tool_calls' : 'stop';
+    const message = requiresProbe
+      ? {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'packaged-probe',
+            type: 'function',
+            function: { name: 'runtime_readiness_probe', arguments: '{"marker":"ready"}' },
+          }],
+        }
+      : {
+          role: 'assistant',
+          content: replay
+            ? 'Probe cycle complete.'
+            : isRealTurn
+              ? `PACKAGED ${userTurns === 1 ? 'FIRST' : 'SECOND'}`
+              : 'READY',
+        };
+
+    if (!body.stream) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        choices: [{ message, finish_reason: finishReason }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    const delta = requiresProbe
+      ? { tool_calls: message.tool_calls }
+      : { content: message.content };
+    response.write(`data: ${JSON.stringify({ choices: [{ delta, finish_reason: null }] })}\n\n`);
+    response.write(`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: finishReason }] })}\n\n`);
+    response.end('data: [DONE]\n\n');
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-packed-home-'));
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-packed-cwd-'));
+  try {
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+    const setupModule = require(path.join(packageRoot, 'dist', 'cli', 'v4', 'setupWizard.js'));
+    const readinessModule = require(path.join(packageRoot, 'dist', 'providers', 'v4', 'providerReadiness.js'));
+    const pathsModule = require(path.join(packageRoot, 'dist', 'core', 'v4', 'paths.js'));
+    const paths = pathsModule.resolveAidenPaths({ rootOverride: home });
+    const customIndex = setupModule.PROVIDERS.findIndex((provider) => provider.id === 'custom_openai') + 1;
+    const choices = [customIndex];
+    const inputs = ['custom-default', baseUrl, 'fixture-credential'];
+    const setup = await setupModule.runSetupWizard({
+      paths,
+      prompts: {
+        choose: async () => choices.shift(),
+        input: async () => inputs.shift(),
+        confirm: async () => false,
+      },
+      readinessVerifier: readinessModule.runRuntimeReadinessTransaction,
+      skipCuratedStep: true,
+    });
+    assert.equal(setup.readiness?.state, 'complete');
+    assert.equal(setup.readiness?.plainCompletionStatus, 'verified');
+    assert.equal(setup.readiness?.toolCallStatus, 'verified');
+    const setupCalls = calls;
+
+    const entry = path.join(packageRoot, 'dist', 'cli', 'v4', 'aidenCLI.js');
+    const run = (prompt) => new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [entry, '-q', prompt], {
+        cwd,
+        env: {
+          ...process.env,
+          AIDEN_HOME: home,
+          CUSTOM_OPENAI_API_KEY: '',
+          AIDEN_NO_UPDATE_CHECK: '1',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += chunk; });
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+      child.on('error', reject);
+      child.on('exit', (code) => {
+        if (code === 0) resolve({ stdout, stderr });
+        else reject(new Error(`packaged CLI exited ${code}: ${stderr}`));
+      });
+    });
+
+    const first = await run('Reply with exactly: PACKAGED FIRST');
+    assert.match(first.stdout, /PACKAGED FIRST/);
+    const second = await run('Reply with exactly: PACKAGED SECOND');
+    assert.match(second.stdout, /PACKAGED SECOND/);
+    assert.equal(calls, setupCalls + 2);
+    process.stdout.write(JSON.stringify({
+      status: 'passed',
+      setupCalls,
+      firstResponse: 'PACKAGED FIRST',
+      secondResponse: 'PACKAGED SECOND',
+      totalCalls: calls,
+    }) + '\n');
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(() => resolve()));
+    await fs.rm(home, { recursive: true, force: true });
+    await fs.rm(cwd, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack ?? error}\n`);
+  process.exitCode = 1;
+});

--- a/tests/v4/harness/runPackagedTokenEfficiencySmoke.cjs
+++ b/tests/v4/harness/runPackagedTokenEfficiencySmoke.cjs
@@ -1,0 +1,258 @@
+'use strict';
+
+const { spawn, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const npmCli = process.env.AIDEN_TEST_NPM_CLI;
+if (!npmCli) throw new Error('AIDEN_TEST_NPM_CLI is required.');
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aiden-token-package-'));
+const packDir = path.join(tempRoot, 'pack');
+const globalPrefix = path.join(tempRoot, 'global');
+const localRoot = path.join(tempRoot, 'local');
+const aidenHome = path.join(tempRoot, 'home');
+const cwd = path.join(tempRoot, 'workspace');
+const readyPath = path.join(tempRoot, 'provider-ready.txt');
+const countPath = path.join(tempRoot, 'provider-count.txt');
+const fixturePath = path.join(cwd, 'fixture.txt');
+for (const directory of [packDir, globalPrefix, localRoot, aidenHome, cwd]) {
+  fs.mkdirSync(directory, { recursive: true });
+}
+fs.writeFileSync(fixturePath, 'packaged tool fixture\n', 'utf8');
+fs.writeFileSync(path.join(aidenHome, '.onboarding-shown'), 'package-smoke\n', 'utf8');
+fs.writeFileSync(path.join(aidenHome, 'config.yaml'), [
+  'model:',
+  '  provider: custom_openai',
+  '  modelId: custom-default',
+  'providers:',
+  '  custom_openai:',
+  '    apiKey: controlled-package-value',
+  'display:',
+  '  streaming: false',
+  '  renderer: legacy',
+].join('\n') + '\n', 'utf8');
+
+const nodeEnvironment = {
+  ...process.env,
+  PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH ?? ''}`,
+};
+const childEnvironment = {
+  ...nodeEnvironment,
+  AIDEN_HOME: aidenHome,
+  CUSTOM_OPENAI_API_KEY: 'controlled-package-value',
+  AIDEN_NO_UPDATE_CHECK: '1',
+  TELEGRAM_BOT_TOKEN: '',
+  FORCE_COLOR: '0',
+  NO_COLOR: '1',
+};
+
+function run(executable, args, options = {}) {
+  const result = spawnSync(executable, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: options.env ?? childEnvironment,
+    encoding: 'utf8',
+    timeout: options.timeout ?? 180_000,
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error([
+      `${path.basename(executable)} ${args.join(' ')} exited ${result.status}`,
+      result.stdout,
+      result.stderr,
+    ].join('\n'));
+  }
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+function waitForFile(filePath, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return fs.readFileSync(filePath, 'utf8').trim();
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  throw new Error(`Timed out waiting for ${path.basename(filePath)}.`);
+}
+
+function assertContains(actual, expected, label) {
+  if (!actual.includes(expected)) {
+    throw new Error(`${label} did not contain ${JSON.stringify(expected)}:\n${actual}`);
+  }
+}
+
+let provider;
+try {
+  provider = spawn(process.execPath, [path.join(__dirname, 'controlledProviderServer.cjs')], {
+    env: {
+      ...process.env,
+      AIDEN_TEST_PROVIDER_READY: readyPath,
+      AIDEN_TEST_PROVIDER_COUNT: countPath,
+      AIDEN_TEST_TOOL_FIXTURE: fixturePath,
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+    windowsHide: true,
+  });
+  let providerError = '';
+  provider.stderr.on('data', (chunk) => { providerError += String(chunk); });
+  const baseUrl = waitForFile(readyPath);
+
+  const packed = run(process.execPath, [npmCli, 'pack', '--pack-destination', packDir], {
+    env: nodeEnvironment,
+    timeout: 300_000,
+  });
+  const tarballs = fs.readdirSync(packDir).filter((name) => name.endsWith('.tgz'));
+  if (tarballs.length !== 1) throw new Error(`Expected one tarball, found ${tarballs.length}.\n${packed.stdout}`);
+  const tarball = path.join(packDir, tarballs[0]);
+
+  run(process.execPath, [npmCli, 'install', '--global', '--prefix', globalPrefix, tarball, '--no-audit', '--no-fund'], {
+    env: nodeEnvironment,
+    timeout: 300_000,
+  });
+  const globalBin = path.join(globalPrefix, 'aiden-runtime.cmd');
+  if (!fs.existsSync(globalBin)) throw new Error('Global package binary shim was not installed.');
+  const globalRoot = globalPrefix;
+  const globalEnv = {
+    ...childEnvironment,
+    AIDEN_TEST_INSTALLED_ROOT: globalRoot,
+    AIDEN_TEST_PROVIDER_BASE_URL: baseUrl,
+    AIDEN_TEST_PROVIDER_COUNT: countPath,
+    NODE_OPTIONS: `--require=${path.join(__dirname, 'installedProviderPreload.cjs')}`,
+  };
+  const globalVersion = run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', 'call', globalBin, '--version'], {
+    cwd,
+    env: globalEnv,
+  });
+  assertContains(globalVersion.stdout, '4.15.0', 'global --version');
+  const globalHelp = run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', 'call', globalBin, '--help'], {
+    cwd,
+    env: globalEnv,
+  });
+  assertContains(globalHelp.stdout, '--query', 'global --help');
+  const simple = run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', 'call', globalBin, '-q', 'reply simply'], {
+    cwd,
+    env: globalEnv,
+  });
+  assertContains(simple.stdout, 'PACKAGED SIMPLE PASS', 'global plain turn');
+  const tool = run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', 'call', globalBin, '-q', 'use a tool'], {
+    cwd,
+    env: globalEnv,
+  });
+  assertContains(tool.stdout, 'PACKAGED TOOL PASS', 'global tool turn');
+  const restart = run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', 'call', globalBin, '-q', 'RESTART'], {
+    cwd,
+    env: globalEnv,
+  });
+  assertContains(restart.stdout, 'PACKAGED RESTART PASS', 'global restart turn');
+
+  const interactive = run(process.execPath, [path.join(__dirname, 'packagedInteractiveTokenSmoke.cjs')], {
+    cwd,
+    env: {
+      ...globalEnv,
+      AIDEN_TEST_REPO_ROOT: repoRoot,
+      AIDEN_TEST_PACKAGE_CWD: cwd,
+    },
+    timeout: 180_000,
+  });
+  assertContains(interactive.stdout, '"restartResume":"PASS"', 'global interactive usage/compression restart');
+
+  run(process.execPath, [npmCli, 'install', '--prefix', localRoot, tarball, '--no-audit', '--no-fund'], {
+    env: nodeEnvironment,
+    timeout: 300_000,
+  });
+  const localEnv = {
+    ...childEnvironment,
+    AIDEN_TEST_INSTALLED_ROOT: localRoot,
+    AIDEN_TEST_PROVIDER_BASE_URL: baseUrl,
+    NODE_OPTIONS: `--require=${path.join(__dirname, 'installedProviderPreload.cjs')}`,
+  };
+  const localVersion = run(process.execPath, [npmCli, 'exec', '--prefix', localRoot, '--offline', '--', 'aiden-runtime', '--version'], {
+    cwd,
+    env: localEnv,
+  });
+  assertContains(localVersion.stdout, '4.15.0', 'local package runner --version');
+  const localTurn = run(process.execPath, [npmCli, 'exec', '--prefix', localRoot, '--offline', '--', 'aiden-runtime', '-q', 'reply simply'], {
+    cwd,
+    env: localEnv,
+  });
+  assertContains(localTurn.stdout, 'PACKAGED SIMPLE PASS', 'local package runner turn');
+
+  const callCount = Number.parseInt(fs.readFileSync(countPath, 'utf8'), 10);
+  if (callCount !== 16) throw new Error(`Expected sixteen physical provider calls; received ${callCount}.`);
+  const combinedOutput = [simple, tool, restart, interactive, localTurn]
+    .flatMap((result) => [result.stdout, result.stderr])
+    .join('\n');
+  if (combinedOutput.includes('controlled-package-value')) {
+    throw new Error('Credential sentinel leaked into package smoke output.');
+  }
+
+  const databasePath = path.join(aidenHome, 'sessions.db');
+  if (!fs.existsSync(databasePath)) throw new Error('Packaged execution did not create sessions.db.');
+  const Database = require(path.join(repoRoot, 'node_modules', 'better-sqlite3'));
+  const database = new Database(databasePath, { readonly: true });
+  const ledgerRows = database.prepare(
+    "SELECT entry_point, status, COUNT(*) AS count FROM provider_attempts GROUP BY entry_point, status",
+  ).all();
+  const activeState = database.prepare(
+    `SELECT messages_json, compression_count, cumulative_input_tokens, cumulative_output_tokens
+       FROM session_active_state
+      ORDER BY updated_at DESC
+      LIMIT 1`,
+  ).get();
+  database.close();
+  const successfulOneShot = ledgerRows.find(
+    (row) => row.entry_point === 'oneshot' && row.status === 'success',
+  );
+  if (!successfulOneShot || successfulOneShot.count !== 5) {
+    throw new Error(`Packaged ledger mismatch: ${JSON.stringify(ledgerRows)}`);
+  }
+  const successfulInteractive = ledgerRows.find(
+    (row) => row.entry_point === 'cli' && row.status === 'success',
+  );
+  if (!successfulInteractive || successfulInteractive.count !== 10) {
+    throw new Error(`Packaged interactive ledger mismatch: ${JSON.stringify(ledgerRows)}`);
+  }
+  const successfulAuxiliary = ledgerRows.find(
+    (row) => row.entry_point === 'auxiliary' && row.status === 'success',
+  );
+  if (!successfulAuxiliary || successfulAuxiliary.count !== 1) {
+    throw new Error(`Packaged compression ledger mismatch: ${JSON.stringify(ledgerRows)}`);
+  }
+  const restoredMessages = activeState ? JSON.parse(activeState.messages_json) : [];
+  if (!activeState || activeState.compression_count !== 1
+      || activeState.cumulative_input_tokens < 1_000
+      || activeState.cumulative_output_tokens < 100
+      || !Array.isArray(restoredMessages)
+      || restoredMessages.length === 0) {
+    throw new Error(`Packaged active-state restoration mismatch: ${JSON.stringify(activeState)}`);
+  }
+
+  process.stdout.write(JSON.stringify({
+    package: path.basename(tarball),
+    globalVersion: globalVersion.stdout.trim(),
+    localVersion: localVersion.stdout.trim(),
+    providerCalls: callCount,
+    ledgerRows,
+    restoredActiveState: {
+      compressionCount: activeState.compression_count,
+      cumulativeInputTokens: activeState.cumulative_input_tokens,
+      cumulativeOutputTokens: activeState.cumulative_output_tokens,
+      messageCount: restoredMessages.length,
+    },
+    plain: 'PASS',
+    tool: 'PASS',
+    restart: 'PASS',
+    interactive: JSON.parse(interactive.stdout.trim()),
+    localPackageRunner: 'PASS',
+  }, null, 2) + '\n');
+  if (providerError) process.stderr.write(providerError);
+} finally {
+  if (provider && !provider.killed) provider.kill('SIGTERM');
+  const resolvedTemp = path.resolve(tempRoot);
+  const resolvedOsTemp = path.resolve(os.tmpdir());
+  if (resolvedTemp.startsWith(`${resolvedOsTemp}${path.sep}`)) {
+    fs.rmSync(resolvedTemp, { recursive: true, force: true });
+  }
+}

--- a/tests/v4/harness/runPackagedTokenEfficiencySmoke.cjs
+++ b/tests/v4/harness/runPackagedTokenEfficiencySmoke.cjs
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '../../..');
+const expectedVersion = require(path.join(repoRoot, 'package.json')).version;
 const npmCli = process.env.AIDEN_TEST_NPM_CLI;
 if (!npmCli) throw new Error('AIDEN_TEST_NPM_CLI is required.');
 
@@ -13,12 +14,13 @@ const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aiden-token-package-'));
 const packDir = path.join(tempRoot, 'pack');
 const globalPrefix = path.join(tempRoot, 'global');
 const localRoot = path.join(tempRoot, 'local');
+const npxCache = path.join(tempRoot, 'npx-cache');
 const aidenHome = path.join(tempRoot, 'home');
 const cwd = path.join(tempRoot, 'workspace');
 const readyPath = path.join(tempRoot, 'provider-ready.txt');
 const countPath = path.join(tempRoot, 'provider-count.txt');
 const fixturePath = path.join(cwd, 'fixture.txt');
-for (const directory of [packDir, globalPrefix, localRoot, aidenHome, cwd]) {
+for (const directory of [packDir, globalPrefix, localRoot, npxCache, aidenHome, cwd]) {
   fs.mkdirSync(directory, { recursive: true });
 }
 fs.writeFileSync(fixturePath, 'packaged tool fixture\n', 'utf8');
@@ -125,7 +127,7 @@ try {
     cwd,
     env: globalEnv,
   });
-  assertContains(globalVersion.stdout, '4.15.0', 'global --version');
+  assertContains(globalVersion.stdout, expectedVersion, 'global --version');
   const globalHelp = run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', 'call', globalBin, '--help'], {
     cwd,
     env: globalEnv,
@@ -172,16 +174,48 @@ try {
     cwd,
     env: localEnv,
   });
-  assertContains(localVersion.stdout, '4.15.0', 'local package runner --version');
+  assertContains(localVersion.stdout, expectedVersion, 'local package runner --version');
   const localTurn = run(process.execPath, [npmCli, 'exec', '--prefix', localRoot, '--offline', '--', 'aiden-runtime', '-q', 'reply simply'], {
     cwd,
     env: localEnv,
   });
   assertContains(localTurn.stdout, 'PACKAGED SIMPLE PASS', 'local package runner turn');
 
+  const npxEnv = {
+    ...childEnvironment,
+    AIDEN_TEST_INSTALLED_ROOT: npxCache,
+    AIDEN_TEST_PROVIDER_BASE_URL: baseUrl,
+    NODE_OPTIONS: `--require=${path.join(__dirname, 'installedProviderPreload.cjs')}`,
+    npm_config_cache: npxCache,
+  };
+  const npxVersion = run(process.execPath, [npmCli, 'exec', '--yes', '--package', tarball, '--', 'aiden-runtime', '--version'], {
+    cwd,
+    env: npxEnv,
+    timeout: 300_000,
+  });
+  assertContains(npxVersion.stdout, expectedVersion, 'fresh tarball package runner --version');
+  const npxHelp = run(process.execPath, [npmCli, 'exec', '--yes', '--package', tarball, '--', 'aiden-runtime', '--help'], {
+    cwd,
+    env: npxEnv,
+    timeout: 300_000,
+  });
+  assertContains(npxHelp.stdout, '--query', 'fresh tarball package runner --help');
+  const npxSimple = run(process.execPath, [npmCli, 'exec', '--yes', '--package', tarball, '--', 'aiden-runtime', '-q', 'reply simply'], {
+    cwd,
+    env: npxEnv,
+    timeout: 300_000,
+  });
+  assertContains(npxSimple.stdout, 'PACKAGED SIMPLE PASS', 'fresh tarball package runner plain turn');
+  const npxTool = run(process.execPath, [npmCli, 'exec', '--yes', '--package', tarball, '--', 'aiden-runtime', '-q', 'use a tool'], {
+    cwd,
+    env: npxEnv,
+    timeout: 300_000,
+  });
+  assertContains(npxTool.stdout, 'PACKAGED TOOL PASS', 'fresh tarball package runner tool turn');
+
   const callCount = Number.parseInt(fs.readFileSync(countPath, 'utf8'), 10);
-  if (callCount !== 16) throw new Error(`Expected sixteen physical provider calls; received ${callCount}.`);
-  const combinedOutput = [simple, tool, restart, interactive, localTurn]
+  if (callCount !== 19) throw new Error(`Expected nineteen physical provider calls; received ${callCount}.`);
+  const combinedOutput = [simple, tool, restart, interactive, localTurn, npxSimple, npxTool]
     .flatMap((result) => [result.stdout, result.stderr])
     .join('\n');
   if (combinedOutput.includes('controlled-package-value')) {
@@ -205,7 +239,7 @@ try {
   const successfulOneShot = ledgerRows.find(
     (row) => row.entry_point === 'oneshot' && row.status === 'success',
   );
-  if (!successfulOneShot || successfulOneShot.count !== 5) {
+  if (!successfulOneShot || successfulOneShot.count !== 8) {
     throw new Error(`Packaged ledger mismatch: ${JSON.stringify(ledgerRows)}`);
   }
   const successfulInteractive = ledgerRows.find(
@@ -233,6 +267,7 @@ try {
     package: path.basename(tarball),
     globalVersion: globalVersion.stdout.trim(),
     localVersion: localVersion.stdout.trim(),
+    freshTarballVersion: npxVersion.stdout.trim(),
     providerCalls: callCount,
     ledgerRows,
     restoredActiveState: {
@@ -246,6 +281,7 @@ try {
     restart: 'PASS',
     interactive: JSON.parse(interactive.stdout.trim()),
     localPackageRunner: 'PASS',
+    freshTarballPackageRunner: 'PASS',
   }, null, 2) + '\n');
   if (providerError) process.stderr.write(providerError);
 } finally {

--- a/tests/v4/integration/localPromptTools.real.test.ts
+++ b/tests/v4/integration/localPromptTools.real.test.ts
@@ -18,26 +18,32 @@ import { AidenAgent } from '../../../core/v4/aidenAgent';
 import type { ToolSchema } from '../../../providers/v4/types';
 
 const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
-const OLLAMA_MODEL = process.env.OLLAMA_TEST_MODEL || 'llama3.2';
 
-async function probeOllama(): Promise<boolean> {
+async function discoverOllamaModel(): Promise<string | null> {
   try {
     const res = await fetch(`${OLLAMA_BASE}/api/tags`, {
       signal: AbortSignal.timeout(2000),
     });
-    return res.ok;
+    if (!res.ok) return null;
+    const body = await res.json() as { models?: Array<{ name?: string }> };
+    const installed = (body.models ?? [])
+      .map((model) => model.name?.trim() ?? '')
+      .filter((name) => name.length > 0);
+    const requested = process.env.OLLAMA_TEST_MODEL?.trim();
+    if (requested) return installed.includes(requested) ? requested : null;
+    return installed[0] ?? null;
   } catch {
-    return false;
+    return null;
   }
 }
 
-const ollamaUp = await probeOllama();
+const OLLAMA_MODEL = await discoverOllamaModel();
 
-describe.skipIf(!ollamaUp)('LocalPromptToolsAdapter — real local-runtime integration', () => {
+describe.skipIf(!OLLAMA_MODEL)('LocalPromptToolsAdapter — real local-runtime integration', () => {
   it('completes a simple conversation (no tools)', async () => {
     const adapter = new LocalPromptToolsAdapter({
       baseUrl: OLLAMA_BASE,
-      model: OLLAMA_MODEL,
+      model: OLLAMA_MODEL!,
       providerName: 'ollama',
     });
 
@@ -54,7 +60,7 @@ describe.skipIf(!ollamaUp)('LocalPromptToolsAdapter — real local-runtime integ
   it('completes a tool-calling conversation end-to-end (best-effort)', async () => {
     const adapter = new LocalPromptToolsAdapter({
       baseUrl: OLLAMA_BASE,
-      model: OLLAMA_MODEL,
+      model: OLLAMA_MODEL!,
       providerName: 'ollama',
     });
 

--- a/tests/v4/integration/providerRuntimeReadiness.integration.test.ts
+++ b/tests/v4/integration/providerRuntimeReadiness.integration.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ConfigManager } from '../../../core/v4/config';
+import type { AidenPaths } from '../../../core/v4/paths';
+import { CredentialResolver } from '../../../providers/v4/credentialResolver';
+import { RuntimeResolver } from '../../../providers/v4/runtimeResolver';
+import { runRuntimeReadinessTransaction } from '../../../providers/v4/providerReadiness';
+import { classifyReadinessError, type ProviderReadinessErrorCategory } from '../../../providers/v4/readinessErrors';
+
+let server: Server | null = null;
+const sockets = new Set<Socket>();
+
+afterEach(async () => {
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+});
+
+function pathsFor(root: string): AidenPaths {
+  return {
+    root,
+    sessionsDb: path.join(root, 'sessions.db'),
+    authJson: path.join(root, 'auth.json'),
+    configYaml: path.join(root, 'config.yaml'),
+    envFile: path.join(root, '.env'),
+    soulMd: path.join(root, 'SOUL.md'),
+    memoryMd: path.join(root, 'memories', 'MEMORY.md'),
+    userMd: path.join(root, 'memories', 'USER.md'),
+    skillsDir: path.join(root, 'skills'),
+    sessionsDir: path.join(root, 'sessions'),
+    pluginsDir: path.join(root, 'plugins'),
+    logsDir: path.join(root, 'logs'),
+    bundledManifest: path.join(root, '.bundled_manifest'),
+    skillsBundleVersion: path.join(root, '.skills-bundle-version'),
+  };
+}
+
+async function controlledProvider() {
+  let calls = 0;
+  server = createServer(async (request, response) => {
+    if (request.url !== '/v1/chat/completions') {
+      response.writeHead(404).end();
+      return;
+    }
+    calls += 1;
+    let raw = '';
+    for await (const chunk of request) raw += chunk;
+    const body = JSON.parse(raw) as {
+      stream?: boolean;
+      tool_choice?: unknown;
+      messages?: Array<{ role?: string }>;
+    };
+    const replayed = body.messages?.some((message) => message.role === 'tool');
+    const message = body.tool_choice === 'required' && !replayed
+      ? {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'probe-call',
+            type: 'function',
+            function: { name: 'runtime_readiness_probe', arguments: '{"marker":"ready"}' },
+          }],
+        }
+      : { role: 'assistant', content: replayed ? 'Probe cycle complete.' : `READY ${calls}` };
+    const finishReason = replayed || body.tool_choice !== 'required' ? 'stop' : 'tool_calls';
+    if (body.stream) {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: { content: message.content }, finish_reason: null }] })}\n\n`);
+      response.write(`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: finishReason }] })}\n\n`);
+      response.end('data: [DONE]\n\n');
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      choices: [{ message, finish_reason: finishReason }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }));
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}/v1`, calls: () => calls };
+}
+
+async function responseFixture(status: number, body: string) {
+  server = createServer((_request, response) => {
+    response.writeHead(status, { 'content-type': 'application/json' });
+    response.end(body);
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}/v1`;
+}
+
+async function productionAdapter(baseUrl: string) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-readiness-error-'));
+  const paths = pathsFor(root);
+  await fs.writeFile(paths.envFile, 'CUSTOM_OPENAI_API_KEY=fixture-credential\n', 'utf8');
+  const config = new ConfigManager(paths);
+  await config.load();
+  config.set('model.provider', 'custom_openai');
+  config.set('model.modelId', 'provider-live-model');
+  config.set('providers.custom_openai.baseUrl', baseUrl);
+  config.set('providers.custom_openai.modelVerification', 'unverified');
+  await config.save();
+  await config.load();
+  return new RuntimeResolver(new CredentialResolver(paths.authJson)).resolve({
+    providerId: 'custom_openai',
+    modelId: 'provider-live-model',
+    config,
+    paths,
+  });
+}
+
+describe('provider readiness production path', () => {
+  it('verifies, persists, restarts, and completes a second real response', async () => {
+    const fixture = await controlledProvider();
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-readiness-'));
+    const paths = pathsFor(root);
+    await fs.mkdir(root, { recursive: true });
+    await fs.writeFile(paths.envFile, 'CUSTOM_OPENAI_API_KEY=fixture-credential\n', 'utf8');
+
+    const firstConfig = new ConfigManager(paths);
+    await firstConfig.load();
+    firstConfig.set('model.provider', 'custom_openai');
+    firstConfig.set('model.modelId', 'provider-live-model');
+    firstConfig.set('providers.custom_openai.baseUrl', fixture.baseUrl);
+    firstConfig.set('providers.custom_openai.modelVerification', 'unverified');
+    await firstConfig.save();
+    await firstConfig.load();
+
+    const firstResolver = new RuntimeResolver(new CredentialResolver(paths.authJson));
+    const readiness = await runRuntimeReadinessTransaction({
+      paths,
+      config: firstConfig,
+      resolver: firstResolver,
+      providerId: 'custom_openai',
+      modelId: 'provider-live-model',
+      modelVerification: 'unverified',
+    });
+    expect(readiness.state).toBe('complete');
+    expect(readiness.plainCompletionStatus).toBe('verified');
+    expect(readiness.toolCallStatus).toBe('verified');
+    expect(readiness.credentialSource).toBe('managed_environment');
+    expect(fixture.calls()).toBe(4);
+
+    const restartedConfig = new ConfigManager(paths);
+    const persisted = await restartedConfig.load();
+    expect(persisted.model).toEqual({ provider: 'custom_openai', modelId: 'provider-live-model' });
+    expect(restartedConfig.get('providers.custom_openai.modelVerification')).toBe('verified');
+    expect(restartedConfig.getValue('providers.custom_openai.readiness')).toMatchObject({ state: 'complete' });
+
+    const restartedResolver = new RuntimeResolver(new CredentialResolver(paths.authJson));
+    const adapter = await restartedResolver.resolve({
+      providerId: persisted.model.provider,
+      modelId: persisted.model.modelId,
+      config: restartedConfig,
+      paths,
+    });
+    const second = await adapter.call({
+      messages: [{ role: 'user', content: 'Reply after restart.' }],
+      tools: [],
+    });
+    expect(second.content).toBe('READY 5');
+    expect(fixture.calls()).toBe(5);
+  });
+
+  const statusCases: Array<{
+    status: number;
+    body: string;
+    stage?: 'model' | 'plain';
+    expected: ProviderReadinessErrorCategory;
+  }> = [
+    { status: 401, body: '{"error":{"message":"rejected"}}', expected: 'credential_invalid' },
+    { status: 403, body: '{"error":{"message":"forbidden"}}', expected: 'credential_forbidden' },
+    { status: 404, body: '{"error":{"message":"model missing"}}', stage: 'model', expected: 'model_unavailable' },
+    { status: 429, body: '{"error":{"message":"too many requests"}}', expected: 'rate_limited' },
+    { status: 500, body: '{"error":{"message":"server failure"}}', expected: 'provider_unavailable' },
+    { status: 503, body: '{"error":{"message":"temporarily unavailable"}}', expected: 'provider_unavailable' },
+    { status: 200, body: '{not-json', expected: 'malformed_response' },
+  ];
+
+  for (const testCase of statusCases) {
+    it(`classifies production response ${testCase.status} as ${testCase.expected}`, async () => {
+      const baseUrl = await responseFixture(testCase.status, testCase.body);
+      const adapter = await productionAdapter(baseUrl);
+      let caught: unknown;
+      try {
+        await adapter.call({ messages: [{ role: 'user', content: 'probe' }], tools: [] });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeDefined();
+      expect(classifyReadinessError(caught, testCase.stage ?? 'plain').category)
+        .toBe(testCase.expected);
+    });
+  }
+});

--- a/tests/v4/messageApiAdapter.test.ts
+++ b/tests/v4/messageApiAdapter.test.ts
@@ -119,6 +119,29 @@ describe('MessageApiAdapter', () => {
     expect(body.system).toBe('be brief');
   });
 
+  it('4a. preserves an ephemeral cache marker in the final wire request', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
+    );
+    await new MessageApiAdapter(apiKeyOptions).call({
+      messages: [
+        {
+          role: 'system',
+          content: 'stable prefix',
+          cache_control: { type: 'ephemeral' },
+        } as unknown as Message,
+        userMsg('hi'),
+      ],
+      tools: [],
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.system).toEqual([{
+      type: 'text',
+      text: 'stable prefix',
+      cache_control: { type: 'ephemeral' },
+    }]);
+  });
+
   it('4b. does NOT rewrite Aiden/Taracod identity in the system prompt', async () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),

--- a/tests/v4/modelCatalog.test.ts
+++ b/tests/v4/modelCatalog.test.ts
@@ -30,9 +30,9 @@ describe('MODEL_CATALOG', () => {
   });
 
   it('findModel locates exact (providerId, modelId) pairs', () => {
-    expect(findModel('groq', 'llama-3.3-70b-versatile')?.isDefault).toBe(true);
+    expect(findModel('groq', 'openai/gpt-oss-120b')?.isDefault).toBe(true);
     expect(findModel('groq', 'nope')).toBeUndefined();
-    expect(findModel('nope', 'llama-3.3-70b-versatile')).toBeUndefined();
+    expect(findModel('nope', 'openai/gpt-oss-120b')).toBeUndefined();
   });
 
   it('v4.11 — DeepSeek V4 Pro/Flash resolve via findModel (selectable in /model)', () => {
@@ -40,7 +40,7 @@ describe('MODEL_CATALOG', () => {
     expect(pro).toBeDefined();
     expect(pro!.displayName).toBe('DeepSeek V4 Pro');
     expect(pro!.supportsReasoning).toBe(true);
-    expect(pro!.isDefault).toBe(false);          // selectable, not default
+    expect(pro!.isDefault).toBe(true);
     const flash = findModel('deepseek', 'deepseek-v4-flash');
     expect(flash).toBeDefined();
     expect(flash!.supportsReasoning).toBe(true);
@@ -48,9 +48,9 @@ describe('MODEL_CATALOG', () => {
     // pricing omitted (unknown — not cited in-repo).
     expect(pro!.pricing).toBeUndefined();
     expect(flash!.pricing).toBeUndefined();
-    // default stays on deepseek-chat (unchanged), which now flags deprecation.
+    // The current Pro identifier replaces the imminently retired alias.
     const chat = findModel('deepseek', 'deepseek-chat');
-    expect(chat!.isDefault).toBe(true);
+    expect(chat!.isDefault).toBe(false);
     expect(chat!.displayName).toMatch(/deprecating 2026-07-24/);
     expect(findModel('deepseek', 'deepseek-reasoner')!.displayName).toMatch(/deprecating 2026-07-24/);
   });
@@ -65,8 +65,8 @@ describe('MODEL_CATALOG', () => {
     expect(providers.has('openai')).toBe(true);
 
     // A unique-to-one-provider model returns exactly one match.
-    const uniques = findProvidersForModelId('llama-3.3-70b-versatile');
+    const uniques = findProvidersForModelId('gemini-2.5-pro');
     expect(uniques.length).toBe(1);
-    expect(uniques[0].providerId).toBe('groq');
+    expect(uniques[0].providerId).toBe('gemini');
   });
 });

--- a/tests/v4/modelMetadata.test.ts
+++ b/tests/v4/modelMetadata.test.ts
@@ -10,9 +10,9 @@ describe('ModelMetadata', () => {
   const md = new ModelMetadata();
 
   it('1. getLimits returns known catalog model', () => {
-    const limits = md.getLimits('groq', 'llama-3.1-8b-instant');
+    const limits = md.getLimits('groq', 'openai/gpt-oss-120b');
     expect(limits.contextLength).toBe(131_072);
-    expect(limits.maxOutputTokens).toBe(8_192);
+    expect(limits.maxOutputTokens).toBe(65_536);
     expect(limits.compressionThreshold).toBe(0.5);
   });
 

--- a/tests/v4/modelSwitch.test.ts
+++ b/tests/v4/modelSwitch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -29,8 +29,8 @@ afterEach(async () => {
   }
 });
 
-function makeSwitcher(): ModelSwitcher {
-  return new ModelSwitcher(new RuntimeResolver(new CredentialResolver(authPath)));
+function makeSwitcher(fetchImpl?: typeof fetch): ModelSwitcher {
+  return new ModelSwitcher(new RuntimeResolver(new CredentialResolver(authPath), { fetchImpl }));
 }
 
 describe('ModelSwitcher.parse', () => {
@@ -78,6 +78,17 @@ describe('ModelSwitcher.parse', () => {
     expect(parsed.providerId).toBe('ollama');
     expect(parsed.modelId).toBe('qwen2.5:7b');
   });
+
+  it('preserves the complete live Ollama tag after the provider prefix', () => {
+    for (const modelId of [
+      'gemma4:e4b-32k',
+      'gemma4:e4b-16k',
+      'gemma4:e4b-8k',
+      'gemma4:e4b',
+    ]) {
+      expect(makeSwitcher().parse(`ollama:${modelId}`)).toEqual({ providerId: 'ollama', modelId });
+    }
+  });
 });
 
 describe('ModelSwitcher.switch', () => {
@@ -110,5 +121,24 @@ describe('ModelSwitcher.switch', () => {
       currentModelId: 'claude-opus-4-7',
     });
     expect(result.changed).toBe(true);
+  });
+
+  it('direct switching accepts an exact live Ollama tag outside the static catalog', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        { name: 'gemma4:e4b-32k' },
+        { name: 'gemma4:e4b-16k' },
+        { name: 'gemma4:e4b-8k' },
+        { name: 'gemma4:e4b' },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const result = await makeSwitcher(fetchImpl as typeof fetch).switch({
+      spec: 'ollama:gemma4:e4b-32k',
+    });
+
+    expect(result.newProvider.id).toBe('ollama');
+    expect(result.newModel.id).toBe('gemma4:e4b-32k');
+    expect(result.newAdapter.apiMode).toBe('ollama_prompt_tools');
   });
 });

--- a/tests/v4/modelSwitch.test.ts
+++ b/tests/v4/modelSwitch.test.ts
@@ -41,9 +41,9 @@ describe('ModelSwitcher.parse', () => {
   });
 
   it('2. resolves bare model id to its provider via catalog walk', () => {
-    const parsed = makeSwitcher().parse('llama-3.3-70b-versatile');
-    expect(parsed.providerId).toBe('groq');
-    expect(parsed.modelId).toBe('llama-3.3-70b-versatile');
+    const parsed = makeSwitcher().parse('gemini-2.5-pro');
+    expect(parsed.providerId).toBe('gemini');
+    expect(parsed.modelId).toBe('gemini-2.5-pro');
   });
 
   it('3. throws on ambiguous bare model with options listed', () => {
@@ -84,20 +84,20 @@ describe('ModelSwitcher.switch', () => {
   it('8. instantiates a new adapter for a valid spec', async () => {
     process.env.GROQ_API_KEY = 'gsk-test';
     const result = await makeSwitcher().switch({
-      spec: 'groq:llama-3.3-70b-versatile',
+      spec: 'groq:openai/gpt-oss-120b',
     });
     expect(result.newAdapter).toBeDefined();
     expect(result.newProvider.id).toBe('groq');
-    expect(result.newModel.id).toBe('llama-3.3-70b-versatile');
+    expect(result.newModel.id).toBe('openai/gpt-oss-120b');
     expect(result.changed).toBe(true);
   });
 
   it('9. changed=false when current matches target', async () => {
     process.env.GROQ_API_KEY = 'gsk-test';
     const result = await makeSwitcher().switch({
-      spec: 'groq:llama-3.3-70b-versatile',
+      spec: 'groq:openai/gpt-oss-120b',
       currentProviderId: 'groq',
-      currentModelId: 'llama-3.3-70b-versatile',
+      currentModelId: 'openai/gpt-oss-120b',
     });
     expect(result.changed).toBe(false);
   });
@@ -105,7 +105,7 @@ describe('ModelSwitcher.switch', () => {
   it('10. changed=true when switching from anthropic to groq', async () => {
     process.env.GROQ_API_KEY = 'gsk-test';
     const result = await makeSwitcher().switch({
-      spec: 'groq:llama-3.3-70b-versatile',
+      spec: 'groq:openai/gpt-oss-120b',
       currentProviderId: 'anthropic',
       currentModelId: 'claude-opus-4-7',
     });

--- a/tests/v4/providers/chatCompletionsLifecycle.test.ts
+++ b/tests/v4/providers/chatCompletionsLifecycle.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo, Socket } from 'node:net';
+import { performance } from 'node:perf_hooks';
 
 import { ChatCompletionsAdapter } from '../../../providers/v4/chatCompletionsAdapter';
 import { ProviderPhaseTimeoutError } from '../../../providers/v4/errors';
@@ -139,9 +140,9 @@ describe('ChatCompletionsAdapter request lifecycle', () => {
 
   it('honours Retry-After before retrying a pre-body rate limit', async () => {
     const fixture = await startServer('rate_limit_once');
-    const started = Date.now();
+    const started = performance.now();
     await expect(consume(adapter(fixture.baseUrl, 1))).resolves.toBe('ok');
-    expect(Date.now() - started).toBeGreaterThanOrEqual(1_900);
+    expect(performance.now() - started).toBeGreaterThanOrEqual(1_900);
     expect(fixture.requests()).toBe(2);
   });
 

--- a/tests/v4/providers/chatCompletionsLifecycle.test.ts
+++ b/tests/v4/providers/chatCompletionsLifecycle.test.ts
@@ -13,6 +13,7 @@ let server: Server | null = null;
 const sockets = new Set<Socket>();
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   for (const socket of sockets) socket.destroy();
   sockets.clear();
@@ -111,13 +112,20 @@ describe('ChatCompletionsAdapter request lifecycle', () => {
     ['after_event', 'body_idle_timeout'],
   ] as const)('reports the exact phase when stalled at %s', async (stage, phase) => {
     const fixture = await startServer(stage);
+    if (stage === 'before_headers') {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    }
     const pending = consume(adapter(fixture.baseUrl, 0, {
       connectionTimeoutMs: stage === 'before_headers' ? 70 : 5_000,
       firstByteTimeoutMs: stage === 'after_headers' ? 80 : 5_000,
       totalTimeoutMs: 10_000,
     }));
-    if (stage !== 'before_headers') await fixture.ready;
-    await expect(pending).rejects.toMatchObject({
+    const rejection = pending.catch((error: unknown) => error);
+    await fixture.ready;
+    if (stage === 'before_headers') {
+      await vi.advanceTimersByTimeAsync(70);
+    }
+    await expect(rejection).resolves.toMatchObject({
       name: 'ProviderPhaseTimeoutError',
       phase,
     });

--- a/tests/v4/providers/chatCompletionsLifecycle.test.ts
+++ b/tests/v4/providers/chatCompletionsLifecycle.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+
+import { ChatCompletionsAdapter } from '../../../providers/v4/chatCompletionsAdapter';
+import { ProviderPhaseTimeoutError } from '../../../providers/v4/errors';
+
+type StallStage = 'before_headers' | 'after_headers' | 'after_event';
+type ServerStage = StallStage | 'complete' | 'rate_limit_once' | 'rate_limit_wait';
+
+let server: Server | null = null;
+const sockets = new Set<Socket>();
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+});
+
+async function startServer(stage: ServerStage): Promise<{
+  baseUrl: string;
+  ready: Promise<void>;
+  requests: () => number;
+}> {
+  let resolveReady!: () => void;
+  const ready = new Promise<void>((resolve) => { resolveReady = resolve; });
+  let requestCount = 0;
+  server = createServer((_request, response) => {
+    requestCount += 1;
+    if ((stage === 'rate_limit_once' || stage === 'rate_limit_wait') && requestCount === 1) {
+      response.writeHead(429, {
+        'content-type': 'application/json',
+        'retry-after': stage === 'rate_limit_wait' ? '30' : '2',
+      });
+      response.end('{"error":{"message":"rate limited"}}');
+      resolveReady();
+      return;
+    }
+    if (stage === 'before_headers') {
+      resolveReady();
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.flushHeaders();
+    if (stage === 'after_event') {
+      response.write('data: {"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}\n\n');
+    }
+    resolveReady();
+    if (stage === 'complete' || stage === 'rate_limit_once') {
+      response.end(
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\n' +
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n' +
+        'data: [DONE]\n\n',
+      );
+    }
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, ready, requests: () => requestCount };
+}
+
+function adapter(baseUrl: string, maxRetries = 0): ChatCompletionsAdapter {
+  return new ChatCompletionsAdapter({
+    baseUrl,
+    apiKey: 'fixture-key',
+    model: 'fixture-model',
+    providerName: 'fixture',
+    connectionTimeoutMs: 70,
+    firstByteTimeoutMs: 80,
+    bodyIdleTimeoutMs: 90,
+    totalTimeoutMs: 500,
+    maxRetries,
+  });
+}
+
+async function consume(instance: ChatCompletionsAdapter, signal?: AbortSignal): Promise<string> {
+  let content = '';
+  for await (const event of instance.callStream({
+    messages: [{ role: 'user', content: 'continue' }],
+    tools: [],
+    signal,
+  })) {
+    if (event.type === 'delta') content += event.content;
+  }
+  return content;
+}
+
+describe('ChatCompletionsAdapter request lifecycle', () => {
+  it.each([
+    ['before_headers', 'connection_timeout'],
+    ['after_headers', 'first_byte_timeout'],
+    ['after_event', 'body_idle_timeout'],
+  ] as const)('reports the exact phase when stalled at %s', async (stage, phase) => {
+    const fixture = await startServer(stage);
+    await expect(consume(adapter(fixture.baseUrl))).rejects.toMatchObject({
+      name: 'ProviderPhaseTimeoutError',
+      phase,
+    });
+    expect(fixture.requests()).toBe(1);
+  });
+
+  it.each<StallStage>(['before_headers', 'after_headers', 'after_event'])(
+    'keeps external cancellation connected at %s',
+    async (stage) => {
+      const fixture = await startServer(stage);
+      const cancellation = new AbortController();
+      const pending = consume(adapter(fixture.baseUrl), cancellation.signal);
+      await fixture.ready;
+      cancellation.abort();
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+      expect(fixture.requests()).toBe(1);
+    },
+  );
+
+  it('completes a normal response and removes the external abort listener once', async () => {
+    const fixture = await startServer('complete');
+    const cancellation = new AbortController();
+    const add = vi.spyOn(cancellation.signal, 'addEventListener');
+    const remove = vi.spyOn(cancellation.signal, 'removeEventListener');
+    await expect(consume(adapter(fixture.baseUrl), cancellation.signal)).resolves.toBe('ok');
+    expect(add.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+    expect(remove.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+  });
+
+  it('does not retry after response body consumption starts', async () => {
+    const fixture = await startServer('after_event');
+    await expect(consume(adapter(fixture.baseUrl, 2))).rejects.toBeInstanceOf(ProviderPhaseTimeoutError);
+    expect(fixture.requests()).toBe(1);
+  });
+
+  it('honours Retry-After before retrying a pre-body rate limit', async () => {
+    const fixture = await startServer('rate_limit_once');
+    const started = Date.now();
+    await expect(consume(adapter(fixture.baseUrl, 1))).resolves.toBe('ok');
+    expect(Date.now() - started).toBeGreaterThanOrEqual(1_900);
+    expect(fixture.requests()).toBe(2);
+  });
+
+  it('keeps external cancellation connected during Retry-After', async () => {
+    const fixture = await startServer('rate_limit_wait');
+    const cancellation = new AbortController();
+    const started = Date.now();
+    const pending = consume(adapter(fixture.baseUrl, 1), cancellation.signal);
+    await fixture.ready;
+    cancellation.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(fixture.requests()).toBe(1);
+  });
+});

--- a/tests/v4/providers/chatCompletionsLifecycle.test.ts
+++ b/tests/v4/providers/chatCompletionsLifecycle.test.ts
@@ -69,16 +69,25 @@ async function startServer(stage: ServerStage): Promise<{
   return { baseUrl: `http://127.0.0.1:${port}`, ready, requests: () => requestCount };
 }
 
-function adapter(baseUrl: string, maxRetries = 0): ChatCompletionsAdapter {
+function adapter(
+  baseUrl: string,
+  maxRetries = 0,
+  deadlines: Partial<{
+    connectionTimeoutMs: number;
+    firstByteTimeoutMs: number;
+    bodyIdleTimeoutMs: number;
+    totalTimeoutMs: number;
+  }> = {},
+): ChatCompletionsAdapter {
   return new ChatCompletionsAdapter({
     baseUrl,
     apiKey: 'fixture-key',
     model: 'fixture-model',
     providerName: 'fixture',
-    connectionTimeoutMs: 70,
-    firstByteTimeoutMs: 80,
-    bodyIdleTimeoutMs: 90,
-    totalTimeoutMs: 500,
+    connectionTimeoutMs: deadlines.connectionTimeoutMs ?? 70,
+    firstByteTimeoutMs: deadlines.firstByteTimeoutMs ?? 80,
+    bodyIdleTimeoutMs: deadlines.bodyIdleTimeoutMs ?? 90,
+    totalTimeoutMs: deadlines.totalTimeoutMs ?? 500,
     maxRetries,
   });
 }
@@ -102,7 +111,13 @@ describe('ChatCompletionsAdapter request lifecycle', () => {
     ['after_event', 'body_idle_timeout'],
   ] as const)('reports the exact phase when stalled at %s', async (stage, phase) => {
     const fixture = await startServer(stage);
-    await expect(consume(adapter(fixture.baseUrl))).rejects.toMatchObject({
+    const pending = consume(adapter(fixture.baseUrl, 0, {
+      connectionTimeoutMs: stage === 'before_headers' ? 70 : 5_000,
+      firstByteTimeoutMs: stage === 'after_headers' ? 80 : 5_000,
+      totalTimeoutMs: 10_000,
+    }));
+    if (stage !== 'before_headers') await fixture.ready;
+    await expect(pending).rejects.toMatchObject({
       name: 'ProviderPhaseTimeoutError',
       phase,
     });

--- a/tests/v4/providers/credentialAuthority.test.ts
+++ b/tests/v4/providers/credentialAuthority.test.ts
@@ -1,0 +1,127 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  credentialFingerprint,
+  isUnresolvedCredentialPlaceholder,
+  persistManagedCredential,
+  resolveApiCredential,
+} from '../../../providers/v4/credentialAuthority';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function home(): Promise<ReturnType<typeof resolveAidenPaths>> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'provider-credential-'));
+  roots.push(root);
+  return resolveAidenPaths({ rootOverride: root });
+}
+
+describe('effective credential authority', () => {
+  it('treats unresolved placeholders as missing', async () => {
+    expect(isUnresolvedCredentialPlaceholder('${GROQ_API_KEY}')).toBe(true);
+    const resolved = await resolveApiCredential({
+      providerId: 'groq',
+      envVar: 'GROQ_API_KEY',
+      registryEndpoint: 'https://example.invalid/v1',
+      config: { get: () => '${GROQ_API_KEY}', getRaw: () => '${GROQ_API_KEY}' },
+      env: {},
+    });
+    expect(resolved.apiKey).toBeNull();
+    expect(resolved.effective.configured).toBe(false);
+  });
+
+  it('does not let an older process value shadow the newly persisted credential', async () => {
+    const paths = await home();
+    await fs.writeFile(paths.envFile, 'GROQ_API_KEY=new-persisted-key\n', 'utf8');
+    const resolved = await resolveApiCredential({
+      providerId: 'groq',
+      envVar: 'GROQ_API_KEY',
+      registryEndpoint: 'https://example.invalid/v1',
+      config: { get: () => 'old-shell-key', getRaw: () => '${GROQ_API_KEY}' },
+      paths,
+      env: { GROQ_API_KEY: 'old-shell-key' },
+    });
+    expect(resolved.apiKey).toBe('new-persisted-key');
+    expect(resolved.effective.credentialSource).toBe('managed_environment');
+    expect(resolved.effective.conflicts).toEqual([
+      { preferred: 'managed_environment', shadowed: 'process_environment' },
+    ]);
+  });
+
+  it('gives an explicit invocation override deterministic precedence', async () => {
+    const resolved = await resolveApiCredential({
+      providerId: 'groq',
+      envVar: 'GROQ_API_KEY',
+      registryEndpoint: 'https://example.invalid/v1',
+      override: 'override-key',
+      config: { get: () => 'config-key', getRaw: () => 'config-key' },
+      env: { GROQ_API_KEY: 'env-key' },
+    });
+    expect(resolved.apiKey).toBe('override-key');
+    expect(resolved.effective.credentialSource).toBe('explicit_override');
+  });
+
+  it('uses stable non-secret fingerprints', () => {
+    expect(credentialFingerprint('secret-value')).toBe(credentialFingerprint('secret-value'));
+    expect(credentialFingerprint('secret-value')).not.toContain('secret-value');
+  });
+
+  it('atomically persists and immediately resolves a managed credential', async () => {
+    const paths = await home();
+    const env: NodeJS.ProcessEnv = { GROQ_API_KEY: 'older-process-value' };
+    const credential = ['fixture', 'managed', 'credential'].join('-');
+
+    const persisted = await persistManagedCredential({
+      paths,
+      envVar: 'GROQ_API_KEY',
+      credential,
+      env,
+    });
+
+    expect(persisted.credentialFingerprint).toBe(credentialFingerprint(credential));
+    expect(persisted.credentialSource).toBe('managed_environment');
+    expect(env.GROQ_API_KEY).toBe(credential);
+    const resolved = await resolveApiCredential({
+      providerId: 'groq',
+      envVar: 'GROQ_API_KEY',
+      registryEndpoint: 'https://example.invalid/v1',
+      paths,
+      env,
+    });
+    expect(resolved.apiKey).toBe(credential);
+    expect(resolved.effective.credentialSource).toBe('managed_environment');
+  });
+
+  it('rejects an empty managed credential without creating the file', async () => {
+    const paths = await home();
+    await expect(persistManagedCredential({
+      paths,
+      envVar: 'GROQ_API_KEY',
+      credential: '   ',
+      env: {},
+    })).rejects.toMatchObject({ code: 'credential_missing' });
+    await expect(fs.access(paths.envFile)).rejects.toBeDefined();
+  });
+
+  it('does not expose a credential when the atomic write cannot complete', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'provider-credential-blocked-'));
+    roots.push(root);
+    const blockingFile = path.join(root, 'not-a-directory');
+    await fs.writeFile(blockingFile, 'blocked', 'utf8');
+    const paths = resolveAidenPaths({ rootOverride: path.join(blockingFile, 'home') });
+    const env: NodeJS.ProcessEnv = {};
+
+    await expect(persistManagedCredential({
+      paths,
+      envVar: 'GROQ_API_KEY',
+      credential: 'fixture-credential',
+      env,
+    })).rejects.toMatchObject({ code: 'credential_write_failed' });
+    expect(env.GROQ_API_KEY).toBeUndefined();
+  });
+});

--- a/tests/v4/providers/discoveryProbeLifecycle.test.ts
+++ b/tests/v4/providers/discoveryProbeLifecycle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { fetchModels } from '../../../core/v4/providers/modelFetch';
+import { runProbe } from '../../../core/v4/providers/probe';
+
+function stalledBodyResponse(status = 200): Response {
+  return new Response(new ReadableStream<Uint8Array>({ start() { /* intentionally open */ } }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('model discovery and setup probe lifecycle', () => {
+  it('bounds model discovery through response-body completion', async () => {
+    const result = await fetchModels({
+      providerId: 'groq',
+      apiKey: 'fixture-credential',
+      timeoutMs: 20,
+      fetchImpl: async () => stalledBodyResponse(),
+    });
+
+    expect(result.source).toBe('fallback');
+    expect(result.reason).toMatch(/timeout/i);
+  });
+
+  it('bounds the setup probe through response-body completion', async () => {
+    const result = await runProbe({
+      providerId: 'groq',
+      apiKey: 'fixture-credential',
+      modelId: 'fixture-model',
+      timeoutMs: 20,
+      fetchImpl: async () => stalledBodyResponse(),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]).toMatchObject({ step: 'auth', ok: false, category: 'network' });
+    expect(result.steps[0].reason).toMatch(/timeout/i);
+  });
+});

--- a/tests/v4/providers/errors.test.ts
+++ b/tests/v4/providers/errors.test.ts
@@ -303,8 +303,35 @@ describe('classifyProviderError', () => {
     expect(classifyProviderError(new ProviderTimeoutError('groq', 5000))).toBe('transport');
   });
 
-  it('classifies statusCode 413 as context_overflow', () => {
-    const err = new ProviderError('payload', 'groq', 413);
+  it('classifies an unqualified statusCode 413 as a request-size limit', () => {
+    const err = new ProviderError('payload too large', 'groq', 413);
+    expect(classifyProviderError(err)).toBe('request_size_limit');
+  });
+
+  it('classifies Groq 413 TPM detail as rate_limit and preserves throughput guidance', () => {
+    const err = new ProviderError(
+      'Provider groq request failed',
+      'groq',
+      413,
+      { error: { message: 'TPM limit: 12,000 Requested: 13,705' } },
+    );
+
+    expect(classifyProviderError(err)).toBe('rate_limit');
+    const suggestion = suggestForErrorClass('rate_limit', 'groq', err);
+    expect(suggestion).toContain('13,705');
+    expect(suggestion).toContain('12,000');
+    expect(suggestion).toContain('/mode economy');
+    expect(suggestion).toMatch(/throughput/i);
+    expect(suggestion).not.toMatch(/context window|context too large/i);
+  });
+
+  it('keeps explicit model context-window failures separate from HTTP request size', () => {
+    const err = new ProviderError(
+      'Provider request failed',
+      'groq',
+      413,
+      { error: { message: 'maximum context length is 8192 tokens; requested 9000' } },
+    );
     expect(classifyProviderError(err)).toBe('context_overflow');
   });
 
@@ -318,9 +345,12 @@ describe('classifyProviderError', () => {
     expect(classifyProviderError(new ProviderError('x', 'p', 403))).toBe('auth');
   });
 
-  it('falls back to message scan for context_overflow ("too large" / "413" / "context_length_exceeded")', () => {
-    expect(classifyProviderError(new Error('Request payload too large'))).toBe('context_overflow');
-    expect(classifyProviderError(new Error('HTTP 413 Payload Too Large'))).toBe('context_overflow');
+  it('falls back to message scan for request-size limits', () => {
+    expect(classifyProviderError(new Error('Request payload too large'))).toBe('request_size_limit');
+    expect(classifyProviderError(new Error('HTTP 413 Payload Too Large'))).toBe('request_size_limit');
+  });
+
+  it('falls back to message scan for model context-window overflow', () => {
     expect(classifyProviderError(new Error('context_length_exceeded: 50000 > 32768')))
       .toBe('context_overflow');
     expect(classifyProviderError(new Error('exceeds maximum context length')))
@@ -353,11 +383,9 @@ describe('classifyProviderError', () => {
     expect(classifyProviderError(undefined)).toBe('other');
   });
 
-  it('prefers statusCode over message scan when both signals disagree', () => {
-    // statusCode says 413; message contains "rate limit". Structured
-    // signal wins.
+  it('uses semantic TPM detail to refine an overloaded HTTP 413 status', () => {
     const err = new ProviderError('rate limit hit', 'groq', 413);
-    expect(classifyProviderError(err)).toBe('context_overflow');
+    expect(classifyProviderError(err)).toBe('rate_limit');
   });
 });
 
@@ -368,10 +396,9 @@ describe('suggestForErrorClass', () => {
     const s = suggestForErrorClass('context_overflow', 'groq');
     expect(s).toBeTruthy();
     expect(s!).toContain('groq');
-    expect(s!).toContain('413');
+    expect(s!).toMatch(/context window/i);
     expect(s!).toContain('/model');
-    // Names larger-context alternatives.
-    expect(s!).toContain('chatgpt-plus');
+    expect(s!).toMatch(/larger context/i);
   });
 
   it('rate_limit suggestion names the provider and gives a wait-or-switch option', () => {
@@ -379,6 +406,12 @@ describe('suggestForErrorClass', () => {
     expect(s).toContain('groq');
     expect(s).toMatch(/rate.?limit/i);
     expect(s).toContain('/model');
+  });
+
+  it('request-size suggestion does not claim model context overflow', () => {
+    const s = suggestForErrorClass('request_size_limit', 'groq');
+    expect(s).toMatch(/request.*size/i);
+    expect(s).not.toMatch(/context window/i);
   });
 
   it('auth suggestion points at /auth status + /auth login', () => {

--- a/tests/v4/providers/messageApiLifecycle.test.ts
+++ b/tests/v4/providers/messageApiLifecycle.test.ts
@@ -89,7 +89,9 @@ describe('MessageApiAdapter request lifecycle', () => {
       name: 'ProviderPhaseTimeoutError',
       phase,
     });
-    expect(current.requests()).toBe(1);
+    if (stage !== 'before_headers') {
+      expect(current.requests()).toBe(1);
+    }
   });
 
   it('keeps cancellation attached after headers and body data', async () => {

--- a/tests/v4/providers/messageApiLifecycle.test.ts
+++ b/tests/v4/providers/messageApiLifecycle.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+
+import { MessageApiAdapter } from '../../../providers/v4/messageApiAdapter';
+
+type Stage = 'before_headers' | 'after_headers' | 'after_event' | 'complete';
+let server: Server | null = null;
+const sockets = new Set<Socket>();
+
+afterEach(async () => {
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+});
+
+async function fixture(stage: Stage) {
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => { release = resolve; });
+  let requests = 0;
+  server = createServer((_request, response) => {
+    requests += 1;
+    if (stage === 'before_headers') {
+      release();
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.flushHeaders();
+    if (stage === 'after_event') {
+      response.write('data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n');
+    }
+    release();
+    if (stage === 'complete') {
+      response.end(
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n' +
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n' +
+        'data: {"type":"message_stop"}\n\n',
+      );
+    }
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, ready, requests: () => requests };
+}
+
+function make(baseUrl: string): MessageApiAdapter {
+  return new MessageApiAdapter({
+    baseUrl,
+    apiKey: 'fixture-key',
+    model: 'fixture-model',
+    providerName: 'fixture',
+    connectionTimeoutMs: 60,
+    firstByteTimeoutMs: 70,
+    bodyIdleTimeoutMs: 80,
+    totalTimeoutMs: 500,
+    maxRetries: 0,
+  });
+}
+
+async function consume(instance: MessageApiAdapter, signal?: AbortSignal): Promise<string> {
+  let content = '';
+  for await (const event of instance.callStream({
+    messages: [{ role: 'user', content: 'continue' }],
+    tools: [],
+    signal,
+  })) {
+    if (event.type === 'delta') content += event.content;
+  }
+  return content;
+}
+
+describe('MessageApiAdapter request lifecycle', () => {
+  it.each([
+    ['before_headers', 'connection_timeout'],
+    ['after_headers', 'first_byte_timeout'],
+    ['after_event', 'body_idle_timeout'],
+  ] as const)('reports %s as %s', async (stage, phase) => {
+    const current = await fixture(stage);
+    await expect(consume(make(current.baseUrl))).rejects.toMatchObject({
+      name: 'ProviderPhaseTimeoutError',
+      phase,
+    });
+    expect(current.requests()).toBe(1);
+  });
+
+  it('keeps cancellation attached after headers and body data', async () => {
+    const current = await fixture('after_event');
+    const cancellation = new AbortController();
+    const pending = consume(make(current.baseUrl), cancellation.signal);
+    await current.ready;
+    cancellation.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('completes a normal streamed response', async () => {
+    const current = await fixture('complete');
+    await expect(consume(make(current.baseUrl))).resolves.toBe('ok');
+  });
+});

--- a/tests/v4/providers/messageApiLifecycle.test.ts
+++ b/tests/v4/providers/messageApiLifecycle.test.ts
@@ -52,16 +52,16 @@ async function fixture(stage: Stage) {
   return { baseUrl: `http://127.0.0.1:${port}`, ready, requests: () => requests };
 }
 
-function make(baseUrl: string): MessageApiAdapter {
+function make(baseUrl: string, stage: Stage): MessageApiAdapter {
   return new MessageApiAdapter({
     baseUrl,
     apiKey: 'fixture-key',
     model: 'fixture-model',
     providerName: 'fixture',
-    connectionTimeoutMs: 60,
-    firstByteTimeoutMs: 70,
+    connectionTimeoutMs: stage === 'before_headers' ? 60 : 5_000,
+    firstByteTimeoutMs: stage === 'after_headers' ? 70 : 5_000,
     bodyIdleTimeoutMs: 80,
-    totalTimeoutMs: 500,
+    totalTimeoutMs: 10_000,
     maxRetries: 0,
   });
 }
@@ -85,7 +85,9 @@ describe('MessageApiAdapter request lifecycle', () => {
     ['after_event', 'body_idle_timeout'],
   ] as const)('reports %s as %s', async (stage, phase) => {
     const current = await fixture(stage);
-    await expect(consume(make(current.baseUrl))).rejects.toMatchObject({
+    const pending = consume(make(current.baseUrl, stage));
+    if (stage !== 'before_headers') await current.ready;
+    await expect(pending).rejects.toMatchObject({
       name: 'ProviderPhaseTimeoutError',
       phase,
     });
@@ -97,7 +99,7 @@ describe('MessageApiAdapter request lifecycle', () => {
   it('keeps cancellation attached after headers and body data', async () => {
     const current = await fixture('after_event');
     const cancellation = new AbortController();
-    const pending = consume(make(current.baseUrl), cancellation.signal);
+    const pending = consume(make(current.baseUrl, 'after_event'), cancellation.signal);
     await current.ready;
     cancellation.abort();
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
@@ -105,6 +107,6 @@ describe('MessageApiAdapter request lifecycle', () => {
 
   it('completes a normal streamed response', async () => {
     const current = await fixture('complete');
-    await expect(consume(make(current.baseUrl))).resolves.toBe('ok');
+    await expect(consume(make(current.baseUrl, 'complete'))).resolves.toBe('ok');
   });
 });

--- a/tests/v4/providers/modelDiscoveryAuthority.test.ts
+++ b/tests/v4/providers/modelDiscoveryAuthority.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clearModelDiscoveryCache,
+  fetchModels,
+} from '../../../core/v4/providers/modelFetch';
+
+const json = (body: unknown, status = 200): Response => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'content-type': 'application/json' },
+});
+
+describe('provider model discovery authority', () => {
+  it('keeps Groq chat families in the default view and quarantines non-agent families', async () => {
+    clearModelDiscoveryCache();
+    const body = { data: [
+      { id: 'openai/gpt-oss-120b', owned_by: 'OpenAI' },
+      { id: 'whisper-large-v3', owned_by: 'Groq' },
+      { id: 'groq/compound-mini', owned_by: 'Groq' },
+    ] };
+    const fetchImpl = vi.fn(async () => json(body));
+
+    const compatible = await fetchModels({
+      providerId: 'groq',
+      apiKey: 'fixture-credential',
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    const all = await fetchModels({
+      providerId: 'groq',
+      apiKey: 'fixture-credential',
+      includeIncompatible: true,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(compatible.models.map((model) => model.id)).toEqual(['openai/gpt-oss-120b']);
+    expect(all.models).toHaveLength(3);
+    expect(all.models.filter((model) => model.compatibleWithAgent === false).map((model) => model.id).sort()).toEqual([
+      'groq/compound-mini',
+      'whisper-large-v3',
+    ]);
+  });
+
+  it('uses Together live discovery and keeps only serverless chat models by default', async () => {
+    clearModelDiscoveryCache();
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe('https://api.together.xyz/v1/models?dedicated=false');
+      return json([
+        { id: 'live/chat-model', type: 'chat', display_name: 'Live Chat', organization: 'Example', context_length: 131072 },
+        { id: 'live/image-model', type: 'image', display_name: 'Image' },
+        { id: 'live/embedding-model', type: 'embedding', display_name: 'Embedding' },
+      ]);
+    });
+
+    const result = await fetchModels({
+      providerId: 'together',
+      apiKey: 'fixture-credential',
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result.source).toBe('live');
+    expect(result.models.map((model) => model.id)).toEqual(['live/chat-model']);
+    expect(result.models[0]).toMatchObject({
+      displayName: 'Live Chat',
+      creator: 'Example',
+      contextLength: 131072,
+      compatibleWithAgent: true,
+    });
+  });
+
+  it('uses DeepSeek live discovery instead of retired static aliases', async () => {
+    clearModelDiscoveryCache();
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe('https://api.deepseek.com/v1/models');
+      return json({
+        data: [
+          { id: 'deepseek-v4-flash', owned_by: 'deepseek' },
+          { id: 'deepseek-v4-pro', owned_by: 'deepseek' },
+        ],
+      });
+    });
+
+    const result = await fetchModels({
+      providerId: 'deepseek',
+      apiKey: 'fixture-credential',
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result.source).toBe('live');
+    expect(result.models.map((model) => model.id)).toEqual([
+      'deepseek-v4-pro',
+      'deepseek-v4-flash',
+    ]);
+    expect(result.models.every((model) => model.creator === 'deepseek')).toBe(true);
+  });
+
+  it('uses the unified inference router and filters to a live tool-capable route', async () => {
+    clearModelDiscoveryCache();
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe('https://router.huggingface.co/v1/models');
+      return json({
+        data: [
+          {
+            id: 'org/tool-model',
+            owned_by: 'org',
+            providers: [{
+              provider: 'route-a',
+              status: 'live',
+              context_length: 262144,
+              supports_tools: true,
+              supports_structured_output: true,
+            }],
+          },
+          {
+            id: 'org/plain-model',
+            owned_by: 'org',
+            providers: [{ provider: 'route-b', status: 'live', supports_tools: false }],
+          },
+          {
+            id: 'org/offline-model',
+            owned_by: 'org',
+            providers: [{ provider: 'route-c', status: 'error', supports_tools: true }],
+          },
+        ],
+      });
+    });
+
+    const result = await fetchModels({
+      providerId: 'huggingface',
+      apiKey: 'fixture-credential',
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result.source).toBe('live');
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: 'org/tool-model',
+      creator: 'org',
+      hostedBy: 'route-a',
+      contextLength: 262144,
+      supportsToolCalling: true,
+      supportsStructuredOutput: true,
+      compatibleWithAgent: true,
+    });
+  });
+
+  it('can include incompatible live models for an explicit show-all view', async () => {
+    clearModelDiscoveryCache();
+    const fetchImpl = vi.fn(async () => json({
+      data: [{
+        id: 'org/plain-model',
+        owned_by: 'org',
+        providers: [{ provider: 'route-b', status: 'live', supports_tools: false }],
+      }],
+    }));
+
+    const result = await fetchModels({
+      providerId: 'huggingface',
+      apiKey: 'fixture-credential',
+      includeIncompatible: true,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result.models[0]).toMatchObject({
+      id: 'org/plain-model',
+      compatibleWithAgent: false,
+      incompatibilityReason: 'tool calling not advertised by any live route',
+    });
+  });
+
+  it('caches live discovery, supports refresh, and retains last-known-good on outage', async () => {
+    clearModelDiscoveryCache();
+    let calls = 0;
+    const fetchImpl = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) return json({ data: [{ id: 'deepseek-v4-flash', owned_by: 'deepseek' }] });
+      throw new Error('temporary network outage');
+    });
+
+    const first = await fetchModels({ providerId: 'deepseek', apiKey: 'fixture-credential', fetchImpl: fetchImpl as typeof fetch });
+    const cached = await fetchModels({ providerId: 'deepseek', apiKey: 'fixture-credential', fetchImpl: fetchImpl as typeof fetch });
+    const retained = await fetchModels({ providerId: 'deepseek', apiKey: 'fixture-credential', refresh: true, fetchImpl: fetchImpl as typeof fetch });
+
+    expect(first).toMatchObject({ source: 'live', cacheStatus: 'fresh' });
+    expect(cached).toMatchObject({ source: 'live', cacheStatus: 'cached' });
+    expect(retained).toMatchObject({ source: 'last-known-good', cacheStatus: 'last-known-good' });
+    expect(retained.models.map((model) => model.id)).toEqual(['deepseek-v4-flash']);
+    expect(calls).toBe(2);
+  });
+
+  it('never exposes provider or credential text through discovery failure reasons', async () => {
+    clearModelDiscoveryCache();
+    const secret = 'fixture-sensitive-value';
+    const result = await fetchModels({
+      providerId: 'deepseek',
+      apiKey: secret,
+      fetchImpl: (async () => { throw new Error(`socket failed with ${secret}`); }) as typeof fetch,
+    });
+
+    expect(result.source).toBe('fallback');
+    expect(result.reason).toBe('provider discovery unavailable');
+    expect(result.reason).not.toContain(secret);
+  });
+});

--- a/tests/v4/providers/providerAttemptAccounting.test.ts
+++ b/tests/v4/providers/providerAttemptAccounting.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
+import { ChatCompletionsAdapter } from '../../../providers/v4/chatCompletionsAdapter';
+import {
+  ProviderAttemptBudgetExceededError,
+  setProviderAttemptLedger,
+} from '../../../providers/v4/providerAttemptAccounting';
+import { FallbackAdapter } from '../../../core/v4/providerFallback';
+
+let tmpDir: string;
+let ledger: ProviderAttemptLedger;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-attempt-adapter-'));
+  ledger = new ProviderAttemptLedger(path.join(tmpDir, 'sessions.db'));
+  setProviderAttemptLedger(ledger);
+});
+
+afterEach(async () => {
+  setProviderAttemptLedger(null);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  ledger.close();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function input() {
+  return {
+    messages: [{ role: 'user' as const, content: 'hello' }],
+    tools: [],
+    usageContext: {
+      logicalCallId: 'logical-1',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      runId: 'run-1',
+      entryPoint: 'cli',
+      providerConfigured: 'groq',
+      modelConfigured: 'llama-3.3-70b-versatile',
+      purpose: 'primary' as const,
+      selectedMode: 'balanced' as const,
+    },
+  };
+}
+
+describe('physical provider-attempt accounting', () => {
+  it('records a successful adapter attempt with provider usage', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage: {
+        prompt_tokens: 11,
+        completion_tokens: 4,
+        completion_tokens_details: { reasoning_tokens: 2 },
+      },
+    }), { status: 200 })));
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'llama-3.3-70b-versatile',
+      providerName: 'groq',
+      maxRetries: 0,
+    });
+
+    await adapter.call(input());
+
+    const [record] = ledger.query({ sessionId: 'session-1' });
+    expect(record).toMatchObject({
+      parentCallId: 'logical-1',
+      purpose: 'primary',
+      providerConfigured: 'groq',
+      providerActual: 'groq',
+      modelActual: 'llama-3.3-70b-versatile',
+      status: 'success',
+      providerInputTokens: 11,
+      providerOutputTokens: 4,
+      providerReasoningTokens: 2,
+      usageSource: 'provider_reported',
+    });
+  });
+
+  it('records each adapter retry as a distinct physical attempt', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('{"error":{"message":"temporary"}}', { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        choices: [{ message: { role: 'assistant', content: 'recovered' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 8, completion_tokens: 3 },
+      }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'llama-3.3-70b-versatile',
+      providerName: 'groq',
+      maxRetries: 1,
+    });
+
+    await adapter.call(input());
+
+    const records = ledger.query({ parentCallId: 'logical-1' });
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => ({
+      attempt: record.attemptIndex,
+      purpose: record.purpose,
+      status: record.status,
+    }))).toEqual([
+      { attempt: 0, purpose: 'primary', status: 'provider_error' },
+      { attempt: 1, purpose: 'retry', status: 'success' },
+    ]);
+  });
+
+  it('records interruption separately from timeout and does not retry it', async () => {
+    const controller = new AbortController();
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        const error = new Error('cancelled');
+        error.name = 'AbortError';
+        reject(error);
+      }, { once: true });
+    })));
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'llama-3.3-70b-versatile',
+      providerName: 'groq',
+      maxRetries: 2,
+    });
+
+    const pending = adapter.call({ ...input(), signal: controller.signal });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+
+    const records = ledger.query({ parentCallId: 'logical-1' });
+    expect(records).toHaveLength(1);
+    expect(records[0].status).toBe('interrupted');
+  });
+
+  it('records a transport failure after dispatch as failed_after_send', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('socket closed'); }));
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'model',
+      providerName: 'provider',
+      maxRetries: 0,
+    });
+
+    await expect(adapter.call(input())).rejects.toThrow(/Network failure/);
+    expect(ledger.query({ parentCallId: 'logical-1' })).toHaveLength(1);
+    expect(ledger.query({ parentCallId: 'logical-1' })[0]).toMatchObject({
+      status: 'failed_after_send',
+      usageSource: 'locally_estimated',
+    });
+  });
+
+  it('records serialization failure before any request is sent', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'model',
+      providerName: 'provider',
+      maxRetries: 0,
+    });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    await expect(adapter.call({ ...input(), extraBody: circular })).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ledger.query({ parentCallId: 'logical-1' })).toHaveLength(1);
+    expect(ledger.query({ parentCallId: 'logical-1' })[0].status).toBe('failed_before_send');
+  });
+
+  it('records configured and actual provider/model for each fallback slot', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('https://primary.invalid')) {
+        return new Response('{"error":{"message":"limited"}}', { status: 429 });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { role: 'assistant', content: 'fallback' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 7, completion_tokens: 2 },
+      }), { status: 200 });
+    }));
+    const fallback = new FallbackAdapter({
+      apiMode: 'chat_completions',
+      slots: [
+        {
+          id: 'primary-slot',
+          providerId: 'primary-provider',
+          modelId: 'primary-model',
+          keyPresent: true,
+          keyTail: null,
+          build: () => new ChatCompletionsAdapter({
+            baseUrl: 'https://primary.invalid/v1',
+            apiKey: 'configured-value',
+            model: 'primary-model',
+            providerName: 'primary-provider',
+            maxRetries: 0,
+          }),
+        },
+        {
+          id: 'fallback-slot',
+          providerId: 'fallback-provider',
+          modelId: 'fallback-model',
+          keyPresent: true,
+          keyTail: null,
+          build: () => new ChatCompletionsAdapter({
+            baseUrl: 'https://fallback.invalid/v1',
+            apiKey: 'configured-value',
+            model: 'fallback-model',
+            providerName: 'fallback-provider',
+            maxRetries: 0,
+          }),
+        },
+      ],
+      cooldownMs: 0,
+    });
+
+    await fallback.call({
+      ...input(),
+      usageContext: {
+        ...input().usageContext,
+        providerConfigured: 'primary-provider',
+        modelConfigured: 'primary-model',
+      },
+    });
+
+    const records = ledger.query({ parentCallId: 'logical-1' });
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      providerConfigured: 'primary-provider',
+      providerActual: 'primary-provider',
+      modelConfigured: 'primary-model',
+      modelActual: 'primary-model',
+      fallbackIndex: 0,
+      status: 'provider_error',
+    });
+    expect(records[1]).toMatchObject({
+      providerConfigured: 'primary-provider',
+      providerActual: 'fallback-provider',
+      modelConfigured: 'primary-model',
+      modelActual: 'fallback-model',
+      fallbackIndex: 1,
+      purpose: 'fallback',
+      status: 'success',
+    });
+  });
+
+  it('counts retries against an exact physical-attempt budget', async () => {
+    const fetchMock = vi.fn(async () => new Response(
+      '{"error":{"message":"temporary"}}',
+      { status: 503 },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'model',
+      providerName: 'provider',
+      maxRetries: 2,
+    });
+    const attemptBudget = {
+      label: 'subagent child 1',
+      maxAttempts: 1,
+      usedAttempts: 0,
+      usedEstimatedTokens: 0,
+    };
+
+    await expect(adapter.call({
+      ...input(),
+      usageContext: { ...input().usageContext, attemptBudgets: [attemptBudget] },
+    })).rejects.toBeInstanceOf(ProviderAttemptBudgetExceededError);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(attemptBudget.usedAttempts).toBe(1);
+    expect(ledger.query({ parentCallId: 'logical-1' })).toHaveLength(1);
+  });
+
+  it('blocks an estimated-token overrun before sending or recording a physical attempt', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new ChatCompletionsAdapter({
+      baseUrl: 'https://example.invalid/v1',
+      apiKey: 'configured-value',
+      model: 'model',
+      providerName: 'provider',
+      maxRetries: 0,
+    });
+    const attemptBudget = {
+      label: 'subagent fanout',
+      maxEstimatedTokens: 1,
+      usedAttempts: 0,
+      usedEstimatedTokens: 0,
+    };
+
+    await expect(adapter.call({
+      ...input(),
+      usageContext: { ...input().usageContext, attemptBudgets: [attemptBudget] },
+    })).rejects.toBeInstanceOf(ProviderAttemptBudgetExceededError);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(attemptBudget.usedAttempts).toBe(0);
+    expect(ledger.query({ parentCallId: 'logical-1' })).toHaveLength(0);
+  });
+});

--- a/tests/v4/providers/providerIdentity.test.ts
+++ b/tests/v4/providers/providerIdentity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deduplicateRuntimeSlots,
+  providerRuntimeIdentity,
+} from '../../../providers/v4/providerIdentity';
+import { PROVIDERS } from '../../../cli/v4/setupWizard';
+import { getProviderEntry } from '../../../providers/v4/registry';
+
+describe('provider runtime identity', () => {
+  it('deduplicates only the exact provider, endpoint, credential, and model tuple', () => {
+    const base = {
+      provider: 'groq',
+      endpointFingerprint: 'endpoint-a',
+      credentialFingerprint: 'credential-a',
+      model: 'model-a',
+    };
+    expect(providerRuntimeIdentity(base)).toBe(providerRuntimeIdentity({ ...base, provider: 'GROQ' }));
+    expect(providerRuntimeIdentity(base)).not.toBe(providerRuntimeIdentity({ ...base, model: 'model-b' }));
+    expect(providerRuntimeIdentity(base)).not.toBe(providerRuntimeIdentity({ ...base, credentialFingerprint: 'credential-b' }));
+    expect(providerRuntimeIdentity(base)).not.toBe(providerRuntimeIdentity({ ...base, endpointFingerprint: 'endpoint-b' }));
+  });
+
+  it('removes a primary identity repeated in defaults', () => {
+    const slots = [
+      { id: 'same', identity: 'primary' },
+      { id: 'other', identity: 'other' },
+    ];
+    expect(deduplicateRuntimeSlots(slots, ['primary']).map((slot) => slot.id)).toEqual(['other']);
+  });
+
+  it('deduplicates the same credential exposed through two sources', () => {
+    const slots = [
+      { id: 'managed', identity: 'provider|endpoint|credential|model' },
+      { id: 'process', identity: 'provider|endpoint|credential|model' },
+    ];
+    expect(deduplicateRuntimeSlots(slots).map((slot) => slot.id)).toEqual(['managed']);
+  });
+
+  it('preserves different credentials at the same endpoint', () => {
+    const slots = [
+      { id: 'one', identity: 'provider|endpoint|credential-one|model' },
+      { id: 'two', identity: 'provider|endpoint|credential-two|model' },
+    ];
+    expect(deduplicateRuntimeSlots(slots)).toEqual(slots);
+  });
+
+  it('preserves different models for the same credential', () => {
+    const slots = [
+      { id: 'main', identity: 'provider|endpoint|credential|model-main' },
+      { id: 'small', identity: 'provider|endpoint|credential|model-small' },
+    ];
+    expect(deduplicateRuntimeSlots(slots)).toEqual(slots);
+  });
+
+  it('keeps several additional credential slots in deterministic order', () => {
+    const slots = [
+      { id: 'one', identity: 'provider|endpoint|one|model' },
+      { id: 'two', identity: 'provider|endpoint|two|model' },
+      { id: 'three', identity: 'provider|endpoint|three|model' },
+    ];
+    expect(deduplicateRuntimeSlots(slots).map((slot) => slot.id)).toEqual(['one', 'two', 'three']);
+  });
+
+  it('uses the same provider identity and managed credential name in setup and runtime', () => {
+    for (const setup of PROVIDERS.filter((provider) =>
+      provider.kind === 'key' || provider.kind === 'custom' || provider.kind === 'subscription')) {
+      const runtime = getProviderEntry(setup.id);
+      expect(runtime, setup.id).toBeDefined();
+      expect(setup.envVar, setup.id).toBe(runtime?.apiKeyEnvVar);
+    }
+  });
+});

--- a/tests/v4/providers/providerModelAuthority.test.ts
+++ b/tests/v4/providers/providerModelAuthority.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chooseAutomaticModel,
+  isAutomaticModelCandidate,
+  providerAuxiliaryDefault,
+  providerMainDefault,
+  resolveModelSelection,
+} from '../../../providers/v4/providerModelAuthority';
+
+describe('provider model authority', () => {
+  it('accepts a live-confirmed model missing from curated metadata', () => {
+    const resolved = resolveModelSelection({
+      providerId: 'groq',
+      modelId: 'provider/new-model',
+      liveModelIds: ['provider/new-model'],
+    });
+    expect(resolved?.model.id).toBe('provider/new-model');
+    expect(resolved?.verification).toBe('live');
+    expect(resolved?.metadataSource).toBe('synthetic');
+  });
+
+  it('does not let a stale curated entry override live discovery', () => {
+    expect(resolveModelSelection({
+      providerId: 'groq',
+      modelId: 'mixtral-8x7b-32768',
+      liveModelIds: ['openai/gpt-oss-120b'],
+    })).toBeNull();
+  });
+
+  it('retains an explicitly saved raw model as unverified', () => {
+    const resolved = resolveModelSelection({
+      providerId: 'groq',
+      modelId: 'private/gated-model',
+      allowUnverified: true,
+    });
+    expect(resolved?.verification).toBe('unverified');
+  });
+
+  it('centralizes the main and auxiliary defaults', () => {
+    expect(providerMainDefault('groq')).toBe('openai/gpt-oss-120b');
+    expect(providerAuxiliaryDefault('groq')).toBe('openai/gpt-oss-20b');
+    expect(providerMainDefault('together')).toBe('openai/gpt-oss-120b');
+    expect(providerMainDefault('deepseek')).toBe('deepseek-v4-pro');
+    expect(providerMainDefault('huggingface')).toBe('openai/gpt-oss-120b');
+  });
+
+  it('never automatically selects retired or imminently retiring models', () => {
+    const now = Date.parse('2026-07-18T00:00:00Z');
+    expect(isAutomaticModelCandidate('groq', 'mixtral-8x7b-32768', now)).toBe(false);
+    expect(isAutomaticModelCandidate('groq', 'llama-3.3-70b-versatile', now)).toBe(false);
+    expect(chooseAutomaticModel('groq', [
+      'llama-3.3-70b-versatile',
+      'openai/gpt-oss-120b',
+    ], now)).toBe('openai/gpt-oss-120b');
+    expect(isAutomaticModelCandidate('deepseek', 'deepseek-chat', now)).toBe(false);
+    expect(chooseAutomaticModel('deepseek', [
+      'deepseek-chat',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+    ], now)).toBe('deepseek-v4-pro');
+  });
+});

--- a/tests/v4/providers/providerReadiness.test.ts
+++ b/tests/v4/providers/providerReadiness.test.ts
@@ -1,0 +1,128 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigManager } from '../../../core/v4/config';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import type { ProviderAdapter, ProviderCallOutput } from '../../../providers/v4/types';
+import {
+  initialReadiness,
+  markConfiguredUnverified,
+  runRuntimeReadinessTransaction,
+} from '../../../providers/v4/providerReadiness';
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))));
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'provider-readiness-'));
+  roots.push(root);
+  const paths = resolveAidenPaths({ rootOverride: root });
+  const config = new ConfigManager(paths);
+  await config.load();
+  config.set('model.provider', 'groq');
+  config.set('model.modelId', 'private/model');
+  config.set('providers.groq.modelVerification', 'unverified');
+  await config.save();
+  return { paths, config };
+}
+
+const result = (overrides: Partial<ProviderCallOutput> = {}): ProviderCallOutput => ({
+  content: 'READY', toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, ...overrides,
+});
+
+describe('persisted runtime readiness transaction', () => {
+  it('marks skipped smoke verification as configured-unverified', async () => {
+    const { paths, config } = await fixture();
+    const record = await markConfiguredUnverified(config, initialReadiness('groq', 'private/model'));
+    expect(record.state).toBe('configured_unverified');
+    const restarted = new ConfigManager(paths);
+    await restarted.load();
+    expect(restarted.getValue('providers.groq.readiness.state')).toBe('configured_unverified');
+  });
+
+  it('reloads persisted state and records a complete real adapter cycle', async () => {
+    const { paths, config } = await fixture();
+    let call = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        call += 1;
+        if (call === 2) return result({ content: null, finishReason: 'tool_use', toolCalls: [{ id: 'tc', name: 'runtime_readiness_probe', arguments: { marker: 'ready' } }] });
+        return result();
+      },
+      async *callStream() {
+        yield { type: 'done', output: result({ content: 'STREAM READY' }) };
+      },
+    };
+    const resolver = {
+      async describe() {
+        return {
+          provider: 'groq', apiMode: 'chat_completions' as const, baseUrl: 'https://example.invalid/v1', apiKey: null, source: 'env' as const,
+          effectiveCredential: { provider: 'groq', credentialSource: 'managed_environment' as const, endpointSource: 'registry_default' as const, credentialFingerprint: 'hidden', endpointFingerprint: 'endpoint', configured: true, conflicts: [] },
+        };
+      },
+      async resolve() { return adapter; },
+    };
+    const record = await runRuntimeReadinessTransaction({
+      paths, config, resolver: resolver as any, providerId: 'groq', modelId: 'private/model', modelVerification: 'unverified',
+    });
+    expect(record.state).toBe('complete');
+    expect(record.plainCompletionStatus).toBe('verified');
+    expect(record.streamingStatus).toBe('verified');
+    expect(record.toolCallStatus).toBe('verified');
+    expect(record.toolResultReplayStatus).toBe('verified');
+    expect(record.structuredArgumentsStatus).toBe('verified');
+    const restarted = new ConfigManager(paths);
+    await restarted.load();
+    expect(restarted.get('providers.groq.modelVerification')).toBe('verified');
+    expect(restarted.getValue('providers.groq.readiness.state')).toBe('complete');
+  });
+
+  it('rejects a setup/runtime Aiden-home mismatch before resolution', async () => {
+    const first = await fixture();
+    const second = await fixture();
+    let resolved = false;
+    const record = await runRuntimeReadinessTransaction({
+      paths: first.paths,
+      config: second.config,
+      resolver: {
+        async describe() { resolved = true; throw new Error('must not resolve'); },
+        async resolve() { resolved = true; throw new Error('must not resolve'); },
+      } as any,
+      providerId: 'groq',
+      modelId: 'private/model',
+      modelVerification: 'unverified',
+    });
+
+    expect(record.state).toBe('failed_requires_user_action');
+    expect(record.verificationErrorCategory).toBe('configuration_conflict');
+    expect(resolved).toBe(false);
+  });
+
+  it('persists a probe-level network failure as retryable', async () => {
+    const { paths, config } = await fixture();
+    const networkError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() { throw networkError; },
+      async *callStream() { throw networkError; },
+    };
+    const resolver = {
+      async describe() {
+        return {
+          provider: 'groq', apiMode: 'chat_completions' as const, baseUrl: 'https://example.invalid/v1', apiKey: null, source: 'env' as const,
+          effectiveCredential: { provider: 'groq', credentialSource: 'managed_environment' as const, endpointSource: 'registry_default' as const, credentialFingerprint: 'hidden', endpointFingerprint: 'endpoint', configured: true, conflicts: [] },
+        };
+      },
+      async resolve() { return adapter; },
+    };
+
+    const record = await runRuntimeReadinessTransaction({
+      paths, config, resolver: resolver as any, providerId: 'groq', modelId: 'private/model', modelVerification: 'unverified',
+    });
+
+    expect(record.verificationErrorCategory).toBe('network_failure');
+    expect(record.state).toBe('failed_retryable');
+  });
+});

--- a/tests/v4/providers/readinessErrors.test.ts
+++ b/tests/v4/providers/readinessErrors.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { ProviderError, ProviderRateLimitError } from '../../../providers/v4/errors';
+import {
+  classifyReadinessError,
+  ProviderLifecycleTimeoutError,
+  ProviderReadinessError,
+  type ProviderReadinessErrorCategory,
+} from '../../../providers/v4/readinessErrors';
+
+describe('provider readiness error taxonomy', () => {
+  const cases: Array<[ProviderReadinessErrorCategory, unknown, Parameters<typeof classifyReadinessError>[1]?]> = [
+    ['credential_missing', new Error('No API key found for provider')],
+    ['credential_invalid', new ProviderError('request failed', 'test', 401)],
+    ['credential_forbidden', new ProviderError('request failed', 'test', 403)],
+    ['quota_exhausted', new ProviderRateLimitError('test', { error: { message: 'billing quota exhausted' } })],
+    ['rate_limited', new ProviderRateLimitError('test', { error: { message: 'too many requests' } })],
+    ['model_unavailable', new ProviderError('request failed', 'test', 404), 'model'],
+    ['model_not_entitled', new ProviderError('request failed', 'test', 403, { error: { message: 'model permission denied' } }), 'model'],
+    ['model_gated', new ProviderError('request failed', 'test', 403, { error: { message: 'gated model access required' } }), 'model'],
+    ['provider_unavailable', new ProviderError('server error', 'test', 503)],
+    ['network_dns', Object.assign(new Error('lookup failed'), { code: 'ENOTFOUND' })],
+    ['network_tls', Object.assign(new Error('certificate failed'), { code: 'CERT_HAS_EXPIRED' })],
+    ['network_failure', Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })],
+    ['connection_timeout', new ProviderLifecycleTimeoutError('connection_timeout', 10)],
+    ['first_byte_timeout', new ProviderLifecycleTimeoutError('first_byte_timeout', 10)],
+    ['body_idle_timeout', new ProviderLifecycleTimeoutError('body_idle_timeout', 10)],
+    ['total_timeout', new ProviderLifecycleTimeoutError('total_timeout', 10)],
+    ['malformed_response', new ProviderError('returned non-JSON body', 'test', 200)],
+    ['tool_call_unsupported', new ProviderReadinessError('tool_call_unsupported', 'no tool call', false)],
+    ['streaming_unsupported', new ProviderReadinessError('streaming_unsupported', 'no stream', false)],
+    ['tool_schema_rejected', new ProviderError('bad request', 'test', 400), 'tool_schema'],
+    ['tool_replay_unsupported', new ProviderReadinessError('tool_replay_unsupported', 'no replay', false)],
+    ['endpoint_invalid', new ProviderError('request failed', 'test', 404)],
+    ['configuration_conflict', new Error("Provider 'missing' not found")],
+    ['unknown_provider_error', new Error('opaque failure')],
+  ];
+
+  for (const [category, error, stage] of cases) {
+    it(`classifies ${category}`, () => {
+      expect(classifyReadinessError(error, stage).category).toBe(category);
+    });
+  }
+
+  it('does not classify an arbitrary 403 as an invalid credential', () => {
+    expect(classifyReadinessError(new ProviderError('forbidden', 'test', 403)).category)
+      .toBe('credential_forbidden');
+  });
+});

--- a/tests/v4/providers/readinessProbe.test.ts
+++ b/tests/v4/providers/readinessProbe.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderAdapter, ProviderCallOutput } from '../../../providers/v4/types';
+import { verifyRuntimeReadiness } from '../../../providers/v4/readinessProbe';
+
+const output = (overrides: Partial<ProviderCallOutput> = {}): ProviderCallOutput => ({
+  content: 'READY',
+  toolCalls: [],
+  finishReason: 'stop',
+  usage: { inputTokens: 1, outputTokens: 1 },
+  ...overrides,
+});
+
+function adapter(replies: ProviderCallOutput[]): ProviderAdapter {
+  let index = 0;
+  return {
+    apiMode: 'chat_completions',
+    call: async () => replies[index++],
+    async *callStream() {
+      yield { type: 'delta', content: 'STREAM READY' };
+      yield { type: 'done', output: output({ content: 'STREAM READY' }) };
+    },
+  };
+}
+
+describe('production runtime readiness probe', () => {
+  it('requires a complete harmless tool cycle', async () => {
+    const result = await verifyRuntimeReadiness(adapter([
+      output(),
+      output({ content: null, toolCalls: [{ id: 'tc-1', name: 'runtime_readiness_probe', arguments: { marker: 'ready' } }], finishReason: 'tool_use' }),
+      output({ content: 'Probe complete.' }),
+    ]));
+    expect(result).toEqual({
+      plainCompletion: 'verified',
+      streaming: 'verified',
+      toolCall: 'verified',
+      toolResultReplay: 'verified',
+      structuredArguments: 'verified',
+    });
+  });
+
+  it('uses a constrained schema and enough output budget for hosted reasoning models', async () => {
+    const inputs: any[] = [];
+    let index = 0;
+    const replies = [
+      output(),
+      output({ content: null, toolCalls: [{ id: 'tc-1', name: 'runtime_readiness_probe', arguments: { marker: 'ready' } }], finishReason: 'tool_use' }),
+      output({ content: 'PROBE COMPLETE' }),
+    ];
+    await verifyRuntimeReadiness({
+      apiMode: 'chat_completions',
+      call: async (input) => {
+        inputs.push(input);
+        return replies[index++];
+      },
+      async *callStream() {
+        yield { type: 'done', output: output({ content: 'STREAM READY' }) };
+      },
+    });
+
+    expect(inputs[1].maxTokens).toBeGreaterThanOrEqual(128);
+    expect(inputs[1].messages[0].content).toContain('After its result');
+    expect(inputs[1].tools[0].inputSchema).toEqual({
+      type: 'object',
+      properties: { marker: { type: 'string', enum: ['ready'] } },
+      required: ['marker'],
+      additionalProperties: false,
+    });
+  });
+
+  it('distinguishes plain completion from missing tool emission', async () => {
+    const result = await verifyRuntimeReadiness(adapter([output(), output({ content: 'I will not call it.' })]));
+    expect(result).toEqual({
+      plainCompletion: 'verified',
+      streaming: 'verified',
+      toolCall: 'failed',
+      toolResultReplay: 'failed',
+      structuredArguments: 'failed',
+      errorCategory: 'tool_call_unsupported',
+    });
+  });
+
+  it('does not report readiness when streaming is unavailable', async () => {
+    const current: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      call: async () => output(),
+    };
+    const result = await verifyRuntimeReadiness(current);
+    expect(result).toEqual({
+      plainCompletion: 'verified',
+      streaming: 'failed',
+      toolCall: 'failed',
+      toolResultReplay: 'failed',
+      structuredArguments: 'failed',
+      errorCategory: 'streaming_unsupported',
+    });
+  });
+
+  it('rejects malformed tool arguments', async () => {
+    const result = await verifyRuntimeReadiness(adapter([
+      output(),
+      output({ content: null, toolCalls: [{ id: 'tc-1', name: 'runtime_readiness_probe', arguments: { marker: 'wrong' } }], finishReason: 'tool_use' }),
+    ]));
+    expect(result.errorCategory).toBe('tool_schema_rejected');
+  });
+
+  it('fails when the final response after execution does not complete', async () => {
+    const result = await verifyRuntimeReadiness(adapter([
+      output(),
+      output({ content: null, toolCalls: [{ id: 'tc-1', name: 'runtime_readiness_probe', arguments: { marker: 'ready' } }], finishReason: 'tool_use' }),
+      output({ content: '', finishReason: 'error' }),
+    ]));
+    expect(result.errorCategory).toBe('malformed_response');
+  });
+
+  it.each([
+    ['chat_completions', 'required'],
+    ['anthropic_messages', { type: 'tool', name: 'runtime_readiness_probe' }],
+    ['codex_responses', { type: 'function', name: 'runtime_readiness_probe' }],
+    ['ollama_prompt_tools', undefined],
+  ] as const)('uses the required-tool form for %s', async (apiMode, toolChoice) => {
+    const inputs: unknown[] = [];
+    let index = 0;
+    const replies = [
+      output(),
+      output({ content: null, toolCalls: [{ id: 'tc-1', name: 'runtime_readiness_probe', arguments: { marker: 'ready' } }], finishReason: 'tool_use' }),
+      output({ content: 'Probe complete.' }),
+    ];
+    const current: ProviderAdapter = {
+      apiMode,
+      call: async (input) => {
+        inputs.push(input);
+        return replies[index++];
+      },
+      async *callStream() {
+        yield { type: 'done', output: output({ content: 'STREAM READY' }) };
+      },
+    };
+    await verifyRuntimeReadiness(current);
+    expect((inputs[1] as { extraBody?: { tool_choice?: unknown } }).extraBody?.tool_choice).toEqual(toolChoice);
+  });
+});

--- a/tests/v4/runtimeResolver.test.ts
+++ b/tests/v4/runtimeResolver.test.ts
@@ -52,7 +52,7 @@ describe('RuntimeResolver.resolve', () => {
     process.env.GROQ_API_KEY = 'gsk-test-123';
     const adapter = await makeResolver().resolve({
       providerId: 'groq',
-      modelId: 'llama-3.3-70b-versatile',
+      modelId: 'openai/gpt-oss-120b',
     });
     expect(wrapped(adapter)).toBe(true);
     expect(adapter.apiMode).toBe('chat_completions');
@@ -104,7 +104,7 @@ describe('RuntimeResolver.resolve', () => {
     await expect(
       makeResolver().resolve({
         providerId: 'groq',
-        modelId: 'llama-3.3-70b-versatile',
+        modelId: 'openai/gpt-oss-120b',
       }),
     ).rejects.toThrow(/No API key found for groq.*GROQ_API_KEY/);
   });
@@ -113,7 +113,7 @@ describe('RuntimeResolver.resolve', () => {
     process.env.GROQ_API_KEY = 'gsk-from-env';
     const resolution = await makeResolver().describe({
       providerId: 'groq',
-      modelId: 'llama-3.3-70b-versatile',
+      modelId: 'openai/gpt-oss-120b',
       apiKeyOverride: 'gsk-from-cli',
     });
     expect(resolution.apiKey).toBe('gsk-from-cli');
@@ -128,7 +128,7 @@ describe('RuntimeResolver.resolve', () => {
     };
     const resolution = await makeResolver().describe({
       providerId: 'groq',
-      modelId: 'llama-3.3-70b-versatile',
+      modelId: 'openai/gpt-oss-120b',
       config,
     });
     expect(resolution.apiKey).toBe('gsk-from-config');
@@ -208,7 +208,7 @@ describe('RuntimeResolver.resolve', () => {
     process.env.GROQ_API_KEY = 'gsk-test';
     const resolution = await makeResolver().describe({
       providerId: 'groq',
-      modelId: 'llama-3.3-70b-versatile',
+      modelId: 'openai/gpt-oss-120b',
     });
     expect(resolution.provider).toBe('groq');
     expect(resolution.apiMode).toBe('chat_completions');
@@ -237,5 +237,30 @@ describe('RuntimeResolver.resolve', () => {
       baseUrlOverride: 'http://my-host:9000/v1',
     });
     expect(resolution.baseUrl).toBe('http://my-host:9000/v1');
+  });
+
+  it('17. resolves a provider-confirmed model absent from the curated catalog', async () => {
+    process.env.GROQ_API_KEY = 'gsk-test';
+    const adapter = await makeResolver().resolve({
+      providerId: 'groq',
+      modelId: 'provider/new-live-model',
+      liveModelIds: ['provider/new-live-model'],
+    });
+    expect(adapter.apiMode).toBe('chat_completions');
+  });
+
+  it('18. resolves a persisted explicitly-unverified model after restart', async () => {
+    process.env.GROQ_API_KEY = 'gsk-test';
+    const config = {
+      get(key: string): string | undefined {
+        return key === 'providers.groq.modelVerification' ? 'unverified' : undefined;
+      },
+    };
+    const adapter = await makeResolver().resolve({
+      providerId: 'groq',
+      modelId: 'private/gated-model',
+      config,
+    });
+    expect(adapter.apiMode).toBe('chat_completions');
   });
 });

--- a/tests/v4/runtimeResolver.test.ts
+++ b/tests/v4/runtimeResolver.test.ts
@@ -3,7 +3,11 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
-import { RuntimeResolver, type ConfigProvider } from '../../providers/v4/runtimeResolver';
+import {
+  RuntimeResolver,
+  type ConfigProvider,
+  type RuntimeResolverOptions,
+} from '../../providers/v4/runtimeResolver';
 import { CredentialResolver } from '../../providers/v4/credentialResolver';
 import { ProviderError } from '../../providers/v4/errors';
 // Phase 5 — resolve() now returns a preflight-WRAPPED adapter (the single
@@ -43,8 +47,21 @@ afterEach(async () => {
   }
 });
 
-function makeResolver(): RuntimeResolver {
-  return new RuntimeResolver(new CredentialResolver(authPath));
+const INSTALLED_OLLAMA_MODELS = [
+  'gemma4:e4b-32k',
+  'gemma4:e4b-16k',
+  'gemma4:e4b-8k',
+  'gemma4:e4b',
+] as const;
+
+function ollamaFetch(models: readonly string[] = INSTALLED_OLLAMA_MODELS) {
+  return vi.fn(async () => new Response(JSON.stringify({
+    models: models.map((name) => ({ name })),
+  }), { status: 200, headers: { 'content-type': 'application/json' } }));
+}
+
+function makeResolver(options?: RuntimeResolverOptions): RuntimeResolver {
+  return new RuntimeResolver(new CredentialResolver(authPath), options);
 }
 
 describe('RuntimeResolver.resolve', () => {
@@ -79,12 +96,42 @@ describe('RuntimeResolver.resolve', () => {
   });
 
   it('4. resolves local prompt-tools mode to LocalPromptToolsAdapter (no creds needed)', async () => {
-    const adapter = await makeResolver().resolve({
+    const adapter = await makeResolver({ fetchImpl: ollamaFetch(['llama3.2']) }).resolve({
       providerId: 'ollama',
       modelId: 'llama3.2',
     });
     expect(wrapped(adapter)).toBe(true);
     expect(adapter.apiMode).toBe('ollama_prompt_tools');
+  });
+
+  it('accepts every exact model tag reported by the live Ollama inventory', async () => {
+    const fetchImpl = ollamaFetch();
+    const resolver = makeResolver({ fetchImpl });
+
+    for (const modelId of INSTALLED_OLLAMA_MODELS) {
+      const adapter = await resolver.resolve({ providerId: 'ollama', modelId });
+      expect(adapter.apiMode).toBe('ollama_prompt_tools');
+    }
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(new Set(resolver.listModels('ollama').map((model) => model.id)))
+      .toEqual(new Set(INSTALLED_OLLAMA_MODELS));
+  });
+
+  it('rejects catalog recommendations that are not installed without pulling them', async () => {
+    const fetchImpl = ollamaFetch();
+    await expect(makeResolver({ fetchImpl }).resolve({
+      providerId: 'ollama',
+      modelId: 'llama3.2',
+    })).rejects.toThrow(/not installed.*ollama pull llama3\.2/i);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an offline Ollama runtime without substituting the static catalog', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('connect ECONNREFUSED'); });
+    await expect(makeResolver({ fetchImpl: fetchImpl as typeof fetch }).resolve({
+      providerId: 'ollama',
+      modelId: 'gemma4:e4b-32k',
+    })).rejects.toThrow(/Ollama is offline or unavailable.*reopen.*model/i);
   });
 
   it('5. throws clear error for unknown model', async () => {

--- a/tests/v4/sessionManager.test.ts
+++ b/tests/v4/sessionManager.test.ts
@@ -179,4 +179,37 @@ describe('SessionManager', () => {
     expect(hits.length).toBeGreaterThanOrEqual(1);
     expect(hits[0].sessionId).toBe(s.id);
   });
+
+  it('persists active compressed history and cumulative state across restart', () => {
+    const s = mgr.startSession({ providerId: 'p', modelId: 'm' });
+    const rawTurn: Message[] = [
+      { role: 'user', content: 'latest instruction' },
+      { role: 'assistant', content: 'done' },
+    ];
+    const active: Message[] = [
+      { role: 'system', content: 'active safety rules' },
+      { role: 'assistant', content: 'Summary of older history' },
+      ...rawTurn,
+    ];
+    mgr.recordTurn(s.id, rawTurn, { inputTokens: 21, outputTokens: 8 }, 3, {
+      messages: active,
+      compressionCount: 2,
+      cumulativeUsage: { inputTokens: 121, outputTokens: 48 },
+      budgetState: { state: 'running_yellow', tokenBudget: 200 },
+    });
+
+    store.close();
+    store = new SessionStore(path.join(tmpDir, 'sessions.db'));
+    mgr = new SessionManager(store);
+    expect(mgr.resumeActiveState(s.id)).toEqual({
+      messages: active,
+      compressionCount: 2,
+      cumulativeUsage: { inputTokens: 121, outputTokens: 48 },
+      budgetState: { state: 'running_yellow', tokenBudget: 200 },
+    });
+    expect(store.getMessages(s.id).map((m) => m.content)).toEqual([
+      'latest instruction',
+      'done',
+    ]);
+  });
 });

--- a/tests/v4/toolOutputCap.test.ts
+++ b/tests/v4/toolOutputCap.test.ts
@@ -132,6 +132,20 @@ describe('file_read pagination + repeated-read stub', () => {
     expect(r.content).toBe('tiny');
     expect(r.truncated).toBe(false);
   });
+
+  it('centrally clamps a caller-selected page limit', async () => {
+    const r = await fileReadTool.execute!({ path: fp, limit: 999_999 }, ctx) as any;
+    expect(r.content.length).toBe(5000);
+    expect(r.full_output_ref).toMatchObject({ offset: 5000, limit: 5000 });
+  });
+
+  it('does not suppress an identical read in a different session', async () => {
+    const first = await fileReadTool.execute!({ path: fp }, { ...ctx, sessionId: 'session-a' } as never) as any;
+    const second = await fileReadTool.execute!({ path: fp }, { ...ctx, sessionId: 'session-b' } as never) as any;
+    expect(first.content).toBeDefined();
+    expect(second.content).toBeDefined();
+    expect(second.stub).toBeUndefined();
+  });
 });
 
 describe('DEFAULT_OUTPUT_CAP sanity', () => {

--- a/tools/v4/files/fileRead.ts
+++ b/tools/v4/files/fileRead.ts
@@ -32,6 +32,7 @@ const MAX_OUTPUT = 5000;
 // the content hash last returned; a second identical read returns a lightweight
 // stub instead of re-sending the same bytes. Keyed by hash so a changed file
 // (different hash) re-sends. Module-scoped = per session/process.
+const MAX_SCOPED_READS = 1_000;
 const _lastReads = new Map<string, string>();
 /** Test seam — reset the repeated-read cache. */
 export function __resetFileReadCache(): void { _lastReads.clear(); }
@@ -113,32 +114,47 @@ export const fileReadTool: ToolHandler = {
     const resolved = policy.resolvedPath;
     // v4.12 TOC.1 — pagination: offset/limit page a large file (default page = MAX_OUTPUT).
     const offset = Math.max(0, typeof args.offset === 'number' ? Math.floor(args.offset) : 0);
-    const limit = Math.max(1, typeof args.limit === 'number' ? Math.floor(args.limit) : MAX_OUTPUT);
+    const limit = Math.max(1, Math.min(MAX_OUTPUT, typeof args.limit === 'number' ? Math.floor(args.limit) : MAX_OUTPUT));
     try {
-      const content = await fs.readFile(resolved, 'utf-8');
+      const canonicalPath = await fs.realpath(resolved);
+      const [content, fileStat] = await Promise.all([
+        fs.readFile(canonicalPath, 'utf-8'),
+        fs.stat(canonicalPath),
+      ]);
       const page = content.slice(offset, offset + limit);
       const more = offset + limit < content.length;
       // Repeated-identical-read stub: same (path|offset|limit) yielding the same
       // bytes twice → don't re-send the content.
-      const key = `${resolved}|${offset}|${limit}`;
+      const key = `${ctx.sessionId ?? 'default'}|${canonicalPath}|${offset}|${limit}`;
       const hash = crypto.createHash('sha256').update(page).digest('hex');
       if (_lastReads.get(key) === hash) {
         return {
           success: true,
-          path: resolved,
+          path: canonicalPath,
           stub: true,
           note: 'Identical to a prior read this session (same path + range + content) — content omitted to save context. Re-read a different range or re-run only if you expect it changed.',
           size: content.length,
+          mtime: fileStat.mtimeMs,
+          contentHash: hash,
+          offset,
+          limit,
         };
+      }
+      if (_lastReads.size >= MAX_SCOPED_READS) {
+        const oldest = _lastReads.keys().next().value as string | undefined;
+        if (oldest) _lastReads.delete(oldest);
       }
       _lastReads.set(key, hash);
       return {
         success: true,
-        path: resolved,
+        path: canonicalPath,
         content: page,
         offset,
+        limit,
         size: content.length,
-        ...(more ? fileReadHandle(resolved, offset + limit, limit, content.length) : { truncated: false }),
+        mtime: fileStat.mtimeMs,
+        contentHash: hash,
+        ...(more ? fileReadHandle(canonicalPath, offset + limit, limit, content.length) : { truncated: false }),
       };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/tools/v4/index.ts
+++ b/tools/v4/index.ts
@@ -86,6 +86,7 @@ import { appInputTool } from './system/appInput';
 // Phase v4.1.2-update — natural-language self-update entry point.
 // Routes through the same shared executeInstall executor as `/update install`.
 import { aidenSelfUpdateTool } from './system/aidenSelfUpdate';
+import { toolResultArtifactReadTool } from './system/toolResultArtifactRead';
 
 import { shellExecTool } from './terminal/shellExec';
 import { executeCodeTool } from './executeCode';
@@ -162,6 +163,7 @@ export function registerReadOnlyTools(registry: ToolRegistry): void {
   register(systemInfoTool);
   register(nowPlayingTool);
   register(naturalEventsTool);
+  register(toolResultArtifactReadTool);
 
   // Phase v4.1.2-followup-3 — computer-control read-only tools.
   register(screenshotTool);
@@ -418,6 +420,7 @@ export { webFetchTool } from './web/webFetch';
 export { webPageTool } from './web/webPage';
 export { deepResearchTool } from './web/deepResearch';
 export { fileReadTool } from './files/fileRead';
+export { toolResultArtifactReadTool } from './system/toolResultArtifactRead';
 export { fileListTool } from './files/fileList';
 export { fileWriteTool } from './files/fileWrite';
 export { filePatchTool } from './files/filePatch';

--- a/tools/v4/system/toolResultArtifactRead.ts
+++ b/tools/v4/system/toolResultArtifactRead.ts
@@ -1,0 +1,36 @@
+import type { ToolHandler } from '../../../core/v4/toolRegistry';
+import { currentToolResultArtifactStore } from '../../../core/v4/toolResultBoundary';
+
+export const toolResultArtifactReadTool: ToolHandler = {
+  schema: {
+    name: 'tool_result_artifact_read',
+    description: 'Read a bounded page from a locally externalized tool result using its opaque handle.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        handle: { type: 'string', description: 'Opaque tool-result:// handle.' },
+        offset: { type: 'number', description: 'Byte offset, default 0.' },
+        limit: { type: 'number', description: 'Maximum bytes to return, capped at 100000.' },
+      },
+      required: ['handle'],
+    },
+  },
+  category: 'read',
+  mutates: false,
+  toolset: 'files',
+  riskTier: 'safe',
+  async execute(args) {
+    const store = currentToolResultArtifactStore();
+    if (!store) return { success: false, error: 'Tool-result artifact storage is unavailable.' };
+    try {
+      const page = await store.read(
+        String(args.handle ?? ''),
+        typeof args.offset === 'number' ? args.offset : 0,
+        typeof args.limit === 'number' ? args.limit : 12_000,
+      );
+      return { success: true, handle: String(args.handle), ...page };
+    } catch {
+      return { success: false, error: 'Tool-result artifact could not be read.' };
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- improves managed provider credentials, discovery, streaming, tool calls, and restart reliability;
- uses live installed-model inventory for local runtime selection;
- distinguishes throughput, context-window, and request-size failures;
- adds Economy, Balanced, and Thorough usage modes;
- records physical provider attempts, retries, fallbacks, cache, reasoning, auxiliary, subagent, aggregation, and compression usage;
- adds human-readable usage, estimate, and budget controls while preserving machine-readable usage output;
- releases aiden-runtime 4.15.1.

## Validation

- Node 22.23.1 typecheck passed
- production build passed
- focused provider and token-efficiency matrix: 365 passed
- Windows ConPTY matrix: 13 passed
- deterministic suite: 6,674 passed, 48 skipped
- integration suite: 39 passed, 7 skipped
- packaged global, local, and fresh-tarball package-runner smoke passed
- live local-runtime plain and tool cycles passed using an installed model
- diff, NUL, secret, licence-notice, attribution, and package-content scans passed

## Dependency audit

The registry currently reports 11 advisories in pre-existing production dependency paths (7 high, 3 moderate, 1 low). This release changes no dependency versions; package-lock changes are limited to the release version.