### PR TITLE
feat: add durable job engine and input controls

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -46,6 +46,11 @@ import { pwClose } from '../core/playwrightBridge'
 // runtime lock, crash recovery, health endpoints, signal handlers.
 import { bootstrapDaemon } from '../core/v4/daemon'
 import { resolveAidenPaths } from '../core/v4/paths'
+import { daemonDbPath } from '../core/v4/daemon/daemonConfig'
+import { openDaemonDb } from '../core/v4/daemon/db/connection'
+import { createJobEngine } from '../core/v4/daemon/jobEngine'
+import { createHttpJobCoordinator } from '../core/v4/daemon/httpJobIngress'
+import { currentJobExecutionContext } from '../core/v4/daemon/jobExecutionContext'
 import { estimateCompatibilityUsage } from '../core/v4/compatibilityUsage'
 import {
   beginPhysicalProviderAttempt,
@@ -490,7 +495,20 @@ const kbProgress = new Map<string, { status: 'processing' | 'done' | 'error'; pr
 // â”€â”€ App factory â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 export function createApiServer(): Express {
-  configureProviderAttemptLedger(resolveAidenPaths().sessionsDb)
+  const aidenPaths = resolveAidenPaths()
+  configureProviderAttemptLedger(aidenPaths.sessionsDb)
+  const apiDb = openDaemonDb(daemonDbPath(aidenPaths.root))
+  const apiInstanceId = `api_${process.pid}`
+  const apiNow = Date.now()
+  apiDb.prepare(
+    `INSERT OR IGNORE INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES (?, ?, 'localhost', ?, ?, ?)`,
+  ).run(apiInstanceId, process.pid, apiNow, apiNow, VERSION)
+  const apiJobCoordinator = createHttpJobCoordinator({
+    engine: createJobEngine({ db: apiDb }),
+    instanceId: apiInstanceId,
+  })
   const app = express()
 
   // â”€â”€ Middleware â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -520,6 +538,9 @@ export function createApiServer(): Express {
     if (req.path.startsWith('/api/triggers/webhook/')) return next()
     return _jsonParser(req, res, next)
   })
+
+  app.use('/api/chat', apiJobCoordinator.middleware({ entryPoint: 'compatibility_api', source: 'api' }))
+  app.use('/v1/chat/completions', apiJobCoordinator.middleware({ entryPoint: 'openai_compatible_api', source: 'api' }))
 
   // Security headers
   app.use((_req: Request, res: Response, next: NextFunction) => {
@@ -5202,6 +5223,7 @@ export function createApiServer(): Express {
     sessionId: string,
     port:      number,
     onToken:   (tok: string) => void,
+    internalJobToken?: string | null,
   ): Promise<string> {
     return new Promise((resolve, reject) => {
       const body = JSON.stringify({ message: userText, history, sessionId, mode: 'auto' })
@@ -5214,6 +5236,7 @@ export function createApiServer(): Express {
           'Content-Type':   'application/json',
           'Accept':         'text/event-stream',
           'Content-Length': Buffer.byteLength(body),
+          ...apiJobCoordinator.internalHeaders(internalJobToken ?? null),
         },
       }
       // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -5337,6 +5360,9 @@ export function createApiServer(): Express {
         purpose: 'legacy_api' as const,
         providerConfigured: 'legacy-router',
         modelConfigured: modelName,
+        jobId: currentJobExecutionContext()?.jobId,
+        attemptId: currentJobExecutionContext()?.attemptId,
+        attemptGeneration: currentJobExecutionContext()?.generation,
       },
     }
     const attempt = beginPhysicalProviderAttempt(requestForAccounting, {
@@ -5367,7 +5393,7 @@ export function createApiServer(): Express {
       try {
         const fullText = await _driveAgentSSE(userText, history, sessionId, port, (tok) => {
           res.write(chunk({ content: tok }, null))
-        })
+        }, apiJobCoordinator.internalToken(res))
         const usage = estimateCompatibilityUsage(normalizedUsageMessages, fullText)
         attempt.success({ content: fullText, toolCalls: [], finishReason: 'stop', usage: { inputTokens: 0, outputTokens: 0 } }, providerByteLength(fullText))
         res.write(`data: ${JSON.stringify({
@@ -5389,7 +5415,14 @@ export function createApiServer(): Express {
     } else {
       // ── Non-streaming: collect full response, return as JSON ────
       try {
-        const fullText = await _driveAgentSSE(userText, history, sessionId, port, () => {})
+        const fullText = await _driveAgentSSE(
+          userText,
+          history,
+          sessionId,
+          port,
+          () => {},
+          apiJobCoordinator.internalToken(res),
+        )
         const usage = estimateCompatibilityUsage(normalizedUsageMessages, fullText)
         attempt.success({ content: fullText, toolCalls: [], finishReason: 'stop', usage: { inputTokens: 0, outputTokens: 0 } }, providerByteLength(fullText))
         res.json({

--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -27,6 +27,8 @@ interface ActivityEntry {
 export interface ModalActivityOptions<T> {
   /** Return false when the settled modal outcome makes the paused activity terminal. */
   resumeActivityWhen?: (result: T) => boolean;
+  /** Restore terminal-owned fixed surfaces before activity rows repaint. */
+  beforeActivityResume?: () => void;
 }
 
 export interface ActivitySnapshot {
@@ -246,6 +248,7 @@ export class ActivityRegistry {
       }
       return result;
     } finally {
+      options.beforeActivityResume?.();
       this.resumeAfterModal();
     }
   }

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -80,6 +80,11 @@ import os from 'node:os';
 import { daemonDbPath } from '../../core/v4/daemon/daemonConfig';
 import { openDaemonDb } from '../../core/v4/daemon/db/connection';
 import { createRunStore } from '../../core/v4/daemon/runStore';
+import { createJobEngine } from '../../core/v4/daemon/jobEngine';
+import type { JobEngine } from '../../core/v4/daemon/jobEngine';
+import { executeDurableJob } from '../../core/v4/daemon/jobLifecycle';
+import { computeTaskFinalization } from '../../core/v4/taskVerification';
+import { runWithProviderUsageContext } from '../../providers/v4/providerAttemptAccounting';
 // v4.10 Slice 10.2b — shared event taxonomy. Tool name → (category, kind).
 import { categorizeEvent } from '../../core/v4/daemon/eventCategories';
 import { makeSpawnSubAgentTool } from '../../tools/v4/subagent/spawnSubAgentTool';
@@ -507,43 +512,33 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
       const { openBrowser }          = await import('../../core/v4/workbench/openBrowser');
       const { createSessionLister }  = await import('../../core/v4/workbench/sessionList');
       const { createTriggerBus }     = await import('../../core/v4/daemon/triggerBus');
-      const { randomBytes, randomUUID } = await import('node:crypto');
+      const { createWorkbenchJobCommands } = await import('../../core/v4/workbench/jobCommands');
+      const { randomBytes } = await import('node:crypto');
       const paths    = resolveAidenPaths();
       const dbPath   = daemonDbPath(paths.root);
       const db       = openDaemonDb(dbPath);
       const runStore = createRunStore({ db });
+      const jobEngine = createJobEngine({ db });
+      const workbenchInstanceId = `workbench_${process.pid}`;
+      const workbenchStartedAt = Date.now();
+      db.prepare(
+        `INSERT OR IGNORE INTO daemon_instances
+           (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(workbenchInstanceId, process.pid, os.hostname(), workbenchStartedAt, workbenchStartedAt, VERSION);
       const sessions = createSessionLister(new SessionStore(paths.sessionsDb));
       // WRITE path: a per-launch token gates it, and the task is only ENQUEUED
       // onto the daemon's safe job path (manual trigger → dispatcher runs it
       // under the default safe-only policy: risky/mutating tools auto-denied).
       const triggerBus = createTriggerBus({ db });
       const token = randomBytes(24).toString('hex');
-      const enqueue = {
-        enqueue(task: { message: string; sessionId?: string }): { accepted: boolean; triggerEventId?: number; duplicate?: boolean } {
-          const r = triggerBus.insert({
-            source:         'manual',
-            sourceKey:      'workbench-web',
-            idempotencyKey: randomUUID(),
-            payload:        { body: { prompt: task.message, source: 'workbench-web' }, sessionId: task.sessionId },
-          });
-          return { accepted: true, triggerEventId: r.id, duplicate: !r.inserted };
-        },
-      };
+      const { enqueue, cancel } = createWorkbenchJobCommands({
+        db, triggerBus, jobEngine, runStore, instanceId: workbenchInstanceId,
+      });
       // STEER path: the stop button cancels a running job by run id. We record
       // the stop durably — mark the run `cancelled` (so the dispatcher won't
       // dispatch it again) and emit a `task_cancelled` event so it shows in the
       // feed. We never abort the agent in-process from here.
-      const FINAL_RUN = new Set(['completed', 'failed', 'cancelled', 'interrupted']);
-      const cancel = {
-        cancel(runId: number): { accepted: boolean; runId: number; alreadyFinal?: boolean } {
-          const run = runStore.get(runId);
-          if (!run) return { accepted: false, runId };
-          if (FINAL_RUN.has(String(run.status))) return { accepted: true, runId, alreadyFinal: true };
-          runStore.setStatus(runId, 'cancelled', { finishReason: 'stopped from workbench web' });
-          runStore.emitEvent(runId, 'task_cancelled', { source: 'workbench-web', reason: 'stopped from dashboard' });
-          return { accepted: true, runId };
-        },
-      };
       // Primary UI: the built React dashboard (dashboard-next/out) if present;
       // otherwise the built-in page (still reachable at /plain either way).
       const nodePath = await import('node:path');
@@ -1204,6 +1199,7 @@ export async function buildAgentRuntime(
      VALUES (?, ?, ?, ?, ?, ?)`,
   ).run(replInstanceId, process.pid, os.hostname(), Date.now(), Date.now(), VERSION);
   const replRunStore = createRunStore({ db: replDb });
+  const jobEngine = createJobEngine({ db: replDb });
   // v4.10 Slice 10.8 — durable Task-lite store. Shares the daemon.db
   // handle with replRunStore so /tasks listing + /adjust mutations
   // see the same WAL view chatSession's runAgentTurn writes through.
@@ -2932,6 +2928,7 @@ export async function buildAgentRuntime(
       resolveUiOnly,
       resolveToolInteraction,
       runStore:            replRunStore,
+      jobEngine,
       instanceId:          replInstanceId,
       logger:              bootLogger.child('subagent'),
       // v4.11 toolset grouping — children inherit the parent's
@@ -3108,12 +3105,57 @@ export async function buildAgentRuntime(
       const history: import('../../providers/v4/types').Message[] = [...past, userTurn];
 
       // 3. Run one agent turn.
-      const result = await agent.runConversation(history, {
-        sessionId: storeSid,
-        runId: `gateway-${randomUUID()}`,
-        entryPoint: 'gateway',
-        purpose: 'primary',
+      const gatewayKey = message.replyTo ?? `${message.timestamp}`;
+      const execution = await executeDurableJob({
+        engine: jobEngine,
+        ownerId: replInstanceId,
+        admission: {
+          entryPoint: 'gateway',
+          source: message.channel,
+          sessionId: storeSid,
+          workspaceId: process.cwd(),
+          principalId: message.userId,
+          instanceId: replInstanceId,
+          idempotencyNamespace: `gateway:${message.channel}:${message.channelId}`,
+          idempotencyKey: gatewayKey,
+          goal: message.text,
+          title: message.text,
+          channelId: message.channelId,
+        },
+        execute: (handle) => runWithProviderUsageContext({
+          sessionId: storeSid,
+          taskId: handle.jobId,
+          runId: handle.runId,
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          attemptGeneration: handle.generation,
+          entryPoint: 'gateway',
+          purpose: 'primary',
+        }, () => agent.runConversation(history, {
+          sessionId: storeSid,
+          taskId: handle.jobId,
+          runId: handle.runId,
+          entryPoint: 'gateway',
+          purpose: 'primary',
+          signal: handle.signal,
+        })),
+        finalize: (value) => {
+          const fin = computeTaskFinalization({
+            finishReason: value.finishReason,
+            toolCallTrace: value.toolCallTrace,
+          });
+          return {
+            status: value.finishReason === 'interrupted'
+              ? 'cancelled'
+              : fin.status === 'completed' || fin.status === 'completed_unverified' ? 'completed' : 'failed',
+            outcome: fin.status,
+            finishReason: value.finishReason,
+            evidence: fin.evidence,
+            jobCard: fin.jobCard,
+          };
+        },
       });
+      const result = execution.value;
 
       // 4. Persist the new tail (everything past the loaded history) so
       //    the next inbound resumes seamlessly. Mirror chatSession's
@@ -3449,7 +3491,20 @@ export async function buildAgentRuntime(
           ctx.display.warn(`Task ${taskId} is ${existing.status}; marking cancelled anyway.`);
         }
         try {
-          replTaskStore.setStatus(taskId, 'cancelled');
+          const durable = jobEngine.getJob(taskId);
+          if (durable) {
+            const cancelled = jobEngine.cancelJob({
+              jobId: taskId,
+              reason: 'cancelled from /adjust',
+              producer: 'repl',
+              eventIdempotencyKey: `adjust-cancel:${taskId}`,
+            });
+            if (!cancelled.applied && !cancelled.duplicate) {
+              throw new Error(`durable cancellation rejected: ${cancelled.conflict ?? 'unknown'}`);
+            }
+          } else {
+            replTaskStore.setStatus(taskId, 'cancelled');
+          }
           ctx.display.success(`Task ${taskId} cancelled.`);
           ctx.display.dim(
             '  Note: this records intent. Any in-flight agent turn keeps running — mid-turn abort is a future capability.',
@@ -3628,6 +3683,7 @@ export async function buildAgentRuntime(
     daemonAgentBuilder,
     // v4.6 Phase 2Q-B — REPL parent-run wiring.
     replRunStore,
+    jobEngine,
     replInstanceId,
     replParentRunRef,
     // v4.10 Slice 10.8 — durable Task-lite store.
@@ -3739,6 +3795,7 @@ export interface AgentRuntime {
    * children link via `spawned_from_run_id`.
    */
   replRunStore:     import('../../core/v4/daemon/runStore').RunStore;
+  jobEngine:        import('../../core/v4/daemon/jobEngine').JobEngine;
   replInstanceId:   string;
   /**
    * v4.10 Slice 10.8 — durable Task-lite store. Mirrors replRunStore's
@@ -3780,7 +3837,13 @@ export interface AgentRuntime {
 interface OneShotAgent {
   runConversation(
     history: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>,
-    options?: { sessionId?: string; runId?: string; entryPoint?: string; purpose?: 'primary' },
+    options?: {
+      sessionId?: string;
+      runId?: string | number;
+      entryPoint?: string;
+      purpose?: 'primary';
+      signal?: AbortSignal;
+    },
   ): Promise<{
     finalContent?:  string;
     finishReason?:  string;
@@ -3802,6 +3865,12 @@ export interface OneShotDeps {
   paths?:    AidenPaths;
   /** Working dir for path minimization + the on-disk artifact check. */
   cwd?:      string;
+  /** Production durable authority. Tests may omit it for compatibility. */
+  jobEngine?: JobEngine;
+  /** Required with jobEngine; owns the Attempt lease. */
+  instanceId?: string;
+  /** Optional stable session identity; otherwise the one-shot ID is used. */
+  sessionId?: string;
 }
 
 /**
@@ -3817,10 +3886,71 @@ export async function executeOneShotTurn(deps: OneShotDeps): Promise<number> {
   let code = 0;
   try {
     const oneShotId = `oneshot-${randomUUID()}`;
-    const result = await deps.agent.runConversation(
+    const sessionId = deps.sessionId ?? oneShotId;
+    if (deps.jobEngine && !deps.instanceId) {
+      throw new Error('Durable one-shot execution requires an instance identity');
+    }
+    const runAgent = () => deps.agent.runConversation(
       [{ role: 'user', content: deps.prompt }],
-      { sessionId: oneShotId, runId: oneShotId, entryPoint: 'oneshot', purpose: 'primary' },
+      { sessionId, runId: oneShotId, entryPoint: 'oneshot', purpose: 'primary' },
     );
+    const result = deps.jobEngine
+      ? (await executeDurableJob({
+          engine: deps.jobEngine,
+          ownerId: deps.instanceId!,
+          admission: {
+            entryPoint: 'oneshot',
+            source: 'cli',
+            sessionId,
+            workspaceId: deps.cwd ?? process.cwd(),
+            instanceId: deps.instanceId!,
+            idempotencyNamespace: `oneshot:${sessionId}`,
+            goal: deps.prompt,
+            title: deps.prompt,
+          },
+          execute: (handle) => runWithProviderUsageContext({
+            sessionId,
+            taskId: handle.jobId,
+            runId: handle.runId,
+            jobId: handle.jobId,
+            attemptId: handle.attemptId,
+            attemptGeneration: handle.generation,
+            entryPoint: 'oneshot',
+            purpose: 'primary',
+          }, () => deps.agent.runConversation(
+            [{ role: 'user', content: deps.prompt }],
+            {
+              sessionId,
+              runId: String(handle.runId),
+              entryPoint: 'oneshot',
+              purpose: 'primary',
+              signal: handle.signal,
+            },
+          )),
+          finalize: (value) => {
+            const fin = computeTaskFinalization({
+              finishReason: value.finishReason ?? 'stop',
+              toolCallTrace: value.toolCallTrace,
+            }, {
+              fileExists: (candidate) => {
+                try {
+                  const cwd = deps.cwd ?? process.cwd();
+                  return existsSync(path.isAbsolute(candidate) ? candidate : path.resolve(cwd, candidate));
+                } catch { return false; }
+              },
+            });
+            return {
+              status: value.finishReason === 'interrupted'
+                ? 'cancelled'
+                : fin.status === 'completed' || fin.status === 'completed_unverified' ? 'completed' : 'failed',
+              outcome: fin.status,
+              finishReason: value.finishReason ?? 'stop',
+              evidence: fin.evidence,
+              jobCard: fin.jobCard,
+            };
+          },
+        })).value
+      : await runAgent();
     const answer = result.finalContent ?? '';
     // stdout carries ONLY the answer (newline-terminated for pipe hygiene).
     out(answer.endsWith('\n') ? answer : `${answer}\n`);
@@ -3902,6 +4032,8 @@ export async function runQuery(
   return executeOneShotTurn({
     agent:  runtime.agent as unknown as OneShotAgent,
     prompt,
+    jobEngine: runtime.jobEngine,
+    instanceId: runtime.replInstanceId,
     // Dual-run Slice 1 — enable the shadow divergence audit on the headless
     // seam (the interactive REPL wires it via ChatSession). Same local JSONL.
     paths:  runtime.paths,
@@ -4015,6 +4147,7 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
     // ref via their `resolveParentRunId` / `resolveParentSessionId`
     // callbacks so children get `spawned_from_run_id` populated.
     replRunStore:     runtime.replRunStore,
+    jobEngine:        runtime.jobEngine,
     replInstanceId:   runtime.replInstanceId,
     replParentRunRef: runtime.replParentRunRef,
     // v4.10 Slice 10.8 — durable Task-lite store. ChatSession's

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -82,6 +82,8 @@ import { openDaemonDb } from '../../core/v4/daemon/db/connection';
 import { createRunStore } from '../../core/v4/daemon/runStore';
 import { createJobEngine } from '../../core/v4/daemon/jobEngine';
 import type { JobEngine } from '../../core/v4/daemon/jobEngine';
+import { createJobControlAuthority } from '../../core/v4/daemon/jobControlAuthority';
+import { createActionAuthority } from '../../core/v4/actionAuthority';
 import { executeDurableJob } from '../../core/v4/daemon/jobLifecycle';
 import { computeTaskFinalization } from '../../core/v4/taskVerification';
 import { runWithProviderUsageContext } from '../../providers/v4/providerAttemptAccounting';
@@ -532,7 +534,7 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
       // under the default safe-only policy: risky/mutating tools auto-denied).
       const triggerBus = createTriggerBus({ db });
       const token = randomBytes(24).toString('hex');
-      const { enqueue, cancel } = createWorkbenchJobCommands({
+      const { enqueue, cancel, input, control, approval } = createWorkbenchJobCommands({
         db, triggerBus, jobEngine, runStore, instanceId: workbenchInstanceId,
       });
       // STEER path: the stop button cancels a running job by run id. We record
@@ -549,7 +551,19 @@ export async function main(argv: string[], opts: MainOptions = {}): Promise<numb
       ].filter((d): d is string => Boolean(d));
       const staticDir = staticCandidates.find((d) => existsSync(nodePath.join(d, 'index.html')));
       const port     = cmdOpts.port ?? Number(process.env.WORKBENCH_BRIDGE_PORT ?? 4280);
-      const bridge   = await startWorkbenchBridge({ reader: runStore, sessions, enqueue, cancel, token, staticDir, port });
+      const bridge   = await startWorkbenchBridge({
+        reader: runStore,
+        sessions,
+        enqueue,
+        cancel,
+        input,
+        control,
+        approval,
+        jobs: jobEngine,
+        token,
+        staticDir,
+        port,
+      });
       const dashUrl  = `http://${bridge.host}:${bridge.port}/`;
       const daemonUp = process.env.AIDEN_DAEMON === '1';
       process.stdout.write(
@@ -1200,6 +1214,8 @@ export async function buildAgentRuntime(
   ).run(replInstanceId, process.pid, os.hostname(), Date.now(), Date.now(), VERSION);
   const replRunStore = createRunStore({ db: replDb });
   const jobEngine = createJobEngine({ db: replDb });
+  const jobControlAuthority = createJobControlAuthority({ db: replDb, jobEngine });
+  const actionAuthority = createActionAuthority({ db: replDb, jobEngine });
   // v4.10 Slice 10.8 — durable Task-lite store. Shares the daemon.db
   // handle with replRunStore so /tasks listing + /adjust mutations
   // see the same WAL view chatSession's runAgentTurn writes through.
@@ -2281,6 +2297,19 @@ export async function buildAgentRuntime(
     memory: memoryManager,
     memoryGuard,
     approvalEngine,
+    actionAuthority,
+    policySnapshot: {
+      trustLevel: resolveConfiguredAutonomyLevel(config),
+      autonomyPolicy: 'runtime',
+      approvalMode: config.getValue<string>('agent.approval_mode', 'smart'),
+      toolMetadataVersion: VERSION,
+      sandboxPolicy: { roots: [process.cwd()], deny: [] },
+      networkPolicy: {},
+      pluginGrants: [],
+      mcpGrants: [],
+      workspaceOverrides: {},
+      jobOverrides: {},
+    },
     ssrfProtection,
     tirithScanner,
     skillLoader,
@@ -2754,6 +2783,7 @@ export async function buildAgentRuntime(
     fallbackAdapter: adapter,
     toolRegistry,
     toolExecutor,
+    toolContext: toolExecutorContext,
     auxiliaryClient,
     promptBuilder,
     promptBuilderOptions,
@@ -3684,6 +3714,8 @@ export async function buildAgentRuntime(
     // v4.6 Phase 2Q-B — REPL parent-run wiring.
     replRunStore,
     jobEngine,
+    jobControlAuthority,
+    actionAuthority,
     replInstanceId,
     replParentRunRef,
     // v4.10 Slice 10.8 — durable Task-lite store.
@@ -3717,6 +3749,8 @@ export interface AgentRuntime {
   ssrfProtection: SSRFProtection;
   tirithScanner: TirithScanner;
   approvalEngine: ApprovalEngine;
+  actionAuthority: import('../../core/v4/actionAuthority').ActionAuthority;
+  jobControlAuthority: import('../../core/v4/daemon/jobControlAuthority').JobControlAuthority;
   auxiliaryClient: AuxiliaryClient;
   callbacks: CliCallbacks;
   plannerGuard: PlannerGuard;
@@ -4148,6 +4182,7 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
     // callbacks so children get `spawned_from_run_id` populated.
     replRunStore:     runtime.replRunStore,
     jobEngine:        runtime.jobEngine,
+    jobControlAuthority: runtime.jobControlAuthority,
     replInstanceId:   runtime.replInstanceId,
     replParentRunRef: runtime.replParentRunRef,
     // v4.10 Slice 10.8 — durable Task-lite store. ChatSession's

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -72,6 +72,11 @@ export interface AidenPromptConfig {
   /** v4.14 — persistent plain-language idle hint shown in the footer when no
    *  ghost/dropdown is active (e.g. "Type your message · /help · /mode"). */
   hint?: string;
+  /** Route the main prompt through Display's fixed two-row terminal region.
+   * Dropdown/ghost content remains transient above that region. */
+  fixedComposer?: {
+    update: (value: string, hint: string) => void;
+  };
 }
 
 const DEFAULT_DROPDOWN_LIMIT = 8;
@@ -423,5 +428,9 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
 
   const footer = footerParts.length > 0 ? footerParts.join('\n') : undefined;
 
+  if (config.fixedComposer) {
+    if (status === 'idle') config.fixedComposer.update(value, config.hint ?? '');
+    return footer ?? '';
+  }
   return footer ? [line, footer] : line;
 });

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -72,10 +72,11 @@ export interface AidenPromptConfig {
   /** v4.14 — persistent plain-language idle hint shown in the footer when no
    *  ghost/dropdown is active (e.g. "Type your message · /help · /mode"). */
   hint?: string;
-  /** Route the main prompt through Display's fixed two-row terminal region.
-   * Dropdown/ghost content remains transient above that region. */
+  /** Route the main prompt through Display's fixed boxed terminal region.
+   * Inquirer remains input-only and its transient helper rows are suppressed. */
   fixedComposer?: {
-    update: (value: string, hint: string) => void;
+    update: (value: string, hint: string, cursorIndex: number) => void;
+    ready?: () => void;
   };
 }
 
@@ -169,6 +170,7 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [historyIdx, setHistoryIdx] = useState<number | null>(null);
+  const [cursorIndex, setCursorIndex] = useState(0);
   // Snapshot of the typed value when the user starts navigating
   // history — restored when they reach the bottom of the stack.
   const historyDraftRef = useRef('');
@@ -212,11 +214,14 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
         ? diagnosticReadline.isPaused()
         : undefined,
     });
-    emitComposerReadyForTests();
+    if (config.fixedComposer?.ready) config.fixedComposer.ready();
+    else emitComposerReadyForTests();
   }, []);
 
   useKeypress((key, rl) => {
     if (status !== 'idle') return;
+    const readlineCursor = (rl as { cursor?: number }).cursor ?? rl.line.length;
+    setCursorIndex(readlineCursor);
     turnIdleDiagnostic('composer.key', {
       generation: generationRef.current,
       key: key.name ?? null,
@@ -274,6 +279,7 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
         const accepted = value + ghost;
         rl.clearLine(0);
         rl.write(accepted);
+        setCursorIndex(accepted.length);
         rederive(accepted);
         return;
       }
@@ -299,24 +305,24 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
             historyDraftRef.current = value;
             setHistoryIdx(0);
             const next = config.history[0];
-            rl.clearLine(0); rl.write(next); rederive(next);
+            rl.clearLine(0); rl.write(next); setCursorIndex(next.length); rederive(next);
           } else if (historyIdx + 1 < config.history.length) {
             const ni = historyIdx + 1;
             setHistoryIdx(ni);
             const next = config.history[ni];
-            rl.clearLine(0); rl.write(next); rederive(next);
+            rl.clearLine(0); rl.write(next); setCursorIndex(next.length); rederive(next);
           }
         } else { // down
           if (historyIdx !== null) {
             if (historyIdx === 0) {
               setHistoryIdx(null);
               const draft = historyDraftRef.current;
-              rl.clearLine(0); rl.write(draft); rederive(draft);
+              rl.clearLine(0); rl.write(draft); setCursorIndex(draft.length); rederive(draft);
             } else {
               const ni = historyIdx - 1;
               setHistoryIdx(ni);
               const next = config.history[ni];
-              rl.clearLine(0); rl.write(next); rederive(next);
+              rl.clearLine(0); rl.write(next); setCursorIndex(next.length); rederive(next);
             }
           }
         }
@@ -418,10 +424,8 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
 
   const footerParts = [ghostLine, dropdownLines].filter((s): s is string => typeof s === 'string' && s.length > 0);
 
-  // v4.14 — persistent plain-language IDLE hint. When nothing else owns the
-  // footer (no ghost preview, no slash dropdown), show the calm hint so the
-  // idle bar is neat + informative every prompt, not a bare `▲`. Mirrors the
-  // busy bar's always-visible hint — one consistent, plain-language surface.
+  // Compatibility path: when Display does not own the fixed surface, show the
+  // idle hint only if no ghost preview or slash dropdown owns the footer.
   if (shouldShowIdleHint(footerParts.length > 0, config.hint, status)) {
     footerParts.push(`  ${dim(config.hint as string)}`);
   }
@@ -429,7 +433,9 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
   const footer = footerParts.length > 0 ? footerParts.join('\n') : undefined;
 
   if (config.fixedComposer) {
-    if (status === 'idle') config.fixedComposer.update(value, config.hint ?? '');
+    if (status === 'idle') {
+      config.fixedComposer.update(value, config.hint ?? '', cursorIndex);
+    }
     // Display is the sole renderer while the fixed region is active. Returning
     // helper, ghost, dropdown, or answer content here would give Inquirer's
     // screen manager a second prompt row above the reserved composer.

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -430,7 +430,10 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
 
   if (config.fixedComposer) {
     if (status === 'idle') config.fixedComposer.update(value, config.hint ?? '');
-    return footer ?? '';
+    // Display is the sole renderer while the fixed region is active. Returning
+    // helper, ghost, dropdown, or answer content here would give Inquirer's
+    // screen manager a second prompt row above the reserved composer.
+    return '';
   }
   return footer ? [line, footer] : line;
 });

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -319,7 +319,12 @@ export class CliCallbacks {
   }
 
   async withModalActivity<T>(run: () => Promise<T>, options?: ModalActivityOptions<T>): Promise<T> {
-    return this.activities.runModal(run, options);
+    this.display.pauseComposerSurface();
+    try {
+      return await this.activities.runModal(run, options);
+    } finally {
+      this.display.resumeComposerSurface();
+    }
   }
 
   completeActivityTurn(): void {

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -321,8 +321,15 @@ export class CliCallbacks {
   async withModalActivity<T>(run: () => Promise<T>, options?: ModalActivityOptions<T>): Promise<T> {
     this.display.pauseComposerSurface();
     try {
-      return await this.activities.runModal(run, options);
+      return await this.activities.runModal(run, {
+        ...options,
+        beforeActivityResume: () => {
+          this.display.resumeComposerSurface();
+          options?.beforeActivityResume?.();
+        },
+      });
     } finally {
+      // Idempotent fallback for a defensive failure before runModal's finally.
       this.display.resumeComposerSurface();
     }
   }

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -80,6 +80,7 @@ import type { SkillLoader } from '../../core/v4/skillLoader';
 import type { RuntimeResolver } from '../../providers/v4/runtimeResolver';
 import type { ConfigManager } from '../../core/v4/config';
 import type { PersonalityManager } from '../../core/v4/personality';
+import { runWithJobExecutionContext } from '../../core/v4/daemon/jobExecutionContext';
 import type { PluginLoader } from '../../core/v4/plugins/pluginLoader';
 import { ModelMetadata } from '../../core/v4/modelMetadata';
 import type { Message } from '../../providers/v4/types';
@@ -447,6 +448,8 @@ export interface ChatSessionOptions {
    * the REPL continues — never blocks user-facing turns.
    */
   replRunStore?:    import('../../core/v4/daemon/runStore').RunStore;
+  /** Authoritative durable Job/Attempt admission and transition service. */
+  jobEngine?:       import('../../core/v4/daemon/jobEngine').JobEngine;
   replInstanceId?:  string;
   /**
    * v4.10 Slice 10.8 — durable Task-lite store. Optional for tests +
@@ -1819,10 +1822,102 @@ export class ChatSession implements ChatSessionLike {
     // wrapped in try/catch and reduces to a logged warning. The
     // user-facing turn still runs.
     let replRunId: number | null = null;
+    let replTaskId: string | null = null;
     const replRunStore       = this.opts.replRunStore;
     const replInstanceId     = this.opts.replInstanceId;
     const replParentRunRef   = this.opts.replParentRunRef;
-    if (replRunStore && replInstanceId && this.sessionId) {
+    const jobEngine          = this.opts.jobEngine;
+    let jobAttemptId: string | null = null;
+    let jobGeneration: number | null = null;
+    let jobFenceToken: string | null = null;
+    let jobStateVersion = 0;
+    let attemptStateVersion = 0;
+    let jobLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
+    const stopJobLeaseHeartbeat = (): void => {
+      if (jobLeaseHeartbeat !== null) {
+        clearInterval(jobLeaseHeartbeat);
+        jobLeaseHeartbeat = null;
+      }
+    };
+
+    if (jobEngine) {
+      if (!replInstanceId || !this.sessionId) {
+        throw new Error('Durable Job admission requires an instance and session identity');
+      }
+      const admitted = jobEngine.submitJob({
+        entryPoint: 'interactive',
+        source: 'repl',
+        sessionId: this.sessionId,
+        workspaceId: process.cwd(),
+        instanceId: replInstanceId,
+        idempotencyNamespace: `interactive:${this.sessionId}`,
+        goal: userInput,
+        title: userInput,
+        channelId: 'repl',
+      });
+      replRunId = admitted.runId;
+      replTaskId = admitted.jobId;
+      jobAttemptId = admitted.attemptId;
+      if (replParentRunRef) {
+        replParentRunRef.runId = replRunId;
+        replParentRunRef.sessionId = this.sessionId;
+      }
+      const lease = jobEngine.claimAttempt({
+        attemptId: admitted.attemptId,
+        ownerId: replInstanceId,
+        ttlMs: 45_000,
+      });
+      if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
+        throw new Error(`Durable Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
+      }
+      jobFenceToken = lease.fenceToken;
+      jobGeneration = lease.generation;
+      attemptStateVersion = lease.stateVersion;
+      const attemptRunning = jobEngine.transitionAttempt({
+        attemptId: admitted.attemptId,
+        expectedStateVersion: attemptStateVersion,
+        generation: jobGeneration,
+        fenceToken: jobFenceToken,
+        to: 'running',
+        eventIdempotencyKey: `attempt-running:${admitted.attemptId}:${jobGeneration}`,
+        producer: 'repl',
+      });
+      if (!attemptRunning.applied || attemptRunning.stateVersion === undefined) {
+        throw new Error(`Durable Attempt start rejected: ${attemptRunning.conflict ?? 'unknown'}`);
+      }
+      attemptStateVersion = attemptRunning.stateVersion;
+      const jobRunning = jobEngine.transitionJob({
+        jobId: admitted.jobId,
+        attemptId: admitted.attemptId,
+        generation: jobGeneration,
+        fenceToken: jobFenceToken,
+        expectedStateVersion: jobStateVersion,
+        to: 'running',
+        eventIdempotencyKey: `job-running:${admitted.jobId}:${jobGeneration}`,
+        producer: 'repl',
+      });
+      if (!jobRunning.applied || jobRunning.stateVersion === undefined) {
+        throw new Error(`Durable Job start rejected: ${jobRunning.conflict ?? 'unknown'}`);
+      }
+      jobStateVersion = jobRunning.stateVersion;
+      jobLeaseHeartbeat = setInterval(() => {
+        if (!jobAttemptId || jobGeneration === null || !jobFenceToken || turnAbort.signal.aborted) return;
+        const renewed = jobEngine.renewAttemptLease({
+          attemptId: jobAttemptId,
+          ownerId: replInstanceId,
+          generation: jobGeneration,
+          fenceToken: jobFenceToken,
+          ttlMs: 45_000,
+        });
+        if (!renewed.applied || renewed.stateVersion === undefined) {
+          stopJobLeaseHeartbeat();
+          turnAbort.abort(new Error(`Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
+          return;
+        }
+        attemptStateVersion = renewed.stateVersion;
+      }, 15_000);
+      jobLeaseHeartbeat.unref?.();
+    } else if (replRunStore && replInstanceId && this.sessionId) {
       try {
         replRunId = replRunStore.create({
           sessionId:  this.sessionId,
@@ -1884,13 +1979,12 @@ export class ChatSession implements ChatSessionLike {
     // future tools (/adjust, future Memory promotion) can read the
     // original intent without parsing UI display rows. Best-effort —
     // any write failure logs once and the turn proceeds.
-    let replTaskId: string | null = null;
     // v4.13 Gap 1 — last ui_task_done payload the model emitted this
     // turn (collected via the onUiEvent handler). Read by the verify-
     // before-done gate: a declared failure finalizes honestly as failed.
     let declaredTaskDone: Record<string, unknown> | null = null;
     const replTaskStore = this.opts.replTaskStore;
-    if (replTaskStore && this.sessionId) {
+    if (!jobEngine && replTaskStore && this.sessionId) {
       try {
         replTaskId = replTaskStore.create({
           title:     userInput,
@@ -2174,10 +2268,13 @@ export class ChatSession implements ChatSessionLike {
         aborted: turnAbort.signal.aborted,
         pendingPromises: ['agent.runConversation'],
       });
-      const result = await runWithProviderUsageContext({
+      const runAgent = () => runWithProviderUsageContext({
         sessionId: this.sessionId,
         taskId: replTaskId,
         runId: replRunId,
+        jobId: replTaskId,
+        attemptId: jobAttemptId,
+        attemptGeneration: jobGeneration,
         entryPoint: 'cli',
         selectedMode,
         selectedProfile,
@@ -2331,6 +2428,27 @@ export class ChatSession implements ChatSessionLike {
             })
           : undefined,
       }));
+      const result = await (
+        jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && jobFenceToken
+          ? runWithJobExecutionContext({
+              engine: jobEngine,
+              jobId: replTaskId,
+              attemptId: jobAttemptId,
+              generation: jobGeneration,
+              fenceToken: jobFenceToken,
+              producer: 'repl',
+            }, runAgent)
+          : runAgent()
+      );
+      if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && replRunId !== null) {
+        currentProviderAttemptLedger()?.reconcileJobLinkage({
+          taskId: replTaskId,
+          runId: replRunId,
+          jobId: replTaskId,
+          attemptId: jobAttemptId,
+          attemptGeneration: jobGeneration,
+        });
+      }
       emitP2aDiag('turn.agent_run.complete', {
         aborted: turnAbort.signal.aborted,
         finishReason: result.finishReason,
@@ -2400,7 +2518,7 @@ export class ChatSession implements ChatSessionLike {
       // surface as 'interrupted' so it's visible in `runs list`;
       // `budget_exhausted` / `error` → failed. Wrapped in try/catch
       // so even a runStore write failure here can't crash the REPL.
-      if (replRunStore && replRunId !== null) {
+      if (!jobEngine && replRunStore && replRunId !== null) {
         try {
           const dbStatus =
             result.finishReason === 'stop'        ? 'completed'  :
@@ -2472,7 +2590,51 @@ export class ChatSession implements ChatSessionLike {
           err instanceof Error ? err.message : String(err));
       }
 
-      if (replTaskStore && replTaskId !== null && _fin) {
+      if (jobEngine && replTaskId !== null && jobAttemptId && jobGeneration !== null && jobFenceToken && _fin) {
+        stopJobLeaseHeartbeat();
+        const attemptTerminal =
+          result.finishReason === 'stop' ? 'succeeded' :
+          result.finishReason === 'interrupted' ? 'cancelled' :
+          'failed';
+        const attemptFinal = jobEngine.transitionAttempt({
+          attemptId: jobAttemptId,
+          expectedStateVersion: attemptStateVersion,
+          generation: jobGeneration,
+          fenceToken: jobFenceToken,
+          to: attemptTerminal,
+          eventIdempotencyKey: `attempt-final:${jobAttemptId}:${jobGeneration}`,
+          producer: 'repl',
+          finishReason: result.finishReason,
+        });
+        if (!attemptFinal.applied || attemptFinal.stateVersion === undefined) {
+          throw new Error(`Durable Attempt finalization rejected: ${attemptFinal.conflict ?? 'unknown'}`);
+        }
+        attemptStateVersion = attemptFinal.stateVersion;
+        const jobStatus =
+          result.finishReason === 'interrupted' ? 'cancelled' :
+          _fin.status === 'completed' || _fin.status === 'completed_unverified' ? 'completed' :
+          'failed';
+        const jobFinal = jobEngine.finalizeJob({
+          jobId: replTaskId,
+          attemptId: jobAttemptId,
+          generation: jobGeneration,
+          fenceToken: jobFenceToken,
+          expectedStateVersion: jobStateVersion,
+          status: jobStatus,
+          outcome: _fin.status,
+          finishReason: result.finishReason,
+          evidence: _fin.evidence,
+          jobCard: _fin.jobCard,
+          eventIdempotencyKey: `job-final:${replTaskId}:${jobGeneration}`,
+          producer: 'repl',
+        });
+        if (!jobFinal.applied || jobFinal.stateVersion === undefined) {
+          throw new Error(`Durable Job finalization rejected: ${jobFinal.conflict ?? 'unknown'}`);
+        }
+        jobStateVersion = jobFinal.stateVersion;
+      }
+
+      if (!jobEngine && replTaskStore && replTaskId !== null && _fin) {
         const fin = _fin;
         try {
           // v4.14 Pillar 5 Slice C — artifact_verified: the Pillar-3 verdict +
@@ -2749,6 +2911,7 @@ export class ChatSession implements ChatSessionLike {
         (err instanceof Error && err.name === 'AbortError') ||
         turnAbort.signal.aborted;
       if (_abortHit) {
+        stopJobLeaseHeartbeat();
         // v4.11 regression patch — stop the indicator BEFORE printing
         // the dim line so the setInterval can't paint a stray
         // "calling provider… (Ns)" line on top of our cancel
@@ -2764,7 +2927,37 @@ export class ChatSession implements ChatSessionLike {
           replParentRunRef.runId     = null;
           replParentRunRef.sessionId = null;
         }
-        if (replRunStore && replRunId !== null) {
+        if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && jobFenceToken) {
+          const attemptCancelled = jobEngine.transitionAttempt({
+            attemptId: jobAttemptId,
+            expectedStateVersion: attemptStateVersion,
+            generation: jobGeneration,
+            fenceToken: jobFenceToken,
+            to: 'cancelled',
+            eventIdempotencyKey: `attempt-cancelled:${jobAttemptId}:${jobGeneration}`,
+            producer: 'repl',
+            finishReason: 'interrupted',
+          });
+          if (attemptCancelled.applied && attemptCancelled.stateVersion !== undefined) {
+            attemptStateVersion = attemptCancelled.stateVersion;
+          }
+          const jobCancelled = jobEngine.transitionJob({
+            jobId: replTaskId,
+            attemptId: jobAttemptId,
+            generation: jobGeneration,
+            fenceToken: jobFenceToken,
+            expectedStateVersion: jobStateVersion,
+            to: 'cancelled',
+            eventIdempotencyKey: `job-cancelled:${replTaskId}:${jobGeneration}`,
+            producer: 'repl',
+            finishReason: 'interrupted',
+            terminalOutcome: 'cancelled',
+          });
+          if (jobCancelled.applied && jobCancelled.stateVersion !== undefined) {
+            jobStateVersion = jobCancelled.stateVersion;
+          }
+        }
+        if (!jobEngine && replRunStore && replRunId !== null) {
           try {
             replRunStore.setStatus(replRunId, 'interrupted', {
               finishReason: 'interrupted',
@@ -2772,7 +2965,7 @@ export class ChatSession implements ChatSessionLike {
             });
           } catch { /* persistence faults must not crash REPL */ }
         }
-        if (replTaskStore && replTaskId !== null) {
+        if (!jobEngine && replTaskStore && replTaskId !== null) {
           try { replTaskStore.setStatus(replTaskId, 'cancelled'); }
           catch { /* persistence faults must not crash REPL */ }
         }
@@ -2788,7 +2981,38 @@ export class ChatSession implements ChatSessionLike {
       // Visible in `aiden runs list` as a failed top-level row so
       // operators can correlate a chat error with whatever children
       // it had already kicked off this turn.
-      if (replRunStore && replRunId !== null) {
+      stopJobLeaseHeartbeat();
+      if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && jobFenceToken) {
+        const attemptFailed = jobEngine.transitionAttempt({
+          attemptId: jobAttemptId,
+          expectedStateVersion: attemptStateVersion,
+          generation: jobGeneration,
+          fenceToken: jobFenceToken,
+          to: 'failed',
+          eventIdempotencyKey: `attempt-failed:${jobAttemptId}:${jobGeneration}`,
+          producer: 'repl',
+          finishReason: 'error',
+        });
+        if (attemptFailed.applied && attemptFailed.stateVersion !== undefined) {
+          attemptStateVersion = attemptFailed.stateVersion;
+        }
+        const jobFailed = jobEngine.transitionJob({
+          jobId: replTaskId,
+          attemptId: jobAttemptId,
+          generation: jobGeneration,
+          fenceToken: jobFenceToken,
+          expectedStateVersion: jobStateVersion,
+          to: 'failed',
+          eventIdempotencyKey: `job-failed:${replTaskId}:${jobGeneration}`,
+          producer: 'repl',
+          finishReason: 'error',
+          terminalOutcome: 'failed',
+        });
+        if (jobFailed.applied && jobFailed.stateVersion !== undefined) {
+          jobStateVersion = jobFailed.stateVersion;
+        }
+      }
+      if (!jobEngine && replRunStore && replRunId !== null) {
         try {
           replRunStore.setStatus(replRunId, 'failed', {
             finishReason: 'error',
@@ -2804,7 +3028,7 @@ export class ChatSession implements ChatSessionLike {
       // Thrown errors out of runConversation → task status='failed'.
       // /tasks listing surfaces this so the user can re-issue the
       // prompt with a fresh task or /adjust the goal.
-      if (replTaskStore && replTaskId !== null) {
+      if (!jobEngine && replTaskStore && replTaskId !== null) {
         try {
           replTaskStore.setStatus(replTaskId, 'failed');
         } catch (e3) {
@@ -2873,6 +3097,7 @@ export class ChatSession implements ChatSessionLike {
         }
       } catch { /* defensive */ }
     } finally {
+      stopJobLeaseHeartbeat();
       if (p2aHeartbeat) clearInterval(p2aHeartbeat);
       emitP2aDiag('turn.finally.start', {
         aborted: turnAbort.signal.aborted,

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -80,7 +80,11 @@ import type { SkillLoader } from '../../core/v4/skillLoader';
 import type { RuntimeResolver } from '../../providers/v4/runtimeResolver';
 import type { ConfigManager } from '../../core/v4/config';
 import type { PersonalityManager } from '../../core/v4/personality';
-import { runWithJobExecutionContext } from '../../core/v4/daemon/jobExecutionContext';
+import {
+  runWithJobExecutionContext,
+  type JobExecutionContext,
+} from '../../core/v4/daemon/jobExecutionContext';
+import type { ProviderCallUsageContext } from '../../providers/v4/types';
 import type { PluginLoader } from '../../core/v4/plugins/pluginLoader';
 import { ModelMetadata } from '../../core/v4/modelMetadata';
 import type { Message } from '../../providers/v4/types';
@@ -450,6 +454,8 @@ export interface ChatSessionOptions {
   replRunStore?:    import('../../core/v4/daemon/runStore').RunStore;
   /** Authoritative durable Job/Attempt admission and transition service. */
   jobEngine?:       import('../../core/v4/daemon/jobEngine').JobEngine;
+  /** Durable input, steering, pause, resume, and cancellation authority. */
+  jobControlAuthority?: import('../../core/v4/daemon/jobControlAuthority').JobControlAuthority;
   replInstanceId?:  string;
   /**
    * v4.10 Slice 10.8 — durable Task-lite store. Optional for tests +
@@ -667,6 +673,10 @@ export class ChatSession implements ChatSessionLike {
    * listener attached for the duration of each turn.
    */
   private readonly duringTurnInput = new DuringTurnInput();
+  private activeDurableTarget: { jobId: string; attemptId: string; generation: number } | null = null;
+  private readonly durableQueueInputIds: string[] = [];
+  private durableInputOrdinal = 0;
+  private durableBoundarySequence = 0;
   private queueGuidanceShown = false;
   /** P2A transitional lease for prompts that overlap during-turn input. */
   private readonly inputAuthority = new InputAuthority();
@@ -675,7 +685,11 @@ export class ChatSession implements ChatSessionLike {
   setBusyMode(mode: BusyEnterMode): void { this.duringTurnInput.setMode(mode); }
   getBusyMode(): BusyEnterMode { return this.duringTurnInput.getMode(); }
   listQueue(): string[] { return this.duringTurnInput.peek(); }
-  clearQueue(): number { return this.duringTurnInput.clear(); }
+  clearQueue(): number {
+    if (this.sessionId) this.opts.jobControlAuthority?.inputs.cancelPendingForSession(this.sessionId);
+    this.durableQueueInputIds.length = 0;
+    return this.duringTurnInput.clear();
+  }
   queueCount(): number { return this.duringTurnInput.count(); }
 
   /**
@@ -837,6 +851,16 @@ export class ChatSession implements ChatSessionLike {
     // stale.
     if (this.opts.replParentRunRef) {
       this.opts.replParentRunRef.chatSessionId = this.sessionId;
+    }
+
+    // Rebuild the responsive in-memory projection from durable unconsumed
+    // records. The SQLite authority remains the source of truth.
+    if (this.opts.jobControlAuthority) {
+      for (const record of this.opts.jobControlAuthority.inputs.listPendingForSession(this.sessionId)) {
+        if (record.kind !== 'message' || record.content === null) continue;
+        this.duringTurnInput.enqueue(record.content);
+        this.durableQueueInputIds.push(record.inputId);
+      }
     }
 
     // 2. Boxed startup card.
@@ -1090,11 +1114,37 @@ export class ChatSession implements ChatSessionLike {
         // with a rule + blank, so suppress on the very first iteration.
         if (iter > 1) this.opts.display.printTurnSeparator();
         let input: string;
+        let inputAlreadyPersisted = false;
         // v4.12.1 Slice 2a — idle boundary: run a message the user queued
         // WHILE the previous turn was busy before blocking on fresh input.
         // Echo it so a queued message never fires invisibly.
         const queuedNext = this.duringTurnInput.dequeue();
         if (queuedNext !== null) {
+          inputAlreadyPersisted = true;
+          const durableInputId = this.durableQueueInputIds.shift();
+          if (durableInputId && this.opts.jobControlAuthority) {
+            const record = this.opts.jobControlAuthority.inputs.get(durableInputId);
+            if (record?.targetAttemptId && record.targetGeneration !== null) {
+              const claimed = this.opts.jobControlAuthority.inputs.claimNext({
+                jobId: record.jobId,
+                attemptId: record.targetAttemptId,
+                generation: record.targetGeneration,
+                inputId: durableInputId,
+                kinds: ['message'],
+              });
+              if (!claimed || claimed.inputId !== durableInputId) {
+                throw new Error(`Durable queued input claim failed: ${durableInputId}`);
+              }
+              const consumed = this.opts.jobControlAuthority.inputs.consume({
+                inputId: durableInputId,
+                attemptId: record.targetAttemptId,
+                generation: record.targetGeneration,
+              });
+              if (!consumed.applied && !consumed.duplicate) {
+                throw new Error(`Durable queued input consume failed: ${durableInputId}`);
+              }
+            }
+          }
           try { this.opts.display.dim(`▸ running queued: ${queuedNext}`); } catch { /* defensive */ }
           input = queuedNext;
           // Fall through to the slash/agent dispatch below with this input.
@@ -1203,7 +1253,7 @@ export class ChatSession implements ChatSessionLike {
         // slash commands + empty input + /quit all `continue` above and
         // never reach this line, matching the task's edge-case spec.
         this.opts.display.write(`  ${this.opts.display.rule()}\n`);
-        await this.runAgentTurn(input);
+        await this.runAgentTurn(input, inputAlreadyPersisted);
       }
     } finally {
       // v4.10 Slice 10.7a — REPL no longer active; any subsequent
@@ -1619,7 +1669,7 @@ export class ChatSession implements ChatSessionLike {
     }
   }
 
-  private async runAgentTurn(userInput: string): Promise<void> {
+  private async runAgentTurn(userInput: string, inputAlreadyPersisted = false): Promise<void> {
     // v4.11 Slice B — snapshot pre-turn history for /undo (in-memory,
     // bounded). Captured before any mutation; `this.history` is only
     // reassigned at end-of-turn, so this copy is the true pre-turn state.
@@ -1719,6 +1769,17 @@ export class ChatSession implements ChatSessionLike {
           // the Enter-modes), not as prompt-level slash commands.
           const word = submission.trim().toLowerCase();
           if (word === '/pause') {
+            const target = this.activeDurableTarget;
+            if (target && this.opts.jobControlAuthority) {
+              this.opts.jobControlAuthority.commands.request({
+                ...target,
+                kind: 'pause',
+                source: 'tui',
+                reason: 'user requested pause',
+                idempotencyNamespace: `tui-control:${this.sessionId}`,
+                idempotencyKey: `pause:${target.attemptId}:${++this.durableInputOrdinal}`,
+              });
+            }
             const ok = this.duringTurnInput.requestPause();
             try {
               this.opts.display.dim(ok ? '  ‖ paused — /resume to continue (Ctrl+C still stops)' : '  ‖ already paused');
@@ -1727,19 +1788,134 @@ export class ChatSession implements ChatSessionLike {
             return;
           }
           if (word === '/resume') {
-            const ok = this.duringTurnInput.resume();
+            let durableResumed = true;
+            const target = this.activeDurableTarget;
+            if (target && this.opts.jobControlAuthority && jobEngine && replInstanceId) {
+              try {
+                const resumed = this.opts.jobControlAuthority.commands.resume({
+                  jobId: target.jobId,
+                  source: 'tui',
+                  instanceId: replInstanceId,
+                  idempotencyNamespace: `tui-control:${this.sessionId}`,
+                  idempotencyKey: `resume:${target.attemptId}:${++this.durableInputOrdinal}`,
+                });
+                const lease = jobEngine.claimAttempt({
+                  attemptId: resumed.attemptId,
+                  ownerId: replInstanceId,
+                  ttlMs: 45_000,
+                });
+                if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
+                  throw new Error(`resumed Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
+                }
+                const attemptRunning = jobEngine.transitionAttempt({
+                  attemptId: resumed.attemptId,
+                  expectedStateVersion: lease.stateVersion,
+                  generation: lease.generation,
+                  fenceToken: lease.fenceToken,
+                  to: 'running',
+                  eventIdempotencyKey: `attempt-running:${resumed.attemptId}:${lease.generation}`,
+                  producer: 'repl',
+                });
+                const resumedJob = jobEngine.getJob(target.jobId);
+                if (!attemptRunning.applied || attemptRunning.stateVersion === undefined || !resumedJob) {
+                  throw new Error('resumed Attempt start rejected');
+                }
+                const jobRunning = jobEngine.transitionJob({
+                  jobId: target.jobId,
+                  attemptId: resumed.attemptId,
+                  generation: lease.generation,
+                  fenceToken: lease.fenceToken,
+                  expectedStateVersion: resumedJob.stateVersion,
+                  to: 'running',
+                  eventIdempotencyKey: `job-running:${target.jobId}:${lease.generation}`,
+                  producer: 'repl',
+                });
+                if (!jobRunning.applied || jobRunning.stateVersion === undefined) {
+                  throw new Error('resumed Job start rejected');
+                }
+                detachRuntimeControl?.();
+                jobAttemptId = resumed.attemptId;
+                replRunId = resumed.runId;
+                jobGeneration = lease.generation;
+                jobFenceToken = lease.fenceToken;
+                attemptStateVersion = attemptRunning.stateVersion;
+                jobStateVersion = jobRunning.stateVersion;
+                this.activeDurableTarget = {
+                  jobId: target.jobId,
+                  attemptId: resumed.attemptId,
+                  generation: lease.generation,
+                };
+                detachRuntimeControl = this.opts.jobControlAuthority.runtime.attach(resumed.attemptId, turnAbort);
+                if (jobExecutionContextRef) {
+                  jobExecutionContextRef.attemptId = resumed.attemptId;
+                  jobExecutionContextRef.generation = lease.generation;
+                  jobExecutionContextRef.fenceToken = lease.fenceToken;
+                }
+                if (providerUsageContextRef) {
+                  providerUsageContextRef.runId = resumed.runId;
+                  providerUsageContextRef.attemptId = resumed.attemptId;
+                  providerUsageContextRef.attemptGeneration = lease.generation;
+                }
+                startJobLeaseHeartbeat();
+              } catch (error) {
+                durableResumed = false;
+                try { this.opts.display.warn(`  resume failed: ${error instanceof Error ? error.message : String(error)}`); } catch { /* defensive */ }
+              }
+            }
+            const ok = durableResumed && this.duringTurnInput.resume();
             try {
               this.opts.display.dim(ok ? '  ▸ resumed' : '  ▸ not paused');
               this.opts.display.setBusyHint(this.duringTurnInput.busyHint());
             } catch { /* defensive */ }
             return;
           }
+          const target = this.activeDurableTarget;
+          let durableInputId: string | null = null;
+          if (target && this.opts.jobControlAuthority) {
+            const ordinal = ++this.durableInputOrdinal;
+            if (this.duringTurnInput.getMode() === 'redirect') {
+              this.opts.jobControlAuthority.steering.submit({
+                ...target,
+                sessionId: this.sessionId!,
+                source: 'tui',
+                action: 'redirect',
+                payload: submission,
+                idempotencyNamespace: `tui-steering:${this.sessionId}`,
+                idempotencyKey: `steer:${target.attemptId}:${ordinal}`,
+              });
+            } else if (this.duringTurnInput.getMode() === 'interrupt') {
+              this.opts.jobControlAuthority.commands.request({
+                ...target,
+                kind: 'interrupt',
+                source: 'tui',
+                reason: 'busy input requested interruption',
+                idempotencyNamespace: `tui-control:${this.sessionId}`,
+                idempotencyKey: `interrupt:${target.attemptId}:${ordinal}`,
+              });
+            } else {
+              const received = this.opts.jobControlAuthority.inputs.receive({
+                jobId: target.jobId,
+                targetAttemptId: target.attemptId,
+                targetGeneration: target.generation,
+                sessionId: this.sessionId!,
+                channelId: 'repl',
+                source: 'tui',
+                kind: 'message',
+                content: submission,
+                idempotencyNamespace: `tui-input:${this.sessionId}`,
+                idempotencyKey: `input:${target.attemptId}:${ordinal}`,
+              });
+              durableInputId = received.record.inputId;
+            }
+          }
           const act = this.duringTurnInput.onBusyEnter(submission);
           if (act.action === 'queued') {
+            if (durableInputId) this.durableQueueInputIds.push(durableInputId);
             try {
               const guidance = this.queueGuidanceShown ? '' : ' — FIFO after this turn · /queue to inspect';
               this.queueGuidanceShown = true;
-              this.opts.display.dim(`  ✓ queued (${act.count} pending)${guidance}`);
+              const acknowledgment = durableInputId ? ` · ${durableInputId}` : '';
+              this.opts.display.dim(`  ✓ queued (${act.count} pending)${acknowledgment}${guidance}`);
             } catch { /* defensive */ }
           } else if (act.action === 'steered') {
             // Slice 2b — buffered; lands after the current tool, next iteration.
@@ -1751,7 +1927,21 @@ export class ChatSession implements ChatSessionLike {
         // esc cancels the turn AND drops any pending steer (a hard interrupt
         // supersedes a nudge — no stale steer leaks onto the next turn). The
         // queue is kept (Slice-2a decision).
-        onEscape: () => { this.duringTurnInput.clearSteer(); requestTurnCancel(this.currentAbortController); },
+        onEscape: () => {
+          this.duringTurnInput.clearSteer();
+          const target = this.activeDurableTarget;
+          if (target && this.opts.jobControlAuthority) {
+            this.opts.jobControlAuthority.commands.request({
+              ...target,
+              kind: 'interrupt',
+              source: 'tui',
+              reason: 'escape interrupted the turn',
+              idempotencyNamespace: `tui-control:${this.sessionId}`,
+              idempotencyKey: `escape:${target.attemptId}:${++this.durableInputOrdinal}`,
+            });
+          }
+          requestTurnCancel(this.currentAbortController);
+        },
         onCtrlC:  () => { try { (process as NodeJS.Process).emit('SIGINT'); } catch { /* defensive */ } },
         // Slice 2c — paint the live during-turn buffer so the user sees their
         // keystrokes (not blind), labelled with what Enter will do. Empty
@@ -1832,12 +2022,36 @@ export class ChatSession implements ChatSessionLike {
     let jobFenceToken: string | null = null;
     let jobStateVersion = 0;
     let attemptStateVersion = 0;
+    let detachRuntimeControl: (() => void) | null = null;
+    let jobExecutionContextRef: JobExecutionContext | null = null;
+    let providerUsageContextRef: ProviderCallUsageContext | null = null;
     let jobLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
     const stopJobLeaseHeartbeat = (): void => {
       if (jobLeaseHeartbeat !== null) {
         clearInterval(jobLeaseHeartbeat);
         jobLeaseHeartbeat = null;
       }
+    };
+    const startJobLeaseHeartbeat = (): void => {
+      stopJobLeaseHeartbeat();
+      if (!jobEngine || !replInstanceId) return;
+      jobLeaseHeartbeat = setInterval(() => {
+        if (!jobAttemptId || jobGeneration === null || !jobFenceToken || turnAbort.signal.aborted) return;
+        const renewed = jobEngine.renewAttemptLease({
+          attemptId: jobAttemptId,
+          ownerId: replInstanceId,
+          generation: jobGeneration,
+          fenceToken: jobFenceToken,
+          ttlMs: 45_000,
+        });
+        if (!renewed.applied || renewed.stateVersion === undefined) {
+          stopJobLeaseHeartbeat();
+          turnAbort.abort(new Error(`Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
+          return;
+        }
+        attemptStateVersion = renewed.stateVersion;
+      }, 15_000);
+      jobLeaseHeartbeat.unref?.();
     };
 
     if (jobEngine) {
@@ -1858,6 +2072,36 @@ export class ChatSession implements ChatSessionLike {
       replRunId = admitted.runId;
       replTaskId = admitted.jobId;
       jobAttemptId = admitted.attemptId;
+      if (this.opts.jobControlAuthority && !inputAlreadyPersisted) {
+        const durableInput = this.opts.jobControlAuthority.inputs.receive({
+          jobId: admitted.jobId,
+          targetAttemptId: admitted.attemptId,
+          targetGeneration: 1,
+          sessionId: this.sessionId,
+          channelId: 'repl',
+          source: 'tui',
+          kind: 'message',
+          content: userInput,
+          idempotencyNamespace: `interactive-input:${this.sessionId}`,
+          idempotencyKey: `job:${admitted.jobId}:initial`,
+        });
+        const claimed = this.opts.jobControlAuthority.inputs.claimNext({
+          jobId: admitted.jobId,
+          attemptId: admitted.attemptId,
+          generation: 1,
+          inputId: durableInput.record.inputId,
+          kinds: ['message'],
+        });
+        if (!claimed) throw new Error(`Initial durable input claim failed: ${durableInput.record.inputId}`);
+        const consumed = this.opts.jobControlAuthority.inputs.consume({
+          inputId: durableInput.record.inputId,
+          attemptId: admitted.attemptId,
+          generation: 1,
+        });
+        if (!consumed.applied && !consumed.duplicate) {
+          throw new Error(`Initial durable input consume failed: ${durableInput.record.inputId}`);
+        }
+      }
       if (replParentRunRef) {
         replParentRunRef.runId = replRunId;
         replParentRunRef.sessionId = this.sessionId;
@@ -1900,23 +2144,21 @@ export class ChatSession implements ChatSessionLike {
         throw new Error(`Durable Job start rejected: ${jobRunning.conflict ?? 'unknown'}`);
       }
       jobStateVersion = jobRunning.stateVersion;
-      jobLeaseHeartbeat = setInterval(() => {
-        if (!jobAttemptId || jobGeneration === null || !jobFenceToken || turnAbort.signal.aborted) return;
-        const renewed = jobEngine.renewAttemptLease({
-          attemptId: jobAttemptId,
-          ownerId: replInstanceId,
-          generation: jobGeneration,
-          fenceToken: jobFenceToken,
-          ttlMs: 45_000,
-        });
-        if (!renewed.applied || renewed.stateVersion === undefined) {
-          stopJobLeaseHeartbeat();
-          turnAbort.abort(new Error(`Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
-          return;
-        }
-        attemptStateVersion = renewed.stateVersion;
-      }, 15_000);
-      jobLeaseHeartbeat.unref?.();
+      this.activeDurableTarget = {
+        jobId: admitted.jobId,
+        attemptId: admitted.attemptId,
+        generation: jobGeneration,
+      };
+      jobExecutionContextRef = {
+        engine: jobEngine,
+        jobId: admitted.jobId,
+        attemptId: admitted.attemptId,
+        generation: jobGeneration,
+        fenceToken: jobFenceToken,
+        producer: 'repl',
+      };
+      detachRuntimeControl = this.opts.jobControlAuthority?.runtime.attach(admitted.attemptId, turnAbort) ?? null;
+      startJobLeaseHeartbeat();
     } else if (replRunStore && replInstanceId && this.sessionId) {
       try {
         replRunId = replRunStore.create({
@@ -2268,7 +2510,7 @@ export class ChatSession implements ChatSessionLike {
         aborted: turnAbort.signal.aborted,
         pendingPromises: ['agent.runConversation'],
       });
-      const runAgent = () => runWithProviderUsageContext({
+      providerUsageContextRef = {
         sessionId: this.sessionId,
         taskId: replTaskId,
         runId: replRunId,
@@ -2278,7 +2520,8 @@ export class ChatSession implements ChatSessionLike {
         entryPoint: 'cli',
         selectedMode,
         selectedProfile,
-      }, () => this.opts.agent.runConversation(baseHistory, {
+      };
+      const runAgent = () => runWithProviderUsageContext(providerUsageContextRef!, () => this.opts.agent.runConversation(baseHistory, {
         stream: streamingEnabled,
         sessionId: this.sessionId,
         taskId: replTaskId,
@@ -2300,10 +2543,32 @@ export class ChatSession implements ChatSessionLike {
         // v4.12.1 Slice 2b — mid-turn steer pull. The loop drains this at its
         // safe boundary and injects the nudge as tool-stream context. The
         // controller owns the buffer; an interrupt clears it (below).
-        drainSteer: () => this.duringTurnInput.drainSteer(),
+        drainSteer: () => {
+          const projected = this.duringTurnInput.drainSteer();
+          const target = this.activeDurableTarget;
+          if (!target || !this.opts.jobControlAuthority) return projected;
+          const appliedPayloads: string[] = [];
+          while (true) {
+            const applied = this.opts.jobControlAuthority.steering.applyNext({
+              ...target,
+              safeBoundarySequence: ++this.durableBoundarySequence,
+              instanceId: replInstanceId ?? undefined,
+            });
+            if (!applied) break;
+            if (applied.state === 'applied' && applied.payload?.trim()) appliedPayloads.push(applied.payload);
+          }
+          return appliedPayloads.length > 0 ? appliedPayloads.join('\n') : projected;
+        },
         // v4.14 — PAUSE gate. The loop awaits this at the SAME safe boundary;
         // /pause freezes the turn, /resume (or a Ctrl+C abort) unblocks it.
-        waitForResumeIfPaused: (sig) => this.duringTurnInput.waitWhilePaused(sig),
+        waitForResumeIfPaused: async (sig) => {
+          const target = this.activeDurableTarget;
+          if (target && this.opts.jobControlAuthority && this.duringTurnInput.isPaused()) {
+            const paused = this.opts.jobControlAuthority.commands.applyPendingAtBoundary({ jobId: target.jobId });
+            if (paused.applied) stopJobLeaseHeartbeat();
+          }
+          await this.duringTurnInput.waitWhilePaused(sig);
+        },
         // v4.11 Slice 4 — expose the per-turn runtime context to
         // tools via `agent.getCurrentTurnContext()`. The spawn /
         // fanout facades read it to thread parent signal + cost
@@ -2429,15 +2694,8 @@ export class ChatSession implements ChatSessionLike {
           : undefined,
       }));
       const result = await (
-        jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && jobFenceToken
-          ? runWithJobExecutionContext({
-              engine: jobEngine,
-              jobId: replTaskId,
-              attemptId: jobAttemptId,
-              generation: jobGeneration,
-              fenceToken: jobFenceToken,
-              producer: 'repl',
-            }, runAgent)
+        jobExecutionContextRef
+          ? runWithJobExecutionContext(jobExecutionContextRef, runAgent)
           : runAgent()
       );
       if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && replRunId !== null) {
@@ -3113,6 +3371,9 @@ export class ChatSession implements ChatSessionLike {
         activityTimers: this.opts.callbacks.activityTimerCount?.() ?? 0,
         modalPauseDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
       });
+      detachRuntimeControl?.();
+      detachRuntimeControl = null;
+      if (this.activeDurableTarget?.attemptId === jobAttemptId) this.activeDurableTarget = null;
       // v4.11 Slice 3 — release the per-turn cancel handles. ORDER
       // MATTERS:
       //   1. Drop activeTurnId FIRST so any late callbacks already

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -112,6 +112,7 @@ import {
 } from './promotionPrompt';
 import path from 'node:path';
 import { existsSync } from 'node:fs';
+import { Writable } from 'node:stream';
 import {
   enableBracketedPaste,
   disableBracketedPaste,
@@ -135,6 +136,7 @@ import { DuringTurnInput, resolveConfiguredBusyMode, type BusyEnterMode } from '
 import { attachTurnInputListener } from './turnInputListener';
 import { InputAuthority } from './inputAuthority';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
+import { emitComposerReadyForTests } from './composerReadiness';
 import { requestTurnCancel } from './frame/interruptControls';
 import {
   renderStartupDashboard,
@@ -1008,7 +1010,7 @@ export class ChatSession implements ChatSessionLike {
       process.on('exit', exitHandler);
     }
 
-    // The interactive terminal owns a persistent two-row bottom region before
+    // The interactive terminal owns a persistent boxed bottom region before
     // the first composer mounts. Compatibility/non-TTY paths retain the
     // historical post-turn status output.
     if (this.usesFixedBottomRegion()) this.renderStatusLine();
@@ -1958,10 +1960,9 @@ export class ChatSession implements ChatSessionLike {
         },
       },
     });
-    // v4.14 BUG 2 — show the input lane the MOMENT the turn starts (a persistent
-    // plain-language hint), so the user sees they can type/steer/queue without
-    // having to type first. It rides the same owned bottom row (indicator / tool
-    // row) that already survives streaming, and is cleared at turn end below.
+    // Establish busy-mode ownership the moment the turn starts so the boxed
+    // composer is available for steering or queueing before any keystroke.
+    // The existing input buffer remains the sole queue owner.
     try { this.opts.display.setBusyHint(this.duringTurnInput.busyHint()); } catch { /* defensive */ }
     // Helper: wrap a callback so it only fires for the live turn.
     // R1 guard — late events from a cancelled turn early-return.
@@ -4197,23 +4198,33 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
         }
         const fixedBottomRegion = typeof opts.display?.fixedBottomRegionEnabled === 'function'
           && opts.display.fixedBottomRegionEnabled();
+        const promptOutput = fixedBottomRegion
+          ? new Writable({
+              write(_chunk, _encoding, done) {
+                done();
+              },
+            })
+          : undefined;
         const value = await aidenPrompt({
           message:  prompt,
           commands: opts.commands ?? [],
           history,
           theme:    promptTheme as never,
-          // v4.14 — persistent plain-language idle hint on the MAIN prompt (the
-          // "▲" line), so idle shows a neat bar with a hint, not a bare glyph.
+          // Compatibility hint for the non-fixed prompt path. The fixed path
+          // communicates readiness through its labeled composer surface.
           // Skipped on the "… " multi-line continuation.
           hint:     prompt.includes('▲') ? 'Type your message · /help · /mode' : undefined,
           fixedComposer: fixedBottomRegion
             ? {
-                update: (draft, hint) => {
-                  opts.display?.setIdleComposer(draft, hint);
+                update: (draft, hint, cursorIndex) => {
+                  opts.display?.setIdleComposer(draft, hint, cursorIndex);
+                },
+                ready: () => {
+                  emitComposerReadyForTests((marker) => opts.display?.writeAfterComposerCursor(marker));
                 },
               }
             : undefined,
-        });
+        }, { output: promptOutput });
         if (fixedBottomRegion && prompt.includes('▲')) {
           opts.display.submitIdleComposer(
             value ?? '',

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -822,6 +822,7 @@ export class ChatSession implements ChatSessionLike {
     this.opts.agent.setActiveModel(providerId, modelId);
     this.currentProviderId = providerId;
     this.currentModelId = modelId;
+    if (this.usesFixedBottomRegion()) this.renderStatusLine();
   }
 
   /** Skill slash command activation hook (Phase 14c). */
@@ -1007,6 +1008,11 @@ export class ChatSession implements ChatSessionLike {
       process.on('exit', exitHandler);
     }
 
+    // The interactive terminal owns a persistent two-row bottom region before
+    // the first composer mounts. Compatibility/non-TTY paths retain the
+    // historical post-turn status output.
+    if (this.usesFixedBottomRegion()) this.renderStatusLine();
+
     // 4. Main loop.
     // Tier-3.1.1: feed the new aidenPrompt with live slash commands +
     // recent history so ghost-text + dropdown work out of the box.
@@ -1017,6 +1023,7 @@ export class ChatSession implements ChatSessionLike {
       createDefaultPromptApi({
         commands:     this.opts.commandRegistry.list(),
         loadHistory:  () => loadRecent(500),
+        display:      this.opts.display,
       });
     const max = this.opts.maxIterations ?? Number.POSITIVE_INFINITY;
     let iter = 0;
@@ -1974,6 +1981,7 @@ export class ChatSession implements ChatSessionLike {
     // Phase 22 Task 4: status bar reflects the live phase. Set on
     // entry, cleared in both success and error paths below.
     this.setStatusState({ kind: 'generating', sinceMs: Date.now() });
+    if (this.usesFixedBottomRegion()) this.renderStatusLine();
     // v4.8.1 Slice 2 hotfix #3 — removed the prior Tier-3.1a dim
     // rule between the user input echo and the agent reply. The dim
     // colour read as a near-blank row in live smoke, and stacked
@@ -3753,8 +3761,7 @@ export class ChatSession implements ChatSessionLike {
     // with brand prefix (`Aiden v<X.Y>`), session uptime (sessionMs
     // re-enabled), and spelled-out `last <elapsed>` for the per-turn
     // timer. Mid (≥100) and narrow (<100) tiers unchanged.
-    display.write(
-      '\n' + display.statusFooter({
+    const statusArgs = {
         provider,
         model,
         ctxUsed: usedTokens,
@@ -3763,8 +3770,29 @@ export class ChatSession implements ChatSessionLike {
         turnCount: this.turnCount,
         sessionMs: Date.now() - this.startedAt,
         state:     this.lastTurnOutcome,
-      }) + '\n\n',
-    );
+    } as const;
+
+    if (this.usesFixedBottomRegion()) {
+      display.setStatusFooter(() => display.statusFooter({
+        ...statusArgs,
+        elapsedMs: this.statusState.kind === 'generating'
+          ? Date.now() - this.statusState.sinceMs
+          : this.lastTurnElapsedMs,
+        sessionMs: Date.now() - this.startedAt,
+      }));
+      return;
+    }
+
+    display.write('\n' + display.statusFooter(statusArgs) + '\n\n');
+  }
+
+  /** Test and injected integrations may provide a partial Display surface. */
+  private usesFixedBottomRegion(): boolean {
+    const candidate = this.opts.display as Display & {
+      fixedBottomRegionEnabled?: () => boolean;
+    };
+    return typeof candidate.fixedBottomRegionEnabled === 'function'
+      && candidate.fixedBottomRegionEnabled();
   }
 
   // ── Input ──────────────────────────────────────────────────────────
@@ -4109,6 +4137,7 @@ export function formatDuration(ms: number): string {
 interface DefaultPromptOpts {
   commands?:    SlashCommandLite[];
   loadHistory?: () => Promise<string[]>;
+  display?:     Display;
 }
 
 function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
@@ -4164,6 +4193,8 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
           }
           return value ?? '';
         }
+        const fixedBottomRegion = typeof opts.display?.fixedBottomRegionEnabled === 'function'
+          && opts.display.fixedBottomRegionEnabled();
         const value = await aidenPrompt({
           message:  prompt,
           commands: opts.commands ?? [],
@@ -4173,7 +4204,20 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
           // "▲" line), so idle shows a neat bar with a hint, not a bare glyph.
           // Skipped on the "… " multi-line continuation.
           hint:     prompt.includes('▲') ? 'Type your message · /help · /mode' : undefined,
+          fixedComposer: fixedBottomRegion
+            ? {
+                update: (draft, hint) => {
+                  opts.display?.setIdleComposer(draft, hint);
+                },
+              }
+            : undefined,
         });
+        if (fixedBottomRegion && prompt.includes('▲')) {
+          opts.display.submitIdleComposer(
+            value ?? '',
+            'Type your message · /help · /mode',
+          );
+        }
         const trimmed = (value ?? '').trim();
         // Append to disk history. Awaited so the write flushes before
         // the agent loop progresses — `/quit` exits the process and

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -3656,8 +3656,10 @@ export class ChatSession implements ChatSessionLike {
     // the user-input zone together with the new bottom-rule emission
     // in the REPL loop.
     display.write('\n');
-    display.write(display.bottomPromptHint() + '\n');
-    display.write('\n');
+    if (!this.usesFixedBottomRegion()) {
+      display.write(display.bottomPromptHint() + '\n');
+      display.write('\n');
+    }
     display.write(`  ${display.rule(Math.max(1, columns - 4))}\n`);
   }
 

--- a/cli/v4/commands/mcp.ts
+++ b/cli/v4/commands/mcp.ts
@@ -79,6 +79,7 @@ import {
 } from '../../../core/v4/daemon';
 import { VERSION as AIDEN_VERSION } from '../../../core/version';
 import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createActionAuthority } from '../../../core/v4/actionAuthority';
 import type { RunStore } from '../../../core/v4/daemon/runStore';
 import type { Db } from '../../../core/v4/daemon/db/connection';
 // v4.6 Phase 3A — operator kill-switch. Initialised here so
@@ -174,6 +175,7 @@ async function buildMcpRuntime(opts: RunMcpOptions = {}) {
   ).run(mcpInstanceId, process.pid, os.hostname(), Date.now(), Date.now(), AIDEN_VERSION);
   const mcpRunStore = createRunStore({ db: mcpDb });
   const mcpJobEngine = createJobEngine({ db: mcpDb });
+  const actionAuthority = createActionAuthority({ db: mcpDb, jobEngine: mcpJobEngine });
 
   const toolContext = {
     cwd: process.cwd(),
@@ -182,6 +184,19 @@ async function buildMcpRuntime(opts: RunMcpOptions = {}) {
     memory,
     processes,
     skillLoader,
+    actionAuthority,
+    policySnapshot: {
+      trustLevel: 'Observer',
+      autonomyPolicy: 'deny_without_interactive_channel',
+      approvalMode: 'manual',
+      toolMetadataVersion: AIDEN_VERSION,
+      sandboxPolicy: { roots: [process.cwd()], deny: [] },
+      networkPolicy: {},
+      pluginGrants: [],
+      mcpGrants: [],
+      workspaceOverrides: {},
+      jobOverrides: {},
+    },
     // approvalEngine / ssrfProtection / tirithScanner / memoryGuard
     // intentionally omitted — see header comment.
   };

--- a/cli/v4/commands/mcp.ts
+++ b/cli/v4/commands/mcp.ts
@@ -78,6 +78,9 @@ import {
   createRunStore,
 } from '../../../core/v4/daemon';
 import { VERSION as AIDEN_VERSION } from '../../../core/version';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import type { RunStore } from '../../../core/v4/daemon/runStore';
+import type { Db } from '../../../core/v4/daemon/db/connection';
 // v4.6 Phase 3A — operator kill-switch. Initialised here so
 // MCP-side `subagent_fanout` (and any future MCP-side
 // `spawn_sub_agent` exposure) reads from the same marker file the
@@ -162,6 +165,16 @@ async function buildMcpRuntime(opts: RunMcpOptions = {}) {
 
   const processes = new ProcessRegistry();
 
+  const mcpInstanceId = `mcp-${randomUUID().slice(0, 8)}`;
+  const mcpDb = openDaemonDb(daemonDbPath(paths.root));
+  mcpDb.prepare(
+    `INSERT OR IGNORE INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(mcpInstanceId, process.pid, os.hostname(), Date.now(), Date.now(), AIDEN_VERSION);
+  const mcpRunStore = createRunStore({ db: mcpDb });
+  const mcpJobEngine = createJobEngine({ db: mcpDb });
+
   const toolContext = {
     cwd: process.cwd(),
     paths,
@@ -201,9 +214,16 @@ async function buildMcpRuntime(opts: RunMcpOptions = {}) {
     memoryManager: memory,
     skillLoader,
     logger: logger.child('subagent'),
+    db: mcpDb,
+    runStore: mcpRunStore,
+    jobEngine: mcpJobEngine,
+    instanceId: mcpInstanceId,
   });
 
-  return { paths, registry, skillLoader, toolContext, logger };
+  return {
+    paths, registry, skillLoader, toolContext, logger,
+    jobAuthority: { engine: mcpJobEngine, instanceId: mcpInstanceId },
+  };
 }
 
 /** Mirror of `buildAgentFallbackSlots` (cli/v4/aidenCLI.ts) inlined
@@ -243,6 +263,10 @@ interface WireOptions {
   memoryManager: MemoryManager;
   skillLoader: SkillLoader;
   logger: import('../../../core/v4/logger/logger').Logger;
+  db: Db;
+  runStore: RunStore;
+  jobEngine: JobEngine;
+  instanceId: string;
 }
 
 /** Resolve adapter + wire `subagent_fanout` into the MCP registry.
@@ -298,14 +322,9 @@ async function wireSubagentFanout(opts: WireOptions): Promise<void> {
   // REPL writes to. Operators can then see MCP-side fanout
   // activity under `aiden runs list --include-children`. Same
   // WAL-coexistence model as REPL — connection.ts caches per-path.
-  const mcpInstanceId = `mcp-${randomUUID().slice(0, 8)}`;
-  const mcpDb         = openDaemonDb(daemonDbPath(opts.paths.root));
-  mcpDb.prepare(
-    `INSERT OR IGNORE INTO daemon_instances
-       (instance_id, pid, hostname, started_at, last_heartbeat, version)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-  ).run(mcpInstanceId, process.pid, os.hostname(), Date.now(), Date.now(), AIDEN_VERSION);
-  const mcpRunStore = createRunStore({ db: mcpDb });
+  const mcpInstanceId = opts.instanceId;
+  const mcpDb = opts.db;
+  const mcpRunStore = opts.runStore;
 
   // v4.6 Phase 3b — self-improvement loop singleton against the
   // same daemon.db. MCP-side spawn_sub_agent / subagent_fanout
@@ -369,6 +388,7 @@ async function wireSubagentFanout(opts: WireOptions): Promise<void> {
       parentProviderId: providerId,
       parentModelId:    modelId,
       runStore:         mcpRunStore,
+      jobEngine:        opts.jobEngine,
       instanceId:       mcpInstanceId,
       logger:           opts.logger,
     },
@@ -470,7 +490,7 @@ export async function runMcpSubcommand(
         }
       }
 
-      const { registry, skillLoader, toolContext, logger } =
+      const { registry, skillLoader, toolContext, logger, jobAuthority } =
         await buildMcpRuntime(opts);
 
       await startStdioMcpServer({
@@ -478,6 +498,7 @@ export async function runMcpSubcommand(
         skillLoader,
         toolContext,
         logger,
+        jobAuthority,
       });
 
       // Block forever — parent closes stdio when the client disconnects,

--- a/cli/v4/commands/status.ts
+++ b/cli/v4/commands/status.ts
@@ -85,7 +85,12 @@ export const status: SlashCommand = {
     );
     display.write('\n');
     display.write(`  ${display.rule()}\n`);
-    display.write(display.bottomPromptHint() + '\n');
+    if (
+      typeof display.fixedBottomRegionEnabled !== 'function'
+      || !display.fixedBottomRegionEnabled()
+    ) {
+      display.write(display.bottomPromptHint() + '\n');
+    }
     display.write('\n');
     return {};
   },

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -21,8 +21,9 @@
  * hint change / resize — no per-write flicker. This is the reusable
  * composer-ownership seam the future dashboard's steering bar drives too.
  *
- * Shipped OPT-IN via AIDEN_COMPOSER_LANE=1 while the live cursor behaviour is
- * proven in real-terminal smoke; the default render path is untouched.
+ * Enabled for interactive terminals by default. AIDEN_COMPOSER_LANE=0 is an
+ * emergency compatibility escape hatch; non-interactive output never uses the
+ * lane.
  *
  * The escape-sequence builders are pure + unit-tested; the owner wires them to
  * a write sink + a terminal-dimensions source and tracks activate/resize state.
@@ -91,6 +92,7 @@ export interface LaneSink {
  */
 export class ComposerLane {
   private active = false;
+  private sourceText = '';
   private lastText = '';
   private unsubResize: (() => void) | null = null;
 
@@ -114,6 +116,7 @@ export class ComposerLane {
    *  text is unchanged, so a redundant paint never flickers. */
   paint(text: string): void {
     if (!this.active) return;
+    this.sourceText = text;
     const fitted = fitLane(text, this.sink.cols());
     if (fitted === this.lastText) return;
     this.lastText = fitted;
@@ -125,7 +128,7 @@ export class ComposerLane {
     if (!this.active) return;
     const rows = this.sink.rows();
     this.sink.write(reserveSeq(rows));
-    const text = this.lastText;
+    const text = this.sourceText;
     this.lastText = '';        // force the repaint (dims changed)
     this.paint(text);
   }
@@ -137,13 +140,13 @@ export class ComposerLane {
     this.unsubResize?.();
     this.unsubResize = null;
     this.active = false;
+    this.sourceText = '';
     this.lastText = '';
   }
 }
 
-/** True when the fixed-lane renderer is opted into. Default OFF (unchanged
- *  render path) until the live cursor behaviour is proven in real-terminal
- *  smoke; flip the default here once it is. */
+/** True unless the fixed-lane renderer is explicitly disabled. Display also
+ * requires a TTY before emitting terminal control sequences. */
 export function composerLaneEnabled(): boolean {
-  return process.env.AIDEN_COMPOSER_LANE === '1';
+  return process.env.AIDEN_COMPOSER_LANE !== '0';
 }

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -5,148 +5,159 @@
  * Aiden — local-first agent.
  */
 /**
- * cli/v4/composerLane.ts — v4.14 the single-owner FIXED bottom composer lane.
+ * Single-owner fixed terminal bottom region.
  *
- * THE PROBLEM it solves: today the during-turn composer is only a SUFFIX woven
- * into whichever transient status row is live (the activity indicator, a tool
- * row), and it is cleared the moment token streaming begins — so while a turn
- * streams there is no anchored input line, and typing is blind. There is no
- * single renderer that owns a fixed composer region.
+ * One DEC scroll region keeps transcript, activity, and tool output above two
+ * reserved rows. The second-last row is the composer and the last row is the
+ * provider/model/context/timer status strip. Modal prompts release both rows
+ * together; resize re-anchors and repaints both from their full source values.
  *
- * THE FIX: ONE owner reserves the bottom terminal row via a DEC scroll region
- * (DECSTBM). All turn output — streaming text, tool rows, the indicator —
- * scrolls inside the region ABOVE the lane; the terminal itself guarantees the
- * bottom row is never touched by that output, so the composer can never be
- * overwritten, pushed, or garbled. The lane repaints ONLY on a keystroke /
- * hint change / resize — no per-write flicker. This is the reusable
- * composer-ownership seam the future dashboard's steering bar drives too.
- *
- * Enabled for interactive terminals by default. AIDEN_COMPOSER_LANE=0 is an
- * emergency compatibility escape hatch; non-interactive output never uses the
- * lane.
- *
- * The escape-sequence builders are pure + unit-tested; the owner wires them to
- * a write sink + a terminal-dimensions source and tracks activate/resize state.
+ * AIDEN_COMPOSER_LANE=0 remains the compatibility escape hatch. Non-TTY output
+ * never emits terminal-control sequences.
  */
 
-// ── pure escape-sequence builders (unit-tested; no I/O) ──────────────────────
-
 const ESC = '\x1b';
-/** DECSC / DECRC — save / restore cursor (position, not content). */
 const SAVE = `${ESC}7`;
 const RESTORE = `${ESC}8`;
 
 /**
- * Reserve the bottom `laneRows` rows by confining the scroll region to the rows
- * ABOVE them (DECSTBM `CSI top;bottom r`). Cursor-safe: DECSTBM homes the
- * cursor, so we save before and restore after — output keeps flowing from where
- * it was, now bounded to the region. `rows` = terminal height (1-based).
+ * Confine scrolling to the rows above the fixed region and place the transcript
+ * cursor at the bottom of that scrollable area. The explicit cursor placement
+ * avoids restoring a cursor that was already inside a newly reserved row.
  */
-export function reserveSeq(rows: number, laneRows = 1): string {
+export function reserveSeq(rows: number, laneRows = 2): string {
   const bottom = Math.max(1, rows - Math.max(1, laneRows));
-  return `${SAVE}${ESC}[1;${bottom}r${RESTORE}`;
+  return `${ESC}[1;${bottom}r${ESC}[${bottom};1H`;
 }
 
-/**
- * Paint `text` on the reserved bottom row, cursor-safe: save → jump to the
- * bottom row col 1 → clear line → write → restore. The saved/restored cursor is
- * the output cursor inside the region, so painting the lane never disturbs the
- * flowing output above it. `text` must already be width-fit (no wrap).
- */
-export function paintSeq(rows: number, text: string): string {
-  return `${SAVE}${ESC}[${rows};1H${ESC}[2K${text}${RESTORE}`;
+/** Paint one fixed row without disturbing the transcript cursor. */
+export function paintSeq(rows: number, text: string, offsetFromBottom = 0): string {
+  const row = Math.max(1, rows - Math.max(0, offsetFromBottom));
+  return `${SAVE}${ESC}[${row};1H${ESC}[2K${text}${RESTORE}`;
 }
 
-/**
- * Tear down: restore full-screen scrolling (`CSI r` with no params) and clear
- * the lane row so nothing is left pinned once the turn ends.
- */
-export function teardownSeq(rows: number): string {
-  return `${ESC}[r${SAVE}${ESC}[${rows};1H${ESC}[2K${RESTORE}`;
+/** Restore full-screen scrolling and clear every row owned by the region. */
+export function teardownSeq(rows: number, laneRows = 2): string {
+  let clear = '';
+  for (let offset = Math.max(1, laneRows) - 1; offset >= 0; offset -= 1) {
+    clear += `${ESC}[${Math.max(1, rows - offset)};1H${ESC}[2K`;
+  }
+  return `${ESC}[r${SAVE}${clear}${RESTORE}`;
 }
 
-/** Tail-fit `text` to `cols` columns (visible width), ellipsis at the FRONT so
- *  the most-recent keystrokes (the cursor end) stay visible. ANSI-free input. */
+/** Tail-fit composer text so the cursor end remains visible. */
 export function fitLane(text: string, cols: number): string {
   const width = Math.max(4, cols);
   if (text.length <= width) return text;
   return '…' + text.slice(-(width - 1));
 }
 
-// ── the owner ────────────────────────────────────────────────────────────────
+type StatusSource = string | (() => string);
+
+/** ANSI-aware front truncation. Status formatters normally width-tier their
+ * output; this is the final no-wrap guard for custom/test status strings. */
+function fitStatus(text: string, cols: number): string {
+  const width = Math.max(4, cols);
+  let visible = 0;
+  let out = '';
+  for (let i = 0; i < text.length && visible < width;) {
+    if (text[i] === ESC && text[i + 1] === '[') {
+      const match = /^\x1b\[[0-9;]*[A-Za-z]/u.exec(text.slice(i));
+      if (match) {
+        out += match[0];
+        i += match[0].length;
+        continue;
+      }
+    }
+    out += text[i];
+    visible += 1;
+    i += 1;
+  }
+  return out;
+}
 
 export interface LaneSink {
   write: (s: string) => void;
-  /** Terminal height in rows; may change on resize. */
   rows: () => number;
-  /** Terminal width in columns. */
   cols: () => number;
-  /** Subscribe to terminal resize; returns an unsubscribe fn. */
   onResize: (fn: () => void) => () => void;
 }
 
-/**
- * Owns the fixed bottom composer lane for the duration of a turn. Idempotent
- * activate/deactivate; repaints on demand and re-anchors on resize. Holds the
- * last painted text so a resize can restore it without the caller re-supplying.
- */
-export class ComposerLane {
+export class BottomRegion {
   private active = false;
-  private sourceText = '';
-  private lastText = '';
+  private composerSource = '';
+  private statusSource: StatusSource = '';
+  private lastComposer = '';
+  private lastStatus = '';
   private unsubResize: (() => void) | null = null;
 
   constructor(private readonly sink: LaneSink) {}
 
-  isActive(): boolean { return this.active; }
+  isActive(): boolean {
+    return this.active;
+  }
 
-  /** Reserve the lane and paint `text`. Idempotent — a second activate just
-   *  repaints. Subscribes to resize so the lane re-anchors cleanly. */
-  activate(text: string): void {
-    const rows = this.sink.rows();
+  /** Reserve and paint both rows. Repeated activation is an idempotent update. */
+  activate(composer: string, status: StatusSource = this.statusSource): void {
     if (!this.active) {
-      this.sink.write(reserveSeq(rows));
+      this.sink.write(reserveSeq(this.sink.rows()));
       this.unsubResize = this.sink.onResize(() => this.reanchor());
       this.active = true;
     }
-    this.paint(text);
+    this.composerSource = composer;
+    this.statusSource = status;
+    this.paintAll();
   }
 
-  /** Repaint the lane with new text (keystroke / hint change). No-op when the
-   *  text is unchanged, so a redundant paint never flickers. */
+  /** Backward-compatible composer-row update. */
   paint(text: string): void {
     if (!this.active) return;
-    this.sourceText = text;
+    this.composerSource = text;
     const fitted = fitLane(text, this.sink.cols());
-    if (fitted === this.lastText) return;
-    this.lastText = fitted;
-    this.sink.write(paintSeq(this.sink.rows(), fitted));
+    if (fitted === this.lastComposer) return;
+    this.lastComposer = fitted;
+    this.sink.write(paintSeq(this.sink.rows(), fitted, 1));
   }
 
-  /** Resize: re-reserve the region for the new height and repaint in place. */
+  paintStatus(status: StatusSource): void {
+    if (!this.active) return;
+    this.statusSource = status;
+    const raw = typeof status === 'function' ? status() : status;
+    const fitted = fitStatus(raw, this.sink.cols());
+    if (fitted === this.lastStatus) return;
+    this.lastStatus = fitted;
+    this.sink.write(paintSeq(this.sink.rows(), fitted, 0));
+  }
+
+  private paintAll(): void {
+    this.paint(this.composerSource);
+    this.paintStatus(this.statusSource);
+  }
+
   private reanchor(): void {
     if (!this.active) return;
-    const rows = this.sink.rows();
-    this.sink.write(reserveSeq(rows));
-    const text = this.sourceText;
-    this.lastText = '';        // force the repaint (dims changed)
-    this.paint(text);
+    this.sink.write(reserveSeq(this.sink.rows()));
+    this.lastComposer = '';
+    this.lastStatus = '';
+    this.paintAll();
   }
 
-  /** Restore full-screen scrolling + clear the lane. Idempotent. */
+  /** Release and clear both rows exactly once. Source values remain with the
+   * display owner so a balanced modal resume can repaint them. */
   deactivate(): void {
     if (!this.active) return;
     this.sink.write(teardownSeq(this.sink.rows()));
     this.unsubResize?.();
     this.unsubResize = null;
     this.active = false;
-    this.sourceText = '';
-    this.lastText = '';
+    this.lastComposer = '';
+    this.lastStatus = '';
   }
 }
 
-/** True unless the fixed-lane renderer is explicitly disabled. Display also
- * requires a TTY before emitting terminal control sequences. */
+/** Existing importer compatibility; the implementation now owns both rows. */
+export { BottomRegion as ComposerLane };
+
 export function composerLaneEnabled(): boolean {
   return process.env.AIDEN_COMPOSER_LANE !== '0';
 }

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -7,10 +7,10 @@
 /**
  * Single-owner fixed terminal bottom region.
  *
- * One DEC scroll region keeps transcript, activity, and tool output above two
- * reserved rows. The second-last row is the composer and the last row is the
- * provider/model/context/timer status strip. Modal prompts release both rows
- * together; resize re-anchors and repaints both from their full source values.
+ * The owner reserves a variable-height boxed composer plus one status row.
+ * Transcript, activity, and tool writes are restored to the scrollable region;
+ * the hardware cursor is then returned to the draft insertion point. Modal
+ * prompts release the complete surface and a balanced resume reconstructs it.
  *
  * AIDEN_COMPOSER_LANE=0 remains the compatibility escape hatch. Non-TTY output
  * never emits terminal-control sequences.
@@ -19,6 +19,8 @@
 const ESC = '\x1b';
 const SAVE = `${ESC}7`;
 const RESTORE = `${ESC}8`;
+const SAVE_TRANSCRIPT = `${ESC}[s`;
+const RESTORE_TRANSCRIPT = `${ESC}[u`;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
 const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
@@ -29,15 +31,14 @@ function terminalWidth(text: string): number {
 
 /**
  * Confine scrolling to the rows above the fixed region and place the transcript
- * cursor at the bottom of that scrollable area. The explicit cursor placement
- * avoids restoring a cursor that was already inside a newly reserved row.
+ * cursor at the bottom of that scrollable area.
  */
 export function reserveSeq(rows: number, laneRows = 2): string {
   const bottom = Math.max(1, rows - Math.max(1, laneRows));
   return `${ESC}[1;${bottom}r${ESC}[${bottom};1H`;
 }
 
-/** Paint one fixed row without disturbing the transcript cursor. */
+/** Paint one fixed row without disturbing the caller's saved cursor. */
 export function paintSeq(rows: number, text: string, offsetFromBottom = 0): string {
   const row = Math.max(1, rows - Math.max(0, offsetFromBottom));
   return `${SAVE}${ESC}[${row};1H${ESC}[2K${text}${RESTORE}`;
@@ -52,7 +53,7 @@ export function teardownSeq(rows: number, laneRows = 2): string {
   return `${ESC}[r${SAVE}${clear}${RESTORE}`;
 }
 
-/** Tail-fit composer text so the cursor end remains visible. */
+/** Tail-fit compatibility helper retained for legacy importers. */
 export function fitLane(text: string, cols: number): string {
   const width = Math.max(4, cols);
   if (terminalWidth(text) <= width) return text;
@@ -67,8 +68,7 @@ export function fitLane(text: string, cols: number): string {
 
 type StatusSource = string | (() => string);
 
-/** ANSI-aware front truncation. Status formatters normally width-tier their
- * output; this is the final no-wrap guard for custom/test status strings. */
+/** ANSI-aware front truncation used as the final no-wrap status guard. */
 function fitStatus(text: string, cols: number): string {
   const width = Math.max(4, cols);
   if (terminalWidth(text) <= width) return text;
@@ -96,6 +96,142 @@ function fitStatus(text: string, cols: number): string {
   return sawAnsi ? `${out}${ESC}[0m` : out;
 }
 
+function padVisible(text: string, width: number): string {
+  return `${text}${' '.repeat(Math.max(0, width - terminalWidth(text)))}`;
+}
+
+interface WrappedDraft {
+  lines: string[];
+  cursorLine: number;
+  cursorCell: number;
+}
+
+function wrapDraft(
+  text: string,
+  width: number,
+  maxLines: number,
+  cursorIndex = text.length,
+): WrappedDraft {
+  const boundedCursor = Math.max(0, Math.min(text.length, cursorIndex));
+  const beforeCursor = text.slice(0, boundedCursor)
+    .replace(/\r\n?/g, '\n')
+    .replace(/\t/g, '    ');
+  const afterCursor = text.slice(boundedCursor)
+    .replace(/\r\n?/g, '\n')
+    .replace(/\t/g, '    ');
+  const normalized = beforeCursor + afterCursor;
+  const normalizedCursor = beforeCursor.length;
+  const lines: string[] = [];
+  let line = '';
+  let offset = 0;
+  let cursorLine = 0;
+  let cursorCell = 0;
+  let cursorCaptured = false;
+  for (const character of Array.from(normalized)) {
+    if (!cursorCaptured && offset === normalizedCursor) {
+      cursorLine = lines.length;
+      cursorCell = terminalWidth(line);
+      cursorCaptured = true;
+    }
+    if (character === '\n') {
+      lines.push(line);
+      line = '';
+      offset += character.length;
+      continue;
+    }
+    if (terminalWidth(line + character) > width && line.length > 0) {
+      lines.push(line);
+      line = character;
+    } else {
+      line += character;
+    }
+    offset += character.length;
+  }
+  if (!cursorCaptured) {
+    cursorLine = lines.length;
+    cursorCell = terminalWidth(line);
+  }
+  lines.push(line);
+  const visibleCount = Math.max(1, maxLines);
+  const maxStart = Math.max(0, lines.length - visibleCount);
+  const visibleStart = Math.max(
+    0,
+    Math.min(cursorLine - Math.floor(visibleCount / 2), maxStart),
+  );
+  return {
+    lines: lines.slice(visibleStart, visibleStart + visibleCount),
+    cursorLine: cursorLine - visibleStart,
+    cursorCell,
+  };
+}
+
+export type BottomComposerMode = 'idle' | 'queue' | 'interrupt' | 'redirect';
+
+export interface BottomComposerSurface {
+  draft: string;
+  mode: BottomComposerMode;
+  cursorIndex?: number;
+}
+
+type ComposerSource = string | BottomComposerSurface;
+
+interface RenderedSurface {
+  lines: string[];
+  laneRows: number;
+  cursorRow: number;
+  cursorCol: number;
+}
+
+function normalizeComposer(source: ComposerSource): BottomComposerSurface {
+  return typeof source === 'string'
+    ? { draft: source, mode: 'idle' }
+    : source;
+}
+
+function modeTitle(mode: BottomComposerMode): string {
+  if (mode === 'idle') return '▲ You';
+  if (mode === 'queue') return '▲ You · queue mode';
+  if (mode === 'interrupt') return '▲ You · interrupt mode';
+  return '▲ You · steer mode';
+}
+
+export function renderBottomSurface(
+  rows: number,
+  cols: number,
+  composerSource: ComposerSource,
+  status: string,
+): RenderedSurface {
+  const composer = normalizeComposer(composerSource);
+  // Leave the final physical cell unused so Windows ConPTY never enters its
+  // pending-wrap state after painting a border or status row.
+  const outerWidth = Math.max(8, cols - 1);
+  const innerWidth = Math.max(1, outerWidth - 4);
+  const maxContentLines = Math.max(1, rows - 4);
+  const wrapped = wrapDraft(
+    composer.draft,
+    innerWidth,
+    maxContentLines,
+    composer.cursorIndex,
+  );
+  const content = wrapped.lines;
+  const laneRows = Math.min(rows - 1, content.length + 3);
+  const title = modeTitle(composer.mode);
+  const titleRoom = Math.max(1, outerWidth - 5);
+  const fittedTitle = terminalWidth(title) <= titleRoom ? title : fitStatus(title, titleRoom);
+  const topPrefix = `╭─ ${fittedTitle} `;
+  const top = `${topPrefix}${'─'.repeat(Math.max(0, outerWidth - terminalWidth(topPrefix) - 1))}╮`;
+  const body = content.map((line) => `│ ${padVisible(line, innerWidth)} │`);
+  const bottom = `╰${'─'.repeat(Math.max(0, outerWidth - 2))}╯`;
+  const fittedStatus = fitStatus(status, outerWidth);
+  const topRow = rows - laneRows + 1;
+  return {
+    lines: [top, ...body, bottom, fittedStatus],
+    laneRows,
+    cursorRow: topRow + 1 + wrapped.cursorLine,
+    cursorCol: Math.min(outerWidth - 1, 3 + wrapped.cursorCell),
+  };
+}
+
 export interface LaneSink {
   write: (s: string) => void;
   rows: () => number;
@@ -105,10 +241,10 @@ export interface LaneSink {
 
 export class BottomRegion {
   private active = false;
-  private composerSource = '';
+  private composerSource: ComposerSource = { draft: '', mode: 'idle' };
   private statusSource: StatusSource = '';
-  private lastComposer = '';
-  private lastStatus = '';
+  private laneRows = 0;
+  private lastFrame = '';
   private unsubResize: (() => void) | null = null;
 
   constructor(private readonly sink: LaneSink) {}
@@ -117,65 +253,146 @@ export class BottomRegion {
     return this.active;
   }
 
-  /** Reserve and paint both rows. Repeated activation is an idempotent update. */
-  activate(composer: string, status: StatusSource = this.statusSource): void {
-    if (!this.active) {
-      this.sink.write(reserveSeq(this.sink.rows()));
-      this.unsubResize = this.sink.onResize(() => this.reanchor());
-      this.active = true;
-    }
+  /** Reserve and paint the complete surface. Repeated activation is an update. */
+  activate(composer: ComposerSource, status: StatusSource = this.statusSource): void {
     this.composerSource = composer;
     this.statusSource = status;
+    if (!this.active) {
+      this.active = true;
+      this.unsubResize = this.sink.onResize(() => this.reanchor());
+    }
     this.paintAll();
   }
 
-  /** Backward-compatible composer-row update. */
-  paint(text: string): void {
+  /** Backward-compatible composer update. */
+  paint(composer: ComposerSource): void {
     if (!this.active) return;
-    this.composerSource = text;
-    const fitted = fitLane(text, Math.max(4, this.sink.cols() - 2));
-    if (fitted === this.lastComposer) return;
-    this.lastComposer = fitted;
-    this.sink.write(paintSeq(this.sink.rows(), fitted, 1));
+    this.composerSource = composer;
+    this.paintAll();
   }
 
   paintStatus(status: StatusSource): void {
     if (!this.active) return;
     this.statusSource = status;
-    const raw = typeof status === 'function' ? status() : status;
-    const fitted = fitStatus(raw, Math.max(4, this.sink.cols() - 2));
-    if (fitted === this.lastStatus) return;
-    this.lastStatus = fitted;
-    this.sink.write(paintSeq(this.sink.rows(), fitted, 0));
+    this.paintAll();
+  }
+
+  /**
+   * Write flowing output in the scrollable transcript, then return the hardware
+   * cursor to the draft insertion point without repainting or mutating draft.
+   */
+  writeAbove(text: string): void {
+    if (!this.active) {
+      this.sink.write(text);
+      return;
+    }
+    const surface = this.surface();
+    this.sink.write(
+      `${RESTORE_TRANSCRIPT}${text}${SAVE_TRANSCRIPT}` +
+      `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`,
+    );
+  }
+
+  /** Emit a control-only marker after cursor ownership is established. */
+  writeAfterCursor(text: string): void {
+    if (!this.active) {
+      this.sink.write(text);
+      return;
+    }
+    const surface = this.surface();
+    this.sink.write(
+      `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h${text}`,
+    );
+  }
+
+  private surface(): RenderedSurface {
+    const rawStatus = typeof this.statusSource === 'function'
+      ? this.statusSource()
+      : this.statusSource;
+    return renderBottomSurface(
+      this.sink.rows(),
+      this.sink.cols(),
+      this.composerSource,
+      rawStatus,
+    );
+  }
+
+  private clearOwnedRows(count: number): string {
+    let sequence = '';
+    for (let offset = Math.max(1, count) - 1; offset >= 0; offset -= 1) {
+      sequence += `${ESC}[${Math.max(1, this.sink.rows() - offset)};1H${ESC}[2K`;
+    }
+    return sequence;
+  }
+
+  private establishGeometry(nextRows: number): string {
+    if (this.laneRows === nextRows && this.laneRows > 0) return '';
+    const previousRows = this.laneRows;
+    this.laneRows = nextRows;
+    if (previousRows === 0) {
+      // Make physical room before reserving the footer. Painting directly over
+      // the last rows would destroy startup/transcript content already there.
+      // Line feeds at the full-screen bottom move those rows into normal
+      // scrollback and leave clean cells for the new fixed surface.
+      return `${ESC}[r${ESC}[${this.sink.rows()};1H${'\n'.repeat(nextRows)}` +
+        `${reserveSeq(this.sink.rows(), nextRows)}${SAVE_TRANSCRIPT}`;
+    }
+    const growth = Math.max(0, nextRows - previousRows);
+    const previousTranscriptBottom = Math.max(1, this.sink.rows() - previousRows);
+    // When a wrapped draft grows upward, scroll transcript rows before claiming
+    // the additional cells. This preserves the newest transcript content above
+    // the composer instead of erasing it during the geometry change.
+    const makeRoom = growth > 0
+      ? `${ESC}[${previousTranscriptBottom};1H${'\n'.repeat(growth)}`
+      : '';
+    return `${RESTORE_TRANSCRIPT}${makeRoom}${ESC}[r` +
+      `${this.clearOwnedRows(Math.max(previousRows, nextRows))}` +
+      `${reserveSeq(this.sink.rows(), nextRows)}${SAVE_TRANSCRIPT}`;
   }
 
   private paintAll(): void {
-    this.paint(this.composerSource);
-    this.paintStatus(this.statusSource);
+    if (!this.active) return;
+    const surface = this.surface();
+    const frame = surface.lines.join('\n');
+    const geometry = this.establishGeometry(surface.laneRows);
+    if (!geometry && frame === this.lastFrame) {
+      this.sink.write(`${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`);
+      return;
+    }
+    this.lastFrame = frame;
+    const topRow = this.sink.rows() - surface.laneRows + 1;
+    let sequence = geometry;
+    surface.lines.forEach((line, index) => {
+      sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
+    });
+    sequence += `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`;
+    this.sink.write(sequence);
   }
 
   private reanchor(): void {
     if (!this.active) return;
-    this.sink.write(reserveSeq(this.sink.rows()));
-    this.lastComposer = '';
-    this.lastStatus = '';
+    this.lastFrame = '';
+    const previousRows = this.laneRows;
+    this.laneRows = 0;
+    this.sink.write(`${RESTORE_TRANSCRIPT}${ESC}[r${this.clearOwnedRows(previousRows)}`);
     this.paintAll();
   }
 
-  /** Release and clear both rows exactly once. Source values remain with the
-   * display owner so a balanced modal resume can repaint them. */
+  /** Release and clear the complete surface exactly once. */
   deactivate(): void {
     if (!this.active) return;
-    this.sink.write(teardownSeq(this.sink.rows()));
+    this.sink.write(
+      `${RESTORE_TRANSCRIPT}${ESC}[r${this.clearOwnedRows(this.laneRows)}`,
+    );
     this.unsubResize?.();
     this.unsubResize = null;
     this.active = false;
-    this.lastComposer = '';
-    this.lastStatus = '';
+    this.laneRows = 0;
+    this.lastFrame = '';
   }
 }
 
-/** Existing importer compatibility; the implementation now owns both rows. */
+/** Existing importer compatibility. */
 export { BottomRegion as ComposerLane };
 
 export function composerLaneEnabled(): boolean {

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -19,6 +19,13 @@
 const ESC = '\x1b';
 const SAVE = `${ESC}7`;
 const RESTORE = `${ESC}8`;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+function terminalWidth(text: string): number {
+  return stringWidth(text.replace(ANSI_PATTERN, ''));
+}
 
 /**
  * Confine scrolling to the rows above the fixed region and place the transcript
@@ -48,8 +55,14 @@ export function teardownSeq(rows: number, laneRows = 2): string {
 /** Tail-fit composer text so the cursor end remains visible. */
 export function fitLane(text: string, cols: number): string {
   const width = Math.max(4, cols);
-  if (text.length <= width) return text;
-  return '…' + text.slice(-(width - 1));
+  if (terminalWidth(text) <= width) return text;
+  const plain = text.replace(ANSI_PATTERN, '');
+  let tail = '';
+  for (const character of Array.from(plain).reverse()) {
+    if (stringWidth(`…${character}${tail}`) > width) break;
+    tail = character + tail;
+  }
+  return `…${tail}`;
 }
 
 type StatusSource = string | (() => string);
@@ -58,22 +71,29 @@ type StatusSource = string | (() => string);
  * output; this is the final no-wrap guard for custom/test status strings. */
 function fitStatus(text: string, cols: number): string {
   const width = Math.max(4, cols);
-  let visible = 0;
+  if (terminalWidth(text) <= width) return text;
+  let plain = '';
   let out = '';
-  for (let i = 0; i < text.length && visible < width;) {
+  let sawAnsi = false;
+  for (let i = 0; i < text.length;) {
     if (text[i] === ESC && text[i + 1] === '[') {
       const match = /^\x1b\[[0-9;]*[A-Za-z]/u.exec(text.slice(i));
       if (match) {
         out += match[0];
         i += match[0].length;
+        sawAnsi = true;
         continue;
       }
     }
-    out += text[i];
-    visible += 1;
-    i += 1;
+    const codePoint = text.codePointAt(i);
+    if (codePoint === undefined) break;
+    const character = String.fromCodePoint(codePoint);
+    if (stringWidth(plain + character) > width) break;
+    out += character;
+    plain += character;
+    i += character.length;
   }
-  return out;
+  return sawAnsi ? `${out}${ESC}[0m` : out;
 }
 
 export interface LaneSink {
@@ -113,7 +133,7 @@ export class BottomRegion {
   paint(text: string): void {
     if (!this.active) return;
     this.composerSource = text;
-    const fitted = fitLane(text, this.sink.cols());
+    const fitted = fitLane(text, Math.max(4, this.sink.cols() - 2));
     if (fitted === this.lastComposer) return;
     this.lastComposer = fitted;
     this.sink.write(paintSeq(this.sink.rows(), fitted, 1));
@@ -123,7 +143,7 @@ export class BottomRegion {
     if (!this.active) return;
     this.statusSource = status;
     const raw = typeof status === 'function' ? status() : status;
-    const fitted = fitStatus(raw, this.sink.cols());
+    const fitted = fitStatus(raw, Math.max(4, this.sink.cols() - 2));
     if (fitted === this.lastStatus) return;
     this.lastStatus = fitted;
     this.sink.write(paintSeq(this.sink.rows(), fitted, 0));

--- a/cli/v4/composerReadiness.ts
+++ b/cli/v4/composerReadiness.ts
@@ -5,7 +5,9 @@ export const COMPOSER_READY_TOKEN = '__COMPOSER_READY__';
  * Emit a non-printing terminal marker only for PTY tests. OSC framing keeps
  * cursor position and normal production output unchanged.
  */
-export function emitComposerReadyForTests(): void {
+export function emitComposerReadyForTests(
+  write: (value: string) => void = (value) => process.stderr.write(value),
+): void {
   if (process.env.AIDEN_TEST_COMPOSER_READY !== '1') return;
-  try { process.stderr.write(`\x1b]9;${COMPOSER_READY_TOKEN}\x07`); } catch { /* test seam only */ }
+  try { write(`\x1b]9;${COMPOSER_READY_TOKEN}\x07`); } catch { /* test seam only */ }
 }

--- a/cli/v4/daemonAgentBuilder.ts
+++ b/cli/v4/daemonAgentBuilder.ts
@@ -39,7 +39,7 @@
 import type { AgentBuilder } from '../../core/v4/daemon/dispatcher';
 import { AidenAgent } from '../../core/v4/aidenAgent';
 import type { AidenAgentOptions, ToolExecutor } from '../../core/v4/aidenAgent';
-import type { ToolRegistry } from '../../core/v4/toolRegistry';
+import type { ToolContext, ToolRegistry } from '../../core/v4/toolRegistry';
 import type { RuntimeResolver } from '../../providers/v4/runtimeResolver';
 import type { ProviderAdapter } from '../../providers/v4/types';
 import type { AuxiliaryClient } from '../../core/v4/auxiliaryClient';
@@ -59,6 +59,8 @@ export interface BuildDaemonAgentBuilderInput {
   fallbackAdapter:      ProviderAdapter;
   toolRegistry:         ToolRegistry;
   toolExecutor:         ToolExecutor;
+  /** Shared services used to build a per-turn executor with the daemon policy. */
+  toolContext?:         ToolContext;
   auxiliaryClient:      AuxiliaryClient;
   promptBuilder:        PromptBuilder;
   /** Snapshot the REPL built; daemon-side overrides only providerId/modelId. */
@@ -123,6 +125,9 @@ export function buildDaemonAgentBuilder(
     // allowlist doesn't bleed across daemon turns.
     const approvalEngine = new ApprovalEngine('smart');
     approvalEngine['callbacks'] = input.approvalCallbacks;
+    const toolExecutor = deps.toolContext
+      ? deps.toolRegistry.buildExecutor({ ...deps.toolContext, approvalEngine })
+      : deps.toolExecutor;
 
     // Per-turn promptBuilderOptions — same snapshot the REPL uses,
     // only the providerId/modelId fields overridden to reflect the
@@ -142,7 +147,7 @@ export function buildDaemonAgentBuilder(
       // tools (`spawn_sub_agent` per Q6). Tools without an explicit
       // `contexts` field stay visible to both REPL and daemon.
       tools:                deps.toolRegistry.getSchemas(undefined, 'daemon'),
-      toolExecutor:         deps.toolExecutor,
+      toolExecutor,
       maxTurns,
       auxiliaryClient:      deps.auxiliaryClient,
       // v4.5 Phase 7 — explicit sessionId option threads per-trigger

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -388,11 +388,14 @@ export class Display {
   // refresh it immediately instead of waiting for the owner's next tick. The
   // indicator + tool-row each set/restore this around their lifetime.
   private composerRepaint: (() => void) | null = null;
-  // v4.14 — the OPT-IN single-owner fixed bottom lane (scroll-region). When
-  // AIDEN_COMPOSER_LANE=1, the composer is pinned to a reserved bottom row and
-  // all turn output scrolls above it; otherwise the suffix path below is used
-  // unchanged. Lazily created on first use.
+  // Single-owner fixed bottom lane (scroll-region). Interactive terminals pin
+  // the composer to a reserved bottom row so turn output scrolls above it.
+  // Non-TTY output and the compatibility opt-out use the legacy suffix path.
+  // Lazily created on first use.
   private composerLane: ComposerLane | null = null;
+  // Modal prompts need the full terminal surface while they own stdin. This
+  // depth pauses only composer painting and retains the exact draft/hint.
+  private composerSurfacePauseDepth = 0;
 
   constructor(opts: { skin?: SkinEngine; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream } = {}) {
     this.skin = opts.skin ?? getSkinEngine();
@@ -2109,7 +2112,10 @@ export class Display {
    * live (not blind). Empty buffer → the suffix disappears (never noisy).
    */
   setComposer(buffer: string, mode: 'queue' | 'interrupt' | 'redirect'): void {
-    const next = renderComposerBuffer(buffer, mode, this.composerAvail());
+    const maxWidth = composerLaneEnabled() && this.out.isTTY
+      ? this.composerLaneAvail()
+      : this.composerAvail();
+    const next = renderComposerBuffer(buffer, mode, maxWidth);
     if (next === this.composerText) return;
     this.composerText = next;
     this.paintComposerSurface();
@@ -2143,20 +2149,34 @@ export class Display {
   }
 
   /**
-   * Paint the composer to whichever surface owns it. With AIDEN_COMPOSER_LANE=1
-   * the single-owner fixed lane reserves a bottom row (activate reserves the
-   * scroll region once, then repaints; empty content tears it down at turn
-   * end). Otherwise the legacy suffix path — repaint the live owned bottom row
-   * — is used exactly as before (default, unchanged).
+   * Paint the composer to whichever surface owns it. On an interactive
+   * terminal, the single-owner fixed lane reserves a bottom row; empty content
+   * tears it down at turn end. Non-TTY output uses the legacy suffix path.
    */
   private paintComposerSurface(): void {
-    if (composerLaneEnabled()) {
+    if (this.composerSurfacePauseDepth > 0) return;
+    if (composerLaneEnabled() && this.out.isTTY) {
       if (!this.composerLane) this.composerLane = new ComposerLane(this.laneSink());
-      const content = this.composerContent();
+      const content = this.composerLaneContent();
       if (content) this.composerLane.activate(content); else this.composerLane.deactivate();
       return;
     }
     this.composerRepaint?.();
+  }
+
+  /** Temporarily release the fixed row while a modal prompt owns the terminal.
+   * Draft and hint state remain intact and are repainted after the final
+   * matching resume. */
+  pauseComposerSurface(): void {
+    this.composerSurfacePauseDepth += 1;
+    if (this.composerSurfacePauseDepth === 1) this.composerLane?.deactivate();
+  }
+
+  /** Restore the fixed row once the outermost modal prompt has settled. */
+  resumeComposerSurface(): void {
+    if (this.composerSurfacePauseDepth === 0) return;
+    this.composerSurfacePauseDepth -= 1;
+    if (this.composerSurfacePauseDepth === 0) this.paintComposerSurface();
   }
 
   /** Wire the lane to this display's real terminal stream + resize events. */
@@ -2188,6 +2208,23 @@ export class Display {
    */
   private composerAvail(): number {
     return Math.max(12, (this.out.columns ?? 80) - 30);
+  }
+
+  /** Width available to the independently owned bottom row. */
+  private composerLaneAvail(): number {
+    return Math.max(4, (this.out.columns ?? 80) - 2);
+  }
+
+  /** Preserve the actionable front of an idle hint at narrow widths. Typed
+   * input is already tail-fitted by renderComposerBuffer so its cursor end
+   * remains visible. */
+  private composerLaneContent(): string {
+    const content = this.composerContent();
+    if (this.composerText || !content) return content;
+    const available = this.composerLaneAvail();
+    return visibleLength(content) <= available
+      ? content
+      : `${truncateVisible(content, Math.max(1, available - 1))}…`;
   }
 
   private composerSuffix(): string {

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -393,6 +393,14 @@ export class Display {
   // Non-TTY output and the compatibility opt-out use the legacy suffix path.
   // Lazily created on first use.
   private composerLane: ComposerLane | null = null;
+  // The fixed status row is owned by the same controller as the composer.
+  // A factory is retained so resize can select the correct width tier.
+  private statusFooterSource: string | (() => string) = '';
+  // Main-prompt content is routed through the same fixed composer row. It is
+  // distinct from during-turn input so the existing queue buffer remains the
+  // sole owner of busy type-ahead.
+  private idleComposerContent = '';
+  private idleComposerHasDraft = false;
   // Modal prompts need the full terminal surface while they own stdin. This
   // depth pauses only composer painting and retains the exact draft/hint.
   private composerSurfacePauseDepth = 0;
@@ -934,8 +942,9 @@ export class Display {
       ? `${sk.applyColors(glyphs.status.timer, 'success')} ${sk.applyColors(formatElapsedShort(args.elapsedMs), 'success')}`
       : '';
     // ctxRatio + ctxPctText are pre-painted (warn + ctxKind respectively).
-    const ctxSegFull = `${ctxRatio} ${bar} ${ctxPctText}`;
-    const ctxSegCompact = `${bar} ${ctxPctText}`;
+    const ctxLabel = sk.applyColors('ctx', 'muted');
+    const ctxSegFull = `${ctxLabel} ${ctxRatio} ${bar} ${ctxPctText}`;
+    const ctxSegCompact = `${ctxLabel} ${bar} ${ctxPctText}`;
 
     // v4.10 Slice 10.3 — full-density-tier extras:
     //   - brand prefix `Aiden v4.X`
@@ -965,8 +974,32 @@ export class Display {
       // turn counter retired; mid tier collapses to 2 separators.
       // v4.10 Slice 10.3: brand + spell-out withheld here (width budget).
       segments = [provModel, ctxSegFull, sessionSeg || elapsed];
-    } else {
+    } else if (cols >= 60) {
       segments = [provModel, ctxSegCompact, sessionSeg || elapsed];
+    } else {
+      // The fixed footer must retain all four essential signals even on a
+      // classic 44-column PowerShell window. Decoration degrades first.
+      const compactContext = `ctx${pct}%`;
+      const compactTimer = sessionSeg || elapsed;
+      const providerModelBudget = Math.max(
+        8,
+        (cols - 4)
+          - visibleLength(compactContext)
+          - visibleLength(compactTimer)
+          - 6,
+      );
+      const fullProviderModel = `${args.provider}:${args.model}`;
+      const abbreviatedProviderModel = `${args.provider.slice(0, 1)}:${args.model}`;
+      const compactProviderModel = visibleLength(fullProviderModel) <= providerModelBudget
+        ? fullProviderModel
+        : args.provider.length <= 8 && visibleLength(abbreviatedProviderModel) <= providerModelBudget
+          ? abbreviatedProviderModel
+          : truncateVisible(fullProviderModel, providerModelBudget);
+      segments = [
+        this.skin.applyColors(compactProviderModel, 'tool'),
+        this.skin.applyColors(compactContext, ctxKind),
+        compactTimer,
+      ];
     }
     return truncateVisible(`  ${segments.join(SEP)}`, Math.max(1, cols - 2));
   }
@@ -1526,6 +1559,7 @@ export class Display {
       lastBody = '';
     };
     const refresh = (frame?: number): void => {
+      this.refreshStatusFooter();
       if (!active || paused || !isTty) return;
       if (typeof frame === 'number') frameIndex = frame;
       const next = body();
@@ -2112,11 +2146,14 @@ export class Display {
    * live (not blind). Empty buffer → the suffix disappears (never noisy).
    */
   setComposer(buffer: string, mode: 'queue' | 'interrupt' | 'redirect'): void {
+    const idleChanged = this.idleComposerContent !== '';
+    this.idleComposerContent = '';
+    this.idleComposerHasDraft = false;
     const maxWidth = composerLaneEnabled() && this.out.isTTY
       ? this.composerLaneAvail()
       : this.composerAvail();
     const next = renderComposerBuffer(buffer, mode, maxWidth);
-    if (next === this.composerText) return;
+    if (next === this.composerText && !idleChanged) return;
     this.composerText = next;
     this.paintComposerSurface();
   }
@@ -2128,9 +2165,57 @@ export class Display {
    * owned bottom row so it shows immediately.
    */
   setBusyHint(hint: string): void {
-    if (hint === this.busyComposerHint) return;
+    const idleChanged = this.idleComposerContent !== '';
+    this.idleComposerContent = '';
+    this.idleComposerHasDraft = false;
+    if (hint === this.busyComposerHint && !idleChanged) return;
     this.busyComposerHint = hint;
     this.paintComposerSurface();
+  }
+
+  /** Update the normal prompt inside the fixed composer row. */
+  setIdleComposer(buffer: string, hint: string): void {
+    const busyChanged = this.composerText !== '' || this.busyComposerHint !== '';
+    this.composerText = '';
+    this.busyComposerHint = '';
+    const body = buffer || hint;
+    const next = `${this.promptPrefix()} ${body}`;
+    this.idleComposerHasDraft = buffer.length > 0;
+    if (next === this.idleComposerContent && !busyChanged) return;
+    this.idleComposerContent = next;
+    this.paintComposerSurface();
+  }
+
+  /** Commit one normal submission above the fixed footer, then immediately
+   * restore an empty ready composer. Empty Enter remains a local no-op. */
+  submitIdleComposer(value: string, hint: string): void {
+    if (value.length > 0) {
+      this.write(`${this.promptPrefix()} ${value}\n`);
+    }
+    this.idleComposerContent = `${this.promptPrefix()} ${hint}`;
+    this.idleComposerHasDraft = false;
+    this.paintComposerSurface();
+  }
+
+  /** Set the persistent status row. The optional factory is evaluated again
+   * after terminal resize so compact and wide tiers remain truthful. */
+  setStatusFooter(source: string | (() => string)): void {
+    this.statusFooterSource = source;
+    if (this.composerLane?.isActive()) {
+      this.composerLane.paintStatus(source);
+    } else {
+      this.paintComposerSurface();
+    }
+  }
+
+  private refreshStatusFooter(): void {
+    if (!this.composerLane?.isActive()) return;
+    this.composerLane.paintStatus(this.statusFooterSource);
+  }
+
+  /** True only when this interactive Display owns the two-row surface. */
+  fixedBottomRegionEnabled(): boolean {
+    return composerLaneEnabled() && !!this.out.isTTY;
   }
 
   /** Clear the composer (turn end / handoff back to the normal prompt). Drops
@@ -2145,7 +2230,7 @@ export class Display {
   /** The raw composer content: the typed text if any, else the persistent hint,
    *  else '' (no turn running). Shared by the lane and the suffix path. */
   private composerContent(): string {
-    return this.composerText || this.busyComposerHint;
+    return this.composerText || this.busyComposerHint || this.idleComposerContent;
   }
 
   /**
@@ -2158,7 +2243,13 @@ export class Display {
     if (composerLaneEnabled() && this.out.isTTY) {
       if (!this.composerLane) this.composerLane = new ComposerLane(this.laneSink());
       const content = this.composerLaneContent();
-      if (content) this.composerLane.activate(content); else this.composerLane.deactivate();
+      const hasStatus = typeof this.statusFooterSource === 'function'
+        || this.statusFooterSource.length > 0;
+      if (content || hasStatus) {
+        this.composerLane.activate(content, this.statusFooterSource);
+      } else {
+        this.composerLane.deactivate();
+      }
       return;
     }
     this.composerRepaint?.();
@@ -2220,7 +2311,7 @@ export class Display {
    * remains visible. */
   private composerLaneContent(): string {
     const content = this.composerContent();
-    if (this.composerText || !content) return content;
+    if (this.composerText || this.idleComposerHasDraft || !content) return content;
     const available = this.composerLaneAvail();
     return visibleLength(content) <= available
       ? content

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -38,7 +38,6 @@ import {
 } from './display/toolTrail';
 // v4.1.3-essentials — capability card renderer (auth/platform failures).
 // v4.10 Slice 10.3 — brand prefix in the full-density status bar tier.
-import { VERSION as AIDEN_VERSION } from '../../core/version';
 import { renderCapabilityCard } from './display/capabilityCard';
 import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
@@ -84,7 +83,13 @@ import { getReplyRenderer } from './replyRenderer';
 import { renderCitationFooter } from './citationFooter';
 import { buildToolPreview } from './toolPreview';
 import { renderComposerBuffer } from './composerRow';
-import { ComposerLane, composerLaneEnabled, type LaneSink } from './composerLane';
+import {
+  ComposerLane,
+  composerLaneEnabled,
+  type BottomComposerMode,
+  type BottomComposerSurface,
+  type LaneSink,
+} from './composerLane';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 import type { ActivitySnapshot } from './activityRegistry';
 // v4.1.4 reply-quality polish: shared frame math for width + indent.
@@ -408,32 +413,31 @@ export class Display {
   private err: NodeJS.WriteStream;
 
   // ── v4.12.1 Pillar 4 Slice 2c — live during-turn composer ────────────────
-  // The rendered composer suffix (mode label + typed text), woven into
-  // whichever owned bottom row is live (activity indicator OR tool row) so it
-  // survives long tool calls. Empty string = nothing appended (not noisy).
+  // Legacy suffix projection plus the raw draft used by the fixed surface.
+  // Empty string means there is no busy draft.
   private composerText = '';
-  // v4.14 BUG 2 — the PERSISTENT plain-language busy hint ("Enter → steer ·
-  // …"). Set at turn start so the input lane is ALWAYS visible during a turn
-  // (not only after the user types); shown when `composerText` is empty. Empty
-  // = no turn running (or handed back to the normal prompt).
+  private composerDraft = '';
+  private composerMode: BottomComposerMode = 'queue';
+  // Existing busy guidance determines the fixed-surface mode and remains the
+  // legacy suffix fallback. Empty means no turn is running.
   private busyComposerHint = '';
   // The active bottom-owner registers a repaint fn here so a keystroke can
   // refresh it immediately instead of waiting for the owner's next tick. The
   // indicator + tool-row each set/restore this around their lifetime.
   private composerRepaint: (() => void) | null = null;
-  // Single-owner fixed bottom lane (scroll-region). Interactive terminals pin
-  // the composer to a reserved bottom row so turn output scrolls above it.
-  // Non-TTY output and the compatibility opt-out use the legacy suffix path.
+  // Single-owner fixed bottom surface. Interactive terminals reserve a
+  // variable-height composer plus status row so turn output scrolls above it.
+  // Non-TTY output and the compatibility opt-out retain the legacy suffix path.
   // Lazily created on first use.
   private composerLane: ComposerLane | null = null;
   // The fixed status row is owned by the same controller as the composer.
   // A factory is retained so resize can select the correct width tier.
   private statusFooterSource: string | (() => string) = '';
-  // Main-prompt content is routed through the same fixed composer row. It is
-  // distinct from during-turn input so the existing queue buffer remains the
-  // sole owner of busy type-ahead.
+  // Main-prompt state is distinct from during-turn input so the existing queue
+  // buffer remains the sole owner of busy type-ahead.
   private idleComposerContent = '';
-  private idleComposerHasDraft = false;
+  private idleComposerDraft = '';
+  private idleComposerCursor = 0;
   // Modal prompts need the full terminal surface while they own stdin. This
   // depth pauses only composer painting and retains the exact draft/hint.
   private composerSurfacePauseDepth = 0;
@@ -479,7 +483,7 @@ export class Display {
 
   /** Print the banner. `opts.tip` accepted for backward compat; unused. */
   printBanner(version?: string, opts: { tip?: string } = {}): void {
-    this.out.write(this.banner(version, opts));
+    this.writeOutput(this.banner(version, opts));
   }
 
   // ── Phase 23.6 — v3 visual primitives ──────────────────────────────────
@@ -559,7 +563,7 @@ export class Display {
 
   /**
    * Phase 26.2.3 — single-line assistant header in the
-   * `┃ Aiden` style. `┃` (U+2503 heavy vertical) and `Aiden` are
+   * `│ Aiden` style. The transcript rail and `Aiden` are
    * both brand-orange. The thin rule that previously sat under the
    * label is gone — the per-turn separator (printed BEFORE the user
    * prompt by chatSession) carries that visual weight now.
@@ -573,11 +577,7 @@ export class Display {
    * Returns one indented line with a trailing newline.
    */
   agentHeader(): string {
-    // v4.8.0 Slice 7 hotfix — replace v4.7 ┃ heavy-vertical with the
-    // Slice 4 framedPanel bar `▎` so reply chrome matches /help,
-    // approval prompt, and other Slice 4+ surfaces. Trailing `\n\n`
-    // (was `\n`) puts one blank between header and first content row.
-    const bar = this.skin.applyColors(glyphs.panel.bar, 'brand');
+    const bar = this.skin.applyColors('│', 'brand');
     const head = this.skin.applyColors('Aiden', 'brand');
     if (process.env.AIDEN_UI_TIMESTAMPS === '1') {
       return `${this.timestampPrefix()}  ${bar} ${head}\n\n`;
@@ -598,7 +598,7 @@ export class Display {
     // indent provide enough breathing room; the extra blank was
     // stacking with other emit points to produce 3+ blank lines
     // between user prompt and reply.
-    this.out.write(`  ${this.rule()}\n`);
+    this.writeOutput(`  ${this.rule()}\n`);
   }
 
   /**
@@ -923,21 +923,14 @@ export class Display {
   }): string {
     const sk = this.skin;
     const SEP = sk.applyColors(' │ ', 'muted');
-    // v4.9.0 pre-ship UI hotfix — dropped the leading `▲` from
-    // provModel (prompt `▲` owns the marker; footer `▲` read as
-    // a duplicate orphan). Slice 7 per-metric palette preserved.
-    const provModel =
+    const providerModel =
+      `${sk.applyColors('◆', 'brand')} ` +
       `${sk.applyColors(args.provider, 'muted')}` +
       `${sk.applyColors(' · ', 'muted')}` +
       sk.applyColors(args.model, 'tool');
-
     const pct = args.ctxMax > 0
       ? Math.min(100, Math.round((args.ctxUsed / args.ctxMax) * 100))
       : 0;
-    // v4.9.0 pre-ship UI hotfix — bar math extracted to
-    // `computeContextBarFill` (1 cell per 20% bucket, ≥1 when any
-    // context used). Old `Math.round(pct/100 * barW)` floored to 0
-    // below ~10% so the bar stayed empty all session at typical use.
     const barW = 5;
     const filled = computeContextBarFill(pct, barW);
     const ctxKind: 'success' | 'warn' | 'error' =
@@ -949,77 +942,30 @@ export class Display {
       'warn',
     );
     const ctxPctText = sk.applyColors(`${pct}%`, ctxKind);
-
-    const elapsed = sk.applyColors(formatElapsedShort(args.elapsedMs), 'success');
-
-    // Progressive disclosure: pick layout based on RAW terminal width.
-    // `this.cols()` caps at 100 (frame budget for body content), but
-    // the footer wants the full physical width to choose its tier.
     const cols = (typeof this.out.columns === 'number' && this.out.columns >= 1)
       ? this.out.columns
       : 100;
-    // Tier ≥120: full density (ratio + bar + pct + turn + session + state).
-    // Tier ≥100: ratio + bar + pct + turn + elapsed.
-    // Tier <100: bar + pct + elapsed.
-    const stateDot = args.state
-      ? sk.applyColors(glyphs.status.dot, this.stateKind(args.state))
-      : '';
-    // v4.9.0 pre-ship UI: turn counter retired entirely — value-to-pixel
-    // ratio too low. `args.turnCount` stays in the signature for caller
-    // back-compat; ignored here.
     void args.turnCount;
-    // v4.8.0 Slice 9 hotfix — ⌛ restored ahead of the bare elapsed
-    // string. Wider font support than the retired ⏱. `sessionMs` arg
-    // stays plumbed-but-unused for backward compat with the field name.
-    const sessionSeg = args.elapsedMs !== undefined
-      ? `${sk.applyColors(glyphs.status.timer, 'success')} ${sk.applyColors(formatElapsedShort(args.elapsedMs), 'success')}`
-      : '';
-    // ctxRatio + ctxPctText are pre-painted (warn + ctxKind respectively).
-    const ctxLabel = sk.applyColors('ctx', 'muted');
-    const ctxSegFull = `${ctxLabel} ${ctxRatio} ${bar} ${ctxPctText}`;
-    const ctxSegCompact = `${ctxLabel} ${bar} ${ctxPctText}`;
-
-    // v4.10 Slice 10.3 — full-density-tier extras:
-    //   - brand prefix `Aiden v4.X`
-    //   - spelled-out `last <elapsed>` for last-turn time
-    //   - session uptime `<elapsed>` from sessionMs (re-enabled; the
-    //     v4.9.0 comment retired it but Slice 10.3 brings it back
-    //     because it's signal users want during long sessions)
-    const brandSeg = `${sk.applyColors(`Aiden v${AIDEN_VERSION}`, 'brand')}`;
-    const lastTurnSpelled = args.elapsedMs !== undefined
-      ? `${sk.applyColors(glyphs.status.timer, 'success')} ${sk.applyColors(`last ${formatElapsedShort(args.elapsedMs)}`, 'success')}`
-      : '';
-    const sessionUptimeSeg = (typeof args.sessionMs === 'number' && args.sessionMs > 0)
-      ? sk.applyColors(formatElapsedShort(args.sessionMs), 'muted')
-      : '';
-
+    void args.sessionMs;
+    void args.state;
+    const contextFull =
+      `${sk.applyColors('◉ context', 'muted')} ${ctxRatio} ${bar} ${ctxPctText}`;
+    const contextCompact = `${sk.applyColors('◉ context', 'muted')} ${ctxPctText}`;
+    const timer =
+      `${sk.applyColors('⧖', 'success')} ${sk.applyColors(formatElapsedShort(args.elapsedMs), 'success')}`;
     let segments: string[];
-    if (cols >= 120 && stateDot && sessionSeg) {
-      // Full density — v4.10 Slice 10.3 adds brand + session uptime
-      // + spelled-out "last <elapsed>" for the per-turn timer. Order:
-      //   Aiden v4.X · provider · model │ ctx │ session-uptime │ last 18s │ state
-      segments = [brandSeg, provModel, ctxSegFull];
-      if (sessionUptimeSeg) segments.push(sessionUptimeSeg);
-      segments.push(lastTurnSpelled, stateDot);
-    } else if (cols >= 100) {
-      // v4.8.1 Slice 2 hotfix — sessionSeg keeps the ⌛ identity glyph
-      // (single-cell, cheap) even at this tier. v4.9.0 pre-ship UI:
-      // turn counter retired; mid tier collapses to 2 separators.
-      // v4.10 Slice 10.3: brand + spell-out withheld here (width budget).
-      segments = [provModel, ctxSegFull, sessionSeg || elapsed];
-    } else if (cols >= 60) {
-      segments = [provModel, ctxSegCompact, sessionSeg || elapsed];
+    if (cols >= 80) {
+      segments = [providerModel, contextFull, timer];
+    } else if (cols >= 54) {
+      segments = [providerModel, contextCompact, timer];
     } else {
-      // The fixed footer must retain all four essential signals even on a
-      // classic 44-column PowerShell window. Decoration degrades first.
-      const compactContext = `ctx${pct}%`;
-      const compactTimer = sessionSeg || elapsed;
+      const compactContext = `◉ ${pct}%`;
       const providerModelBudget = Math.max(
         8,
-        (cols - 4)
+        (cols - 1)
           - terminalVisibleLength(compactContext)
-          - terminalVisibleLength(compactTimer)
-          - 6,
+          - terminalVisibleLength(timer)
+          - 8,
       );
       const fullProviderModel = `${args.provider}:${args.model}`;
       const abbreviatedProviderModel = `${args.provider.slice(0, 1)}:${args.model}`;
@@ -1029,20 +975,12 @@ export class Display {
           ? abbreviatedProviderModel
           : truncateTerminalVisible(fullProviderModel, providerModelBudget);
       segments = [
-        this.skin.applyColors(compactProviderModel, 'tool'),
-        this.skin.applyColors(compactContext, ctxKind),
-        compactTimer,
+        `${sk.applyColors('◆', 'brand')} ${sk.applyColors(compactProviderModel, 'tool')}`,
+        sk.applyColors(compactContext, ctxKind),
+        timer,
       ];
     }
-    return truncateTerminalVisible(`  ${segments.join(SEP)}`, Math.max(1, cols - 2));
-  }
-
-  /** Map a per-turn outcome to the colour kind used by the state dot. */
-  private stateKind(state: 'ok' | 'warn' | 'error' | 'muted'): ColorKind {
-    if (state === 'ok')    return 'success';
-    if (state === 'warn')  return 'warn';
-    if (state === 'error') return 'error';
-    return 'muted';
+    return truncateTerminalVisible(segments.join(SEP), Math.max(1, cols - 1));
   }
 
   /**
@@ -1187,7 +1125,7 @@ export class Display {
       // Phase 23.5: spinner glyph in soft cyan (muted), not brand orange.
       // Quiet color, not loud.
       const glyph = skin.applyColors(frames[frame % frames.length], 'muted');
-      this.out.write(`\r${glyph} ${current}   `);
+      this.writeOutput(`\r${glyph} ${current}   `);
       frame += 1;
     };
 
@@ -1195,7 +1133,7 @@ export class Display {
       render();
       timer = setInterval(render, 90);
     } else {
-      this.out.write(`${text}\n`);
+      this.writeOutput(`${text}\n`);
     }
 
     return {
@@ -1208,9 +1146,9 @@ export class Display {
         if (timer) clearInterval(timer);
         if (isTty) {
           // clear the spinner line and write the final text on its own line
-          this.out.write('\r\x1b[K');
+          this.writeOutput('\r\x1b[K');
         }
-        if (finalText) this.out.write(`${finalText}\n`);
+        if (finalText) this.writeOutput(`${finalText}\n`);
       },
     };
   }
@@ -1419,7 +1357,7 @@ export class Display {
       // Single-row layout: walk up 1, erase, repaint, newline. Cursor
       // lands on the row below the indicator, ready for the next
       // tick to walk back up.
-      out.write(`${ANSI_UP_ERASE}${buildLine()}\n`);
+      this.writeOutput(`${ANSI_UP_ERASE}${buildLine()}\n`);
     };
 
     const startTick = (): void => {
@@ -1441,7 +1379,7 @@ export class Display {
       // space and acts as a Windows ConPTY flush trigger (v4.1.5
       // Issue M). Slice 11 collapsed the prior 2-row layout to 1.
       if (!isTty || !printed) return;
-      out.write(`${ANSI_UP_ERASE}\n`);
+      this.writeOutput(`${ANSI_UP_ERASE}\n`);
     };
 
     // Initial paint — only on TTY.
@@ -1460,11 +1398,11 @@ export class Display {
       if (stopped || paused || !isTty || !printed) return;
       type GFlag = typeof globalThis & { __aiden_legacy_indicator_paused?: boolean };
       if ((globalThis as GFlag).__aiden_legacy_indicator_paused) return;
-      out.write(`${ANSI_UP_ERASE}${buildLine()}\n`);
+      this.writeOutput(`${ANSI_UP_ERASE}${buildLine()}\n`);
     };
 
     if (isTty) {
-      out.write(`\n${buildLine()}\n`);
+      this.writeOutput(`\n${buildLine()}\n`);
       printed = true;
       startTick();
       // While the indicator owns the bottom row, a keystroke repaints it here.
@@ -1508,7 +1446,7 @@ export class Display {
         // resume omits it because the caller has already written its
         // own content above this point and an extra blank would
         // double up.)
-        out.write(`${buildLine()}\n`);
+        this.writeOutput(`${buildLine()}\n`);
         printed = true;
         startTick();
         // Re-claim composer repaint from the tool row that just finished.
@@ -1535,9 +1473,9 @@ export class Display {
         // (agentHeader → ▎ Aiden) produces a clean single-blank gap.
         if (!printed || !isTty) return;
         if (movedFromInitial) {
-          out.write(`${ANSI_UP_ERASE}\n`);
+          this.writeOutput(`${ANSI_UP_ERASE}\n`);
         } else {
-          out.write(`${ANSI_UP_ERASE}${ANSI_UP_ERASE}\n`);
+          this.writeOutput(`${ANSI_UP_ERASE}${ANSI_UP_ERASE}\n`);
         }
       },
       isPaused:  () => paused,
@@ -1587,7 +1525,7 @@ export class Display {
     };
     const erase = (): void => {
       if (!printed || !isTty) return;
-      out.write('\x1b[1A\x1b[2K\r');
+      this.writeOutput('\x1b[1A\x1b[2K\r');
       printed = false;
       lastBody = '';
     };
@@ -1597,7 +1535,7 @@ export class Display {
       if (typeof frame === 'number') frameIndex = frame;
       const next = body();
       if (printed && !invalidated && next === lastBody) return;
-      out.write(printed
+      this.writeOutput(printed
         ? `\x1b[1A\x1b[2K\r${next}\x1b[1B\r`
         : `${next}\n`);
       printed = true;
@@ -1728,7 +1666,8 @@ export class Display {
       const liveSuffix = elapsed >= 1000
         ? `  ${sk.applyColors(`${phaseLabel} ${formatToolDuration(elapsed)}…`, 'muted')}`
         : '';
-      const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${glyph}  ` +
+      const runningGlyph = useIcons ? sk.applyColors('⚙', 'tool') : sk.applyColors('·', 'muted');
+      const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph}  ` +
         `${sk.applyColors(padVerb(verb), 'tool')} `;
       const suffix = `${liveSuffix}${this.composerSuffix()}`;
       const detailText = sk.applyColors(detail, 'muted');
@@ -1743,7 +1682,9 @@ export class Display {
 
     // Outcome row — entire line colored by outcome kind.
     const outcomeRow = (suffix: string, kind: ColorKindForBracket): string => {
-      const prefix = `${TRAIL_PIPE} ${glyph}  ${padVerb(verb)} `;
+      const failed = kind === 'error' || kind === 'warn' || /^(?:cancelled|denied|blocked|timed out|fail)/u.test(suffix);
+      const outcomeGlyph = failed ? '!' : '✓';
+      const prefix = `${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(verb)} `;
       const suffixText = suffix ? `  ${suffix}` : '';
       const width = terminalRowWidth();
       const availableDetail = width === null
@@ -1757,6 +1698,7 @@ export class Display {
 
     // Capture stream reference so closures don't need `this`.
     const out = this.out;
+    const writeOutput = (text: string): void => this.writeOutput(text);
     const isTty = !!out.isTTY;
     // Keep a two-cell safety margin. Windows ConPTY can report the cursor
     // width one cell beyond the last safe printable column; filling that cell
@@ -1803,18 +1745,18 @@ export class Display {
       const fitted = fitTerminalRow(row);
       if (isTty && printed) {
         const body = fitted.endsWith('\n') ? fitted.slice(0, -1) : fitted;
-        out.write(settle
+        this.writeOutput(settle
           ? `\x1b[1A\x1b[2K\r${body}\n`
           : `\x1b[1A\x1b[2K\r${body}\x1b[1B\r`);
       }
-      else out.write(fitted);
+      else this.writeOutput(fitted);
       printed = true;
     };
 
     // Erase the last printed line (TTY only).
     const eraseLast = (): void => {
       if (isTty && printed) {
-        out.write('\x1b[1A\x1b[2K\r');
+        this.writeOutput('\x1b[1A\x1b[2K\r');
         printed = false;
       }
     };
@@ -1845,7 +1787,7 @@ export class Display {
       // its own newline-fencing + in-place rerender of the just-streamed
       // chunk so this row lands cleanly on its own line below.
       this.commitStreamChunk();
-      out.write(fitTerminalRow(runningRow()));
+      this.writeOutput(fitTerminalRow(runningRow()));
       printed = true;
       // v4.1.3-essentials: start the live-elapsed ticker. Fires every
       // 1s; first tick at +1s, when `runningRow()` starts emitting the
@@ -2015,7 +1957,7 @@ export class Display {
         if (settled || !pausedRow) return;
         pausedRow = false;
         if (!isTty) return;
-        out.write(fitTerminalRow(runningRow()));
+        writeOutput(fitTerminalRow(runningRow()));
         printed = true;
         startRunningTick();
       },
@@ -2165,57 +2107,80 @@ export class Display {
 
   /** Direct write helpers used by callers that already formatted text. */
   write(text: string): void {
+    this.writeOutput(text);
+  }
+
+  /** Test-only control markers are emitted after fixed composer cursor setup. */
+  writeAfterComposerCursor(text: string): void {
+    if (this.composerSurfacePauseDepth === 0 && composerLaneEnabled() && this.out.isTTY) {
+      this.paintComposerSurface();
+    }
+    if (this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()) {
+      this.composerLane.writeAfterCursor(text);
+      return;
+    }
     this.out.write(text);
   }
+
   writeError(text: string): void {
     this.err.write(text);
   }
 
+  /** Route flowing output through the fixed-region owner while it is active. */
+  private writeOutput(text: string): void {
+    if (this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()) {
+      this.composerLane.writeAbove(text);
+      return;
+    }
+    this.out.write(text);
+  }
+
   // ── v4.12.1 Pillar 4 Slice 2c — live composer surface ────────────────────
-  /**
-   * Update the live during-turn composer from a keystroke. `buffer` is the
-   * user's typed-so-far (already paste-stripped); `mode` is the busy-Enter
-   * mode. Repaints the active owned bottom row immediately so typing shows
-   * live (not blind). Empty buffer → the suffix disappears (never noisy).
-   */
+  /** Update the live during-turn draft and mode on the owned surface. */
   setComposer(buffer: string, mode: 'queue' | 'interrupt' | 'redirect'): void {
     const idleChanged = this.idleComposerContent !== '';
     this.idleComposerContent = '';
-    this.idleComposerHasDraft = false;
+    this.idleComposerDraft = '';
     const maxWidth = composerLaneEnabled() && this.out.isTTY
       ? this.composerLaneAvail()
       : this.composerAvail();
     const next = renderComposerBuffer(buffer, mode, maxWidth);
-    if (next === this.composerText && !idleChanged) return;
+    if (next === this.composerText && buffer === this.composerDraft
+      && mode === this.composerMode && !idleChanged) return;
     this.composerText = next;
+    this.composerDraft = buffer;
+    this.composerMode = mode;
     this.paintComposerSurface();
   }
 
-  /**
-   * v4.14 BUG 2 — set the PERSISTENT plain-language busy hint so the input lane
-   * is visible the moment a turn starts (before any keystroke). Called at turn
-   * start and whenever the hint changes (e.g. pause/resume). Repaints the live
-   * owned bottom row so it shows immediately.
-   */
+  /** Derive the fixed-surface mode from existing busy guidance. */
   setBusyHint(hint: string): void {
     const idleChanged = this.idleComposerContent !== '';
     this.idleComposerContent = '';
-    this.idleComposerHasDraft = false;
+    this.idleComposerDraft = '';
+    if (/\bqueue\b/i.test(hint)) this.composerMode = 'queue';
+    else if (/\bsteer\b|\bredirect\b/i.test(hint)) this.composerMode = 'redirect';
+    else if (/\bstop\b|\binterrupt\b/i.test(hint)) this.composerMode = 'interrupt';
     if (hint === this.busyComposerHint && !idleChanged) return;
     this.busyComposerHint = hint;
     this.paintComposerSurface();
   }
 
-  /** Update the normal prompt inside the fixed composer row. */
-  setIdleComposer(buffer: string, hint: string): void {
+  /** Update the normal prompt inside the fixed composer surface. */
+  setIdleComposer(buffer: string, hint: string, cursorIndex = buffer.length): void {
     const busyChanged = this.composerText !== '' || this.busyComposerHint !== '';
     this.composerText = '';
+    this.composerDraft = '';
     this.busyComposerHint = '';
     const body = buffer || hint;
     const next = `${this.promptPrefix()} ${body}`;
-    this.idleComposerHasDraft = buffer.length > 0;
-    if (next === this.idleComposerContent && !busyChanged) return;
+    if (next === this.idleComposerContent
+      && buffer === this.idleComposerDraft
+      && cursorIndex === this.idleComposerCursor
+      && !busyChanged) return;
     this.idleComposerContent = next;
+    this.idleComposerDraft = buffer;
+    this.idleComposerCursor = cursorIndex;
     this.paintComposerSurface();
   }
 
@@ -2223,10 +2188,11 @@ export class Display {
    * restore an empty ready composer. Empty Enter remains a local no-op. */
   submitIdleComposer(value: string, hint: string): void {
     if (value.length > 0) {
-      this.write(`${this.promptPrefix()} ${value}\n`);
+      this.write(`${this.promptPrefix()}You  ${value}\n`);
     }
     this.idleComposerContent = `${this.promptPrefix()} ${hint}`;
-    this.idleComposerHasDraft = false;
+    this.idleComposerDraft = '';
+    this.idleComposerCursor = 0;
     this.paintComposerSurface();
   }
 
@@ -2246,7 +2212,7 @@ export class Display {
     this.composerLane.paintStatus(this.statusFooterSource);
   }
 
-  /** True only when this interactive Display owns the two-row surface. */
+  /** True only when this interactive Display owns the boxed bottom surface. */
   fixedBottomRegionEnabled(): boolean {
     return composerLaneEnabled() && !!this.out.isTTY;
   }
@@ -2256,30 +2222,44 @@ export class Display {
   clearComposer(): void {
     if (this.composerText === '' && this.busyComposerHint === '') return;
     this.composerText = '';
+    this.composerDraft = '';
     this.busyComposerHint = '';
     this.paintComposerSurface();
   }
 
-  /** The raw composer content: the typed text if any, else the persistent hint,
-   *  else '' (no turn running). Shared by the lane and the suffix path. */
+  /** Activation content for the fixed surface and legacy suffix fallback. */
   private composerContent(): string {
     return this.composerText || this.busyComposerHint || this.idleComposerContent;
   }
 
+  private composerSurface(): BottomComposerSurface {
+    if (this.composerText || this.busyComposerHint) {
+      return {
+        draft: this.composerDraft,
+        mode: this.composerMode,
+        cursorIndex: this.composerDraft.length,
+      };
+    }
+    return {
+      draft: this.idleComposerDraft,
+      mode: 'idle',
+      cursorIndex: this.idleComposerCursor,
+    };
+  }
+
   /**
-   * Paint the composer to whichever surface owns it. On an interactive
-   * terminal, the single-owner fixed lane reserves a bottom row; empty content
-   * tears it down at turn end. Non-TTY output uses the legacy suffix path.
+   * Paint through the single fixed-surface owner on interactive terminals.
+   * Empty content tears it down at turn end; non-TTY uses the legacy suffix.
    */
   private paintComposerSurface(): void {
     if (this.composerSurfacePauseDepth > 0) return;
     if (composerLaneEnabled() && this.out.isTTY) {
       if (!this.composerLane) this.composerLane = new ComposerLane(this.laneSink());
-      const content = this.composerLaneContent();
+      const content = this.composerContent();
       const hasStatus = typeof this.statusFooterSource === 'function'
         || this.statusFooterSource.length > 0;
       if (content || hasStatus) {
-        this.composerLane.activate(content, this.statusFooterSource);
+        this.composerLane.activate(this.composerSurface(), this.statusFooterSource);
       } else {
         this.composerLane.deactivate();
       }
@@ -2288,7 +2268,7 @@ export class Display {
     this.composerRepaint?.();
   }
 
-  /** Temporarily release the fixed row while a modal prompt owns the terminal.
+  /** Temporarily release the fixed surface while a modal prompt owns the terminal.
    * Draft and hint state remain intact and are repainted after the final
    * matching resume. */
   pauseComposerSurface(): void {
@@ -2296,7 +2276,7 @@ export class Display {
     if (this.composerSurfacePauseDepth === 1) this.composerLane?.deactivate();
   }
 
-  /** Restore the fixed row once the outermost modal prompt has settled. */
+  /** Restore the fixed surface once the outermost modal prompt has settled. */
   resumeComposerSurface(): void {
     if (this.composerSurfacePauseDepth === 0) return;
     this.composerSurfacePauseDepth -= 1;
@@ -2339,18 +2319,6 @@ export class Display {
     return Math.max(4, (this.out.columns ?? 80) - 2);
   }
 
-  /** Preserve the actionable front of an idle hint at narrow widths. Typed
-   * input is already tail-fitted by renderComposerBuffer so its cursor end
-   * remains visible. */
-  private composerLaneContent(): string {
-    const content = this.composerContent();
-    if (this.composerText || this.idleComposerHasDraft || !content) return content;
-    const available = this.composerLaneAvail();
-    return visibleLength(content) <= available
-      ? content
-      : `${truncateVisible(content, Math.max(1, available - 1))}…`;
-  }
-
   private composerSuffix(): string {
     if (this.composerLane?.isActive()) return '';
     const a = this.composerAvail();
@@ -2389,22 +2357,22 @@ export class Display {
 
   /** Informational line, e.g. "Switching model…". */
   info(text: string): void {
-    this.out.write(`${this.skin.applyColors('›', 'accent')} ${text}\n`);
+    this.writeOutput(`${this.skin.applyColors('›', 'accent')} ${text}\n`);
   }
 
   /** Success line, e.g. "Switched to anthropic:claude-opus-4-7". */
   success(text: string): void {
-    this.out.write(`${this.skin.applyColors('✓', 'success')} ${text}\n`);
+    this.writeOutput(`${this.skin.applyColors('✓', 'success')} ${text}\n`);
   }
 
   /** Warning line, e.g. "Verbose mode requires restart." */
   warn(text: string): void {
-    this.out.write(`${this.skin.applyColors('!', 'warn')} ${text}\n`);
+    this.writeOutput(`${this.skin.applyColors('!', 'warn')} ${text}\n`);
   }
 
   /** Muted ("dim") line for low-priority diagnostics. */
   dim(text: string): void {
-    this.out.write(`${this.skin.applyColors(text, 'muted')}\n`);
+    this.writeOutput(`${this.skin.applyColors(text, 'muted')}\n`);
   }
 
   /** Render the single structured outcome owned by turn finalization. */
@@ -2470,12 +2438,12 @@ export class Display {
   /** Horizontal rule for grouping CLI output. */
   line(width = 60): void {
     const ch = this.skin.getActive().glyphs?.bullet === '*' ? '-' : '─';
-    this.out.write(`${this.skin.applyColors(ch.repeat(width), 'muted')}\n`);
+    this.writeOutput(`${this.skin.applyColors(ch.repeat(width), 'muted')}\n`);
   }
 
   /** Convenience: format an error and write it directly to stdout. */
   printError(message: string, suggestion?: string): void {
-    this.out.write(this.error(message, suggestion));
+    this.writeOutput(this.error(message, suggestion));
   }
 
   /**
@@ -2498,9 +2466,9 @@ export class Display {
     this.commitStreamChunk();
     const lines = renderCapabilityCard(data, (t, k) => this.applyColors(t, k));
     for (const line of lines) {
-      this.out.write(line + '\n');
+      this.writeOutput(line + '\n');
     }
-    this.out.write('\n');
+    this.writeOutput('\n');
   }
 
   // ── Phase 16c: streaming surface ─────────────────────────────────────
@@ -2562,7 +2530,7 @@ export class Display {
     if (!this.streamHeaderShown) {
       // Phase 26.2.3 — share the `▎ Aiden` header with non-streaming
       // agentTurn so streamed + non-streamed responses open identically.
-      this.out.write(this.agentHeader());
+      this.writeOutput(this.agentHeader());
       this.streamHeaderShown = true;
       this.streamBuffer = '';
       this.streamLineCount = 0;
@@ -2583,7 +2551,7 @@ export class Display {
     const endsNl = toWrite.endsWith('\n');
     const body = endsNl ? toWrite.slice(0, -1) : toWrite;
     toWrite = body.replace(/\n/g, '\n' + indent) + (endsNl ? '\n' : '');
-    this.out.write(toWrite);
+    this.writeOutput(toWrite);
     this.streamLastEndedNewline = text.endsWith('\n');
     // Phase v4.1-reply-formatting: track buffer + line count for the
     // post-stream re-render.
@@ -2723,7 +2691,7 @@ export class Display {
       // BOUNDED rerender erase: move up `lines` to the block start and clear
       // EXACTLY those lines — never `\x1b[J` (erase-to-end-of-screen), so a
       // re-render can't wipe anything parked below the stream's footprint.
-      this.out.write(clearLinesUpSeq(lines));
+      this.writeOutput(clearLinesUpSeq(lines));
       const formatted = this.markdown(buffered).trimEnd();
       // v4.1.4 reply-quality polish: same detect-and-skip indent + wrap
       // as agentTurn so streamed and one-shot replies share the visible
@@ -2732,14 +2700,14 @@ export class Display {
       // rails) pass through unchanged so their own gutter + wrap stays
       // intact.
       const indented = this.applyFrameToRendered(formatted);
-      this.out.write(indented + '\n');
+      this.writeOutput(indented + '\n');
     } catch {
       // Eraser already ran. v4.1.3-essentials: write the raw buffered
       // text back so the body doesn't vanish silently. The user sees
       // unformatted markdown rather than a missing reply — the honest
       // failure mode.
-      this.out.write(buffered);
-      if (!buffered.endsWith('\n')) this.out.write('\n');
+      this.writeOutput(buffered);
+      if (!buffered.endsWith('\n')) this.writeOutput('\n');
     }
   }
 
@@ -2769,7 +2737,7 @@ export class Display {
     // Ensure the streamed chunk ends with a newline so the interrupt
     // row doesn't stick to mid-token text from the prior delta.
     if (!this.streamLastEndedNewline) {
-      this.out.write('\n');
+      this.writeOutput('\n');
       this.streamLastEndedNewline = true;
       // The trailing newline we just wrote DOES bump the cursor's row,
       // but only by 1 — and `streamLineCount` should reflect physical
@@ -2816,7 +2784,7 @@ export class Display {
       // BOUNDED rerender erase (see clearLinesUpSeq): clears EXACTLY the
       // streamLineCount lines this chunk wrote, never `\x1b[J`, so nothing
       // parked below the stream is wiped.
-      this.out.write(clearLinesUpSeq(this.streamLineCount));
+      this.writeOutput(clearLinesUpSeq(this.streamLineCount));
     }
     // Rerender the closed prefix (handles its own heuristic gate
     // internally — a prefix without structure stays raw, which is
@@ -2824,7 +2792,7 @@ export class Display {
     this.tryRerenderInPlace(split.rerenderable, rerenderableLines);
     // Re-emit the carry verbatim. It's intentionally raw because the
     // unmatched `**` can't be rendered without its closing pair.
-    this.out.write(split.carry);
+    this.writeOutput(split.carry);
     // Reset the per-chunk window to the carry only. Next streamPartial
     // extends it; when the closing `**` lands, the next commit (or
     // streamComplete) rerenders cleanly.
@@ -2844,7 +2812,7 @@ export class Display {
   streamComplete(): void {
     if (!this.streamHeaderShown) return;
     if (!this.streamLastEndedNewline) {
-      this.out.write('\n');
+      this.writeOutput('\n');
       this.streamLineCount += 1;
     }
     // Final chunk: same in-place rerender path as commitStreamChunk
@@ -2872,7 +2840,7 @@ export class Display {
     const footer = renderCitationFooter(trace);
     if (!footer) return;
     if (!this.out.isTTY) return;
-    this.out.write(footer);
+    this.writeOutput(footer);
   }
 
   /**
@@ -2890,7 +2858,7 @@ export class Display {
     this.commitStreamChunk();
     const sk = this.skin;
     const arrow = sk.getActive().glyphs?.arrow ?? '>';
-    this.out.write(`${sk.applyColors(`${arrow} ${name}…`, 'tool')}\n`);
+    this.writeOutput(`${sk.applyColors(`${arrow} ${name}…`, 'tool')}\n`);
     this.streamLastEndedNewline = true;
   }
 
@@ -2972,7 +2940,7 @@ export class Display {
     // v4.8.0 Phase 2.4 — subagent kind: indent by depth inside the
     // gutter so nested rows tier below their parent.
     const indent = kindArg === 'subagent' ? '  '.repeat(depth) : '';
-    this.out.write(this.uiTrailRow(`${indent}${glyph} ${short}`, colorKind));
+    this.writeOutput(this.uiTrailRow(`${indent}${glyph} ${short}`, colorKind));
     this.streamLastEndedNewline = true;
   }
 
@@ -2992,7 +2960,7 @@ export class Display {
     const shortLabel = label.length > 80 ? label.slice(0, 79) + '…' : label;
     const shortSum   = summary.length > 120 ? summary.slice(0, 119) + '…' : summary;
     const tail = shortSum ? ` — ${shortSum}` : '';
-    this.out.write(this.uiTrailRow(`${glyph} ${shortLabel}${tail}`, kind));
+    this.writeOutput(this.uiTrailRow(`${glyph} ${shortLabel}${tail}`, kind));
     this.streamLastEndedNewline = true;
   }
 
@@ -3009,7 +2977,7 @@ export class Display {
     if (stdout) out += this.uiTrailRow(cap(stdout), 'muted');
     if (stderr) out += this.uiTrailRow(cap(stderr), 'error');
     if (!ok)    out += this.uiTrailRow(`(exit ${exitCode})`, 'error');
-    this.out.write(out);
+    this.writeOutput(out);
     this.streamLastEndedNewline = true;
   }
 
@@ -3025,7 +2993,7 @@ export class Display {
     const parts = [`${passed} passed`, `${failed} failed`];
     if (skipped > 0) parts.push(`${skipped} skipped`);
     const dur = durationMs > 0 ? ` in ${durationMs}ms` : '';
-    this.out.write(this.uiTrailRow(`${ok ? '✓' : '✗'} ${framework}: ${parts.join(', ')}${dur}`, ok ? 'success' : 'error'));
+    this.writeOutput(this.uiTrailRow(`${ok ? '✓' : '✗'} ${framework}: ${parts.join(', ')}${dur}`, ok ? 'success' : 'error'));
     this.streamLastEndedNewline = true;
   }
 
@@ -3058,7 +3026,7 @@ export class Display {
     const glyph = kindArg === 'success' ? '✓' : kindArg === 'warning' ? '⚠' : kindArg === 'error' ? '✗' : 'ℹ';
     const kind: ColorKind = kindArg === 'success' ? 'success' : kindArg === 'warning' ? 'warn' : kindArg === 'error' ? 'error' : 'tool';
     const short = message.length > 120 ? message.slice(0, 119) + '…' : message;
-    this.out.write(this.uiTrailRow(`${glyph} ${short}`, kind));
+    this.writeOutput(this.uiTrailRow(`${glyph} ${short}`, kind));
     this.streamLastEndedNewline = true;
   }
 
@@ -3074,7 +3042,7 @@ export class Display {
       const shortP = preview.length > 200 ? preview.slice(0, 199) + '…' : preview;
       out += this.uiTrailRow(`  ${shortP}`, 'muted');
     }
-    this.out.write(out);
+    this.writeOutput(out);
     this.streamLastEndedNewline = true;
   }
 }

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -43,6 +43,39 @@ import { renderCapabilityCard } from './display/capabilityCard';
 import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
 import { recoveryActionsForOutcome } from './recoveryActions';
+
+const DISPLAY_ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+function terminalVisibleLength(value: string): number {
+  return stringWidth(value.replace(DISPLAY_ANSI_PATTERN, ''));
+}
+
+function truncateTerminalVisible(value: string, maxVisible: number): string {
+  if (terminalVisibleLength(value) <= maxVisible) return value;
+  let output = '';
+  let plain = '';
+  let index = 0;
+  let sawAnsi = false;
+  while (index < value.length) {
+    if (value[index] === '\x1b' && value[index + 1] === '[') {
+      const match = value.slice(index).match(/^\x1b\[[0-9;]*[A-Za-z]/);
+      if (match) {
+        output += match[0];
+        index += match[0].length;
+        sawAnsi = true;
+        continue;
+      }
+    }
+    const codePoint = value.codePointAt(index);
+    if (codePoint === undefined) break;
+    const character = String.fromCodePoint(codePoint);
+    if (stringWidth(plain + character) > maxVisible) break;
+    output += character;
+    plain += character;
+    index += character.length;
+  }
+  return sawAnsi ? output + '\x1b[0m' : output;
+}
 // Phase v4.1-reply-formatting: skin-aware markdown renderer that
 // replaces marked-terminal's defaults with structured headers, lists,
 // code blocks, blockquotes, and links.
@@ -984,24 +1017,24 @@ export class Display {
       const providerModelBudget = Math.max(
         8,
         (cols - 4)
-          - visibleLength(compactContext)
-          - visibleLength(compactTimer)
+          - terminalVisibleLength(compactContext)
+          - terminalVisibleLength(compactTimer)
           - 6,
       );
       const fullProviderModel = `${args.provider}:${args.model}`;
       const abbreviatedProviderModel = `${args.provider.slice(0, 1)}:${args.model}`;
-      const compactProviderModel = visibleLength(fullProviderModel) <= providerModelBudget
+      const compactProviderModel = terminalVisibleLength(fullProviderModel) <= providerModelBudget
         ? fullProviderModel
-        : args.provider.length <= 8 && visibleLength(abbreviatedProviderModel) <= providerModelBudget
+        : args.provider.length <= 8 && terminalVisibleLength(abbreviatedProviderModel) <= providerModelBudget
           ? abbreviatedProviderModel
-          : truncateVisible(fullProviderModel, providerModelBudget);
+          : truncateTerminalVisible(fullProviderModel, providerModelBudget);
       segments = [
         this.skin.applyColors(compactProviderModel, 'tool'),
         this.skin.applyColors(compactContext, ctxKind),
         compactTimer,
       ];
     }
-    return truncateVisible(`  ${segments.join(SEP)}`, Math.max(1, cols - 2));
+    return truncateTerminalVisible(`  ${segments.join(SEP)}`, Math.max(1, cols - 2));
   }
 
   /** Map a per-turn outcome to the colour kind used by the state dot. */

--- a/cli/v4/turnIdleDiagnostics.ts
+++ b/cli/v4/turnIdleDiagnostics.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from 'node:fs';
+
 let composerGeneration = 0;
 
 export function nextComposerGeneration(): number {
@@ -10,7 +12,7 @@ export function turnIdleDiagnostic(event: string, data: Record<string, unknown> 
   try {
     const stdin = process.stdin;
     const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[turn-idle] ${JSON.stringify({
+    const line = `[turn-idle] ${JSON.stringify({
       monoMs,
       event,
       stdin: {
@@ -23,6 +25,12 @@ export function turnIdleDiagnostic(event: string, data: Record<string, unknown> 
       },
       sigintListeners: process.listenerCount('SIGINT'),
       ...data,
-    })}\n`);
+    })}\n`;
+    const diagnosticFile = process.env.AIDEN_TEST_TURN_IDLE_DIAG_FILE;
+    if (diagnosticFile) {
+      appendFileSync(diagnosticFile, line, 'utf8');
+    } else {
+      process.stderr.write(line);
+    }
   } catch { /* test diagnostics must not affect the terminal lifecycle */ }
 }

--- a/core/channels/telegram.ts
+++ b/core/channels/telegram.ts
@@ -250,6 +250,8 @@ export class TelegramAdapter implements ChannelAdapter {
   private voiceTranscribedCount: number = 0
   /** Number of voice messages received (any outcome) since adapter start. */
   private voiceReceivedCount:    number = 0
+  /** Startup cache maintenance remains owned until shutdown has observed it. */
+  private cacheMaintenance:      Promise<void> | null = null
   // Phase v4.1-3.1 — idempotency guard for the defensive secondary
   // subscriptions. NTBA always fires 'message' AND the type-specific
   // event ('voice', 'audio') for media attachments; we subscribe to
@@ -463,7 +465,7 @@ export class TelegramAdapter implements ChannelAdapter {
     // Phase v4.1-3 — voice cache janitor runs once at adapter start.
     // No background timer (defer real TTL to v4.2). Best-effort: a
     // janitor failure must not block polling.
-    this.runVoiceCacheJanitor().catch((e: any) => {
+    this.cacheMaintenance = this.runVoiceCacheJanitor().catch((e: any) => {
       this.logWarn(`voice cache janitor failed: ${e?.message ?? String(e)}`)
     })
 
@@ -661,6 +663,9 @@ export class TelegramAdapter implements ChannelAdapter {
   async stop(): Promise<void> {
     this.healthy = false
     this.state   = 'inactive'
+
+    await this.cacheMaintenance
+    this.cacheMaintenance = null
 
     // Phase v4.1-2 — flush group state + dispose rate-limiter timers.
     // Best-effort; never let cleanup throw stop the shutdown chain.

--- a/core/toolRegistry.ts
+++ b/core/toolRegistry.ts
@@ -11,7 +11,9 @@ import { promisify } from 'util'
 import fs   from 'fs'
 import path from 'path'
 import os   from 'os'
+import { randomUUID } from 'crypto'
 import { getUserDataDir } from './paths'
+import { executeWithDurableToolCall } from './v4/daemon/jobExecutionContext'
 
 import {
   moveMouse,
@@ -2880,7 +2882,7 @@ async function runTool(tool: string, input: Record<string, any>): Promise<RawRes
 // maxRetries: number of retries AFTER the first attempt (default 2 = 3 total tries)
 // timeoutMs: fallback timeout when tool has no entry in TOOL_TIMEOUTS
 
-export async function executeTool(
+async function executeToolInner(
   tool:       string,
   input:      Record<string, any>,
   maxRetries: number = 2,
@@ -2966,6 +2968,25 @@ export async function executeTool(
 // ── Sprint 29: TOOL_DESCRIPTIONS ────────────────────────────────
 // Human-readable descriptions for all tools, used by the MCP server to advertise
 // capabilities to Claude Desktop and other MCP clients.
+
+export async function executeTool(
+  tool:       string,
+  input:      Record<string, any>,
+  maxRetries: number = 2,
+  timeoutMs:  number = 30000,
+): Promise<ToolResult> {
+  const metadata = TOOL_REGISTRY[tool]
+  const mutates = metadata?.retry === false || metadata?.mcp === 'destructive'
+  return executeWithDurableToolCall({
+    toolCallId: `tool_${randomUUID()}`,
+    toolName: tool,
+    args: input,
+    riskTier: String(metadata?.tier ?? 'unknown'),
+    mutates,
+    execute: () => executeToolInner(tool, input, maxRetries, timeoutMs),
+    isSuccessful: (result) => result.success,
+  })
+}
 
 export const TOOL_DESCRIPTIONS: Record<string, string> = {
   web_search:              'Search the web for current information, news, or any topic',

--- a/core/v4/actionAuthority.ts
+++ b/core/v4/actionAuthority.ts
@@ -1,0 +1,538 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Db } from './daemon/db/connection';
+import type { JobEngine } from './daemon/jobEngine';
+
+export interface PolicySnapshotInput {
+  trustLevel: string;
+  autonomyPolicy: string;
+  approvalMode: string;
+  toolMetadataVersion: string;
+  sandboxPolicy: unknown;
+  networkPolicy: unknown;
+  pluginGrants: unknown;
+  mcpGrants: unknown;
+  spendingLimits?: unknown;
+  workspaceOverrides: unknown;
+  jobOverrides: unknown;
+}
+
+export interface PolicySnapshot extends PolicySnapshotInput {
+  policySnapshotId: string;
+  schemaVersion: 1;
+  digest: string;
+}
+
+export interface NormalizedExecutionPlan {
+  toolName: string;
+  args: Readonly<Record<string, unknown>>;
+  cwd: string;
+  executable: string | null;
+  shell: string | null;
+  environmentFingerprint: string | null;
+  networkTargets: readonly string[];
+  affectedResources: readonly string[];
+  mutates: boolean;
+  riskTier: string;
+}
+
+export interface NormalizedAction {
+  plan: Readonly<NormalizedExecutionPlan>;
+  actionDigest: string;
+  policySnapshot: PolicySnapshot;
+}
+
+export interface ApprovalRecord {
+  approvalId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  toolCallId: string;
+  requestSequence: number;
+  toolName: string;
+  riskTier: string;
+  actionDigest: string;
+  policySnapshotId: string;
+  state: 'created' | 'displayed' | 'approved' | 'denied' | 'expired' | 'cancelled' | 'invalidated' | 'executed' | 'stale_rejected';
+  decision: string | null;
+  requestedAt: number;
+  displayedAt: number | null;
+  decidedAt: number | null;
+  expiresAt: number | null;
+  executedAt: number | null;
+  invalidationReason: string | null;
+}
+
+export interface ActionAuthority {
+  request(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    toolCallId: string;
+    toolName: string;
+    riskTier: string;
+    riskReasons: string[];
+    normalized: NormalizedAction;
+    expiresAt?: number | null;
+    now?: number;
+  }): ApprovalRecord;
+  get(approvalId: string): ApprovalRecord | null;
+  listPending(jobId: string): ApprovalRecord[];
+  markDisplayed(approvalId: string, now?: number): ApprovalRecord;
+  decide(command: {
+    approvalId: string;
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    actionDigest: string;
+    policySnapshotId: string;
+    decision: 'approved' | 'denied' | 'cancelled';
+    decisionInputId?: string | null;
+    decisionScope?: string | null;
+    decidedBy: string;
+    decisionChannel: string;
+    now?: number;
+  }): ApprovalRecord;
+  decideFromInput(command: { approvalId: string; inputKind: string; content: string }): never;
+  authorizeExecution(command: {
+    approvalId: string;
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    toolCallId: string;
+    actionDigest: string;
+    policySnapshotId: string;
+    now?: number;
+  }): { authorized: boolean; duplicate?: boolean; reason?: string };
+  invalidate(approvalId: string, reason: string, now?: number): ApprovalRecord;
+}
+
+interface ApprovalRow {
+  approval_id: string;
+  job_id: string;
+  attempt_id: string;
+  generation: number;
+  tool_call_id: string;
+  request_sequence: number;
+  tool_name: string;
+  risk_tier: string;
+  action_digest: string;
+  policy_snapshot_id: string;
+  state: ApprovalRecord['state'];
+  decision: string | null;
+  requested_at: number;
+  displayed_at: number | null;
+  decided_at: number | null;
+  expires_at: number | null;
+  executed_at: number | null;
+  invalidation_reason: string | null;
+}
+
+const SENSITIVE_KEY = /(?:api[_-]?key|token|secret|password|authorization|cookie|credential)/i;
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(source).sort().map((key) => [key, canonical(source[key])]));
+  }
+  return value;
+}
+
+function redactedCanonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactedCanonical);
+  if (value && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(source).sort().map((key) => [
+      key,
+      SENSITIVE_KEY.test(key) ? '[redacted]' : redactedCanonical(source[key]),
+    ]));
+  }
+  return value;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(canonical(value));
+}
+
+function sha(value: unknown): string {
+  return createHash('sha256').update(typeof value === 'string' ? value : stableJson(value)).digest('hex');
+}
+
+function makeId(prefix: string): string {
+  return `${prefix}_${randomBytes(12).toString('hex')}`;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  }
+  return value;
+}
+
+function policySnapshot(input: PolicySnapshotInput): PolicySnapshot {
+  const safe = redactedCanonical(input) as PolicySnapshotInput;
+  const digest = sha({ schemaVersion: 1, ...safe });
+  return deepFreeze({
+    ...safe,
+    schemaVersion: 1 as const,
+    digest,
+    policySnapshotId: `policy_${digest}`,
+  });
+}
+
+function firstCommandToken(command: string): string | null {
+  const match = command.trim().match(/^(?:"([^"]+)"|'([^']+)'|([^\s]+))/);
+  return match ? (match[1] ?? match[2] ?? match[3] ?? null) : null;
+}
+
+function canonicalPath(value: string): string {
+  const suffix: string[] = [];
+  let cursor = path.resolve(value);
+  while (!fs.existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) return path.resolve(value);
+    suffix.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  let resolved: string;
+  try { resolved = fs.realpathSync.native(cursor); }
+  catch { resolved = cursor; }
+  return path.join(resolved, ...suffix);
+}
+
+function resolveResource(value: unknown, cwd: string): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
+  return canonicalPath(path.resolve(cwd, value));
+}
+
+export function normalizeExecutionPlan(command: {
+  toolName: string;
+  args: Record<string, unknown>;
+  cwd: string;
+  mutates: boolean;
+  riskTier: string;
+  policy: PolicySnapshotInput;
+}): NormalizedAction {
+  const requestedCwd = typeof command.args.cwd === 'string' ? command.args.cwd : command.cwd;
+  const cwd = canonicalPath(path.resolve(command.cwd, requestedCwd));
+  const rawCommand = typeof command.args.command === 'string' ? command.args.command : null;
+  const executable = rawCommand ? firstCommandToken(rawCommand) : null;
+  const shell = rawCommand ? (process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/sh') : null;
+  const env = command.args.env && typeof command.args.env === 'object' && !Array.isArray(command.args.env)
+    ? command.args.env as Record<string, unknown>
+    : null;
+  const environmentFingerprint = env ? sha(env) : null;
+  const networkTargets = ['url', 'endpoint', 'host'].map((key) => command.args[key])
+    .filter((value): value is string => typeof value === 'string' && /^[a-z][a-z0-9+.-]*:\/\//i.test(value))
+    .sort();
+  const affectedResources = ['path', 'file', 'source', 'destination', 'cwd']
+    .map((key) => resolveResource(command.args[key], cwd))
+    .filter((value): value is string => value !== null)
+    .sort();
+  const safeArgs = redactedCanonical(command.args) as Record<string, unknown>;
+  const plan: NormalizedExecutionPlan = deepFreeze({
+    toolName: command.toolName,
+    args: safeArgs,
+    cwd,
+    executable,
+    shell,
+    environmentFingerprint,
+    networkTargets,
+    affectedResources,
+    mutates: command.mutates,
+    riskTier: command.riskTier,
+  });
+  const snapshot = policySnapshot(command.policy);
+  const actionDigest = sha({
+    toolName: command.toolName,
+    args: canonical(command.args),
+    cwd,
+    executable,
+    shell,
+    environmentFingerprint,
+    networkTargets,
+    affectedResources,
+    mutates: command.mutates,
+    riskTier: command.riskTier,
+    policyDigest: snapshot.digest,
+  });
+  return deepFreeze({ plan, actionDigest, policySnapshot: snapshot });
+}
+
+function mapApproval(row: ApprovalRow): ApprovalRecord {
+  return {
+    approvalId: row.approval_id,
+    jobId: row.job_id,
+    attemptId: row.attempt_id,
+    generation: row.generation,
+    toolCallId: row.tool_call_id,
+    requestSequence: row.request_sequence,
+    toolName: row.tool_name,
+    riskTier: row.risk_tier,
+    actionDigest: row.action_digest,
+    policySnapshotId: row.policy_snapshot_id,
+    state: row.state,
+    decision: row.decision,
+    requestedAt: row.requested_at,
+    displayedAt: row.displayed_at,
+    decidedAt: row.decided_at,
+    expiresAt: row.expires_at,
+    executedAt: row.executed_at,
+    invalidationReason: row.invalidation_reason,
+  };
+}
+
+export function createActionAuthority(options: { db: Db; jobEngine: JobEngine }): ActionAuthority {
+  const { db, jobEngine } = options;
+  const get = (approvalId: string): ApprovalRecord | null => {
+    const row = db.prepare('SELECT * FROM approvals WHERE approval_id = ?').get(approvalId) as ApprovalRow | undefined;
+    return row ? mapApproval(row) : null;
+  };
+  const persistPolicy = (snapshot: PolicySnapshot, now: number): void => {
+    const p = snapshot;
+    db.prepare(
+      `INSERT OR IGNORE INTO policy_snapshots (
+         policy_snapshot_id, schema_version, digest, trust_level, autonomy_policy,
+         approval_mode, tool_metadata_version, sandbox_policy_json,
+         network_policy_json, plugin_grants_json, mcp_grants_json,
+         spending_limits_json, workspace_overrides_json, job_overrides_json, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      p.policySnapshotId,
+      p.schemaVersion,
+      p.digest,
+      p.trustLevel,
+      p.autonomyPolicy,
+      p.approvalMode,
+      p.toolMetadataVersion,
+      stableJson(p.sandboxPolicy),
+      stableJson(p.networkPolicy),
+      stableJson(p.pluginGrants),
+      stableJson(p.mcpGrants),
+      p.spendingLimits === undefined ? null : stableJson(p.spendingLimits),
+      stableJson(p.workspaceOverrides),
+      stableJson(p.jobOverrides),
+      now,
+    );
+  };
+  const appendApprovalEvent = (record: ApprovalRecord, type: string, producer: string): void => {
+    const result = jobEngine.appendJobEvent({
+      jobId: record.jobId,
+      attemptId: record.attemptId,
+      generation: record.generation,
+      type,
+      producer,
+      idempotencyKey: `approval:${record.approvalId}:${type}`,
+      payload: {
+        approvalId: record.approvalId,
+        toolCallId: record.toolCallId,
+        actionDigest: record.actionDigest,
+        policySnapshotId: record.policySnapshotId,
+        state: record.state,
+      },
+    });
+    if (!result.applied && !result.duplicate) {
+      throw new Error(`Approval event rejected: ${result.conflict ?? 'unknown conflict'}`);
+    }
+  };
+
+  return {
+    request(command) {
+      const job = jobEngine.getJob(command.jobId);
+      const attempt = jobEngine.getAttempt(command.attemptId);
+      if (
+        !job || !attempt || job.activeAttemptId !== command.attemptId ||
+        attempt.jobId !== command.jobId || attempt.generation !== command.generation ||
+        ['cancelled', 'completed', 'failed', 'dead_letter'].includes(job.status)
+      ) {
+        throw new Error('Approval target has a stale generation');
+      }
+      const now = command.now ?? Date.now();
+      const transaction = db.transaction(() => {
+        persistPolicy(command.normalized.policySnapshot, now);
+        const sequence = (db.prepare(
+          'SELECT COALESCE(MAX(request_sequence), 0) + 1 AS sequence FROM approvals WHERE job_id = ?',
+        ).get(command.jobId) as { sequence: number }).sequence;
+        const approvalId = makeId('approval');
+        db.prepare(
+          `INSERT INTO approvals (
+             approval_id, job_id, attempt_id, generation, tool_call_id,
+             request_sequence, tool_name, risk_tier, risk_reasons_json,
+             normalized_execution_plan, action_digest, policy_snapshot_id,
+             state, requested_at, expires_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created', ?, ?)`,
+        ).run(
+          approvalId,
+          command.jobId,
+          command.attemptId,
+          command.generation,
+          command.toolCallId,
+          sequence,
+          command.toolName,
+          command.riskTier,
+          stableJson(command.riskReasons),
+          stableJson(command.normalized.plan),
+          command.normalized.actionDigest,
+          command.normalized.policySnapshot.policySnapshotId,
+          now,
+          command.expiresAt ?? null,
+        );
+        const record = get(approvalId)!;
+        appendApprovalEvent(record, 'approval.created', 'approval');
+        return record;
+      });
+      return transaction.immediate();
+    },
+    get,
+    listPending(jobId) {
+      return (db.prepare(
+        `SELECT * FROM approvals
+          WHERE job_id = ? AND state IN ('created','displayed')
+          ORDER BY request_sequence`,
+      ).all(jobId) as ApprovalRow[]).map(mapApproval);
+    },
+    markDisplayed(approvalId, now = Date.now()) {
+      return db.transaction(() => {
+        db.prepare(
+          `UPDATE approvals SET state = 'displayed', displayed_at = COALESCE(displayed_at, ?)
+            WHERE approval_id = ? AND state = 'created'`,
+        ).run(now, approvalId);
+        const record = get(approvalId);
+        if (!record) throw new Error('Approval not found');
+        appendApprovalEvent(record, 'approval.displayed', 'approval');
+        return record;
+      }).immediate();
+    },
+    decide(command) {
+      let expired = false;
+      const result = db.transaction(() => {
+        const record = get(command.approvalId);
+        if (!record) throw new Error('Approval not found');
+        const job = jobEngine.getJob(command.jobId);
+        const attempt = jobEngine.getAttempt(command.attemptId);
+        if (!job || ['cancelled', 'completed', 'failed', 'dead_letter'].includes(job.status)) {
+          throw new Error('Terminal Job rejects approval decisions');
+        }
+        if (
+          !attempt || job.activeAttemptId !== command.attemptId ||
+          attempt.jobId !== command.jobId || attempt.generation !== command.generation
+        ) {
+          throw new Error('Approval decision has a stale generation');
+        }
+        if (
+          record.jobId !== command.jobId || record.attemptId !== command.attemptId ||
+          record.generation !== command.generation
+        ) throw new Error('Approval decision binding mismatch or stale generation');
+        if (record.actionDigest !== command.actionDigest || record.policySnapshotId !== command.policySnapshotId) {
+          this.invalidate(command.approvalId, 'action or policy changed', command.now);
+          throw new Error('Approval action or policy changed');
+        }
+        if (record.state === 'approved' || record.state === 'denied' || record.state === 'cancelled') {
+          if (record.decision !== command.decision) throw new Error('Approval received a conflicting decision');
+          return record;
+        }
+        if (!['created', 'displayed'].includes(record.state)) throw new Error(`Approval is ${record.state}`);
+        const now = command.now ?? Date.now();
+        if (record.expiresAt !== null && record.expiresAt <= now) {
+          db.prepare(
+            `UPDATE approvals SET state = 'expired', decided_at = ? WHERE approval_id = ? AND state IN ('created','displayed')`,
+          ).run(now, command.approvalId);
+          expired = true;
+          const updated = get(command.approvalId)!;
+          appendApprovalEvent(updated, 'approval.expired', command.decidedBy);
+          return updated;
+        }
+        db.prepare(
+          `UPDATE approvals SET state = ?, decision = ?, decision_input_id = ?, decision_scope = ?,
+              decided_by = ?, decision_channel = ?, decided_at = ?
+            WHERE approval_id = ? AND state IN ('created','displayed')`,
+        ).run(
+          command.decision,
+          command.decision,
+          command.decisionInputId ?? null,
+          command.decisionScope ?? 'once',
+          command.decidedBy,
+          command.decisionChannel,
+          now,
+          command.approvalId,
+        );
+        const updated = get(command.approvalId)!;
+        appendApprovalEvent(updated, `approval.${command.decision}`, command.decidedBy);
+        return updated;
+      }).immediate();
+      if (expired) throw new Error('Approval expired');
+      return result;
+    },
+    decideFromInput() {
+      throw new Error('An explicit approval decision command is required; normal text is never consent');
+    },
+    authorizeExecution(command) {
+      return db.transaction(() => {
+        const record = get(command.approvalId);
+        if (!record) return { authorized: false, reason: 'approval not found' };
+        if (record.state === 'executed') return { authorized: false, duplicate: true, reason: 'approval already executed' };
+        if (record.state !== 'approved') return { authorized: false, reason: `approval is ${record.state}` };
+        const job = jobEngine.getJob(command.jobId);
+        const attempt = jobEngine.getAttempt(command.attemptId);
+        const now = command.now ?? Date.now();
+        if (
+          !job || !attempt || job.activeAttemptId !== command.attemptId ||
+          attempt.generation !== command.generation ||
+          attempt.fenceToken !== command.fenceToken ||
+          attempt.leaseExpiresAt === null || attempt.leaseExpiresAt <= now ||
+          !['running', 'waiting'].includes(job.status) ||
+          !['running', 'waiting', 'leased'].includes(attempt.status)
+        ) {
+          this.invalidate(command.approvalId, 'stale Job or Attempt generation', command.now);
+          return { authorized: false, reason: 'stale Job, Attempt generation, or fence' };
+        }
+        if (
+          record.jobId !== command.jobId || record.attemptId !== command.attemptId ||
+          record.generation !== command.generation || record.toolCallId !== command.toolCallId ||
+          record.actionDigest !== command.actionDigest || record.policySnapshotId !== command.policySnapshotId
+        ) {
+          this.invalidate(command.approvalId, 'approved action changed or binding mismatch', command.now);
+          return { authorized: false, reason: 'approved action changed or binding mismatch' };
+        }
+        if (record.expiresAt !== null && record.expiresAt <= now) {
+          db.prepare(`UPDATE approvals SET state = 'expired', invalidated_at = ? WHERE approval_id = ? AND state = 'approved'`)
+            .run(now, command.approvalId);
+          appendApprovalEvent(get(command.approvalId)!, 'approval.expired', 'approval');
+          return { authorized: false, reason: 'approval expired' };
+        }
+        const changed = db.prepare(
+          `UPDATE approvals SET state = 'executed', executed_at = ? WHERE approval_id = ? AND state = 'approved'`,
+        ).run(now, command.approvalId);
+        if (changed.changes !== 1) {
+          return { authorized: false, duplicate: true, reason: 'approval execution already claimed' };
+        }
+        appendApprovalEvent(get(command.approvalId)!, 'approval.executed', 'approval');
+        return { authorized: true };
+      }).immediate();
+    },
+    invalidate(approvalId, reason, now = Date.now()) {
+      return db.transaction(() => {
+        db.prepare(
+          `UPDATE approvals
+              SET state = 'invalidated', invalidated_at = ?, invalidation_reason = ?
+            WHERE approval_id = ? AND state IN ('created','displayed','approved')`,
+        ).run(now, reason, approvalId);
+        const record = get(approvalId);
+        if (!record) throw new Error('Approval not found');
+        appendApprovalEvent(record, 'approval.invalidated', 'approval');
+        return record;
+      }).immediate();
+    },
+  };
+}

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -55,6 +55,7 @@ import {
   type ToolResultArtifactStore,
 } from './toolResultBoundary';
 import { selectEconomyTools } from './usagePolicy';
+import { recordDurableToolVerification } from './daemon/jobExecutionContext';
 import {
   createLogicalProviderCallId,
   currentProviderAttemptLedger,
@@ -1997,6 +1998,13 @@ export class AidenAgent {
             } catch {
               // Defensive — a buggy verifier never breaks the agent loop.
               verification = undefined;
+            }
+            // Denied, blocked, and interrupted approvals never reach the tool
+            // handler, so no durable ToolCall exists to receive verification.
+            // Keep their verifier result in the normal trace, but do not turn a
+            // deliberate non-execution into a stale-fence persistence error.
+            if (verification && result.approvalDecision?.approved !== false) {
+              recordDurableToolVerification(call.id, verification);
             }
             const verificationEndedAt = Date.now();
             if (aggregateTiming) {

--- a/core/v4/daemon/api/runs.ts
+++ b/core/v4/daemon/api/runs.ts
@@ -31,6 +31,8 @@ import type { Express, Request, Response, NextFunction } from 'express';
 import express from 'express';
 
 import type { TriggerBus } from '../triggerBus';
+import type { Db } from '../db/connection';
+import { IdempotencyConflictError, type JobEngine } from '../jobEngine';
 import { fingerprintCanonical } from '../idempotency/runIdempotencyStore';
 // v4.9.0 Slice 7 — inbound trace adoption.
 import {
@@ -48,6 +50,9 @@ import { getCurrentDaemonId, getCurrentIncarnationId, getCurrentDaemonDb } from 
 export interface MountRunsRoutesOptions {
   app:        Express;
   triggerBus: TriggerBus;
+  db:         Db;
+  jobEngine:  JobEngine;
+  instanceId: string;
   log:        (level: 'info' | 'warn' | 'error', msg: string) => void;
   /** Optional shared-secret check via `AIDEN_API_KEY` env var. */
   apiKeyRequired?: boolean;
@@ -123,16 +128,46 @@ export function mountRunsRoutes(opts: MountRunsRoutesOptions): MountedRunsRoutes
 
       void runWithContext(ctx, () => {
         try {
-          const result = opts.triggerBus.insert({
-            source:         'manual',
-            sourceKey,
-            idempotencyKey,
-            payload:        {
+          const accepted = opts.db.transaction(() => {
+            const result = opts.triggerBus.insert({
+              source:         'manual',
+              sourceKey,
+              idempotencyKey,
+              payload:        {
+                body, fingerprint, headerKey,
+                external_trace_id:  incomingTp?.traceId ?? null,
+                external_request_id: externalReqId ?? null,
+              },
+            });
+            const sessionId = `api:${sourceKey}:${idempotencyKey.slice(0, 24)}`;
+            const admission = opts.jobEngine.submitJob({
+              entryPoint: 'daemon_api',
+              source: 'api',
+              sessionId,
+              instanceId: opts.instanceId,
+              idempotencyNamespace: `daemon-api:${sourceKey}`,
+              idempotencyKey,
+              requestFingerprint: fingerprint,
+              goal: `Daemon API request ${fingerprint.slice(0, 16)}`,
+              triggerEventId: result.id,
+            });
+            opts.db.prepare(
+              `UPDATE trigger_events
+                  SET payload_json = ?
+                WHERE id = ?`,
+            ).run(JSON.stringify({
               body, fingerprint, headerKey,
-              external_trace_id:  incomingTp?.traceId ?? null,
+              external_trace_id: incomingTp?.traceId ?? null,
               external_request_id: externalReqId ?? null,
-            },
-          });
+              durable_job: {
+                job_id: admission.jobId,
+                attempt_id: admission.attemptId,
+                run_id: admission.runId,
+              },
+            }), result.id);
+            return { result, admission };
+          })();
+          const { result, admission } = accepted;
           // Persist `external_trace_id` on the trigger payload so the
           // dispatcher can copy it onto the `runs` row when it
           // creates one. We can't write to `runs` here (no run row
@@ -146,11 +181,18 @@ export function mountRunsRoutes(opts: MountRunsRoutesOptions): MountedRunsRoutes
             duplicate:           !result.inserted,
             trigger_event_id:    result.id,
             idempotency_key:     idempotencyKey,
-            run_id:              ctx.runId,
+            run_id:              admission.runId,
+            job_id:              admission.jobId,
+            attempt_id:          admission.attemptId,
             trace_id:            ctx.traceId,
             external_trace_id:   incomingTp?.traceId ?? null,
           });
         } catch (e) {
+          if (e instanceof IdempotencyConflictError) {
+            opts.log('warn', `[api/runs] idempotency conflict namespace=${e.namespace}`);
+            res.status(409).json({ error: 'idempotency_conflict' });
+            return;
+          }
           opts.log('error', `[api/runs] insert failed: ${e instanceof Error ? e.message : String(e)}`);
           res.status(500).json({ error: 'internal_error' });
         }

--- a/core/v4/daemon/api/runs.ts
+++ b/core/v4/daemon/api/runs.ts
@@ -33,6 +33,7 @@ import express from 'express';
 import type { TriggerBus } from '../triggerBus';
 import type { Db } from '../db/connection';
 import { IdempotencyConflictError, type JobEngine } from '../jobEngine';
+import { createJobControlAuthority, type JobControlAuthority } from '../jobControlAuthority';
 import { fingerprintCanonical } from '../idempotency/runIdempotencyStore';
 // v4.9.0 Slice 7 — inbound trace adoption.
 import {
@@ -53,6 +54,7 @@ export interface MountRunsRoutesOptions {
   db:         Db;
   jobEngine:  JobEngine;
   instanceId: string;
+  jobControlAuthority?: JobControlAuthority;
   log:        (level: 'info' | 'warn' | 'error', msg: string) => void;
   /** Optional shared-secret check via `AIDEN_API_KEY` env var. */
   apiKeyRequired?: boolean;
@@ -65,22 +67,28 @@ export interface MountedRunsRoutes {
 
 export function mountRunsRoutes(opts: MountRunsRoutesOptions): MountedRunsRoutes {
   const PATH = '/api/runs';
+  const controlAuthority = opts.jobControlAuthority ?? createJobControlAuthority({
+    db: opts.db,
+    jobEngine: opts.jobEngine,
+  });
+
+  const authorized = (req: Request, res: Response): boolean => {
+    if (!opts.apiKeyRequired) return true;
+    const expected = process.env.AIDEN_API_KEY ?? '';
+    const auth = req.header('authorization') ?? '';
+    const tokenMatch = /^Bearer\s+(\S+)/i.exec(auth);
+    const provided = tokenMatch ? tokenMatch[1] : '';
+    if (expected && expected === provided) return true;
+    res.status(401).json({ error: 'unauthorized' });
+    return false;
+  };
 
   opts.app.post(
     PATH,
     express.json({ limit: '1mb' }),
     (req: Request, res: Response, _next: NextFunction): void => {
       // Optional shared-secret auth.
-      if (opts.apiKeyRequired) {
-        const expected = process.env.AIDEN_API_KEY ?? '';
-        const auth = req.header('authorization') ?? '';
-        const tokenMatch = /^Bearer\s+(\S+)/i.exec(auth);
-        const provided = tokenMatch ? tokenMatch[1] : '';
-        if (!expected || expected !== provided) {
-          res.status(401).json({ error: 'unauthorized' });
-          return;
-        }
-      }
+      if (!authorized(req, res)) return;
 
       const body = (req.body ?? {}) as Record<string, unknown>;
       if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -200,6 +208,112 @@ export function mountRunsRoutes(opts: MountRunsRoutesOptions): MountedRunsRoutes
       // Quiet unused-warning on the db handle; future Slice 8 uses it
       // to back-fill the `runs.external_trace_id` column on creation.
       void getCurrentDaemonDb;
+    },
+  );
+
+  opts.app.post(
+    `${PATH}/:attemptId/:command`,
+    express.json({ limit: '64kb' }),
+    (req: Request, res: Response): void => {
+      if (!authorized(req, res)) return;
+      const command = String(req.params.command ?? '');
+      if (!['input', 'pause', 'resume', 'cancel', 'interrupt'].includes(command)) {
+        res.status(404).json({ error: 'unknown_run_command' });
+        return;
+      }
+      const attempt = opts.jobEngine.getAttempt(String(req.params.attemptId ?? ''));
+      if (!attempt) { res.status(404).json({ error: 'attempt_not_found' }); return; }
+      const job = attempt.jobId ? opts.jobEngine.getJob(attempt.jobId) : null;
+      if (!job) { res.status(404).json({ error: 'job_not_found' }); return; }
+      const body = req.body && typeof req.body === 'object' && !Array.isArray(req.body)
+        ? req.body as Record<string, unknown>
+        : {};
+      const providedKey = (req.header('idempotency-key') ?? '').trim();
+      const key = providedKey || newRequestId();
+      try {
+        if (command === 'input') {
+          const content = typeof body.message === 'string' ? body.message : '';
+          if (!content.trim()) { res.status(400).json({ error: 'message_required' }); return; }
+          const received = controlAuthority.inputs.receive({
+            jobId: attempt.jobId,
+            targetAttemptId: attempt.id,
+            targetGeneration: attempt.generation,
+            sessionId: job.sessionId,
+            channelId: 'daemon-api',
+            source: 'api',
+            kind: 'message',
+            content,
+            idempotencyNamespace: 'daemon-api-input',
+            idempotencyKey: key,
+          });
+          res.status(202).json({
+            accepted: true,
+            duplicate: received.duplicate,
+            input_id: received.record.inputId,
+            job_id: attempt.jobId,
+            attempt_id: attempt.id,
+          });
+          return;
+        }
+        if (command === 'resume') {
+          const resumed = controlAuthority.commands.resume({
+            jobId: attempt.jobId,
+            source: 'api',
+            instanceId: opts.instanceId,
+            idempotencyNamespace: 'daemon-api-control',
+            idempotencyKey: key,
+          });
+          const trigger = opts.triggerBus.insert({
+            source: 'manual',
+            sourceKey: `api-resume:${attempt.jobId}`,
+            idempotencyKey: `resume:${key}`,
+            payload: {
+              body: { prompt: job.goal, source: 'api-resume' },
+              sessionId: job.sessionId,
+              durable_job: {
+                job_id: job.id,
+                attempt_id: resumed.attemptId,
+                run_id: resumed.runId,
+              },
+            },
+          });
+          opts.db.prepare('UPDATE runs SET trigger_event_id = ? WHERE attempt_id = ?')
+            .run(trigger.id, resumed.attemptId);
+          res.status(202).json({
+            accepted: true,
+            duplicate: resumed.duplicate,
+            control_id: resumed.controlId,
+            job_id: attempt.jobId,
+            attempt_id: resumed.attemptId,
+            run_id: resumed.runId,
+            generation: resumed.generation,
+            trigger_event_id: trigger.id,
+          });
+          return;
+        }
+        const result = controlAuthority.commands.request({
+          jobId: attempt.jobId,
+          attemptId: attempt.id,
+          generation: attempt.generation,
+          kind: command as 'pause' | 'cancel' | 'interrupt',
+          source: 'api',
+          reason: typeof body.reason === 'string' ? body.reason : command,
+          idempotencyNamespace: 'daemon-api-control',
+          idempotencyKey: key,
+        });
+        res.status(202).json({
+          accepted: true,
+          persisted: result.persisted,
+          applied: result.applied,
+          duplicate: result.duplicate,
+          control_id: result.controlId,
+          job_id: attempt.jobId,
+          attempt_id: attempt.id,
+        });
+      } catch (error) {
+        opts.log('warn', `[api/runs] ${command} rejected: ${error instanceof Error ? error.message : String(error)}`);
+        res.status(409).json({ error: 'run_command_rejected' });
+      }
     },
   );
 

--- a/core/v4/daemon/bootstrap.ts
+++ b/core/v4/daemon/bootstrap.ts
@@ -49,10 +49,11 @@ import { createIdempotencyStore } from './idempotencyStore';
 import type { IdempotencyStore } from './idempotencyStore';
 import { createRunStore } from './runStore';
 import { createTaskStore } from './taskStore';
+import { createJobEngine } from './jobEngine';
+import { sweepDurableJobRecovery } from './jobRecoverySweep';
 import { sweepResumePending } from './resumeSweep';
 import type { RunStore } from './runStore';
 // v4.10 Slice 10.2b — shared event taxonomy.
-import { categorizeEvent } from './eventCategories';
 import { createRestartFailureCounter } from './restartFailureCounter';
 import type { RestartFailureCounter } from './restartFailureCounter';
 import { getResourceRegistry } from './resourceRegistry';
@@ -548,6 +549,7 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
     });
     const idempotencyStore      = createIdempotencyStore({ db });
     const runStore              = createRunStore({ db });
+    const jobEngine             = createJobEngine({ db });
     const restartFailureCounter = createRestartFailureCounter({ db, threshold: cfg.restartFailureThreshold });
     const resourceRegistry      = getResourceRegistry();
     try { idempotencyStore.reseed(); } catch { /* best-effort */ }
@@ -601,7 +603,10 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
       const ingressBindHost = process.env.AIDEN_DAEMON_BIND ?? '127.0.0.1';
       mountRunsRoutes({
         app,
+        db,
         triggerBus,
+        jobEngine,
+        instanceId: tracker.instanceId,
         log,
         apiKeyRequired: ingressBindHost !== '127.0.0.1' && ingressBindHost !== 'localhost',
       });
@@ -934,7 +939,7 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
       // fires or just an immediate stop.
       const runnerFactory: () => DaemonAgentRunner = opts.agentBuilder
         ? () => createRealAgentRunner({
-            db, runStore, resourceRegistry,
+            db, runStore, jobEngine, resourceRegistry,
             log, agentBuilder: opts.agentBuilder!,
             persistedDefault: opts.persistedDefaultModel,
             // v4.13 Gap 4 — daemon runs carry the durable job-card.
@@ -943,55 +948,55 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
         : () => makeRunner(async (input) => {
           // Phase 5a placeholder runner — used when no AgentBuilder
           // is injected (e.g. user has no provider configured yet).
-          // Marks the run completed with finishReason='stop' after
-          // creating the run row + emitting a placeholder event.
-          // The bus / dispatch / lease / markDone path is fully
-          // exercised end-to-end so soak harness + tests still
-          // work without a real model wired.
-          const runId = runStore.create({
+          // Admission has already created the Job and Attempt. Missing
+          // provider runtime is retryable and must never look successful.
+          const runId = input.admission?.runId ?? runStore.create({
             sessionId:      input.sessionId,
             instanceId:     input.instanceId,
             triggerEventId: input.triggerEventId,
-            status:         'running',
+            status:         'queued',
           });
-          // v4.10 Slice 10.2b — rich emission via the shared taxonomy.
-          // Placeholder runner path; still wants a categorised row so
-          // trace_query produces consistent shape regardless of which
-          // runner was wired.
-          const tags = categorizeEvent('dispatcher:invoked');
-          runStore.emitEventRich({
+          const result: DaemonAgentResult = {
             runId,
-            category:  tags.category,
-            kind:      tags.kind,
-            name:      'dispatcher:invoked',
-            sessionId: input.sessionId,
-            summary:   `placeholder/${input.triggerContext.source}`,
-            payload: {
-              source:    input.triggerContext.source,
-              triggerId: input.triggerContext.triggerId,
-              eventId:   input.triggerEventId,
-              templated: input.triggerContext.promptTemplate !== null,
-              messageLen: input.initialMessage.length,
-            },
-            visibility:'system',
-            source:    'daemon',
-          });
-          runStore.setStatus(runId, 'completed', { finishReason: 'stop' });
-          const result: DaemonAgentResult = { runId, finishReason: 'stop' };
+            finishReason: 'error',
+            error: 'agent_runtime_unavailable',
+          };
           return result;
         });
       dispatcher = createDispatcher({
         triggerBus,
         runStore,
+        jobEngine,
         db,
         ownerId:       tracker.instanceId,
         instanceId:    tracker.instanceId,
         workerCount:   1,                   // Q-P5-1(a)
         runnerFactory,
+        initialRunnerKind: opts.agentBuilder ? 'real' : 'placeholder',
         log,
       });
       dispatcher.start();
       log('info', `[dispatcher] active workerCount=1 runner=${opts.agentBuilder ? 'real' : 'placeholder'}`);
+      const runDurableRecoverySweep = (): void => {
+        if (dispatcher?.runnerKind() !== 'real') return;
+        try {
+          const sweep = sweepDurableJobRecovery({
+            jobEngine,
+            triggerBus,
+            instanceId: tracker.instanceId,
+            producer: 'daemon-recovery',
+          });
+          if (sweep.expired > 0 || sweep.enqueued > 0) {
+            log('warn', `[job-recovery] expired=${sweep.expired} retried=${sweep.retried} ` +
+              `needs_user=${sweep.needsUser} dead_letter=${sweep.deadLettered} enqueued=${sweep.enqueued}`);
+          }
+        } catch (e) {
+          log('warn', `[job-recovery] sweep failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      };
+      runDurableRecoverySweep();
+      const durableRecoveryTimer = setInterval(runDurableRecoverySweep, 30_000);
+      if (typeof durableRecoveryTimer.unref === 'function') durableRecoveryTimer.unref();
       // v4.13 Gap 4 — resume sweep: act on the resume_pending marks
       // crash recovery left. Gated on a REAL runner — re-driving into
       // the placeholder would fake-complete resumed tasks. Best-effort.
@@ -1126,9 +1131,11 @@ export function installDaemonAgentBuilder(
   try {
     const dbHandle = openDaemonDb(handle.dbPath!);
     const taskStore = createTaskStore({ db: dbHandle });
+    const jobEngine = createJobEngine({ db: dbHandle });
     const realRunner = createRealAgentRunner({
       db:               dbHandle,
       runStore:         handle.runStore,
+      jobEngine,
       resourceRegistry: handle.resourceRegistry ?? undefined,
       log:              logFn,
       agentBuilder,
@@ -1137,6 +1144,18 @@ export function installDaemonAgentBuilder(
       taskStore,
     });
     handle.dispatcher.installRunner(realRunner);
+    if (handle.triggerBus && handle.instanceId) {
+      const sweep = sweepDurableJobRecovery({
+        jobEngine,
+        triggerBus: handle.triggerBus,
+        instanceId: handle.instanceId,
+        producer: 'daemon-recovery',
+      });
+      if (sweep.expired > 0 || sweep.enqueued > 0) {
+        logFn('warn', `[job-recovery] expired=${sweep.expired} retried=${sweep.retried} ` +
+          `needs_user=${sweep.needsUser} dead_letter=${sweep.deadLettered} enqueued=${sweep.enqueued}`);
+      }
+    }
     // v4.13 Gap 4 — with a real runner installed, act on any pending
     // resume marks (the foundation booted with the placeholder, which
     // must never re-drive). Best-effort.

--- a/core/v4/daemon/cleanShutdown.ts
+++ b/core/v4/daemon/cleanShutdown.ts
@@ -177,7 +177,11 @@ export function evaluateBootState(
                   resume_reason  = 'crash_recovery',
                   completed_at   = ?
             WHERE instance_id = ?
-              AND status IN ('queued','running')`,
+              AND status IN ('queued','running')
+              AND NOT EXISTS (
+                SELECT 1 FROM tasks t
+                 WHERE t.id = runs.task_id AND t.idempotency_namespace IS NOT NULL
+              )`,
         )
         .run(now, c.instance_id);
     }

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -175,10 +175,11 @@ CREATE INDEX IF NOT EXISTS idx_file_obs_pending
   ON file_observations(watcher_id, last_status) WHERE last_status = 'pending';
 `;
 
-interface Migration {
+export interface Migration {
   version: number;
   name:    string;
-  sql:     string;
+  sql?:    string;
+  apply?:  (db: Database.Database) => void;
 }
 
 // v4.5 Phase 3 — webhook_deliveries log.
@@ -706,6 +707,221 @@ CREATE INDEX IF NOT EXISTS idx_side_effect_ledger_task
   ON side_effect_ledger(task_id, step);
 `;
 
+function tableColumns(db: Database.Database, table: string): Set<string> {
+  return new Set(
+    (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name),
+  );
+}
+
+function addMissingColumns(
+  db: Database.Database,
+  table: string,
+  definitions: ReadonlyArray<readonly [name: string, definition: string]>,
+): void {
+  const existing = tableColumns(db, table);
+  for (const [name, definition] of definitions) {
+    if (existing.has(name)) continue;
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${name} ${definition}`);
+    existing.add(name);
+  }
+}
+
+/** Promote the existing task/run/event records into the durable Job engine. */
+function applyV20(db: Database.Database): void {
+  addMissingColumns(db, 'tasks', [
+    ['state_version',          'INTEGER NOT NULL DEFAULT 0'],
+    ['active_attempt_id',      'TEXT'],
+    ['root_job_id',            'TEXT'],
+    ['idempotency_namespace',  'TEXT'],
+    ['idempotency_key',        'TEXT'],
+    ['request_fingerprint',    'TEXT'],
+    ['entry_point',            'TEXT'],
+    ['source',                 'TEXT'],
+    ['workspace_id',           'TEXT'],
+    ['principal_id',           'TEXT'],
+    ['terminal_at',            'INTEGER'],
+    ['terminal_outcome',       'TEXT'],
+    ['finish_reason',          'TEXT'],
+    ['recovery_state',         "TEXT NOT NULL DEFAULT 'none'"],
+    ['crash_count',            'INTEGER NOT NULL DEFAULT 0'],
+    ['next_event_sequence',    'INTEGER NOT NULL DEFAULT 1'],
+    ['policy_snapshot_id',     'TEXT'],
+  ]);
+
+  addMissingColumns(db, 'runs', [
+    ['attempt_id',             'TEXT'],
+    ['attempt_number',         'INTEGER NOT NULL DEFAULT 1'],
+    ['generation',             'INTEGER NOT NULL DEFAULT 1'],
+    ['state_version',          'INTEGER NOT NULL DEFAULT 0'],
+    ['lease_id',               'TEXT'],
+    ['lease_owner',            'TEXT'],
+    ['lease_expires_at',       'INTEGER'],
+    ['lease_heartbeat_at',     'INTEGER'],
+    ['fence_token',            'TEXT'],
+    ['recovery_of_attempt_id', 'TEXT'],
+    ['trigger_reason',         'TEXT'],
+    ['provider_route_snapshot','TEXT'],
+    ['budget_snapshot',        'TEXT'],
+    ['ended_at',               'INTEGER'],
+    ['next_event_sequence',    'INTEGER NOT NULL DEFAULT 1'],
+  ]);
+
+  addMissingColumns(db, 'run_events', [
+    ['job_id',          'TEXT'],
+    ['attempt_id',      'TEXT'],
+    ['job_sequence',    'INTEGER'],
+    ['producer',        'TEXT'],
+    ['generation',      'INTEGER'],
+    ['causation_id',    'TEXT'],
+    ['correlation_id',  'TEXT'],
+    ['idempotency_key', 'TEXT'],
+  ]);
+
+  addMissingColumns(db, 'side_effect_ledger', [
+    ['job_id',       'TEXT'],
+    ['attempt_id',   'TEXT'],
+    ['generation',   'INTEGER'],
+    ['tool_call_id', 'TEXT'],
+    ['effect_state', "TEXT NOT NULL DEFAULT 'none'"],
+  ]);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tool_calls (
+      tool_call_id           TEXT PRIMARY KEY,
+      job_id                 TEXT NOT NULL,
+      attempt_id             TEXT NOT NULL,
+      generation             INTEGER NOT NULL,
+      model_call_id          TEXT,
+      tool_name              TEXT NOT NULL,
+      normalized_args_digest TEXT NOT NULL,
+      risk_tier              TEXT NOT NULL,
+      mutates                INTEGER NOT NULL,
+      state                  TEXT NOT NULL,
+      started_at             INTEGER,
+      ended_at               INTEGER,
+      result_ref             TEXT,
+      side_effect_id         TEXT,
+      verification_ref       TEXT,
+      created_at             INTEGER NOT NULL,
+      updated_at             INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_job
+      ON tool_calls(job_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_attempt
+      ON tool_calls(attempt_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_state
+      ON tool_calls(state, updated_at);
+  `);
+
+  db.exec(`
+    UPDATE runs
+       SET attempt_id = 'attempt_legacy_' || id
+     WHERE attempt_id IS NULL OR attempt_id = '';
+
+    WITH numbered AS (
+      SELECT id,
+             CASE
+               WHEN task_id IS NULL THEN 1
+               ELSE ROW_NUMBER() OVER (PARTITION BY task_id ORDER BY id)
+             END AS ordinal
+        FROM runs
+    )
+    UPDATE runs
+       SET attempt_number = (SELECT ordinal FROM numbered WHERE numbered.id = runs.id);
+
+    UPDATE runs
+       SET ended_at = completed_at
+     WHERE ended_at IS NULL AND completed_at IS NOT NULL;
+
+    UPDATE runs
+       SET next_event_sequence = COALESCE(
+         (SELECT MAX(e.seq) + 1 FROM run_events e WHERE e.run_id = runs.id),
+         1
+       );
+
+    WITH RECURSIVE roots(id, root_id) AS (
+      SELECT t.id, t.id
+        FROM tasks t
+       WHERE t.parent_task_id IS NULL
+          OR NOT EXISTS (SELECT 1 FROM tasks parent WHERE parent.id = t.parent_task_id)
+      UNION ALL
+      SELECT child.id, roots.root_id
+        FROM tasks child
+        JOIN roots ON child.parent_task_id = roots.id
+    )
+    UPDATE tasks
+       SET root_job_id = COALESCE(
+         (SELECT root_id FROM roots WHERE roots.id = tasks.id),
+         id
+       )
+     WHERE root_job_id IS NULL OR root_job_id = '';
+
+    UPDATE tasks
+       SET active_attempt_id = (
+         SELECT r.attempt_id
+           FROM runs r
+          WHERE r.task_id = tasks.id
+            AND r.status IN ('queued', 'running', 'active', 'waiting')
+          ORDER BY r.id DESC
+          LIMIT 1
+       )
+     WHERE active_attempt_id IS NULL;
+
+    UPDATE run_events
+       SET job_id = (SELECT r.task_id FROM runs r WHERE r.id = run_events.run_id),
+           attempt_id = (SELECT r.attempt_id FROM runs r WHERE r.id = run_events.run_id),
+           generation = COALESCE(
+             (SELECT r.generation FROM runs r WHERE r.id = run_events.run_id),
+             1
+           )
+     WHERE job_id IS NULL OR attempt_id IS NULL OR generation IS NULL;
+
+    WITH ranked AS (
+      SELECT id,
+             ROW_NUMBER() OVER (PARTITION BY job_id ORDER BY id) AS ordinal
+        FROM run_events
+       WHERE job_id IS NOT NULL
+    )
+    UPDATE run_events
+       SET job_sequence = (SELECT ordinal FROM ranked WHERE ranked.id = run_events.id)
+     WHERE job_id IS NOT NULL;
+
+    UPDATE tasks
+       SET next_event_sequence = COALESCE(
+         (SELECT MAX(e.job_sequence) + 1 FROM run_events e WHERE e.job_id = tasks.id),
+         1
+       );
+
+    UPDATE side_effect_ledger
+       SET job_id = COALESCE(job_id, task_id),
+           effect_state = CASE status
+             WHEN 'attempting' THEN 'started'
+             WHEN 'confirmed' THEN 'committed'
+             ELSE effect_state
+           END;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency
+      ON tasks(idempotency_namespace, idempotency_key)
+      WHERE idempotency_namespace IS NOT NULL AND idempotency_key IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_tasks_root_job
+      ON tasks(root_job_id, created_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_attempt_id
+      ON runs(attempt_id);
+    CREATE INDEX IF NOT EXISTS idx_runs_job_attempt
+      ON runs(task_id, attempt_number);
+    CREATE INDEX IF NOT EXISTS idx_runs_lease_expiry
+      ON runs(lease_expires_at)
+      WHERE lease_id IS NOT NULL;
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_run_events_job_sequence
+      ON run_events(job_id, job_sequence)
+      WHERE job_id IS NOT NULL AND job_sequence IS NOT NULL;
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_run_events_job_idempotency
+      ON run_events(job_id, idempotency_key)
+      WHERE job_id IS NOT NULL AND idempotency_key IS NOT NULL;
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -726,6 +942,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 17, name: 'v4.13 gap 3 — job-card columns',                sql: V17_SQL },
   { version: 18, name: 'v4.13 gap 4 — resume linkage + wake-loop cap',   sql: V18_SQL },
   { version: 19, name: 'v4.12.1 — side-effect idempotency ledger',        sql: V19_SQL },
+  { version: 20, name: 'v4.15.1 — durable Job and Attempt foundation',    apply: applyV20 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -763,14 +980,22 @@ export function runMigrations(db: Database.Database): { from: number; to: number
   const pending = MIGRATIONS.filter((m) => m.version > from);
   if (pending.length === 0) return { from, to: from };
   const apply = db.transaction((m: Migration): void => {
-    db.exec(m.sql);
+    if (m.apply) m.apply(db);
+    else db.exec(m.sql ?? '');
     db.prepare(
       'INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)',
     ).run(m.version, Date.now());
-  });
+  }).immediate;
   let to = from;
   for (const m of pending) {
-    apply(m);
+    try {
+      apply(m);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const wrapped = new Error(`Migration ${m.version} (${m.name}) failed: ${detail}`) as Error & { cause?: unknown };
+      wrapped.cause = error;
+      throw wrapped;
+    }
     to = m.version;
   }
   return { from, to };

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -922,6 +922,146 @@ function applyV20(db: Database.Database): void {
   `);
 }
 
+/** Add the durable Phase 4 input, control, policy, and approval authorities. */
+function applyV21(db: Database.Database): void {
+  addMissingColumns(db, 'tasks', [
+    ['next_input_sequence', 'INTEGER NOT NULL DEFAULT 1'],
+  ]);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS durable_inputs (
+      input_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      target_attempt_id TEXT,
+      target_generation INTEGER,
+      session_id TEXT NOT NULL,
+      channel_id TEXT,
+      source TEXT NOT NULL,
+      sequence INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      content TEXT,
+      content_ref TEXT,
+      content_hash TEXT NOT NULL,
+      state TEXT NOT NULL,
+      idempotency_namespace TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      claimed_by_attempt_id TEXT,
+      claimed_generation INTEGER,
+      claimed_at INTEGER,
+      consumed_at INTEGER,
+      supersedes_input_id TEXT,
+      expires_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (supersedes_input_id) REFERENCES durable_inputs(input_id) ON DELETE SET NULL,
+      UNIQUE (job_id, sequence),
+      UNIQUE (idempotency_namespace, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_durable_inputs_pending
+      ON durable_inputs(job_id, state, sequence);
+    CREATE INDEX IF NOT EXISTS idx_durable_inputs_session
+      ON durable_inputs(session_id, state, created_at);
+
+    CREATE TABLE IF NOT EXISTS steering_commands (
+      steering_id TEXT PRIMARY KEY,
+      input_id TEXT NOT NULL UNIQUE,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      target_scope TEXT NOT NULL,
+      action TEXT NOT NULL,
+      payload TEXT,
+      state TEXT NOT NULL,
+      safe_boundary_sequence INTEGER,
+      invalidates_plan_digest TEXT,
+      applied_at INTEGER,
+      rejection_reason TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (input_id) REFERENCES durable_inputs(input_id) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_steering_pending
+      ON steering_commands(job_id, attempt_id, generation, state, created_at);
+
+    CREATE TABLE IF NOT EXISTS job_control_commands (
+      control_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT,
+      generation INTEGER,
+      kind TEXT NOT NULL,
+      source TEXT NOT NULL,
+      reason TEXT,
+      state TEXT NOT NULL,
+      idempotency_namespace TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      applied_at INTEGER,
+      rejection_reason TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (idempotency_namespace, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_controls_pending
+      ON job_control_commands(job_id, state, created_at);
+
+    CREATE TABLE IF NOT EXISTS policy_snapshots (
+      policy_snapshot_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      digest TEXT NOT NULL UNIQUE,
+      trust_level TEXT NOT NULL,
+      autonomy_policy TEXT NOT NULL,
+      approval_mode TEXT NOT NULL,
+      tool_metadata_version TEXT NOT NULL,
+      sandbox_policy_json TEXT NOT NULL,
+      network_policy_json TEXT NOT NULL,
+      plugin_grants_json TEXT NOT NULL,
+      mcp_grants_json TEXT NOT NULL,
+      spending_limits_json TEXT,
+      workspace_overrides_json TEXT NOT NULL,
+      job_overrides_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS approvals (
+      approval_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      tool_call_id TEXT NOT NULL,
+      request_sequence INTEGER NOT NULL,
+      tool_name TEXT NOT NULL,
+      risk_tier TEXT NOT NULL,
+      risk_reasons_json TEXT NOT NULL,
+      normalized_execution_plan TEXT NOT NULL,
+      action_digest TEXT NOT NULL,
+      policy_snapshot_id TEXT NOT NULL,
+      state TEXT NOT NULL,
+      decision TEXT,
+      decision_input_id TEXT,
+      decision_scope TEXT,
+      decided_by TEXT,
+      decision_channel TEXT,
+      requested_at INTEGER NOT NULL,
+      displayed_at INTEGER,
+      decided_at INTEGER,
+      expires_at INTEGER,
+      invalidated_at INTEGER,
+      invalidation_reason TEXT,
+      executed_at INTEGER,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (policy_snapshot_id) REFERENCES policy_snapshots(policy_snapshot_id),
+      FOREIGN KEY (decision_input_id) REFERENCES durable_inputs(input_id) ON DELETE SET NULL,
+      UNIQUE (job_id, request_sequence)
+    );
+    CREATE INDEX IF NOT EXISTS idx_approvals_waiting
+      ON approvals(job_id, state, requested_at);
+    CREATE INDEX IF NOT EXISTS idx_approvals_tool_call
+      ON approvals(tool_call_id, state);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -943,6 +1083,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 18, name: 'v4.13 gap 4 — resume linkage + wake-loop cap',   sql: V18_SQL },
   { version: 19, name: 'v4.12.1 — side-effect idempotency ledger',        sql: V19_SQL },
   { version: 20, name: 'v4.15.1 — durable Job and Attempt foundation',    apply: applyV20 },
+  { version: 21, name: 'v4.15.1 - durable input and approval authority', apply: applyV21 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/dispatcher/agentRunner.ts
+++ b/core/v4/daemon/dispatcher/agentRunner.ts
@@ -39,6 +39,7 @@
 import type { Message } from '../../../../providers/v4/types';
 import type { TriggerSource } from '../types';
 import type { RunStore } from '../runStore';
+import type { JobEngine } from '../jobEngine';
 // v4.10 Slice 10.2b — shared event taxonomy.
 import { categorizeEvent } from '../eventCategories';
 
@@ -73,6 +74,12 @@ export interface DaemonAgentInput {
    * (per Q-P5-4(a) stub). Future phases wire channel adapters.
    */
   deliverOnly:      boolean;
+  /** Durable admission created by an ingress surface before dispatch. */
+  admission?: {
+    jobId: string;
+    attemptId: string;
+    runId: number;
+  };
   /**
    * v4.13 Gap 4 — set when this invocation RESUMES a dead run. The
    * runner reuses the existing task row (the job-card accumulates
@@ -90,7 +97,7 @@ export interface DaemonAgentInput {
 export interface DaemonAgentResult {
   /** Created via runStore.create() — passed to triggerBus.markDone(eventId, …, runId). */
   runId:        number;
-  finishReason: 'stop' | 'tool_loop' | 'budget_exhausted' | 'error' | 'delivered';
+  finishReason: 'stop' | 'tool_loop' | 'budget_exhausted' | 'error' | 'interrupted' | 'delivered';
   /** Optional total-token count (when the provider reports it). */
   totalTokens?: number;
   /** Populated when finishReason === 'error'. */
@@ -136,7 +143,100 @@ export function buildInitialHistory(input: DaemonAgentInput): Message[] {
 export function deliverOnlyStub(
   input: DaemonAgentInput,
   runStore: RunStore,
+  jobEngine?: JobEngine,
 ): DaemonAgentResult {
+  if (jobEngine) {
+    const admitted = input.admission ?? jobEngine.submitJob({
+      entryPoint: 'daemon',
+      source: input.triggerContext.source,
+      sessionId: input.sessionId,
+      instanceId: input.instanceId,
+      idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
+      idempotencyKey: String(input.triggerEventId),
+      goal: input.initialMessage,
+      title: input.initialMessage,
+      triggerEventId: input.triggerEventId,
+    });
+    const job = jobEngine.getJob(admitted.jobId);
+    const attempt = jobEngine.getAttempt(admitted.attemptId);
+    if (!job || !attempt || attempt.rowId !== admitted.runId || job.activeAttemptId !== admitted.attemptId) {
+      throw new Error('Durable delivery admission does not resolve to the active Attempt');
+    }
+    const lease = jobEngine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: input.instanceId, ttlMs: 30_000,
+    });
+    if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
+      throw new Error(`Durable delivery lease unavailable: ${lease.conflict ?? 'unknown'}`);
+    }
+    const attemptStarted = jobEngine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: lease.stateVersion,
+      generation: lease.generation,
+      fenceToken: lease.fenceToken,
+      to: 'running',
+      eventIdempotencyKey: `attempt-running:${admitted.attemptId}:${lease.generation}`,
+      producer: 'daemon-delivery',
+    });
+    const jobStarted = jobEngine.transitionJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation,
+      fenceToken: lease.fenceToken,
+      expectedStateVersion: job.stateVersion,
+      to: 'running',
+      eventIdempotencyKey: `job-running:${admitted.jobId}:${lease.generation}`,
+      producer: 'daemon-delivery',
+    });
+    if (!attemptStarted.applied || attemptStarted.stateVersion === undefined || !jobStarted.applied || jobStarted.stateVersion === undefined) {
+      throw new Error('Durable delivery start was rejected');
+    }
+    const tags = categorizeEvent('delivered');
+    runStore.emitEventRich({
+      runId: admitted.runId,
+      category: tags.category,
+      kind: tags.kind,
+      name: 'delivered',
+      sessionId: input.sessionId,
+      status: 'ok',
+      summary: `delivered ${input.triggerContext.source}/${input.triggerContext.triggerId}`,
+      payload: {
+        source: input.triggerContext.source,
+        triggerId: input.triggerContext.triggerId,
+        eventId: input.triggerEventId,
+        messageBytes: input.initialMessage.length,
+        deliverOnly: true,
+      },
+      visibility: 'system',
+      source: 'daemon',
+    });
+    const attemptFinished = jobEngine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: attemptStarted.stateVersion,
+      generation: lease.generation,
+      fenceToken: lease.fenceToken,
+      to: 'succeeded',
+      eventIdempotencyKey: `attempt-succeeded:${admitted.attemptId}:${lease.generation}`,
+      producer: 'daemon-delivery',
+      finishReason: 'delivered',
+    });
+    const jobFinished = jobEngine.finalizeJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation,
+      fenceToken: lease.fenceToken,
+      expectedStateVersion: jobStarted.stateVersion,
+      status: 'completed',
+      outcome: 'delivered',
+      finishReason: 'delivered',
+      evidence: { delivered: true, messageBytes: input.initialMessage.length },
+      eventIdempotencyKey: `job-finalized:${admitted.jobId}:${lease.generation}`,
+      producer: 'daemon-delivery',
+    });
+    if (!attemptFinished.applied || !jobFinished.applied) {
+      throw new Error('Durable delivery finalization was rejected');
+    }
+    return { runId: admitted.runId, finishReason: 'delivered' };
+  }
   const runId = runStore.create({
     sessionId:      input.sessionId,
     instanceId:     input.instanceId,

--- a/core/v4/daemon/dispatcher/dispatcher.ts
+++ b/core/v4/daemon/dispatcher/dispatcher.ts
@@ -48,6 +48,7 @@ import type { TriggerBus } from '../triggerBus';
 import type { RunStore } from '../runStore';
 import type { ClaimedEvent, TriggerSource } from '../types';
 import type { Db } from '../db/connection';
+import type { JobEngine } from '../jobEngine';
 import type { TriggerRowSql } from '../db/schema/v1.spec';
 import {
   buildTriggerSessionId,
@@ -87,6 +88,7 @@ export interface CreateDispatcherOptions {
   runStore:      RunStore;
   /** SQLite db handle — used to read `triggers` table for spec lookup. */
   db:            Db;
+  jobEngine?:    JobEngine;
   /** Owner id stamped on each claim (typically the instanceId). */
   ownerId:       string;
   /** Instance id stamped on `runs.instance_id`. */
@@ -99,6 +101,8 @@ export interface CreateDispatcherOptions {
    * provider + toolExecutor.
    */
   runnerFactory: () => DaemonAgentRunner;
+  /** Classification of the runner returned by runnerFactory. */
+  initialRunnerKind?: 'placeholder' | 'real';
   workerCount?:  number;
   leaseMs?:     number;
   renewMs?:     number;
@@ -332,6 +336,26 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
               attempt: typeof resumeRaw.attempt === 'number' ? resumeRaw.attempt : 1,
             }
           : undefined;
+      const durable = (event.payload as {
+        durable_job?: { job_id?: unknown; attempt_id?: unknown; run_id?: unknown };
+      } | null)?.durable_job;
+      const existingAdmission = durable
+        && typeof durable.job_id === 'string'
+        && typeof durable.attempt_id === 'string'
+        && typeof durable.run_id === 'number'
+          ? { jobId: durable.job_id, attemptId: durable.attempt_id, runId: durable.run_id }
+          : undefined;
+      const admission = existingAdmission ?? opts.jobEngine?.submitJob({
+        entryPoint: 'daemon_trigger',
+        source: event.source,
+        sessionId,
+        instanceId: opts.instanceId,
+        idempotencyNamespace: `trigger:${event.source}:${event.sourceKey}`,
+        idempotencyKey: String(event.id),
+        requestFingerprint: event.idempotencyKey ?? String(event.id),
+        goal: message,
+        triggerEventId: event.id,
+      });
       const input: DaemonAgentInput = {
         sessionId,
         instanceId:     opts.instanceId,
@@ -339,12 +363,13 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
         triggerContext: context,
         initialMessage: message,
         deliverOnly,
+        ...(admission ? { admission } : {}),
         ...(resume ? { resume } : {}),
       };
 
       let result: DaemonAgentResult;
       if (deliverOnly) {
-        result = deliverOnlyStub(input, opts.runStore);
+        result = deliverOnlyStub(input, opts.runStore, opts.jobEngine);
         _stats.deliverOnly += 1;
       } else {
         if (!runner) {
@@ -439,12 +464,8 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
       if (_started) return;
       _started = true;
       runner = opts.runnerFactory();
-      // Initial runner from the factory is the placeholder unless the
-      // factory itself returned a real runner. The CLI's two-phase
-      // bootstrap (Phase 7c) starts with a placeholder factory and
-      // calls `installRunner` later with the real one.
-      _runnerKind = 'placeholder';
-      log('info', `[dispatcher] starting workerCount=${workerCount} leaseMs=${leaseMs} runner=placeholder`);
+      _runnerKind = opts.initialRunnerKind ?? 'placeholder';
+      log('info', `[dispatcher] starting workerCount=${workerCount} leaseMs=${leaseMs} runner=${_runnerKind}`);
       _schedulePoll();
     },
     installRunner(next: DaemonAgentRunner) {

--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -80,6 +80,7 @@ import { mapTaskOutcomePresentation, taskOutcomeInputFromFinalization } from '..
 import { emitArtifactVerified, emitCostUpdated, type PillarEventSink } from '../../pillarEvents';
 import type { TaskStore } from '../taskStore';
 import type { JobEngine } from '../jobEngine';
+import { createJobControlAuthority } from '../jobControlAuthority';
 import { runWithJobExecutionContext } from '../jobExecutionContext';
 import {
   resolveDaemonModel,
@@ -180,6 +181,9 @@ export function createRealAgentRunner(
         entryPoint: 'daemon',
       })
     : createDailyBudgetTracker({ db: opts.db, budget: configuredBudget });
+  const jobControls = opts.jobEngine
+    ? createJobControlAuthority({ db: opts.db, jobEngine: opts.jobEngine })
+    : null;
 
   return {
     async invoke(input: DaemonAgentInput): Promise<DaemonAgentResult> {
@@ -192,11 +196,17 @@ export function createRealAgentRunner(
       let durableJobVersion = 0;
       let durableAttemptVersion = 0;
       let durableLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
+      let durableControlWatcher: ReturnType<typeof setInterval> | null = null;
       const durableAbort = new AbortController();
+      let pausedAtBoundary = false;
       const stopDurableHeartbeat = (): void => {
         if (durableLeaseHeartbeat !== null) {
           clearInterval(durableLeaseHeartbeat);
           durableLeaseHeartbeat = null;
+        }
+        if (durableControlWatcher !== null) {
+          clearInterval(durableControlWatcher);
+          durableControlWatcher = null;
         }
       };
       const finishDurable = (input2: {
@@ -338,6 +348,17 @@ export function createRealAgentRunner(
           durableAttemptVersion = renewed.stateVersion;
         }, 20_000);
         durableLeaseHeartbeat.unref?.();
+        // Commands can be written by another process (Workbench/API). Observe
+        // the authoritative Job row and physically abort the active provider or
+        // tool when cancellation wins, rather than merely changing a status.
+        durableControlWatcher = setInterval(() => {
+          if (!opts.jobEngine || !durableJobId || durableAbort.signal.aborted) return;
+          const status = opts.jobEngine.getJob(durableJobId)?.status;
+          if (status === 'cancelled' || status === 'cancelling') {
+            durableAbort.abort(new Error('Durable Job cancellation requested'));
+          }
+        }, 250);
+        durableControlWatcher.unref?.();
       }
 
       // ── 1: pre-turn budget gate ────────────────────────────────────────
@@ -545,6 +566,17 @@ export function createRealAgentRunner(
           runId,
           entryPoint: 'daemon',
           signal: invocationSignal,
+          waitForResumeIfPaused: async () => {
+            if (!jobControls || !durableJobId) return;
+            const paused = jobControls.commands.applyPendingAtBoundary({ jobId: durableJobId, now: now() });
+            if (!paused.applied) return;
+            pausedAtBoundary = true;
+            if (durableLeaseHeartbeat !== null) {
+              clearInterval(durableLeaseHeartbeat);
+              durableLeaseHeartbeat = null;
+            }
+            throw new Error('Durable Job paused at safe boundary');
+          },
           // The agent honours its own abort signal via per-tool aborts;
           // tools that respect AbortSignal (shell_exec, fetch_*) will
           // bail when perTurnWatcher trips.
@@ -600,6 +632,30 @@ export function createRealAgentRunner(
       } catch (e) {
         invocationError = e instanceof Error ? (e.stack ?? e.message) : String(e);
         log('error', `[real-runner] runConversation threw eventId=${input.triggerEventId}: ${invocationError.slice(0, 500)}`);
+      }
+
+      if (pausedAtBoundary) {
+        stopDurableHeartbeat();
+        try {
+          opts.runStore.emitEventRich({
+            runId,
+            category: 'dispatcher',
+            kind: 'dispatcher.paused',
+            name: 'dispatcher:paused',
+            sessionId: input.sessionId,
+            status: 'paused',
+            summary: 'paused at safe boundary',
+            payload: { jobId: durableJobId, attemptId: durableAttemptId, generation: durableGeneration },
+            visibility: 'system',
+            source: 'daemon',
+          });
+        } catch { /* the authoritative Job event is already durable */ }
+        return { runId, finishReason: 'interrupted', error: 'paused' };
+      }
+
+      if (opts.jobEngine && durableJobId && opts.jobEngine.getJob(durableJobId)?.status === 'cancelled') {
+        stopDurableHeartbeat();
+        return { runId, finishReason: 'interrupted', error: 'cancelled' };
       }
 
       if (durableJobId && durableAttemptId && durableGeneration !== null) {

--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -79,6 +79,8 @@ import { computeTaskFinalization } from '../../taskVerification';
 import { mapTaskOutcomePresentation, taskOutcomeInputFromFinalization } from '../../taskOutcomePresentation';
 import { emitArtifactVerified, emitCostUpdated, type PillarEventSink } from '../../pillarEvents';
 import type { TaskStore } from '../taskStore';
+import type { JobEngine } from '../jobEngine';
+import { runWithJobExecutionContext } from '../jobExecutionContext';
 import {
   resolveDaemonModel,
 } from './resolveModel';
@@ -137,6 +139,8 @@ export type AgentBuilder = (input: {
 export interface CreateRealAgentRunnerOptions {
   db:                Db;
   runStore:          RunStore;
+  /** Production Job/Attempt authority. Optional only for legacy test fixtures. */
+  jobEngine?:         JobEngine;
   /**
    * v4.13 Gap 4 — when provided, every daemon run gets a durable task
    * row (the job-card): created at claim (or reused on resume), then
@@ -180,16 +184,169 @@ export function createRealAgentRunner(
   return {
     async invoke(input: DaemonAgentInput): Promise<DaemonAgentResult> {
       const dailyBudget = opts.dailyBudget ?? readDailyBudgetFromEnv();
+      let durableJobId: string | null = null;
+      let durableAttemptId: string | null = null;
+      let durableRunId: number | null = null;
+      let durableGeneration: number | null = null;
+      let durableFenceToken: string | null = null;
+      let durableJobVersion = 0;
+      let durableAttemptVersion = 0;
+      let durableLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
+      const durableAbort = new AbortController();
+      const stopDurableHeartbeat = (): void => {
+        if (durableLeaseHeartbeat !== null) {
+          clearInterval(durableLeaseHeartbeat);
+          durableLeaseHeartbeat = null;
+        }
+      };
+      const finishDurable = (input2: {
+        status: 'completed' | 'failed' | 'cancelled';
+        attemptStatus: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | 'unknown';
+        outcome: string;
+        finishReason: string;
+        evidence: unknown;
+        jobCard?: Parameters<JobEngine['finalizeJob']>[0]['jobCard'];
+      }): void => {
+        if (!opts.jobEngine || !durableJobId || !durableAttemptId || durableGeneration === null || !durableFenceToken) return;
+        stopDurableHeartbeat();
+        const attempt = opts.jobEngine.transitionAttempt({
+          attemptId: durableAttemptId,
+          expectedStateVersion: durableAttemptVersion,
+          generation: durableGeneration,
+          fenceToken: durableFenceToken,
+          to: input2.attemptStatus,
+          eventIdempotencyKey: `attempt-${input2.attemptStatus}:${durableAttemptId}:${durableGeneration}`,
+          producer: 'daemon',
+          finishReason: input2.finishReason,
+          now: now(),
+        });
+        if (!attempt.applied) throw new Error(`Durable daemon Attempt finalization rejected: ${attempt.conflict ?? 'unknown'}`);
+        const job = opts.jobEngine.finalizeJob({
+          jobId: durableJobId,
+          attemptId: durableAttemptId,
+          generation: durableGeneration,
+          fenceToken: durableFenceToken,
+          expectedStateVersion: durableJobVersion,
+          status: input2.status,
+          outcome: input2.outcome,
+          finishReason: input2.finishReason,
+          evidence: input2.evidence,
+          jobCard: input2.jobCard,
+          eventIdempotencyKey: `job-finalized:${durableJobId}:${durableGeneration}`,
+          producer: 'daemon',
+        });
+        if (!job.applied) throw new Error(`Durable daemon Job finalization rejected: ${job.conflict ?? 'unknown'}`);
+      };
+
+      if (opts.jobEngine) {
+        let admitted: { jobId: string; attemptId: string; runId: number };
+        if (input.admission) {
+          const admittedJob = opts.jobEngine.getJob(input.admission.jobId);
+          const admittedAttempt = opts.jobEngine.getAttempt(input.admission.attemptId);
+          if (
+            !admittedJob
+            || !admittedAttempt
+            || admittedAttempt.rowId !== input.admission.runId
+            || admittedAttempt.jobId !== input.admission.jobId
+            || admittedJob.activeAttemptId !== input.admission.attemptId
+          ) {
+            throw new Error('Durable daemon admission does not resolve to the active Attempt');
+          }
+          admitted = input.admission;
+        } else if (input.resume?.taskId && opts.jobEngine.getJob(input.resume.taskId)) {
+          const prior = opts.jobEngine.listAttempts(input.resume.taskId)
+            .find((attempt) => attempt.rowId === input.resume!.ofRunId);
+          if (!prior) throw new Error(`Durable recovery Attempt not found for run ${input.resume.ofRunId}`);
+          const recovery = opts.jobEngine.createRecoveryAttempt({
+            jobId: input.resume.taskId,
+            recoveryOfAttemptId: prior.id,
+            instanceId: input.instanceId,
+            triggerReason: 'resume',
+            eventIdempotencyKey: `attempt-resume:${input.triggerEventId}`,
+            producer: 'daemon',
+          });
+          admitted = { jobId: input.resume.taskId, attemptId: recovery.attemptId, runId: recovery.runId };
+        } else {
+          admitted = opts.jobEngine.submitJob({
+            entryPoint: 'daemon',
+            source: input.triggerContext.source,
+            sessionId: input.sessionId,
+            instanceId: input.instanceId,
+            idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
+            idempotencyKey: String(input.triggerEventId),
+            goal: input.initialMessage,
+            title: input.initialMessage,
+            triggerEventId: input.triggerEventId,
+          });
+        }
+        durableJobId = admitted.jobId;
+        durableAttemptId = admitted.attemptId;
+        durableRunId = admitted.runId;
+        durableJobVersion = opts.jobEngine.getJob(admitted.jobId)?.stateVersion ?? 0;
+        const lease = opts.jobEngine.claimAttempt({
+          attemptId: admitted.attemptId, ownerId: input.instanceId, ttlMs: 60_000, now: now(),
+        });
+        if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
+          throw new Error(`Durable daemon Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
+        }
+        durableGeneration = lease.generation;
+        durableFenceToken = lease.fenceToken;
+        durableAttemptVersion = lease.stateVersion;
+        const attemptStarted = opts.jobEngine.transitionAttempt({
+          attemptId: admitted.attemptId,
+          expectedStateVersion: durableAttemptVersion,
+          generation: durableGeneration,
+          fenceToken: durableFenceToken,
+          to: 'running',
+          eventIdempotencyKey: `attempt-running:${admitted.attemptId}:${durableGeneration}`,
+          producer: 'daemon',
+          now: now(),
+        });
+        if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
+          throw new Error(`Durable daemon Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`);
+        }
+        durableAttemptVersion = attemptStarted.stateVersion;
+        const jobStarted = opts.jobEngine.transitionJob({
+          jobId: admitted.jobId,
+          attemptId: admitted.attemptId,
+          generation: durableGeneration,
+          fenceToken: durableFenceToken,
+          expectedStateVersion: durableJobVersion,
+          to: 'running',
+          eventIdempotencyKey: `job-running:${admitted.jobId}:${durableGeneration}`,
+          producer: 'daemon',
+        });
+        if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
+          throw new Error(`Durable daemon Job start rejected: ${jobStarted.conflict ?? 'unknown'}`);
+        }
+        durableJobVersion = jobStarted.stateVersion;
+        durableLeaseHeartbeat = setInterval(() => {
+          if (!opts.jobEngine || !durableAttemptId || durableGeneration === null || !durableFenceToken) return;
+          const renewed = opts.jobEngine.renewAttemptLease({
+            attemptId: durableAttemptId,
+            ownerId: input.instanceId,
+            generation: durableGeneration,
+            fenceToken: durableFenceToken,
+            ttlMs: 60_000,
+            now: now(),
+          });
+          if (!renewed.applied || renewed.stateVersion === undefined) {
+            stopDurableHeartbeat();
+            durableAbort.abort(new Error(`Durable daemon lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
+            return;
+          }
+          durableAttemptVersion = renewed.stateVersion;
+        }, 20_000);
+        durableLeaseHeartbeat.unref?.();
+      }
 
       // ── 1: pre-turn budget gate ────────────────────────────────────────
       const verdict = evaluatePreTurn({ tracker, dailyBudget, now: now() });
       if (!verdict.allowed) {
         // Reject without invoking the agent. Surface as trigger_quota.
-        const runId = opts.runStore.create({
-          sessionId:      input.sessionId,
-          instanceId:     input.instanceId,
-          triggerEventId: input.triggerEventId,
-          status:         'running',
+        const runId = durableRunId ?? opts.runStore.create({
+          sessionId: input.sessionId, instanceId: input.instanceId,
+          triggerEventId: input.triggerEventId, status: 'running',
         });
         // v4.10 Slice 10.2b — rich emission with the daemon taxonomy.
         opts.runStore.emitEventRich({
@@ -207,7 +364,14 @@ export function createRealAgentRunner(
           visibility: 'system',
           source:     'daemon',
         });
-        opts.runStore.setStatus(runId, 'failed', { finishReason: 'budget_exhausted' });
+        if (opts.jobEngine) {
+          finishDurable({
+            status: 'failed', attemptStatus: 'failed', outcome: 'failed',
+            finishReason: 'budget_exhausted', evidence: { reason: 'budget_exhausted' },
+          });
+        } else {
+          opts.runStore.setStatus(runId, 'failed', { finishReason: 'budget_exhausted' });
+        }
         log('warn', `[real-runner] rejected eventId=${input.triggerEventId}: ${verdict.reason}`);
         return {
           runId,
@@ -244,8 +408,8 @@ export function createRealAgentRunner(
       // REPL writes: created fresh per run, or REUSED when this is a
       // resume (the card accumulates evidence across attempts). Best-
       // effort — a card failure never blocks dispatch.
-      let taskId: string | null = null;
-      if (opts.taskStore) {
+      let taskId: string | null = durableJobId;
+      if (!opts.jobEngine && opts.taskStore) {
         try {
           if (input.resume?.taskId && opts.taskStore.get(input.resume.taskId)) {
             taskId = input.resume.taskId;
@@ -261,11 +425,9 @@ export function createRealAgentRunner(
           }
         } catch { taskId = null; }
       }
-      const runId = opts.runStore.create({
-        sessionId:      input.sessionId,
-        instanceId:     input.instanceId,
-        triggerEventId: input.triggerEventId,
-        status:         'running',
+      const runId = durableRunId ?? opts.runStore.create({
+        sessionId: input.sessionId, instanceId: input.instanceId,
+        triggerEventId: input.triggerEventId, status: 'running',
         ...(taskId ? { taskId } : {}),
       });
       opts.runStore.emitEventRich({
@@ -348,7 +510,14 @@ export function createRealAgentRunner(
           visibility:'system',
           source:    'daemon',
         });
-        opts.runStore.setStatus(runId, 'failed', { finishReason: 'error' });
+        if (opts.jobEngine) {
+          finishDurable({
+            status: 'failed', attemptStatus: 'failed', outcome: 'failed',
+            finishReason: 'error', evidence: { errorClass: e instanceof Error ? e.name : 'Error' },
+          });
+        } else {
+          opts.runStore.setStatus(runId, 'failed', { finishReason: 'error' });
+        }
         return { runId, finishReason: 'error', error: msg };
       }
 
@@ -359,17 +528,23 @@ export function createRealAgentRunner(
       // status) feeds the verify-before-done gate below, same as the REPL.
       let declaredTaskStatus: string | null = null;
       try {
-        result = await runWithProviderUsageContext({
+        const invocationSignal = opts.jobEngine
+          ? AbortSignal.any([perTurnWatcher.signal, durableAbort.signal])
+          : perTurnWatcher.signal;
+        const invokeAgent = () => runWithProviderUsageContext({
           sessionId: input.sessionId,
           taskId,
           runId,
+          jobId: durableJobId,
+          attemptId: durableAttemptId,
+          attemptGeneration: durableGeneration,
           entryPoint: 'daemon',
         }, () => agent.runConversation(history, {
           sessionId: input.sessionId,
           taskId,
           runId,
           entryPoint: 'daemon',
-          signal: perTurnWatcher.signal,
+          signal: invocationSignal,
           // The agent honours its own abort signal via per-tool aborts;
           // tools that respect AbortSignal (shell_exec, fetch_*) will
           // bail when perTurnWatcher trips.
@@ -408,6 +583,16 @@ export function createRealAgentRunner(
             } catch { /* persistence faults must never break dispatch */ }
           },
         }));
+        result = opts.jobEngine && durableJobId && durableAttemptId && durableGeneration !== null && durableFenceToken
+          ? await runWithJobExecutionContext({
+              engine: opts.jobEngine,
+              jobId: durableJobId,
+              attemptId: durableAttemptId,
+              generation: durableGeneration,
+              fenceToken: durableFenceToken,
+              producer: 'daemon',
+            }, invokeAgent)
+          : await invokeAgent();
         // Stamp the actual token usage onto the watcher for the
         // post-turn snapshot below.
         const tokens = extractLedgerTokens(runId) ?? extractTokens(result);
@@ -415,6 +600,16 @@ export function createRealAgentRunner(
       } catch (e) {
         invocationError = e instanceof Error ? (e.stack ?? e.message) : String(e);
         log('error', `[real-runner] runConversation threw eventId=${input.triggerEventId}: ${invocationError.slice(0, 500)}`);
+      }
+
+      if (durableJobId && durableAttemptId && durableGeneration !== null) {
+        currentProviderAttemptLedger()?.reconcileJobLinkage({
+          taskId: durableJobId,
+          runId,
+          jobId: durableJobId,
+          attemptId: durableAttemptId,
+          attemptGeneration: durableGeneration,
+        });
       }
 
       // Route the agent's final WRITTEN reply to consumers. The CLI renders
@@ -484,17 +679,42 @@ export function createRealAgentRunner(
       // ── 10: map result → DaemonAgentResult ────────────────────────────
       const runStatus =
         finishReason === 'stop'              ? 'completed' :
+        finishReason === 'interrupted'       ? 'interrupted' :
         finishReason === 'budget_exhausted'  ? 'failed'    :
         finishReason === 'error'             ? 'failed'    :
         finishReason === 'tool_loop'         ? 'failed'    : 'completed';
-      opts.runStore.setStatus(runId, runStatus, { finishReason });
+      if (opts.jobEngine) {
+        const fin = computeTaskFinalization(
+          {
+            finishReason: finishReason === 'delivered' ? 'stop' : finishReason,
+            toolCallTrace: result?.toolCallTrace,
+            declaredStatus: declaredTaskStatus,
+          },
+          { approvalMode: approvalPolicy, now: now() },
+        );
+        const jobStatus = finishReason === 'interrupted'
+          ? 'cancelled'
+          : finishReason === 'stop' || finishReason === 'delivered'
+            ? (fin.status === 'completed' || fin.status === 'completed_unverified' ? 'completed' : 'failed')
+            : 'failed';
+        finishDurable({
+          status: jobStatus,
+          attemptStatus: jobStatus === 'completed' ? 'succeeded' : jobStatus === 'cancelled' ? 'cancelled' : 'failed',
+          outcome: fin.status,
+          finishReason,
+          evidence: fin.evidence,
+          jobCard: fin.jobCard,
+        });
+      } else {
+        opts.runStore.setStatus(runId, runStatus, { finishReason });
+      }
 
       // v4.13 Gap 4 — finalize the job-card through the SAME verify-
       // before-done gate the REPL uses (computeTaskFinalization): a
       // daemon task can no more complete on prose than a REPL one.
       // pending_verification lands first (crash honesty), then the
       // verdict + evidence + card in one UPDATE. Best-effort.
-      if (opts.taskStore && taskId) {
+      if (!opts.jobEngine && opts.taskStore && taskId) {
         try {
           const fin = computeTaskFinalization(
             {
@@ -694,9 +914,10 @@ function pickFinishReason(
   if (fr === 'tool_loop')        return 'tool_loop';
   if (fr === 'budget_exhausted') return 'budget_exhausted';
   if (fr === 'error')            return 'error';
-  // Default conservative — the dispatcher will markDone unless we
-  // say error; treat unknown finishes as success for forward-compat.
-  return 'stop';
+  if (fr === 'interrupted')      return 'interrupted';
+  // Unknown completion truth cannot be promoted to success. A future finish
+  // reason must be mapped explicitly before it can complete durable work.
+  return 'error';
 }
 
 /**

--- a/core/v4/daemon/httpJobIngress.ts
+++ b/core/v4/daemon/httpJobIngress.ts
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import type { JobEngine } from './jobEngine';
+import { runWithJobExecutionContext } from './jobExecutionContext';
+
+export interface HttpJobCoordinatorOptions {
+  engine: JobEngine;
+  instanceId: string;
+  leaseTtlMs?: number;
+}
+
+export interface HttpJobRouteOptions {
+  entryPoint: string;
+  source: string;
+}
+
+interface ActiveHttpJob {
+  token: string;
+  jobId: string;
+  attemptId: string;
+  runId: number;
+  generation: number;
+  fenceToken: string;
+  jobStateVersion: number;
+  attemptStateVersion: number;
+  producer: string;
+  heartbeat: ReturnType<typeof setInterval>;
+  settled: boolean;
+  loanConsumed: boolean;
+}
+
+const TOKEN_HEADER = 'x-aiden-internal-job-token';
+
+function digestRequest(req: Request): string {
+  const body = req.body && typeof req.body === 'object' ? req.body : null;
+  return createHash('sha256')
+    .update(JSON.stringify({ method: req.method, originalUrl: req.originalUrl, body }))
+    .digest('hex');
+}
+
+function sessionIdFor(req: Request): string {
+  const body = req.body as Record<string, unknown> | undefined;
+  const candidate = body?.sessionId ?? body?.user;
+  return typeof candidate === 'string' && candidate.length > 0
+    ? candidate.slice(0, 200)
+    : `http:${randomUUID()}`;
+}
+
+export interface HttpJobCoordinator {
+  middleware(options: HttpJobRouteOptions): RequestHandler;
+  internalToken(res: Response): string | null;
+  internalHeaders(token: string | null): Record<string, string>;
+}
+
+export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): HttpJobCoordinator {
+  const leaseTtlMs = options.leaseTtlMs ?? 60_000;
+  const active = new Map<string, ActiveHttpJob>();
+
+  const installProjection = (res: Response, handle: ActiveHttpJob): void => {
+    res.setHeader('X-Aiden-Job-Id', handle.jobId);
+    res.setHeader('X-Aiden-Attempt-Id', handle.attemptId);
+    res.setHeader('X-Aiden-Run-Id', String(handle.runId));
+    const originalJson = res.json.bind(res);
+    res.json = ((body: unknown) => {
+      if (body && typeof body === 'object' && !Array.isArray(body)) {
+        const projected = body as Record<string, unknown>;
+        if (!Object.prototype.hasOwnProperty.call(projected, 'job_id')) projected.job_id = handle.jobId;
+        if (!Object.prototype.hasOwnProperty.call(projected, 'attempt_id')) projected.attempt_id = handle.attemptId;
+        if (!Object.prototype.hasOwnProperty.call(projected, 'run_id')) projected.run_id = handle.runId;
+      }
+      return originalJson(body);
+    }) as Response['json'];
+  };
+
+  const settle = (handle: ActiveHttpJob, res: Response, reason: 'finish' | 'close'): void => {
+    if (handle.settled) return;
+    handle.settled = true;
+    clearInterval(handle.heartbeat);
+    active.delete(handle.token);
+
+    const interrupted = reason === 'close' && !res.writableFinished;
+    const failed = res.statusCode >= 400;
+    const attemptStatus = interrupted ? 'cancelled' : failed ? 'failed' : 'succeeded';
+    const jobStatus = interrupted ? 'cancelled' : failed ? 'failed' : 'completed';
+    const finishReason = interrupted ? 'client_disconnected' : failed ? 'http_error' : 'stop';
+    const attempt = options.engine.transitionAttempt({
+      attemptId: handle.attemptId,
+      expectedStateVersion: handle.attemptStateVersion,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      to: attemptStatus,
+      eventIdempotencyKey: `http-attempt-final:${handle.attemptId}:${handle.generation}`,
+      producer: handle.producer,
+      finishReason,
+    });
+    if (!attempt.applied) return;
+    options.engine.finalizeJob({
+      jobId: handle.jobId,
+      attemptId: handle.attemptId,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      expectedStateVersion: handle.jobStateVersion,
+      status: jobStatus,
+      outcome: jobStatus,
+      finishReason,
+      evidence: { httpStatus: res.statusCode, responseFinished: res.writableFinished },
+      eventIdempotencyKey: `http-job-final:${handle.jobId}:${handle.generation}`,
+      producer: handle.producer,
+    });
+  };
+
+  const middleware = (route: HttpJobRouteOptions): RequestHandler => (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void => {
+    const borrowedToken = req.header(TOKEN_HEADER);
+    const borrowed = borrowedToken ? active.get(borrowedToken) : undefined;
+    if (borrowedToken && !borrowed) {
+      res.status(409).json({ error: 'invalid_internal_job_token' });
+      return;
+    }
+    if (borrowed) {
+      if (borrowed.loanConsumed) {
+        res.status(409).json({ error: 'internal_job_token_consumed' });
+        return;
+      }
+      const attempt = options.engine.getAttempt(borrowed.attemptId);
+      if (
+        !attempt
+        || attempt.jobId !== borrowed.jobId
+        || attempt.generation !== borrowed.generation
+        || attempt.fenceToken !== borrowed.fenceToken
+        || attempt.leaseExpiresAt === null
+        || attempt.leaseExpiresAt <= Date.now()
+      ) {
+        res.status(409).json({ error: 'stale_internal_job' });
+        return;
+      }
+      borrowed.loanConsumed = true;
+      installProjection(res, borrowed);
+      runWithJobExecutionContext({
+        engine: options.engine,
+        jobId: borrowed.jobId,
+        attemptId: borrowed.attemptId,
+        generation: borrowed.generation,
+        fenceToken: borrowed.fenceToken,
+        producer: borrowed.producer,
+      }, () => next());
+      return;
+    }
+
+    try {
+      const fingerprint = digestRequest(req);
+      const suppliedKey = req.header('idempotency-key')?.trim();
+      const admitted = options.engine.submitJob({
+        entryPoint: route.entryPoint,
+        source: route.source,
+        sessionId: sessionIdFor(req),
+        instanceId: options.instanceId,
+        idempotencyNamespace: `http:${route.entryPoint}`,
+        idempotencyKey: suppliedKey || undefined,
+        requestFingerprint: fingerprint,
+        goal: `${route.entryPoint} request ${fingerprint.slice(0, 16)}`,
+      });
+      if (admitted.reused) {
+        const existing = options.engine.getJob(admitted.jobId);
+        res.status(existing?.terminalAt === null ? 202 : 200).json({
+          accepted: true,
+          duplicate: true,
+          job_id: admitted.jobId,
+          attempt_id: admitted.attemptId,
+          run_id: admitted.runId,
+        });
+        return;
+      }
+      const lease = options.engine.claimAttempt({
+        attemptId: admitted.attemptId,
+        ownerId: options.instanceId,
+        ttlMs: leaseTtlMs,
+      });
+      if (!lease.acquired || lease.generation === undefined || !lease.fenceToken || lease.stateVersion === undefined) {
+        res.status(409).json({ error: 'job_lease_unavailable' });
+        return;
+      }
+      const attemptRunning = options.engine.transitionAttempt({
+        attemptId: admitted.attemptId,
+        expectedStateVersion: lease.stateVersion,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        to: 'running',
+        eventIdempotencyKey: `http-attempt-running:${admitted.attemptId}:${lease.generation}`,
+        producer: route.source,
+      });
+      if (!attemptRunning.applied || attemptRunning.stateVersion === undefined) {
+        res.status(409).json({ error: 'job_attempt_start_rejected' });
+        return;
+      }
+      const jobRunning = options.engine.transitionJob({
+        jobId: admitted.jobId,
+        attemptId: admitted.attemptId,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        expectedStateVersion: 0,
+        to: 'running',
+        eventIdempotencyKey: `http-job-running:${admitted.jobId}:${lease.generation}`,
+        producer: route.source,
+      });
+      if (!jobRunning.applied || jobRunning.stateVersion === undefined) {
+        res.status(409).json({ error: 'job_start_rejected' });
+        return;
+      }
+
+      const token = randomUUID();
+      const handle: ActiveHttpJob = {
+        token,
+        jobId: admitted.jobId,
+        attemptId: admitted.attemptId,
+        runId: admitted.runId,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        jobStateVersion: jobRunning.stateVersion,
+        attemptStateVersion: attemptRunning.stateVersion,
+        producer: route.source,
+        heartbeat: undefined as unknown as ReturnType<typeof setInterval>,
+        settled: false,
+        loanConsumed: false,
+      };
+      handle.heartbeat = setInterval(() => {
+        const renewed = options.engine.renewAttemptLease({
+          attemptId: handle.attemptId,
+          ownerId: options.instanceId,
+          generation: handle.generation,
+          fenceToken: handle.fenceToken,
+          ttlMs: leaseTtlMs,
+        });
+        if (!renewed.applied || renewed.stateVersion === undefined) {
+          clearInterval(handle.heartbeat);
+          return;
+        }
+        handle.attemptStateVersion = renewed.stateVersion;
+      }, Math.max(1_000, Math.floor(leaseTtlMs / 3)));
+      handle.heartbeat.unref?.();
+      active.set(token, handle);
+      installProjection(res, handle);
+      res.once('finish', () => settle(handle, res, 'finish'));
+      res.once('close', () => settle(handle, res, 'close'));
+      (res.locals as Record<string, unknown>).durableJobToken = token;
+      runWithJobExecutionContext({
+        engine: options.engine,
+        jobId: handle.jobId,
+        attemptId: handle.attemptId,
+        generation: handle.generation,
+        fenceToken: handle.fenceToken,
+        producer: handle.producer,
+      }, () => next());
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  return {
+    middleware,
+    internalToken(res) {
+      const value = (res.locals as Record<string, unknown>).durableJobToken;
+      return typeof value === 'string' ? value : null;
+    },
+    internalHeaders(token) {
+      return token ? { [TOKEN_HEADER]: token } : {};
+    },
+  };
+}

--- a/core/v4/daemon/jobControlAuthority.ts
+++ b/core/v4/daemon/jobControlAuthority.ts
@@ -1,0 +1,857 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { Db } from './db/connection';
+import type { JobEngine } from './jobEngine';
+
+export type DurableInputKind = 'message' | 'steering' | 'control' | 'approval_decision' | 'credential';
+export type DurableInputState =
+  | 'received' | 'persisted' | 'queued' | 'claimed' | 'consumed'
+  | 'superseded' | 'cancelled' | 'expired' | 'rejected_stale';
+
+export interface DurableInputRecord {
+  inputId: string;
+  jobId: string;
+  targetAttemptId: string | null;
+  targetGeneration: number | null;
+  sessionId: string;
+  channelId: string | null;
+  source: string;
+  sequence: number;
+  kind: DurableInputKind;
+  content: string | null;
+  contentHash: string;
+  state: DurableInputState;
+  claimedByAttemptId: string | null;
+  claimedGeneration: number | null;
+  claimedAt: number | null;
+  consumedAt: number | null;
+  createdAt: number;
+}
+
+export interface ReceiveInputCommand {
+  jobId: string;
+  targetAttemptId?: string | null;
+  targetGeneration?: number | null;
+  sessionId: string;
+  channelId?: string | null;
+  source: string;
+  kind: DurableInputKind;
+  content: string;
+  idempotencyNamespace: string;
+  idempotencyKey: string;
+  supersedesInputId?: string | null;
+  expiresAt?: number | null;
+}
+
+export interface InputAuthorityStore {
+  receive(command: ReceiveInputCommand): { record: DurableInputRecord; persisted: true; duplicate: boolean };
+  get(inputId: string): DurableInputRecord | null;
+  listPending(jobId: string): DurableInputRecord[];
+  listPendingForSession(sessionId: string): DurableInputRecord[];
+  cancelPendingForSession(sessionId: string, now?: number): number;
+  claimNext(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    inputId?: string;
+    kinds?: DurableInputKind[];
+    now?: number;
+  }): DurableInputRecord | null;
+  consume(command: { inputId: string; attemptId: string; generation: number; now?: number }): {
+    applied: boolean;
+    duplicate?: boolean;
+    conflict?: 'not_found' | 'stale_generation' | 'invalid_state';
+  };
+}
+
+export interface SteeringRecord {
+  steeringId: string;
+  inputId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  targetScope: string;
+  action: 'narrow_scope' | 'redirect' | 'skip' | 'stop' | 'replace_goal';
+  payload: string | null;
+  state: 'pending' | 'applied' | 'rejected';
+  safeBoundarySequence: number | null;
+  invalidatesPlanDigest: string | null;
+  appliedAt: number | null;
+  rejectionReason: string | null;
+}
+
+export interface SteeringAuthority {
+  submit(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    sessionId: string;
+    channelId?: string | null;
+    source: string;
+    targetScope?: string;
+    action: SteeringRecord['action'];
+    payload?: string | null;
+    invalidatesPlanDigest?: string | null;
+    idempotencyNamespace: string;
+    idempotencyKey: string;
+  }): SteeringRecord;
+  listPending(jobId: string): SteeringRecord[];
+  applyNext(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    safeBoundarySequence: number;
+    instanceId?: string;
+    now?: number;
+  }): SteeringRecord | null;
+}
+
+export type JobControlKind = 'pause' | 'resume' | 'cancel' | 'interrupt';
+
+export interface JobControlAuthority {
+  inputs: InputAuthorityStore;
+  steering: SteeringAuthority;
+  commands: {
+    request(command: {
+      jobId: string;
+      attemptId?: string | null;
+      generation?: number | null;
+      kind: Exclude<JobControlKind, 'resume'>;
+      source: string;
+      reason?: string;
+      idempotencyNamespace: string;
+      idempotencyKey: string;
+      now?: number;
+    }): { controlId: string; persisted: true; duplicate: boolean; applied: boolean };
+    resume(command: {
+      jobId: string;
+      source: string;
+      instanceId: string;
+      idempotencyNamespace: string;
+      idempotencyKey: string;
+      now?: number;
+    }): { controlId: string; attemptId: string; runId: number; generation: number; duplicate: boolean };
+    listPending(jobId: string): Array<{ controlId: string; kind: JobControlKind; state: string }>;
+    applyPendingAtBoundary(command: { jobId: string; now?: number }): { applied: boolean; kind?: JobControlKind };
+  };
+  runtime: {
+    attach(attemptId: string, controller: AbortController): () => void;
+    cancel(attemptId: string, reason?: string): boolean;
+    isAttached(attemptId: string): boolean;
+  };
+}
+
+export interface CreateJobControlAuthorityOptions {
+  db: Db;
+  jobEngine: JobEngine;
+}
+
+interface InputRow {
+  input_id: string;
+  job_id: string;
+  target_attempt_id: string | null;
+  target_generation: number | null;
+  session_id: string;
+  channel_id: string | null;
+  source: string;
+  sequence: number;
+  kind: DurableInputKind;
+  content: string | null;
+  content_hash: string;
+  state: DurableInputState;
+  claimed_by_attempt_id: string | null;
+  claimed_generation: number | null;
+  claimed_at: number | null;
+  consumed_at: number | null;
+  created_at: number;
+}
+
+interface SteeringRow {
+  steering_id: string;
+  input_id: string;
+  job_id: string;
+  attempt_id: string;
+  generation: number;
+  target_scope: string;
+  action: SteeringRecord['action'];
+  payload: string | null;
+  state: SteeringRecord['state'];
+  safe_boundary_sequence: number | null;
+  invalidates_plan_digest: string | null;
+  applied_at: number | null;
+  rejection_reason: string | null;
+}
+
+function id(prefix: string): string {
+  return `${prefix}_${randomBytes(12).toString('hex')}`;
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function mapInput(row: InputRow): DurableInputRecord {
+  return {
+    inputId: row.input_id,
+    jobId: row.job_id,
+    targetAttemptId: row.target_attempt_id,
+    targetGeneration: row.target_generation,
+    sessionId: row.session_id,
+    channelId: row.channel_id,
+    source: row.source,
+    sequence: row.sequence,
+    kind: row.kind,
+    content: row.content,
+    contentHash: row.content_hash,
+    state: row.state,
+    claimedByAttemptId: row.claimed_by_attempt_id,
+    claimedGeneration: row.claimed_generation,
+    claimedAt: row.claimed_at,
+    consumedAt: row.consumed_at,
+    createdAt: row.created_at,
+  };
+}
+
+function mapSteering(row: SteeringRow): SteeringRecord {
+  return {
+    steeringId: row.steering_id,
+    inputId: row.input_id,
+    jobId: row.job_id,
+    attemptId: row.attempt_id,
+    generation: row.generation,
+    targetScope: row.target_scope,
+    action: row.action,
+    payload: row.payload,
+    state: row.state,
+    safeBoundarySequence: row.safe_boundary_sequence,
+    invalidatesPlanDigest: row.invalidates_plan_digest,
+    appliedAt: row.applied_at,
+    rejectionReason: row.rejection_reason,
+  };
+}
+
+export function createJobControlAuthority(options: CreateJobControlAuthorityOptions): JobControlAuthority {
+  const { db, jobEngine } = options;
+  const runtimeControllers = new Map<string, { registrationId: string; controller: AbortController }>();
+
+  const getInput = (inputId: string): DurableInputRecord | null => {
+    const row = db.prepare('SELECT * FROM durable_inputs WHERE input_id = ?').get(inputId) as InputRow | undefined;
+    return row ? mapInput(row) : null;
+  };
+
+  const appendReferenceEvent = (command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    type: string;
+    producer: string;
+    idempotencyKey: string;
+    payload: Record<string, unknown>;
+  }): void => {
+    const result = jobEngine.appendJobEvent(command);
+    if (!result.applied && !result.duplicate) {
+      throw new Error(`Durable event rejected: ${result.conflict ?? 'unknown conflict'}`);
+    }
+  };
+
+  const receiveTx = db.transaction((command: ReceiveInputCommand) => {
+    if (command.kind === 'credential') {
+      throw new Error('Credential input belongs to the credential authority and cannot enter the durable Job input store');
+    }
+    const existing = db.prepare(
+      'SELECT * FROM durable_inputs WHERE idempotency_namespace = ? AND idempotency_key = ?',
+    ).get(command.idempotencyNamespace, command.idempotencyKey) as InputRow | undefined;
+    if (existing) {
+      if (existing.content_hash !== digest(command.content) || existing.kind !== command.kind) {
+        throw new Error('Input idempotency conflict');
+      }
+      return { record: mapInput(existing), persisted: true as const, duplicate: true };
+    }
+    const job = jobEngine.getJob(command.jobId);
+    if (!job) throw new Error('Input target Job not found');
+    if (['cancelled', 'completed', 'failed', 'dead_letter'].includes(job.status)) {
+      throw new Error('Input target Job is terminal; submit a new Job or an explicit continuation');
+    }
+    if (command.targetAttemptId && command.targetAttemptId !== job.activeAttemptId) {
+      throw new Error('Input target Attempt is stale');
+    }
+    if (command.targetAttemptId && command.targetGeneration !== null && command.targetGeneration !== undefined) {
+      const attempt = jobEngine.getAttempt(command.targetAttemptId);
+      if (!attempt || attempt.generation !== command.targetGeneration) throw new Error('Input target has a stale generation');
+    }
+    const allocated = db.prepare(
+      `UPDATE tasks SET next_input_sequence = next_input_sequence + 1, updated_at = ?
+        WHERE id = ? RETURNING next_input_sequence - 1 AS sequence`,
+    ).get(Date.now(), command.jobId) as { sequence: number } | undefined;
+    if (!allocated) throw new Error('Input target Job disappeared');
+    const now = Date.now();
+    const inputId = id('input');
+    db.prepare(
+      `INSERT INTO durable_inputs (
+         input_id, job_id, target_attempt_id, target_generation, session_id,
+         channel_id, source, sequence, kind, content, content_hash, state,
+         idempotency_namespace, idempotency_key, supersedes_input_id,
+         expires_at, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      inputId,
+      command.jobId,
+      command.targetAttemptId ?? null,
+      command.targetGeneration ?? null,
+      command.sessionId,
+      command.channelId ?? null,
+      command.source,
+      allocated.sequence,
+      command.kind,
+      command.content,
+      digest(command.content),
+      command.idempotencyNamespace,
+      command.idempotencyKey,
+      command.supersedesInputId ?? null,
+      command.expiresAt ?? null,
+      now,
+      now,
+    );
+    const record = getInput(inputId)!;
+    const attemptId = record.targetAttemptId ?? job.activeAttemptId;
+    const attempt = attemptId ? jobEngine.getAttempt(attemptId) : null;
+    if (!attempt) throw new Error('Input target has no durable Attempt');
+    appendReferenceEvent({
+      jobId: command.jobId,
+      attemptId,
+      generation: record.targetGeneration ?? attempt.generation,
+      type: 'input.queued',
+      producer: command.source,
+      idempotencyKey: `input:${inputId}:queued`,
+      payload: {
+        inputId,
+        kind: record.kind,
+        sequence: record.sequence,
+        state: record.state,
+        contentHash: record.contentHash,
+      },
+    });
+    return { record, persisted: true as const, duplicate: false };
+  }).immediate;
+
+  const claimTx = db.transaction((command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    inputId?: string;
+    kinds?: DurableInputKind[];
+    now?: number;
+  }) => {
+    const attempt = jobEngine.getAttempt(command.attemptId);
+    if (!attempt || attempt.jobId !== command.jobId || attempt.generation !== command.generation) return null;
+    const now = command.now ?? Date.now();
+    const kinds = command.kinds?.length ? command.kinds : null;
+    const kindSql = kinds ? ` AND kind IN (${kinds.map(() => '?').join(',')})` : '';
+    if (command.inputId) {
+      const exact = db.prepare(
+        `SELECT * FROM durable_inputs
+          WHERE input_id = ? AND job_id = ? AND state IN ('queued','claimed')
+            AND (expires_at IS NULL OR expires_at > ?)
+            AND (target_attempt_id IS NULL OR target_attempt_id = ?)
+            AND (target_generation IS NULL OR target_generation = ?)
+            ${kindSql}`,
+      ).get(command.inputId, command.jobId, now, command.attemptId, command.generation, ...(kinds ?? [])) as InputRow | undefined;
+      if (!exact) return null;
+      if (exact.state === 'claimed') {
+        return exact.claimed_by_attempt_id === command.attemptId && exact.claimed_generation === command.generation
+          ? mapInput(exact)
+          : null;
+      }
+    }
+    const row = db.prepare(
+      `SELECT * FROM durable_inputs
+        WHERE job_id = ? AND state = 'queued'
+          ${command.inputId ? 'AND input_id = ?' : ''}
+          AND (expires_at IS NULL OR expires_at > ?)
+          AND (target_attempt_id IS NULL OR target_attempt_id = ?)
+          AND (target_generation IS NULL OR target_generation = ?)
+          ${kindSql}
+        ORDER BY sequence LIMIT 1`,
+    ).get(
+      command.jobId,
+      ...(command.inputId ? [command.inputId] : []),
+      now,
+      command.attemptId,
+      command.generation,
+      ...(kinds ?? []),
+    ) as InputRow | undefined;
+    if (!row) return null;
+    const changed = db.prepare(
+      `UPDATE durable_inputs
+          SET state = 'claimed', claimed_by_attempt_id = ?, claimed_generation = ?,
+              claimed_at = ?, updated_at = ?
+        WHERE input_id = ? AND state = 'queued'`,
+    ).run(command.attemptId, command.generation, now, now, row.input_id);
+    if (changed.changes !== 1) return null;
+    const claimed = getInput(row.input_id)!;
+    appendReferenceEvent({
+      jobId: command.jobId,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: 'input.claimed',
+      producer: claimed.source,
+      idempotencyKey: `input:${row.input_id}:claimed:${command.attemptId}:${command.generation}`,
+      payload: { inputId: row.input_id, kind: claimed.kind, sequence: claimed.sequence, state: claimed.state },
+    });
+    return claimed;
+  }).immediate;
+
+  const consumeTx = db.transaction((command: { inputId: string; attemptId: string; generation: number; now?: number }) => {
+    const row = db.prepare('SELECT * FROM durable_inputs WHERE input_id = ?').get(command.inputId) as InputRow | undefined;
+    if (!row) return { applied: false, conflict: 'not_found' as const };
+    if (row.state === 'consumed') return { applied: false, duplicate: true };
+    if (row.claimed_by_attempt_id !== command.attemptId || row.claimed_generation !== command.generation) {
+      return { applied: false, conflict: 'stale_generation' as const };
+    }
+    if (row.state !== 'claimed') return { applied: false, conflict: 'invalid_state' as const };
+    const now = command.now ?? Date.now();
+    const changed = db.prepare(
+      `UPDATE durable_inputs SET state = 'consumed', consumed_at = ?, updated_at = ?
+        WHERE input_id = ? AND state = 'claimed' AND claimed_by_attempt_id = ? AND claimed_generation = ?`,
+    ).run(now, now, command.inputId, command.attemptId, command.generation);
+    if (changed.changes !== 1) return { applied: false, conflict: 'invalid_state' as const };
+    appendReferenceEvent({
+      jobId: row.job_id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: 'input.consumed',
+      producer: row.source,
+      idempotencyKey: `input:${command.inputId}:consumed`,
+      payload: { inputId: command.inputId, kind: row.kind, sequence: row.sequence, state: 'consumed' },
+    });
+    return { applied: true };
+  }).immediate;
+
+  const inputs: InputAuthorityStore = {
+    receive: receiveTx,
+    get: getInput,
+    listPending(jobId) {
+      return (db.prepare(
+        `SELECT * FROM durable_inputs WHERE job_id = ? AND state IN ('queued','claimed') ORDER BY sequence`,
+      ).all(jobId) as InputRow[]).map(mapInput);
+    },
+    listPendingForSession(sessionId) {
+      return (db.prepare(
+        `SELECT * FROM durable_inputs WHERE session_id = ? AND state IN ('queued','claimed') ORDER BY created_at, sequence`,
+      ).all(sessionId) as InputRow[]).map(mapInput);
+    },
+    cancelPendingForSession(sessionId, now = Date.now()) {
+      return db.prepare(
+        `UPDATE durable_inputs SET state = 'cancelled', updated_at = ?
+          WHERE session_id = ? AND state IN ('queued','claimed')`,
+      ).run(now, sessionId).changes;
+    },
+    claimNext: claimTx,
+    consume: consumeTx,
+  };
+
+  const steering: SteeringAuthority = {
+    submit(command) {
+      return db.transaction(() => {
+        const received = inputs.receive({
+        jobId: command.jobId,
+        targetAttemptId: command.attemptId,
+        targetGeneration: command.generation,
+        sessionId: command.sessionId,
+        channelId: command.channelId,
+        source: command.source,
+        kind: 'steering',
+        content: command.payload ?? '',
+        idempotencyNamespace: command.idempotencyNamespace,
+        idempotencyKey: command.idempotencyKey,
+      });
+        const existing = db.prepare('SELECT * FROM steering_commands WHERE input_id = ?')
+          .get(received.record.inputId) as SteeringRow | undefined;
+        if (existing) return mapSteering(existing);
+        const steeringId = id('steer');
+        const now = Date.now();
+        db.prepare(
+        `INSERT INTO steering_commands (
+           steering_id, input_id, job_id, attempt_id, generation, target_scope,
+           action, payload, state, invalidates_plan_digest, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)`,
+        ).run(
+        steeringId,
+        received.record.inputId,
+        command.jobId,
+        command.attemptId,
+        command.generation,
+        command.targetScope ?? 'attempt',
+        command.action,
+        command.payload ?? null,
+        command.invalidatesPlanDigest ?? null,
+        now,
+        now,
+        );
+        const record = mapSteering(db.prepare('SELECT * FROM steering_commands WHERE steering_id = ?').get(steeringId) as SteeringRow);
+        appendReferenceEvent({
+          jobId: record.jobId,
+          attemptId: record.attemptId,
+          generation: record.generation,
+          type: 'steering.pending',
+          producer: command.source,
+          idempotencyKey: `steering:${record.steeringId}:pending`,
+          payload: {
+            steeringId: record.steeringId,
+            inputId: record.inputId,
+            action: record.action,
+            targetScope: record.targetScope,
+            state: record.state,
+          },
+        });
+        return record;
+      }).immediate();
+    },
+    listPending(jobId) {
+      return (db.prepare(
+        `SELECT * FROM steering_commands WHERE job_id = ? AND state = 'pending' ORDER BY created_at, steering_id`,
+      ).all(jobId) as SteeringRow[]).map(mapSteering);
+    },
+    applyNext(command) {
+      return db.transaction(() => {
+        const row = db.prepare(
+        `SELECT * FROM steering_commands
+          WHERE job_id = ? AND attempt_id = ? AND generation = ? AND state = 'pending'
+          ORDER BY created_at, steering_id LIMIT 1`,
+        ).get(command.jobId, command.attemptId, command.generation) as SteeringRow | undefined;
+        if (!row) return null;
+        const now = command.now ?? Date.now();
+        const job = jobEngine.getJob(command.jobId);
+        const attempt = jobEngine.getAttempt(command.attemptId);
+        if (
+        !job || job.activeAttemptId !== command.attemptId ||
+        !attempt || attempt.jobId !== command.jobId || attempt.generation !== command.generation
+        ) {
+          db.prepare(
+          `UPDATE steering_commands
+              SET state = 'rejected', rejection_reason = 'stale generation', updated_at = ?
+            WHERE steering_id = ? AND state = 'pending'`,
+          ).run(now, row.steering_id);
+          db.prepare(
+          `UPDATE durable_inputs SET state = 'rejected_stale', updated_at = ?
+            WHERE input_id = ? AND state = 'queued'`,
+          ).run(now, row.input_id);
+          const rejected = mapSteering(db.prepare('SELECT * FROM steering_commands WHERE steering_id = ?').get(row.steering_id) as SteeringRow);
+          if (attempt) appendReferenceEvent({
+            jobId: command.jobId,
+            attemptId: command.attemptId,
+            generation: attempt.generation,
+            type: 'steering.rejected',
+            producer: 'steering',
+            idempotencyKey: `steering:${row.steering_id}:rejected`,
+            payload: { steeringId: row.steering_id, inputId: row.input_id, action: row.action, state: 'rejected' },
+          });
+          return rejected;
+        }
+        if (row.action === 'replace_goal') {
+          if (!command.instanceId) {
+            db.prepare(
+            `UPDATE steering_commands
+                SET state = 'rejected', rejection_reason = 'replacement Attempt owner required', updated_at = ?
+              WHERE steering_id = ? AND state = 'pending'`,
+            ).run(now, row.steering_id);
+            const rejected = mapSteering(db.prepare('SELECT * FROM steering_commands WHERE steering_id = ?').get(row.steering_id) as SteeringRow);
+            appendReferenceEvent({
+              jobId: command.jobId,
+              attemptId: command.attemptId,
+              generation: command.generation,
+              type: 'steering.rejected',
+              producer: 'steering',
+              idempotencyKey: `steering:${row.steering_id}:rejected`,
+              payload: { steeringId: row.steering_id, inputId: row.input_id, action: row.action, state: 'rejected' },
+            });
+            return rejected;
+          }
+          const paused = jobEngine.pauseJob({
+          jobId: command.jobId,
+          reason: 'goal replaced by steering',
+          producer: 'steering',
+          eventIdempotencyKey: `steering:${row.steering_id}:pause`,
+          now,
+          });
+          if (!paused.applied && !paused.duplicate) return null;
+          jobEngine.resumeJob({
+          jobId: command.jobId,
+          instanceId: command.instanceId,
+          triggerReason: 'goal_changed',
+          producer: 'steering',
+          eventIdempotencyKey: `steering:${row.steering_id}:resume`,
+          now,
+          });
+        }
+        const changed = db.prepare(
+        `UPDATE steering_commands
+            SET state = 'applied', safe_boundary_sequence = ?, applied_at = ?, updated_at = ?
+          WHERE steering_id = ? AND state = 'pending' AND generation = ?`,
+        ).run(command.safeBoundarySequence, now, now, row.steering_id, command.generation);
+        if (changed.changes !== 1) return null;
+        db.prepare(
+        `UPDATE durable_inputs SET state = 'consumed', consumed_at = ?, updated_at = ?
+          WHERE input_id = ? AND state = 'queued'`,
+        ).run(now, now, row.input_id);
+        const applied = mapSteering(db.prepare('SELECT * FROM steering_commands WHERE steering_id = ?').get(row.steering_id) as SteeringRow);
+        appendReferenceEvent({
+          jobId: command.jobId,
+          attemptId: command.attemptId,
+          generation: command.generation,
+          type: 'steering.applied',
+          producer: 'steering',
+          idempotencyKey: `steering:${row.steering_id}:applied`,
+          payload: {
+            steeringId: row.steering_id,
+            inputId: row.input_id,
+            action: row.action,
+            state: 'applied',
+            safeBoundarySequence: command.safeBoundarySequence,
+          },
+        });
+        return applied;
+      }).immediate();
+    },
+  };
+
+  const persistControl = (command: {
+    jobId: string;
+    attemptId?: string | null;
+    generation?: number | null;
+    kind: JobControlKind;
+    source: string;
+    reason?: string;
+    idempotencyNamespace: string;
+    idempotencyKey: string;
+    now?: number;
+  }): { controlId: string; duplicate: boolean; state: string; attemptId: string | null; generation: number | null } => {
+    const existing = db.prepare(
+      `SELECT control_id, state, attempt_id, generation FROM job_control_commands
+        WHERE idempotency_namespace = ? AND idempotency_key = ?`,
+    ).get(command.idempotencyNamespace, command.idempotencyKey) as {
+      control_id: string; state: string; attempt_id: string | null; generation: number | null;
+    } | undefined;
+    if (existing) return {
+      controlId: existing.control_id,
+      duplicate: true,
+      state: existing.state,
+      attemptId: existing.attempt_id,
+      generation: existing.generation,
+    };
+    const job = jobEngine.getJob(command.jobId);
+    if (!job) throw new Error('Control target Job not found');
+    const attemptId = command.attemptId ?? job.activeAttemptId;
+    const attempt = attemptId ? jobEngine.getAttempt(attemptId) : null;
+    if (!attempt || attempt.jobId !== command.jobId) throw new Error('Control target Attempt not found');
+    const generation = command.generation ?? attempt.generation;
+    if (attempt.generation !== generation) throw new Error('Control target has a stale generation');
+    const controlId = id('control');
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO job_control_commands (
+         control_id, job_id, attempt_id, generation, kind, source, reason, state,
+         idempotency_namespace, idempotency_key, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 'persisted', ?, ?, ?, ?)`,
+    ).run(
+      controlId,
+      command.jobId,
+      attemptId,
+      generation,
+      command.kind,
+      command.source,
+      command.reason ?? null,
+      command.idempotencyNamespace,
+      command.idempotencyKey,
+      now,
+      now,
+    );
+    appendReferenceEvent({
+      jobId: command.jobId,
+      attemptId,
+      generation,
+      type: 'control.persisted',
+      producer: command.source,
+      idempotencyKey: `control:${controlId}:persisted`,
+      payload: { controlId, kind: command.kind, state: 'persisted' },
+    });
+    return { controlId, duplicate: false, state: 'persisted', attemptId, generation };
+  };
+
+  return {
+    inputs,
+    steering,
+    commands: {
+      request(command) {
+        const reason = command.reason ?? command.kind;
+        const outcome = db.transaction(() => {
+          const persisted = persistControl(command);
+          if (persisted.duplicate) {
+            return {
+              controlId: persisted.controlId,
+              persisted: true as const,
+              duplicate: true,
+              applied: persisted.state === 'applied',
+              attemptIds: persisted.attemptId ? [persisted.attemptId] : [],
+            };
+          }
+          if (command.kind === 'pause') {
+            // Pause is acknowledged durably now and applied only when the
+            // active runner reaches an explicit safe boundary.
+            return {
+              controlId: persisted.controlId,
+              persisted: true as const,
+              duplicate: false,
+              applied: false,
+              attemptIds: persisted.attemptId ? [persisted.attemptId] : [],
+            };
+          }
+          const result = jobEngine.cancelJob({
+            jobId: command.jobId,
+            reason,
+            producer: command.source,
+            eventIdempotencyKey: `control:${persisted.controlId}`,
+            now: command.now,
+          });
+          const attemptIds = persisted.attemptId ? [persisted.attemptId] : [];
+          if (result.applied) {
+            const parent = jobEngine.getJob(command.jobId);
+            if (parent) {
+              const family = jobEngine.listJobs({ rootJobId: parent.rootJobId, limit: 1_000 });
+              const byId = new Map(family.map((job) => [job.id, job]));
+              const isDescendant = (candidateId: string): boolean => {
+                let cursor = byId.get(candidateId)?.parentJobId ?? null;
+                const visited = new Set<string>();
+                while (cursor && !visited.has(cursor)) {
+                  if (cursor === command.jobId) return true;
+                  visited.add(cursor);
+                  cursor = byId.get(cursor)?.parentJobId ?? null;
+                }
+                return false;
+              };
+              for (const child of family.filter((job) => isDescendant(job.id))) {
+                if (!child.activeAttemptId) continue;
+                const childAttemptId = child.activeAttemptId;
+                const cancelled = jobEngine.cancelJob({
+                  jobId: child.id,
+                  reason: `parent ${command.kind}: ${reason}`,
+                  producer: command.source,
+                  eventIdempotencyKey: `control:${persisted.controlId}:child:${child.id}`,
+                  now: command.now,
+                });
+                if (cancelled.applied || cancelled.duplicate) attemptIds.push(childAttemptId);
+              }
+            }
+          }
+          const now = command.now ?? Date.now();
+          db.prepare(
+            `UPDATE job_control_commands SET state = ?, applied_at = ?, updated_at = ?, rejection_reason = ?
+              WHERE control_id = ?`,
+          ).run(result.applied ? 'applied' : 'rejected', result.applied ? now : null, now, result.applied ? null : 'state conflict', persisted.controlId);
+          return {
+            controlId: persisted.controlId,
+            persisted: true as const,
+            duplicate: false,
+            applied: result.applied,
+            attemptIds,
+          };
+        }).immediate();
+        if (command.kind !== 'pause' && outcome.applied) {
+          for (const attemptId of outcome.attemptIds) {
+            const active = runtimeControllers.get(attemptId);
+            if (active && !active.controller.signal.aborted) active.controller.abort(reason);
+          }
+        }
+        const { attemptIds: _attemptIds, ...result } = outcome;
+        return result;
+      },
+      resume(command) {
+        return db.transaction(() => {
+          const persisted = persistControl({ ...command, kind: 'resume' });
+          if (persisted.duplicate) {
+            const row = db.prepare(
+              `SELECT r.attempt_id, r.id, r.generation
+                 FROM job_control_commands c JOIN runs r ON r.attempt_id = c.attempt_id
+                WHERE c.control_id = ?`,
+            ).get(persisted.controlId) as { attempt_id: string; id: number; generation: number } | undefined;
+            if (!row || persisted.state !== 'applied') throw new Error('Resume command was not fully applied');
+            return { controlId: persisted.controlId, attemptId: row.attempt_id, runId: row.id, generation: row.generation, duplicate: true };
+          }
+          const resumed = jobEngine.resumeJob({
+            jobId: command.jobId,
+            instanceId: command.instanceId,
+            triggerReason: 'manual_resume',
+            producer: command.source,
+            eventIdempotencyKey: `control:${persisted.controlId}`,
+            now: command.now,
+          });
+          const now = command.now ?? Date.now();
+          db.prepare(
+            `UPDATE job_control_commands
+                SET state = 'applied', attempt_id = ?, generation = ?, applied_at = ?, updated_at = ?
+              WHERE control_id = ?`,
+          ).run(resumed.attemptId, resumed.generation, now, now, persisted.controlId);
+          return { controlId: persisted.controlId, ...resumed, duplicate: false };
+        }).immediate();
+      },
+      listPending(jobId) {
+        return db.prepare(
+          `SELECT control_id AS controlId, kind, state
+             FROM job_control_commands WHERE job_id = ? AND state IN ('persisted','pending') ORDER BY created_at`,
+        ).all(jobId) as Array<{ controlId: string; kind: JobControlKind; state: string }>;
+      },
+      applyPendingAtBoundary(command) {
+        return db.transaction(() => {
+          const row = db.prepare(
+          `SELECT control_id, kind, reason, source FROM job_control_commands
+            WHERE job_id = ? AND state = 'persisted' ORDER BY created_at, control_id LIMIT 1`,
+          ).get(command.jobId) as {
+            control_id: string;
+            kind: JobControlKind;
+            reason: string | null;
+            source: string;
+          } | undefined;
+          if (!row) return { applied: false };
+          if (row.kind !== 'pause') return { applied: false, kind: row.kind };
+          const result = jobEngine.pauseJob({
+            jobId: command.jobId,
+            reason: row.reason ?? 'pause',
+            producer: row.source,
+            eventIdempotencyKey: `control:${row.control_id}`,
+            now: command.now,
+          });
+          const now = command.now ?? Date.now();
+          db.prepare(
+            `UPDATE job_control_commands SET state = ?, applied_at = ?, updated_at = ?, rejection_reason = ?
+              WHERE control_id = ? AND state = 'persisted'`,
+          ).run(result.applied ? 'applied' : 'rejected', result.applied ? now : null, now, result.applied ? null : 'state conflict', row.control_id);
+          return { applied: result.applied, kind: row.kind };
+        }).immediate();
+      },
+    },
+    runtime: {
+      attach(attemptId, controller) {
+        const registrationId = id('runtime');
+        runtimeControllers.set(attemptId, { registrationId, controller });
+        return () => {
+          const current = runtimeControllers.get(attemptId);
+          if (current?.registrationId === registrationId) runtimeControllers.delete(attemptId);
+        };
+      },
+      cancel(attemptId, reason) {
+        const current = runtimeControllers.get(attemptId);
+        if (!current || current.controller.signal.aborted) return false;
+        current.controller.abort(reason);
+        return true;
+      },
+      isAttached(attemptId) {
+        return runtimeControllers.has(attemptId);
+      },
+    },
+  };
+}

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -117,6 +117,17 @@ export interface JobEngine {
   getAttempt(attemptId: string): AttemptRecord | null;
   listAttempts(jobId: string): AttemptRecord[];
   listEvents(jobId: string, afterSequence?: number): JobEventRecord[];
+  appendJobEvent(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    type: string;
+    payload?: Record<string, unknown> | null;
+    producer: string;
+    idempotencyKey: string;
+    causationId?: string | null;
+    correlationId?: string | null;
+  }): { applied: boolean; duplicate: boolean; jobSequence?: number; conflict?: 'not_found' | 'stale_generation' };
   transitionJob(command: {
     jobId: string;
     attemptId: string;
@@ -159,6 +170,21 @@ export interface JobEngine {
     eventIdempotencyKey: string;
     now?: number;
   }): TransitionResult;
+  pauseJob(command: {
+    jobId: string;
+    reason: string;
+    producer: string;
+    eventIdempotencyKey: string;
+    now?: number;
+  }): TransitionResult;
+  resumeJob(command: {
+    jobId: string;
+    instanceId: string;
+    triggerReason: string;
+    producer: string;
+    eventIdempotencyKey: string;
+    now?: number;
+  }): { attemptId: string; runId: number; attemptNumber: number; generation: number };
   transitionAttempt(command: {
     attemptId: string;
     expectedStateVersion: number;
@@ -609,6 +635,43 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     return { jobId, attemptId, runId, reused: false };
   }).immediate;
 
+  const appendJobEventTx = db.transaction((command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    type: string;
+    payload?: Record<string, unknown> | null;
+    producer: string;
+    idempotencyKey: string;
+    causationId?: string | null;
+    correlationId?: string | null;
+  }) => {
+    const attempt = getAttemptRow(command.attemptId);
+    if (!attempt || attempt.task_id !== command.jobId) {
+      return { applied: false, duplicate: false, conflict: 'not_found' as const };
+    }
+    if (attempt.generation !== command.generation) {
+      return { applied: false, duplicate: false, conflict: 'stale_generation' as const };
+    }
+    const appended = appendEvent({
+      jobId: command.jobId,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: command.type,
+      payload: command.payload,
+      producer: command.producer,
+      idempotencyKey: command.idempotencyKey,
+      causationId: command.causationId,
+      correlationId: command.correlationId,
+    });
+    return {
+      applied: !appended.duplicate,
+      duplicate: appended.duplicate,
+      jobSequence: appended.jobSequence,
+    };
+  }).immediate;
+
   const transitionJobTx = db.transaction((command: Parameters<JobEngine['transitionJob']>[0]): TransitionResult => {
     if (existingEvent(command.jobId, command.eventIdempotencyKey)) {
       return { applied: false, duplicate: true };
@@ -910,6 +973,134 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       idempotencyKey: command.eventIdempotencyKey,
     });
     return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const pauseJobTx = db.transaction((command: Parameters<JobEngine['pauseJob']>[0]): TransitionResult => {
+    if (existingEvent(command.jobId, command.eventIdempotencyKey)) {
+      return { applied: false, duplicate: true };
+    }
+    const job = getJobRow(command.jobId);
+    if (!job) return { applied: false, conflict: 'not_found' };
+    if (JOB_TERMINAL.has(job.status)) return { applied: false, conflict: 'terminal_state' };
+    if (job.status === 'paused') return { applied: false, duplicate: true, stateVersion: job.state_version };
+    const attempt = job.active_attempt_id ? getAttemptRow(job.active_attempt_id) : undefined;
+    if (!attempt || ATTEMPT_TERMINAL.has(attempt.status)) return { applied: false, conflict: 'not_found' };
+    const now = command.now ?? Date.now();
+    const attemptVersion = attempt.state_version + 1;
+    const attemptChanged = db.prepare(
+      `UPDATE runs
+          SET status = 'waiting', state_version = ?, finish_reason = ?,
+              lease_id = NULL, lease_owner = NULL, lease_expires_at = NULL,
+              lease_heartbeat_at = NULL, fence_token = NULL
+        WHERE attempt_id = ? AND state_version = ? AND generation = ?`,
+    ).run(attemptVersion, command.reason, attempt.attempt_id, attempt.state_version, attempt.generation);
+    if (attemptChanged.changes !== 1) return { applied: false, conflict: 'state_version' };
+    appendEvent({
+      jobId: job.id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: 'attempt.paused',
+      payload: { reason: command.reason },
+      producer: command.producer,
+      idempotencyKey: `${command.eventIdempotencyKey}:attempt`,
+    });
+    const nextVersion = job.state_version + 1;
+    const jobChanged = db.prepare(
+      `UPDATE tasks SET status = 'paused', state_version = ?, finish_reason = ?, updated_at = ?
+        WHERE id = ? AND state_version = ? AND active_attempt_id = ?`,
+    ).run(nextVersion, command.reason, now, job.id, job.state_version, attempt.attempt_id);
+    if (jobChanged.changes !== 1) return { applied: false, conflict: 'state_version' };
+    appendEvent({
+      jobId: job.id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: 'job.paused',
+      payload: { reason: command.reason },
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const resumeJobTx = db.transaction((command: Parameters<JobEngine['resumeJob']>[0]) => {
+    const job = getJobRow(command.jobId);
+    if (!job) throw new Error('Resume Job not found');
+    if (JOB_TERMINAL.has(job.status)) throw new Error('Cannot resume a terminal Job');
+    if (job.status !== 'paused') throw new Error('Resume requires a paused Job');
+    const previous = job.active_attempt_id ? getAttemptRow(job.active_attempt_id) : undefined;
+    if (!previous) throw new Error('Paused Job has no active Attempt');
+    const now = command.now ?? Date.now();
+    const previousChanged = db.prepare(
+      `UPDATE runs
+          SET status = 'cancelled', state_version = state_version + 1,
+              finish_reason = 'superseded by resume', completed_at = ?, ended_at = ?
+        WHERE attempt_id = ? AND generation = ? AND status = 'waiting'`,
+    ).run(now, now, previous.attempt_id, previous.generation);
+    if (previousChanged.changes !== 1) throw new Error('Paused Attempt changed concurrently');
+    appendEvent({
+      jobId: job.id,
+      runId: previous.id,
+      attemptId: previous.attempt_id,
+      generation: previous.generation,
+      type: 'attempt.cancelled',
+      payload: { reason: 'superseded by resume' },
+      producer: command.producer,
+      idempotencyKey: `${command.eventIdempotencyKey}:previous`,
+    });
+    const max = db.prepare(
+      'SELECT COALESCE(MAX(attempt_number), 0) AS attempt_number, COALESCE(MAX(generation), 0) AS generation FROM runs WHERE task_id = ?',
+    ).get(job.id) as { attempt_number: number; generation: number };
+    const attemptNumber = max.attempt_number + 1;
+    const generation = max.generation + 1;
+    const attemptId = randomId('attempt');
+    const inserted = db.prepare(
+      `INSERT INTO runs (
+         session_id, instance_id, status, started_at, resume_pending,
+         task_id, attempt_id, attempt_number, generation, state_version,
+         recovery_of_attempt_id, trigger_reason
+       ) VALUES (?, ?, 'queued', ?, 0, ?, ?, ?, ?, 0, ?, ?)`,
+    ).run(
+      previous.session_id,
+      command.instanceId,
+      now,
+      job.id,
+      attemptId,
+      attemptNumber,
+      generation,
+      previous.attempt_id,
+      command.triggerReason,
+    );
+    const jobChanged = db.prepare(
+      `UPDATE tasks
+          SET status = 'queued', state_version = state_version + 1,
+              active_attempt_id = ?, finish_reason = NULL, updated_at = ?
+        WHERE id = ? AND state_version = ? AND status = 'paused'`,
+    ).run(attemptId, now, job.id, job.state_version);
+    if (jobChanged.changes !== 1) throw new Error('Paused Job changed concurrently');
+    const runId = Number(inserted.lastInsertRowid);
+    appendEvent({
+      jobId: job.id,
+      runId,
+      attemptId,
+      generation,
+      type: 'job.resumed',
+      payload: { previousAttemptId: previous.attempt_id },
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    appendEvent({
+      jobId: job.id,
+      runId,
+      attemptId,
+      generation,
+      type: 'attempt.created',
+      payload: { attemptNumber, recoveryOfAttemptId: previous.attempt_id, triggerReason: command.triggerReason },
+      producer: command.producer,
+      idempotencyKey: `${command.eventIdempotencyKey}:attempt`,
+    });
+    return { attemptId, runId, attemptNumber, generation };
   }).immediate;
 
   const claimAttemptTx = db.transaction((command: Parameters<JobEngine['claimAttempt']>[0]): LeaseResult => {
@@ -1517,9 +1708,12 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         };
       });
     },
+    appendJobEvent: appendJobEventTx,
     transitionJob: transitionJobTx,
     finalizeJob: finalizeJobTx,
     cancelJob: cancelJobTx,
+    pauseJob: pauseJobTx,
+    resumeJob: resumeJobTx,
     transitionAttempt: transitionAttemptTx,
     claimAttempt: claimAttemptTx,
     renewAttemptLease: renewAttemptTx,

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -1,0 +1,1555 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { Db } from './db/connection';
+
+export type JobStatus =
+  | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
+  | 'cancelled' | 'completed' | 'failed' | 'blocked' | 'unknown'
+  | 'crashed' | 'recovering' | 'dead_letter';
+
+export type AttemptStatus =
+  | 'queued' | 'leased' | 'running' | 'waiting' | 'succeeded'
+  | 'failed' | 'cancelled' | 'timed_out' | 'crashed' | 'unknown';
+
+export type TransitionConflict =
+  | 'not_found' | 'state_version' | 'illegal_transition' | 'terminal_state'
+  | 'stale_fence' | 'lease_held' | 'lease_expired';
+
+export interface JobRecord {
+  id: string;
+  status: string;
+  stateVersion: number;
+  activeAttemptId: string | null;
+  rootJobId: string;
+  parentJobId: string | null;
+  sessionId: string;
+  goal: string;
+  entryPoint: string | null;
+  source: string | null;
+  terminalAt: number | null;
+  terminalOutcome: string | null;
+  finishReason: string | null;
+  nextEventSequence: number;
+}
+
+export interface AttemptRecord {
+  rowId: number;
+  id: string;
+  jobId: string | null;
+  status: string;
+  attemptNumber: number;
+  generation: number;
+  stateVersion: number;
+  leaseId: string | null;
+  leaseOwner: string | null;
+  leaseExpiresAt: number | null;
+  leaseHeartbeatAt: number | null;
+  fenceToken: string | null;
+  recoveryOfAttemptId: string | null;
+}
+
+export interface JobEventRecord {
+  eventId: number;
+  jobSequence: number;
+  jobId: string;
+  attemptId: string | null;
+  type: string;
+  payload: Record<string, unknown> | null;
+  producer: string | null;
+  generation: number | null;
+  idempotencyKey: string;
+  createdAt: number;
+}
+
+export interface SubmitJobCommand {
+  entryPoint: string;
+  source: string;
+  sessionId: string;
+  workspaceId?: string | null;
+  principalId?: string | null;
+  instanceId: string;
+  idempotencyNamespace: string;
+  idempotencyKey?: string;
+  requestFingerprint?: string;
+  goal: string;
+  title?: string;
+  channelId?: string | null;
+  parentJobId?: string | null;
+  rootJobId?: string | null;
+  triggerEventId?: number | null;
+}
+
+export interface AdmissionResult {
+  jobId: string;
+  attemptId: string;
+  runId: number;
+  reused: boolean;
+}
+
+export interface TransitionResult {
+  applied: boolean;
+  stateVersion?: number;
+  conflict?: TransitionConflict;
+  duplicate?: boolean;
+}
+
+export interface LeaseResult extends TransitionResult {
+  acquired: boolean;
+  leaseId?: string;
+  fenceToken?: string;
+  generation?: number;
+}
+
+export interface JobEngine {
+  submitJob(command: SubmitJobCommand): AdmissionResult;
+  getJob(jobId: string): JobRecord | null;
+  listJobs(filters?: {
+    sessionId?: string;
+    status?: string;
+    rootJobId?: string;
+    limit?: number;
+  }): JobRecord[];
+  getAttempt(attemptId: string): AttemptRecord | null;
+  listAttempts(jobId: string): AttemptRecord[];
+  listEvents(jobId: string, afterSequence?: number): JobEventRecord[];
+  transitionJob(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    expectedStateVersion: number;
+    to: JobStatus;
+    eventIdempotencyKey: string;
+    producer: string;
+    finishReason?: string | null;
+    terminalOutcome?: string | null;
+    payload?: Record<string, unknown> | null;
+    now?: number;
+  }): TransitionResult;
+  finalizeJob(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    expectedStateVersion: number;
+    status: 'completed' | 'failed' | 'cancelled';
+    outcome: string;
+    finishReason: string;
+    evidence: unknown;
+    jobCard?: {
+      filesTouched?: string[];
+      sideEffects?: unknown[];
+      failureState?: unknown | null;
+      permissions?: Record<string, unknown> | null;
+      constraints?: Record<string, unknown> | null;
+    };
+    eventIdempotencyKey: string;
+    producer: string;
+    now?: number;
+  }): TransitionResult;
+  cancelJob(command: {
+    jobId: string;
+    reason: string;
+    producer: string;
+    eventIdempotencyKey: string;
+    now?: number;
+  }): TransitionResult;
+  transitionAttempt(command: {
+    attemptId: string;
+    expectedStateVersion: number;
+    generation: number;
+    fenceToken: string;
+    to: AttemptStatus;
+    eventIdempotencyKey: string;
+    producer: string;
+    finishReason?: string | null;
+    payload?: Record<string, unknown> | null;
+    now?: number;
+  }): TransitionResult;
+  claimAttempt(command: {
+    attemptId: string;
+    ownerId: string;
+    ttlMs: number;
+    now?: number;
+  }): LeaseResult;
+  renewAttemptLease(command: {
+    attemptId: string;
+    ownerId: string;
+    generation: number;
+    fenceToken: string;
+    ttlMs: number;
+    now?: number;
+  }): TransitionResult;
+  createRecoveryAttempt(command: {
+    jobId: string;
+    recoveryOfAttemptId: string;
+    instanceId: string;
+    triggerReason: string;
+    eventIdempotencyKey: string;
+    producer: string;
+  }): { attemptId: string; runId: number; attemptNumber: number; generation: number };
+  prepareToolCall(command: {
+    toolCallId: string;
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    toolName: string;
+    normalizedArgsDigest: string;
+    riskTier: string;
+    mutates: boolean;
+    modelCallId?: string | null;
+    producer: string;
+    now?: number;
+  }): TransitionResult;
+  startToolCall(command: {
+    toolCallId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    producer: string;
+    now?: number;
+  }): TransitionResult;
+  completeToolCall(command: {
+    toolCallId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    state: 'completed' | 'failed' | 'cancelled' | 'unknown';
+    sideEffectState?: 'committed' | 'failed' | 'unknown';
+    resultRef?: string | null;
+    verificationRef?: string | null;
+    producer: string;
+    now?: number;
+  }): TransitionResult;
+  attachToolVerification(command: {
+    toolCallId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    verificationRef: string;
+    producer: string;
+    now?: number;
+  }): TransitionResult;
+  recoverExpiredAttempts(command: {
+    now?: number;
+    instanceId: string;
+    producer: string;
+    maxCrashes: number;
+  }): Array<{
+    jobId: string;
+    expiredAttemptId: string;
+    recoveryAttemptId?: string;
+    decision: 'retry' | 'ask_user' | 'dead_letter';
+  }>;
+}
+
+export interface CreateJobEngineOptions {
+  db: Db;
+}
+
+export class IdempotencyConflictError extends Error {
+  readonly code = 'IDEMPOTENCY_CONFLICT';
+  constructor(readonly namespace: string, readonly key: string) {
+    super(`Idempotency key conflict in namespace ${namespace}`);
+    this.name = 'IdempotencyConflictError';
+  }
+}
+
+interface JobSqlRow {
+  id: string;
+  status: string;
+  state_version: number;
+  active_attempt_id: string | null;
+  root_job_id: string | null;
+  parent_task_id: string | null;
+  session_id: string;
+  goal: string;
+  entry_point: string | null;
+  source: string | null;
+  terminal_at: number | null;
+  terminal_outcome: string | null;
+  finish_reason: string | null;
+  next_event_sequence: number;
+}
+
+interface AttemptSqlRow {
+  id: number;
+  attempt_id: string;
+  task_id: string | null;
+  status: string;
+  attempt_number: number;
+  generation: number;
+  state_version: number;
+  lease_id: string | null;
+  lease_owner: string | null;
+  lease_expires_at: number | null;
+  lease_heartbeat_at: number | null;
+  fence_token: string | null;
+  recovery_of_attempt_id: string | null;
+  session_id: string;
+}
+
+interface ToolCallSqlRow {
+  tool_call_id: string;
+  job_id: string;
+  attempt_id: string;
+  generation: number;
+  tool_name: string;
+  normalized_args_digest: string;
+  mutates: number;
+  state: string;
+  side_effect_id: string | null;
+  verification_ref: string | null;
+}
+
+const JOB_TERMINAL = new Set<string>([
+  'cancelled', 'completed', 'failed', 'dead_letter',
+  'completed_unverified', 'verification_failed', 'abandoned',
+]);
+
+const ATTEMPT_TERMINAL = new Set<string>([
+  'succeeded', 'completed', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown', 'interrupted',
+]);
+
+const JOB_TRANSITIONS: Readonly<Record<string, ReadonlySet<string>>> = {
+  pending: new Set(['queued', 'running', 'cancelled', 'failed']),
+  active: new Set(['running', 'waiting', 'paused', 'cancelling', 'cancelled', 'completed', 'failed', 'blocked', 'unknown', 'crashed', 'pending_verification']),
+  pending_verification: new Set(['completed', 'completed_unverified', 'verification_failed', 'failed', 'cancelled']),
+  queued: new Set(['running', 'cancelling', 'cancelled', 'failed', 'blocked', 'crashed']),
+  running: new Set(['waiting', 'paused', 'cancelling', 'cancelled', 'completed', 'failed', 'blocked', 'unknown', 'crashed']),
+  waiting: new Set(['running', 'paused', 'cancelling', 'cancelled', 'failed', 'blocked', 'unknown', 'crashed']),
+  paused: new Set(['cancelling', 'cancelled', 'recovering']),
+  cancelling: new Set(['cancelled', 'failed', 'unknown']),
+  blocked: new Set(['recovering', 'cancelled', 'dead_letter']),
+  unknown: new Set(['recovering', 'failed', 'dead_letter']),
+  crashed: new Set(['recovering', 'failed', 'dead_letter']),
+  recovering: new Set(['queued', 'running', 'blocked', 'failed', 'dead_letter']),
+  interrupted: new Set(['recovering', 'failed', 'dead_letter']),
+  blocked_needs_user: new Set(['recovering', 'cancelled', 'abandoned']),
+};
+
+const ATTEMPT_TRANSITIONS: Readonly<Record<string, ReadonlySet<string>>> = {
+  queued: new Set(['leased', 'cancelled', 'failed', 'crashed']),
+  leased: new Set(['running', 'waiting', 'succeeded', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown']),
+  running: new Set(['waiting', 'succeeded', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown']),
+  waiting: new Set(['running', 'succeeded', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown']),
+};
+
+function randomId(prefix: string): string {
+  return `${prefix}_${randomBytes(12).toString('hex')}`;
+}
+
+function fingerprintOf(command: SubmitJobCommand): string {
+  if (command.requestFingerprint) return command.requestFingerprint;
+  return createHash('sha256')
+    .update(JSON.stringify({
+      entryPoint: command.entryPoint,
+      source: command.source,
+      sessionId: command.sessionId,
+      workspaceId: command.workspaceId ?? null,
+      principalId: command.principalId ?? null,
+      goal: command.goal,
+      parentJobId: command.parentJobId ?? null,
+    }))
+    .digest('hex');
+}
+
+function mapJob(row: JobSqlRow): JobRecord {
+  return {
+    id: row.id,
+    status: row.status,
+    stateVersion: row.state_version,
+    activeAttemptId: row.active_attempt_id,
+    rootJobId: row.root_job_id ?? row.id,
+    parentJobId: row.parent_task_id,
+    sessionId: row.session_id,
+    goal: row.goal,
+    entryPoint: row.entry_point,
+    source: row.source,
+    terminalAt: row.terminal_at,
+    terminalOutcome: row.terminal_outcome,
+    finishReason: row.finish_reason,
+    nextEventSequence: row.next_event_sequence,
+  };
+}
+
+function mapAttempt(row: AttemptSqlRow): AttemptRecord {
+  return {
+    rowId: row.id,
+    id: row.attempt_id,
+    jobId: row.task_id,
+    status: row.status,
+    attemptNumber: row.attempt_number,
+    generation: row.generation,
+    stateVersion: row.state_version,
+    leaseId: row.lease_id,
+    leaseOwner: row.lease_owner,
+    leaseExpiresAt: row.lease_expires_at,
+    leaseHeartbeatAt: row.lease_heartbeat_at,
+    fenceToken: row.fence_token,
+    recoveryOfAttemptId: row.recovery_of_attempt_id,
+  };
+}
+
+function isLegal(
+  transitions: Readonly<Record<string, ReadonlySet<string>>>,
+  from: string,
+  to: string,
+): boolean {
+  return from === to || transitions[from]?.has(to) === true;
+}
+
+function parseArray(raw: string | null | undefined): unknown[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
+  const { db } = opts;
+
+  const getJobRow = (jobId: string): JobSqlRow | undefined => db.prepare(
+    `SELECT id, status, state_version, active_attempt_id, root_job_id,
+            parent_task_id, session_id, goal, entry_point, source,
+            terminal_at, terminal_outcome, finish_reason, next_event_sequence
+       FROM tasks WHERE id = ?`,
+  ).get(jobId) as JobSqlRow | undefined;
+
+  const getAttemptRow = (attemptId: string): AttemptSqlRow | undefined => db.prepare(
+    `SELECT id, attempt_id, task_id, status, attempt_number, generation,
+            state_version, lease_id, lease_owner, lease_expires_at,
+            lease_heartbeat_at, fence_token, recovery_of_attempt_id, session_id
+       FROM runs WHERE attempt_id = ?`,
+  ).get(attemptId) as AttemptSqlRow | undefined;
+
+  const getToolCallRow = (toolCallId: string): ToolCallSqlRow | undefined => db.prepare(
+    `SELECT tool_call_id, job_id, attempt_id, generation, tool_name,
+            normalized_args_digest, mutates, state, side_effect_id, verification_ref
+       FROM tool_calls WHERE tool_call_id = ?`,
+  ).get(toolCallId) as ToolCallSqlRow | undefined;
+
+  const activeFence = (
+    attemptId: string,
+    generation: number,
+    fenceToken: string,
+    now = Date.now(),
+  ): AttemptSqlRow | null => {
+    const attempt = getAttemptRow(attemptId);
+    if (
+      !attempt
+      || !attempt.task_id
+      || attempt.generation !== generation
+      || attempt.fence_token !== fenceToken
+      || ATTEMPT_TERMINAL.has(attempt.status)
+      || attempt.lease_expires_at === null
+      || attempt.lease_expires_at <= now
+    ) return null;
+    return attempt;
+  };
+
+  const existingEvent = (jobId: string, key: string): { id: number; job_sequence: number } | undefined => db.prepare(
+    'SELECT id, job_sequence FROM run_events WHERE job_id = ? AND idempotency_key = ?',
+  ).get(jobId, key) as { id: number; job_sequence: number } | undefined;
+
+  const appendEvent = (event: {
+    jobId: string;
+    runId: number;
+    attemptId: string | null;
+    generation: number | null;
+    type: string;
+    payload?: Record<string, unknown> | null;
+    producer: string;
+    idempotencyKey: string;
+    causationId?: string | null;
+    correlationId?: string | null;
+  }): { eventId: number; jobSequence: number; duplicate: boolean } => {
+    const duplicate = existingEvent(event.jobId, event.idempotencyKey);
+    if (duplicate) return { eventId: duplicate.id, jobSequence: duplicate.job_sequence, duplicate: true };
+
+    const allocated = db.prepare(
+      `UPDATE tasks
+          SET next_event_sequence = next_event_sequence + 1
+        WHERE id = ?
+        RETURNING next_event_sequence - 1 AS job_sequence`,
+    ).get(event.jobId) as { job_sequence: number } | undefined;
+    if (!allocated) throw new Error(`Job not found: ${event.jobId}`);
+    const jobSequence = allocated.job_sequence;
+    const runSequence = db.prepare(
+      `UPDATE runs
+          SET next_event_sequence = next_event_sequence + 1
+        WHERE id = ?
+        RETURNING next_event_sequence - 1 AS run_sequence`,
+    ).get(event.runId) as { run_sequence: number } | undefined;
+    if (!runSequence) throw new Error(`Attempt row not found: ${event.runId}`);
+    const now = Date.now();
+    const payload = JSON.stringify(event.payload ?? null);
+    const inserted = db.prepare(
+      `INSERT INTO run_events (
+         run_id, session_id, seq, ts, category, kind, name, payload,
+         visibility, source, schema_version,
+         job_id, attempt_id, job_sequence, producer, generation,
+         causation_id, correlation_id, idempotency_key
+       ) VALUES (
+         ?, (SELECT session_id FROM runs WHERE id = ?), ?, ?, 'job', ?, ?, ?,
+         'system', ?, 2,
+         ?, ?, ?, ?, ?, ?, ?, ?
+       )`,
+    ).run(
+      event.runId,
+      event.runId,
+      runSequence.run_sequence,
+      now,
+      event.type,
+      event.type,
+      payload,
+      event.producer,
+      event.jobId,
+      event.attemptId,
+      jobSequence,
+      event.producer,
+      event.generation,
+      event.causationId ?? null,
+      event.correlationId ?? null,
+      event.idempotencyKey,
+    );
+    return { eventId: Number(inserted.lastInsertRowid), jobSequence, duplicate: false };
+  };
+
+  const submitTx = db.transaction((command: SubmitJobCommand): AdmissionResult => {
+    const key = command.idempotencyKey ?? randomId('internal');
+    const fingerprint = fingerprintOf(command);
+    const existing = db.prepare(
+      `SELECT id, request_fingerprint, active_attempt_id
+         FROM tasks
+        WHERE idempotency_namespace = ? AND idempotency_key = ?`,
+    ).get(command.idempotencyNamespace, key) as {
+      id: string;
+      request_fingerprint: string | null;
+      active_attempt_id: string | null;
+    } | undefined;
+    if (existing) {
+      if (existing.request_fingerprint !== fingerprint) {
+        throw new IdempotencyConflictError(command.idempotencyNamespace, key);
+      }
+      const attempt = existing.active_attempt_id ? getAttemptRow(existing.active_attempt_id) : undefined;
+      if (!attempt) throw new Error(`Job ${existing.id} has no active Attempt`);
+      return { jobId: existing.id, attemptId: attempt.attempt_id, runId: attempt.id, reused: true };
+    }
+
+    const now = Date.now();
+    const jobId = randomId('task');
+    const attemptId = randomId('attempt');
+    const rootJobId = command.rootJobId ?? command.parentJobId ?? jobId;
+    db.prepare(
+      `INSERT INTO tasks (
+         id, title, goal, status, created_at, updated_at,
+         channel_id, session_id, parent_task_id, trace_ids, artifact_ids,
+         state_version, active_attempt_id, root_job_id,
+         idempotency_namespace, idempotency_key, request_fingerprint,
+         entry_point, source, workspace_id, principal_id,
+         recovery_state, crash_count, next_event_sequence
+       ) VALUES (?, ?, ?, 'queued', ?, ?, ?, ?, ?, '[]', '[]',
+                 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'none', 0, 1)`,
+    ).run(
+      jobId,
+      (command.title ?? command.goal).slice(0, 80),
+      command.goal,
+      now,
+      now,
+      command.channelId ?? null,
+      command.sessionId,
+      command.parentJobId ?? null,
+      attemptId,
+      rootJobId,
+      command.idempotencyNamespace,
+      key,
+      fingerprint,
+      command.entryPoint,
+      command.source,
+      command.workspaceId ?? null,
+      command.principalId ?? null,
+    );
+    const inserted = db.prepare(
+      `INSERT INTO runs (
+         trigger_event_id, session_id, instance_id, status, started_at,
+         resume_pending, task_id, attempt_id, attempt_number, generation,
+         state_version, trigger_reason
+       ) VALUES (?, ?, ?, 'queued', ?, 0, ?, ?, 1, 1, 0, 'submission')`,
+    ).run(
+      command.triggerEventId ?? null,
+      command.sessionId,
+      command.instanceId,
+      now,
+      jobId,
+      attemptId,
+    );
+    const runId = Number(inserted.lastInsertRowid);
+    appendEvent({
+      jobId, runId, attemptId, generation: 1,
+      type: 'job.submitted', producer: command.source,
+      idempotencyKey: `job-submitted:${jobId}`,
+      payload: { entryPoint: command.entryPoint, source: command.source },
+    });
+    appendEvent({
+      jobId, runId, attemptId, generation: 1,
+      type: 'attempt.created', producer: command.source,
+      idempotencyKey: `attempt-created:${attemptId}`,
+      payload: { attemptNumber: 1, triggerReason: 'submission' },
+    });
+    return { jobId, attemptId, runId, reused: false };
+  }).immediate;
+
+  const transitionJobTx = db.transaction((command: Parameters<JobEngine['transitionJob']>[0]): TransitionResult => {
+    if (existingEvent(command.jobId, command.eventIdempotencyKey)) {
+      return { applied: false, duplicate: true };
+    }
+    const job = getJobRow(command.jobId);
+    if (!job) return { applied: false, conflict: 'not_found' };
+    if (JOB_TERMINAL.has(job.status)) {
+      return { applied: false, conflict: 'terminal_state', stateVersion: job.state_version };
+    }
+    if (!isLegal(JOB_TRANSITIONS, job.status, command.to)) {
+      return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
+    }
+    const attempt = job.active_attempt_id ? getAttemptRow(job.active_attempt_id) : undefined;
+    if (!attempt) return { applied: false, conflict: 'not_found' };
+    if (
+      attempt.attempt_id !== command.attemptId
+      || attempt.generation !== command.generation
+      || attempt.fence_token !== command.fenceToken
+    ) {
+      return { applied: false, conflict: 'stale_fence', stateVersion: job.state_version };
+    }
+    if (job.state_version !== command.expectedStateVersion) {
+      return { applied: false, conflict: 'state_version', stateVersion: job.state_version };
+    }
+    if (
+      !ATTEMPT_TERMINAL.has(attempt.status)
+      && (attempt.lease_expires_at === null || attempt.lease_expires_at <= (command.now ?? Date.now()))
+    ) {
+      return { applied: false, conflict: 'lease_expired', stateVersion: job.state_version };
+    }
+    const nextVersion = job.state_version + 1;
+    const terminal = JOB_TERMINAL.has(command.to);
+    const changed = db.prepare(
+      `UPDATE tasks
+          SET status = ?, state_version = ?, updated_at = ?,
+              terminal_at = CASE WHEN ? THEN ? ELSE terminal_at END,
+              terminal_outcome = COALESCE(?, terminal_outcome),
+              finish_reason = COALESCE(?, finish_reason)
+        WHERE id = ? AND state_version = ? AND active_attempt_id = ?`,
+    ).run(
+      command.to,
+      nextVersion,
+      command.now ?? Date.now(),
+      terminal ? 1 : 0,
+      terminal ? (command.now ?? Date.now()) : null,
+      command.terminalOutcome ?? null,
+      command.finishReason ?? null,
+      command.jobId,
+      command.expectedStateVersion,
+      command.attemptId,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_fence' };
+    appendEvent({
+      jobId: command.jobId,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: `job.${command.to}`,
+      payload: command.payload,
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const transitionAttemptTx = db.transaction((command: Parameters<JobEngine['transitionAttempt']>[0]): TransitionResult => {
+    const attempt = getAttemptRow(command.attemptId);
+    if (!attempt || !attempt.task_id) return { applied: false, conflict: 'not_found' };
+    if (existingEvent(attempt.task_id, command.eventIdempotencyKey)) {
+      return { applied: false, duplicate: true };
+    }
+    if (attempt.generation !== command.generation || attempt.fence_token !== command.fenceToken) {
+      return { applied: false, conflict: 'stale_fence', stateVersion: attempt.state_version };
+    }
+    if (ATTEMPT_TERMINAL.has(attempt.status)) {
+      return { applied: false, conflict: 'terminal_state', stateVersion: attempt.state_version };
+    }
+    if (attempt.lease_expires_at === null || attempt.lease_expires_at <= (command.now ?? Date.now())) {
+      return { applied: false, conflict: 'lease_expired', stateVersion: attempt.state_version };
+    }
+    if (attempt.state_version !== command.expectedStateVersion) {
+      return { applied: false, conflict: 'state_version', stateVersion: attempt.state_version };
+    }
+    if (!isLegal(ATTEMPT_TRANSITIONS, attempt.status, command.to)) {
+      return { applied: false, conflict: 'illegal_transition', stateVersion: attempt.state_version };
+    }
+    const nextVersion = attempt.state_version + 1;
+    const terminal = ATTEMPT_TERMINAL.has(command.to);
+    const now = command.now ?? Date.now();
+    const changed = db.prepare(
+      `UPDATE runs
+          SET status = ?, state_version = ?,
+              finish_reason = COALESCE(?, finish_reason),
+              completed_at = CASE WHEN ? THEN ? ELSE completed_at END,
+              ended_at = CASE WHEN ? THEN ? ELSE ended_at END,
+              lease_id = CASE WHEN ? THEN NULL ELSE lease_id END,
+              lease_owner = CASE WHEN ? THEN NULL ELSE lease_owner END,
+              lease_expires_at = CASE WHEN ? THEN NULL ELSE lease_expires_at END,
+              lease_heartbeat_at = CASE WHEN ? THEN NULL ELSE lease_heartbeat_at END
+        WHERE attempt_id = ? AND state_version = ? AND generation = ? AND fence_token = ?`,
+    ).run(
+      command.to,
+      nextVersion,
+      command.finishReason ?? null,
+      terminal ? 1 : 0,
+      terminal ? now : null,
+      terminal ? 1 : 0,
+      terminal ? now : null,
+      terminal ? 1 : 0,
+      terminal ? 1 : 0,
+      terminal ? 1 : 0,
+      terminal ? 1 : 0,
+      command.attemptId,
+      command.expectedStateVersion,
+      command.generation,
+      command.fenceToken,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_fence' };
+    appendEvent({
+      jobId: attempt.task_id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: `attempt.${command.to}`,
+      payload: command.payload,
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const finalizeJobTx = db.transaction((command: Parameters<JobEngine['finalizeJob']>[0]): TransitionResult => {
+    if (existingEvent(command.jobId, command.eventIdempotencyKey)) {
+      return { applied: false, duplicate: true };
+    }
+    const job = getJobRow(command.jobId);
+    if (!job) return { applied: false, conflict: 'not_found' };
+    if (JOB_TERMINAL.has(job.status)) {
+      return { applied: false, conflict: 'terminal_state', stateVersion: job.state_version };
+    }
+    const attempt = job.active_attempt_id ? getAttemptRow(job.active_attempt_id) : undefined;
+    if (!attempt) return { applied: false, conflict: 'not_found' };
+    if (
+      attempt.attempt_id !== command.attemptId
+      || attempt.generation !== command.generation
+      || attempt.fence_token !== command.fenceToken
+    ) {
+      return { applied: false, conflict: 'stale_fence', stateVersion: job.state_version };
+    }
+    if (job.state_version !== command.expectedStateVersion) {
+      return { applied: false, conflict: 'state_version', stateVersion: job.state_version };
+    }
+    if (!isLegal(JOB_TRANSITIONS, job.status, command.status)) {
+      return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
+    }
+    if (
+      !ATTEMPT_TERMINAL.has(attempt.status)
+      && (attempt.lease_expires_at === null || attempt.lease_expires_at <= (command.now ?? Date.now()))
+    ) {
+      return { applied: false, conflict: 'lease_expired', stateVersion: job.state_version };
+    }
+    const stored = db.prepare(
+      `SELECT files_touched, side_effects, failure_state, permissions, constraints
+         FROM tasks WHERE id = ?`,
+    ).get(command.jobId) as {
+      files_touched: string;
+      side_effects: string;
+      failure_state: string | null;
+      permissions: string | null;
+      constraints: string | null;
+    };
+    const files = parseArray(stored.files_touched).filter((value): value is string => typeof value === 'string');
+    for (const file of command.jobCard?.filesTouched ?? []) {
+      if (!files.includes(file)) files.push(file);
+    }
+    const sideEffects = parseArray(stored.side_effects);
+    const sideEffectKeys = new Set(sideEffects.map((value) => JSON.stringify(value)));
+    for (const effect of command.jobCard?.sideEffects ?? []) {
+      const key = JSON.stringify(effect);
+      if (!sideEffectKeys.has(key)) {
+        sideEffects.push(effect);
+        sideEffectKeys.add(key);
+      }
+    }
+    const serializeReplacement = (value: unknown | undefined, current: string | null): string | null => {
+      if (value === undefined) return current;
+      return value === null ? null : JSON.stringify(value);
+    };
+    const toolCallIds = (db.prepare(
+      `SELECT tool_call_id FROM tool_calls
+        WHERE job_id = ? AND attempt_id = ? AND generation = ?
+        ORDER BY created_at, tool_call_id`,
+    ).all(command.jobId, command.attemptId, command.generation) as Array<{ tool_call_id: string }>)
+      .map((row) => row.tool_call_id);
+    const evidenceRecord = command.evidence && typeof command.evidence === 'object' && !Array.isArray(command.evidence)
+      ? { ...(command.evidence as Record<string, unknown>) }
+      : { value: command.evidence };
+    const linkedEvidence = {
+      ...evidenceRecord,
+      durableExecution: {
+        jobId: command.jobId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        toolCallIds,
+      },
+    };
+    const nextVersion = job.state_version + 1;
+    const now = command.now ?? Date.now();
+    const changed = db.prepare(
+      `UPDATE tasks
+          SET status = ?, state_version = ?, evidence = ?,
+              files_touched = ?, side_effects = ?,
+              failure_state = ?, permissions = ?, constraints = ?,
+              terminal_at = ?, terminal_outcome = ?, finish_reason = ?,
+              active_attempt_id = NULL,
+              updated_at = ?
+        WHERE id = ? AND state_version = ? AND active_attempt_id = ?`,
+    ).run(
+      command.status,
+      nextVersion,
+      JSON.stringify(linkedEvidence),
+      JSON.stringify(files),
+      JSON.stringify(sideEffects),
+      serializeReplacement(command.jobCard?.failureState, stored.failure_state),
+      serializeReplacement(command.jobCard?.permissions, stored.permissions),
+      serializeReplacement(command.jobCard?.constraints, stored.constraints),
+      now,
+      command.outcome,
+      command.finishReason,
+      now,
+      command.jobId,
+      command.expectedStateVersion,
+      command.attemptId,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_fence' };
+    appendEvent({
+      jobId: command.jobId,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: 'job.finalized',
+      payload: { status: command.status, outcome: command.outcome, finishReason: command.finishReason },
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const cancelJobTx = db.transaction((command: Parameters<JobEngine['cancelJob']>[0]): TransitionResult => {
+    if (existingEvent(command.jobId, command.eventIdempotencyKey)) {
+      return { applied: false, duplicate: true };
+    }
+    const job = getJobRow(command.jobId);
+    if (!job) return { applied: false, conflict: 'not_found' };
+    if (JOB_TERMINAL.has(job.status)) {
+      return { applied: false, conflict: 'terminal_state', stateVersion: job.state_version };
+    }
+    const attempt = job.active_attempt_id ? getAttemptRow(job.active_attempt_id) : undefined;
+    if (!attempt) return { applied: false, conflict: 'not_found' };
+    const now = command.now ?? Date.now();
+    if (!ATTEMPT_TERMINAL.has(attempt.status)) {
+      const attemptChanged = db.prepare(
+        `UPDATE runs
+            SET status = 'cancelled', state_version = state_version + 1,
+                finish_reason = ?, completed_at = ?, ended_at = ?,
+                lease_id = NULL, lease_owner = NULL, lease_expires_at = NULL,
+                lease_heartbeat_at = NULL
+          WHERE attempt_id = ? AND state_version = ? AND generation = ?`,
+      ).run(command.reason, now, now, attempt.attempt_id, attempt.state_version, attempt.generation);
+      if (attemptChanged.changes !== 1) return { applied: false, conflict: 'state_version' };
+      appendEvent({
+        jobId: job.id,
+        runId: attempt.id,
+        attemptId: attempt.attempt_id,
+        generation: attempt.generation,
+        type: 'attempt.cancelled',
+        payload: { reason: command.reason },
+        producer: command.producer,
+        idempotencyKey: `${command.eventIdempotencyKey}:attempt`,
+      });
+    }
+    const nextVersion = job.state_version + 1;
+    const jobChanged = db.prepare(
+      `UPDATE tasks
+          SET status = 'cancelled', state_version = ?, active_attempt_id = NULL,
+              terminal_at = ?, terminal_outcome = 'cancelled', finish_reason = ?,
+              updated_at = ?
+        WHERE id = ? AND state_version = ? AND active_attempt_id = ?`,
+    ).run(nextVersion, now, command.reason, now, job.id, job.state_version, attempt.attempt_id);
+    if (jobChanged.changes !== 1) return { applied: false, conflict: 'state_version' };
+    appendEvent({
+      jobId: job.id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: 'job.cancelled',
+      payload: { reason: command.reason },
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const claimAttemptTx = db.transaction((command: Parameters<JobEngine['claimAttempt']>[0]): LeaseResult => {
+    const attempt = getAttemptRow(command.attemptId);
+    if (!attempt || !attempt.task_id) return { acquired: false, applied: false, conflict: 'not_found' };
+    if (ATTEMPT_TERMINAL.has(attempt.status)) {
+      return { acquired: false, applied: false, conflict: 'terminal_state', stateVersion: attempt.state_version };
+    }
+    const now = command.now ?? Date.now();
+    if (attempt.lease_id && attempt.lease_expires_at !== null && attempt.lease_expires_at > now) {
+      return { acquired: false, applied: false, conflict: 'lease_held', stateVersion: attempt.state_version };
+    }
+    if (attempt.lease_id) {
+      return { acquired: false, applied: false, conflict: 'lease_expired', stateVersion: attempt.state_version };
+    }
+    const generation = attempt.generation;
+    const leaseId = randomId('lease');
+    const fenceToken = randomId('fence');
+    const nextVersion = attempt.state_version + 1;
+    const changed = db.prepare(
+      `UPDATE runs
+          SET status = 'leased', generation = ?, state_version = ?,
+              lease_id = ?, lease_owner = ?, lease_expires_at = ?,
+              lease_heartbeat_at = ?, fence_token = ?
+        WHERE attempt_id = ? AND state_version = ?
+          AND lease_id IS NULL`,
+    ).run(
+      generation,
+      nextVersion,
+      leaseId,
+      command.ownerId,
+      now + Math.max(1, command.ttlMs),
+      now,
+      fenceToken,
+      command.attemptId,
+      attempt.state_version,
+    );
+    if (changed.changes !== 1) return { acquired: false, applied: false, conflict: 'lease_held' };
+    appendEvent({
+      jobId: attempt.task_id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation,
+      type: 'attempt.leased',
+      payload: { ownerId: command.ownerId, expiresAt: now + Math.max(1, command.ttlMs) },
+      producer: command.ownerId,
+      idempotencyKey: `lease-claimed:${leaseId}`,
+    });
+    return {
+      acquired: true,
+      applied: true,
+      leaseId,
+      fenceToken,
+      generation,
+      stateVersion: nextVersion,
+    };
+  }).immediate;
+
+  const renewAttemptTx = db.transaction((command: Parameters<JobEngine['renewAttemptLease']>[0]): TransitionResult => {
+    const attempt = getAttemptRow(command.attemptId);
+    if (!attempt || !attempt.task_id) return { applied: false, conflict: 'not_found' };
+    const now = command.now ?? Date.now();
+    if (
+      attempt.generation !== command.generation
+      || attempt.fence_token !== command.fenceToken
+      || attempt.lease_owner !== command.ownerId
+    ) return { applied: false, conflict: 'stale_fence', stateVersion: attempt.state_version };
+    if (attempt.lease_expires_at !== null && attempt.lease_expires_at <= now) {
+      return { applied: false, conflict: 'lease_expired', stateVersion: attempt.state_version };
+    }
+    const nextVersion = attempt.state_version + 1;
+    const changed = db.prepare(
+      `UPDATE runs
+          SET lease_expires_at = ?, lease_heartbeat_at = ?, state_version = ?
+        WHERE attempt_id = ? AND generation = ? AND fence_token = ?
+          AND lease_owner = ? AND state_version = ? AND lease_expires_at > ?`,
+    ).run(
+      now + Math.max(1, command.ttlMs),
+      now,
+      nextVersion,
+      command.attemptId,
+      command.generation,
+      command.fenceToken,
+      command.ownerId,
+      attempt.state_version,
+      now,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_fence' };
+    appendEvent({
+      jobId: attempt.task_id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: 'attempt.lease_renewed',
+      payload: { expiresAt: now + Math.max(1, command.ttlMs) },
+      producer: command.ownerId,
+      idempotencyKey: `lease-renewed:${attempt.lease_id}:${nextVersion}`,
+    });
+    return { applied: true, stateVersion: nextVersion };
+  }).immediate;
+
+  const recoveryTx = db.transaction((command: Parameters<JobEngine['createRecoveryAttempt']>[0]) => {
+    const job = getJobRow(command.jobId);
+    const previous = getAttemptRow(command.recoveryOfAttemptId);
+    if (!job || !previous || previous.task_id !== command.jobId) {
+      throw new Error('Recovery Job or Attempt not found');
+    }
+    if (!ATTEMPT_TERMINAL.has(previous.status)) {
+      throw new Error('Recovery requires a terminal Attempt');
+    }
+    const max = db.prepare(
+      'SELECT COALESCE(MAX(attempt_number), 0) AS attempt_number, COALESCE(MAX(generation), 0) AS generation FROM runs WHERE task_id = ?',
+    ).get(command.jobId) as { attempt_number: number; generation: number };
+    const attemptNumber = max.attempt_number + 1;
+    const generation = max.generation + 1;
+    const attemptId = randomId('attempt');
+    const now = Date.now();
+    const inserted = db.prepare(
+      `INSERT INTO runs (
+         session_id, instance_id, status, started_at, resume_pending,
+         task_id, attempt_id, attempt_number, generation, state_version,
+         recovery_of_attempt_id, trigger_reason
+       ) VALUES (?, ?, 'queued', ?, 0, ?, ?, ?, ?, 0, ?, ?)`,
+    ).run(
+      previous.session_id,
+      command.instanceId,
+      now,
+      command.jobId,
+      attemptId,
+      attemptNumber,
+      generation,
+      command.recoveryOfAttemptId,
+      command.triggerReason,
+    );
+    const jobChanged = db.prepare(
+      `UPDATE tasks
+          SET status = 'recovering', state_version = state_version + 1,
+              active_attempt_id = ?, recovery_state = 'recovering',
+              terminal_at = NULL, terminal_outcome = NULL, finish_reason = NULL,
+              updated_at = ?
+        WHERE id = ? AND state_version = ?`,
+    ).run(attemptId, now, command.jobId, job.state_version);
+    if (jobChanged.changes !== 1) throw new Error('Recovery Job changed concurrently');
+    const runId = Number(inserted.lastInsertRowid);
+    appendEvent({
+      jobId: command.jobId,
+      runId,
+      attemptId,
+      generation,
+      type: 'job.recovering',
+      payload: { recoveryOfAttemptId: command.recoveryOfAttemptId, triggerReason: command.triggerReason },
+      producer: command.producer,
+      idempotencyKey: `job-recovering:${attemptId}`,
+    });
+    appendEvent({
+      jobId: command.jobId,
+      runId,
+      attemptId,
+      generation,
+      type: 'attempt.created',
+      payload: { attemptNumber, recoveryOfAttemptId: command.recoveryOfAttemptId, triggerReason: command.triggerReason },
+      producer: command.producer,
+      idempotencyKey: command.eventIdempotencyKey,
+    });
+    return { attemptId, runId, attemptNumber, generation };
+  }).immediate;
+
+  const prepareToolCallTx = db.transaction((command: Parameters<JobEngine['prepareToolCall']>[0]): TransitionResult => {
+    const attempt = activeFence(command.attemptId, command.generation, command.fenceToken, command.now);
+    if (!attempt || attempt.task_id !== command.jobId) {
+      return { applied: false, conflict: 'stale_fence' };
+    }
+    const existing = getToolCallRow(command.toolCallId);
+    if (existing) {
+      const sameIdentity = existing.job_id === command.jobId
+        && existing.attempt_id === command.attemptId
+        && existing.generation === command.generation
+        && existing.tool_name === command.toolName
+        && existing.normalized_args_digest === command.normalizedArgsDigest;
+      return sameIdentity
+        ? { applied: false, duplicate: true }
+        : { applied: false, conflict: 'illegal_transition' };
+    }
+
+    const now = Date.now();
+    const sideEffectId = command.mutates ? `side_effect:${command.toolCallId}` : null;
+    db.prepare(
+      `INSERT INTO tool_calls (
+         tool_call_id, job_id, attempt_id, generation, model_call_id,
+         tool_name, normalized_args_digest, risk_tier, mutates, state,
+         side_effect_id, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared', ?, ?, ?)`,
+    ).run(
+      command.toolCallId,
+      command.jobId,
+      command.attemptId,
+      command.generation,
+      command.modelCallId ?? null,
+      command.toolName,
+      command.normalizedArgsDigest,
+      command.riskTier,
+      command.mutates ? 1 : 0,
+      sideEffectId,
+      now,
+      now,
+    );
+    if (sideEffectId) {
+      const ordinal = db.prepare(
+        'SELECT COUNT(*) + 1 AS ordinal FROM side_effect_ledger WHERE job_id = ?',
+      ).get(command.jobId) as { ordinal: number };
+      db.prepare(
+        `INSERT INTO side_effect_ledger (
+           key, task_id, step, tool, args_hash, status, attempted_at,
+           job_id, attempt_id, generation, tool_call_id, effect_state
+         ) VALUES (?, ?, ?, ?, ?, 'attempting', ?, ?, ?, ?, ?, 'prepared')`,
+      ).run(
+        sideEffectId,
+        command.jobId,
+        ordinal.ordinal,
+        command.toolName,
+        command.normalizedArgsDigest,
+        now,
+        command.jobId,
+        command.attemptId,
+        command.generation,
+        command.toolCallId,
+      );
+    }
+    appendEvent({
+      jobId: command.jobId,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: 'tool_call.prepared',
+      payload: { toolCallId: command.toolCallId, toolName: command.toolName, mutates: command.mutates },
+      producer: command.producer,
+      idempotencyKey: `tool-call-prepared:${command.toolCallId}`,
+    });
+    return { applied: true };
+  }).immediate;
+
+  const startToolCallTx = db.transaction((command: Parameters<JobEngine['startToolCall']>[0]): TransitionResult => {
+    const attempt = activeFence(command.attemptId, command.generation, command.fenceToken, command.now);
+    const toolCall = getToolCallRow(command.toolCallId);
+    if (!attempt || !toolCall || toolCall.attempt_id !== command.attemptId || toolCall.generation !== command.generation) {
+      return { applied: false, conflict: 'stale_fence' };
+    }
+    if (toolCall.state === 'started') return { applied: false, duplicate: true };
+    if (toolCall.state !== 'prepared') return { applied: false, conflict: 'illegal_transition' };
+    const now = Date.now();
+    const changed = db.prepare(
+      `UPDATE tool_calls SET state = 'started', started_at = ?, updated_at = ?
+        WHERE tool_call_id = ? AND state = 'prepared' AND generation = ?`,
+    ).run(now, now, command.toolCallId, command.generation);
+    if (changed.changes !== 1) return { applied: false, conflict: 'illegal_transition' };
+    if (toolCall.side_effect_id) {
+      db.prepare(
+        `UPDATE side_effect_ledger SET effect_state = 'started'
+          WHERE key = ? AND attempt_id = ? AND generation = ? AND effect_state = 'prepared'`,
+      ).run(toolCall.side_effect_id, command.attemptId, command.generation);
+    }
+    appendEvent({
+      jobId: toolCall.job_id,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: 'tool_call.started',
+      payload: { toolCallId: command.toolCallId },
+      producer: command.producer,
+      idempotencyKey: `tool-call-started:${command.toolCallId}`,
+    });
+    return { applied: true };
+  }).immediate;
+
+  const completeToolCallTx = db.transaction((command: Parameters<JobEngine['completeToolCall']>[0]): TransitionResult => {
+    const attempt = activeFence(command.attemptId, command.generation, command.fenceToken, command.now);
+    const toolCall = getToolCallRow(command.toolCallId);
+    if (!attempt || !toolCall || toolCall.attempt_id !== command.attemptId || toolCall.generation !== command.generation) {
+      return { applied: false, conflict: 'stale_fence' };
+    }
+    if (['completed', 'failed', 'cancelled', 'unknown'].includes(toolCall.state)) {
+      return toolCall.state === command.state
+        ? { applied: false, duplicate: true }
+        : { applied: false, conflict: 'terminal_state' };
+    }
+    if (toolCall.state !== 'started') return { applied: false, conflict: 'illegal_transition' };
+    const now = Date.now();
+    const changed = db.prepare(
+      `UPDATE tool_calls
+          SET state = ?, ended_at = ?, result_ref = ?, verification_ref = ?, updated_at = ?
+        WHERE tool_call_id = ? AND state = 'started' AND generation = ?`,
+    ).run(
+      command.state,
+      now,
+      command.resultRef ?? null,
+      command.verificationRef ?? null,
+      now,
+      command.toolCallId,
+      command.generation,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'illegal_transition' };
+    if (toolCall.side_effect_id) {
+      const sideEffectState = command.sideEffectState ?? (command.state === 'completed' ? 'committed' : 'unknown');
+      db.prepare(
+        `UPDATE side_effect_ledger
+            SET effect_state = ?, status = ?, confirmed_at = CASE WHEN ? = 'committed' THEN ? ELSE confirmed_at END
+          WHERE key = ? AND attempt_id = ? AND generation = ? AND effect_state = 'started'`,
+      ).run(
+        sideEffectState,
+        sideEffectState === 'committed' ? 'confirmed' : sideEffectState,
+        sideEffectState,
+        now,
+        toolCall.side_effect_id,
+        command.attemptId,
+        command.generation,
+      );
+    }
+    appendEvent({
+      jobId: toolCall.job_id,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: `tool_call.${command.state}`,
+      payload: { toolCallId: command.toolCallId, sideEffectState: command.sideEffectState ?? null },
+      producer: command.producer,
+      idempotencyKey: `tool-call-${command.state}:${command.toolCallId}`,
+    });
+    return { applied: true };
+  }).immediate;
+
+  const attachToolVerificationTx = db.transaction((
+    command: Parameters<JobEngine['attachToolVerification']>[0],
+  ): TransitionResult => {
+    const attempt = activeFence(command.attemptId, command.generation, command.fenceToken, command.now);
+    const toolCall = getToolCallRow(command.toolCallId);
+    if (!attempt || !toolCall || toolCall.attempt_id !== command.attemptId || toolCall.generation !== command.generation) {
+      return { applied: false, conflict: 'stale_fence' };
+    }
+    if (!['completed', 'failed', 'cancelled', 'unknown'].includes(toolCall.state)) {
+      return { applied: false, conflict: 'illegal_transition' };
+    }
+    if (toolCall.verification_ref === command.verificationRef) return { applied: false, duplicate: true };
+    if (toolCall.verification_ref) return { applied: false, conflict: 'terminal_state' };
+    const now = command.now ?? Date.now();
+    const changed = db.prepare(
+      `UPDATE tool_calls SET verification_ref = ?, updated_at = ?
+        WHERE tool_call_id = ? AND attempt_id = ? AND generation = ? AND verification_ref IS NULL`,
+    ).run(
+      command.verificationRef,
+      now,
+      command.toolCallId,
+      command.attemptId,
+      command.generation,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_fence' };
+    appendEvent({
+      jobId: toolCall.job_id,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: 'tool_call.verification_linked',
+      payload: { toolCallId: command.toolCallId, verificationRef: command.verificationRef },
+      producer: command.producer,
+      idempotencyKey: `tool-call-verification:${command.toolCallId}`,
+    });
+    return { applied: true };
+  }).immediate;
+
+  const recoverExpiredAttemptTx = db.transaction((command: {
+    attemptId: string;
+    now: number;
+    instanceId: string;
+    producer: string;
+    maxCrashes: number;
+  }): {
+    jobId: string;
+    expiredAttemptId: string;
+    recoveryAttemptId?: string;
+    decision: 'retry' | 'ask_user' | 'dead_letter';
+  } | null => {
+    const attempt = getAttemptRow(command.attemptId);
+    if (
+      !attempt
+      || !attempt.task_id
+      || ATTEMPT_TERMINAL.has(attempt.status)
+      || attempt.lease_expires_at === null
+      || attempt.lease_expires_at > command.now
+    ) return null;
+    const job = getJobRow(attempt.task_id);
+    if (!job || job.active_attempt_id !== attempt.attempt_id || JOB_TERMINAL.has(job.status)) return null;
+
+    const ambiguous = db.prepare(
+      `SELECT 1
+         FROM tool_calls tc
+         LEFT JOIN side_effect_ledger se ON se.tool_call_id = tc.tool_call_id
+        WHERE tc.attempt_id = ? AND tc.generation = ? AND tc.mutates = 1
+          AND (tc.state = 'started' OR se.effect_state IN ('started', 'committed', 'partial', 'unknown'))
+        LIMIT 1`,
+    ).get(attempt.attempt_id, attempt.generation) !== undefined;
+    const crashRow = db.prepare('SELECT crash_count FROM tasks WHERE id = ?').get(job.id) as { crash_count: number };
+    const crashCount = crashRow.crash_count + 1;
+    const decision: 'retry' | 'ask_user' | 'dead_letter' = ambiguous
+      ? 'ask_user'
+      : crashCount >= Math.max(1, command.maxCrashes) ? 'dead_letter' : 'retry';
+    const attemptStatus = ambiguous ? 'unknown' : 'crashed';
+    const attemptVersion = attempt.state_version + 1;
+    const cleared = db.prepare(
+      `UPDATE runs
+          SET status = ?, state_version = ?, finish_reason = ?,
+              completed_at = ?, ended_at = ?,
+              lease_id = NULL, lease_owner = NULL, lease_expires_at = NULL,
+              lease_heartbeat_at = NULL
+        WHERE attempt_id = ? AND state_version = ? AND generation = ?
+          AND fence_token = ? AND lease_expires_at <= ?`,
+    ).run(
+      attemptStatus,
+      attemptVersion,
+      ambiguous ? 'unknown_side_effect' : 'lease_expired',
+      command.now,
+      command.now,
+      attempt.attempt_id,
+      attempt.state_version,
+      attempt.generation,
+      attempt.fence_token,
+      command.now,
+    );
+    if (cleared.changes !== 1) return null;
+    appendEvent({
+      jobId: job.id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: `attempt.${attemptStatus}`,
+      payload: { reason: ambiguous ? 'unknown_side_effect' : 'lease_expired' },
+      producer: command.producer,
+      idempotencyKey: `attempt-recovered:${attempt.attempt_id}:${attempt.generation}`,
+    });
+
+    if (decision !== 'retry') {
+      const jobStatus = decision === 'ask_user' ? 'blocked' : 'dead_letter';
+      const jobChanged = db.prepare(
+        `UPDATE tasks
+            SET status = ?, state_version = state_version + 1,
+                active_attempt_id = NULL, crash_count = ?, recovery_state = ?,
+                finish_reason = ?, terminal_at = CASE WHEN ? = 'dead_letter' THEN ? ELSE terminal_at END,
+                terminal_outcome = CASE WHEN ? = 'dead_letter' THEN 'dead_letter' ELSE terminal_outcome END,
+                updated_at = ?
+          WHERE id = ? AND state_version = ?`,
+      ).run(
+        jobStatus,
+        crashCount,
+        decision === 'ask_user' ? 'user_required' : 'dead_letter',
+        ambiguous ? 'unknown_side_effect' : 'crash_loop',
+        jobStatus,
+        command.now,
+        jobStatus,
+        command.now,
+        job.id,
+        job.state_version,
+      );
+      if (jobChanged.changes !== 1) throw new Error('Recovery Job changed concurrently');
+      appendEvent({
+        jobId: job.id,
+        runId: attempt.id,
+        attemptId: attempt.attempt_id,
+        generation: attempt.generation,
+        type: `job.${jobStatus}`,
+        payload: { decision, crashCount },
+        producer: command.producer,
+        idempotencyKey: `job-recovery:${job.id}:${attempt.generation}`,
+      });
+      return { jobId: job.id, expiredAttemptId: attempt.attempt_id, decision };
+    }
+
+    const max = db.prepare(
+      `SELECT COALESCE(MAX(attempt_number), 0) AS attempt_number,
+              COALESCE(MAX(generation), 0) AS generation
+         FROM runs WHERE task_id = ?`,
+    ).get(job.id) as { attempt_number: number; generation: number };
+    const attemptNumber = max.attempt_number + 1;
+    const generation = max.generation + 1;
+    const recoveryAttemptId = randomId('attempt');
+    const inserted = db.prepare(
+      `INSERT INTO runs (
+         session_id, instance_id, status, started_at, resume_pending,
+         task_id, attempt_id, attempt_number, generation, state_version,
+         recovery_of_attempt_id, trigger_reason
+       ) VALUES (?, ?, 'queued', ?, 0, ?, ?, ?, ?, 0, ?, 'lease_expired')`,
+    ).run(
+      attempt.session_id,
+      command.instanceId,
+      command.now,
+      job.id,
+      recoveryAttemptId,
+      attemptNumber,
+      generation,
+      attempt.attempt_id,
+    );
+    const jobChanged = db.prepare(
+      `UPDATE tasks
+          SET status = 'recovering', state_version = state_version + 1,
+              active_attempt_id = ?, crash_count = ?, recovery_state = 'recovering',
+              finish_reason = 'lease_expired', updated_at = ?
+        WHERE id = ? AND state_version = ?`,
+    ).run(recoveryAttemptId, crashCount, command.now, job.id, job.state_version);
+    if (jobChanged.changes !== 1) throw new Error('Recovery Job changed concurrently');
+    appendEvent({
+      jobId: job.id,
+      runId: attempt.id,
+      attemptId: attempt.attempt_id,
+      generation: attempt.generation,
+      type: 'job.recovering',
+      payload: { crashCount, recoveryAttemptId },
+      producer: command.producer,
+      idempotencyKey: `job-recovery:${job.id}:${attempt.generation}`,
+    });
+    appendEvent({
+      jobId: job.id,
+      runId: Number(inserted.lastInsertRowid),
+      attemptId: recoveryAttemptId,
+      generation,
+      type: 'attempt.created',
+      payload: { attemptNumber, recoveryOfAttemptId: attempt.attempt_id, triggerReason: 'lease_expired' },
+      producer: command.producer,
+      idempotencyKey: `attempt-created:${recoveryAttemptId}`,
+    });
+    return { jobId: job.id, expiredAttemptId: attempt.attempt_id, recoveryAttemptId, decision };
+  }).immediate;
+
+  return {
+    submitJob: submitTx,
+    getJob(jobId) {
+      const row = getJobRow(jobId);
+      return row ? mapJob(row) : null;
+    },
+    listJobs(filters = {}) {
+      const clauses: string[] = [];
+      const params: Array<string | number> = [];
+      if (filters.sessionId) { clauses.push('session_id = ?'); params.push(filters.sessionId); }
+      if (filters.status) { clauses.push('status = ?'); params.push(filters.status); }
+      if (filters.rootJobId) { clauses.push('root_job_id = ?'); params.push(filters.rootJobId); }
+      const limit = Math.max(1, Math.min(1_000, filters.limit ?? 100));
+      const rows = db.prepare(
+        `SELECT id, status, state_version, active_attempt_id, root_job_id,
+                parent_task_id, session_id, goal, entry_point, source,
+                terminal_at, terminal_outcome, finish_reason, next_event_sequence
+           FROM tasks
+          ${clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''}
+          ORDER BY created_at ASC, id ASC
+          LIMIT ?`,
+      ).all(...params, limit) as JobSqlRow[];
+      return rows.map(mapJob);
+    },
+    getAttempt(attemptId) {
+      const row = getAttemptRow(attemptId);
+      return row ? mapAttempt(row) : null;
+    },
+    listAttempts(jobId) {
+      const rows = db.prepare(
+        `SELECT id, attempt_id, task_id, status, attempt_number, generation,
+                state_version, lease_id, lease_owner, lease_expires_at,
+                lease_heartbeat_at, fence_token, recovery_of_attempt_id, session_id
+           FROM runs WHERE task_id = ? ORDER BY attempt_number`,
+      ).all(jobId) as AttemptSqlRow[];
+      return rows.map(mapAttempt);
+    },
+    listEvents(jobId, afterSequence = 0) {
+      const rows = db.prepare(
+        `SELECT id, job_sequence, job_id, attempt_id, kind, payload, producer,
+                generation, idempotency_key, ts
+           FROM run_events
+          WHERE job_id = ? AND job_sequence > ?
+          ORDER BY job_sequence`,
+      ).all(jobId, afterSequence) as Array<{
+        id: number;
+        job_sequence: number;
+        job_id: string;
+        attempt_id: string | null;
+        kind: string;
+        payload: string;
+        producer: string | null;
+        generation: number | null;
+        idempotency_key: string;
+        ts: number;
+      }>;
+      return rows.map((row) => {
+        let payload: Record<string, unknown> | null = null;
+        try {
+          const parsed: unknown = JSON.parse(row.payload);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            payload = parsed as Record<string, unknown>;
+          }
+        } catch { /* malformed legacy payload remains null */ }
+        return {
+          eventId: row.id,
+          jobSequence: row.job_sequence,
+          jobId: row.job_id,
+          attemptId: row.attempt_id,
+          type: row.kind,
+          payload,
+          producer: row.producer,
+          generation: row.generation,
+          idempotencyKey: row.idempotency_key,
+          createdAt: row.ts,
+        };
+      });
+    },
+    transitionJob: transitionJobTx,
+    finalizeJob: finalizeJobTx,
+    cancelJob: cancelJobTx,
+    transitionAttempt: transitionAttemptTx,
+    claimAttempt: claimAttemptTx,
+    renewAttemptLease: renewAttemptTx,
+    createRecoveryAttempt: recoveryTx,
+    prepareToolCall: prepareToolCallTx,
+    startToolCall: startToolCallTx,
+    completeToolCall: completeToolCallTx,
+    attachToolVerification: attachToolVerificationTx,
+    recoverExpiredAttempts(command) {
+      const now = command.now ?? Date.now();
+      const rows = db.prepare(
+        `SELECT r.attempt_id
+           FROM runs r
+           JOIN tasks t ON t.active_attempt_id = r.attempt_id
+          WHERE r.lease_expires_at IS NOT NULL AND r.lease_expires_at <= ?
+            AND r.status NOT IN ('succeeded','completed','failed','cancelled','timed_out','crashed','unknown','interrupted')
+            AND t.status NOT IN ('cancelled','completed','failed','dead_letter','completed_unverified','verification_failed','abandoned')
+          ORDER BY r.lease_expires_at ASC, r.id ASC`,
+      ).all(now) as Array<{ attempt_id: string }>;
+      const decisions: Array<{
+        jobId: string;
+        expiredAttemptId: string;
+        recoveryAttemptId?: string;
+        decision: 'retry' | 'ask_user' | 'dead_letter';
+      }> = [];
+      for (const row of rows) {
+        const result = recoverExpiredAttemptTx({ ...command, now, attemptId: row.attempt_id });
+        if (result) decisions.push(result);
+      }
+      return decisions;
+    },
+  };
+}

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -58,6 +58,12 @@ function durableToolCallId(context: JobExecutionContext, modelCallId: string): s
     .digest('hex')}`;
 }
 
+/** Resolve the stable persisted ToolCall identity for the active Attempt. */
+export function currentDurableToolCallId(modelCallId: string): string | null {
+  const context = currentJobExecutionContext();
+  return context ? durableToolCallId(context, modelCallId) : null;
+}
+
 export class DurableToolCallConflictError extends Error {
   constructor(readonly operation: string, readonly result: TransitionResult) {
     super(`Durable ToolCall ${operation} rejected: ${result.conflict ?? 'duplicate'}`);

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createHash } from 'node:crypto';
+
+import type { JobEngine, TransitionResult } from './jobEngine';
+
+export interface JobExecutionContext {
+  engine: JobEngine;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  fenceToken: string;
+  producer: string;
+}
+
+const storage = new AsyncLocalStorage<JobExecutionContext>();
+
+export function runWithJobExecutionContext<T>(context: JobExecutionContext, operation: () => T): T {
+  return storage.run(context, operation);
+}
+
+export function currentJobExecutionContext(): JobExecutionContext | undefined {
+  return storage.getStore();
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record).sort().map((key) => [key, canonicalize(record[key])]),
+    );
+  }
+  return value;
+}
+
+export function normalizedArgsDigest(args: Record<string, unknown>): string {
+  return createHash('sha256').update(JSON.stringify(canonicalize(args))).digest('hex');
+}
+
+function opaqueReference(prefix: string, value: unknown): string {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(canonicalize(value));
+  } catch {
+    serialized = String(value);
+  }
+  return `${prefix}:sha256:${createHash('sha256').update(serialized).digest('hex')}`;
+}
+
+function durableToolCallId(context: JobExecutionContext, modelCallId: string): string {
+  return `tool-call:sha256:${createHash('sha256')
+    .update(`${context.attemptId}\0${context.generation}\0${modelCallId}`)
+    .digest('hex')}`;
+}
+
+export class DurableToolCallConflictError extends Error {
+  constructor(readonly operation: string, readonly result: TransitionResult) {
+    super(`Durable ToolCall ${operation} rejected: ${result.conflict ?? 'duplicate'}`);
+    this.name = 'DurableToolCallConflictError';
+  }
+}
+
+function requireApplied(operation: string, result: TransitionResult): void {
+  if (!result.applied && !result.duplicate) {
+    throw new DurableToolCallConflictError(operation, result);
+  }
+}
+
+export async function executeWithDurableToolCall<T>(command: {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  riskTier: string;
+  mutates: boolean;
+  execute: () => Promise<T>;
+  isSuccessful?: (result: T) => boolean;
+}): Promise<T> {
+  const context = currentJobExecutionContext();
+  if (!context) return command.execute();
+
+  const toolCallId = durableToolCallId(context, command.toolCallId);
+
+  requireApplied('prepare', context.engine.prepareToolCall({
+    toolCallId,
+    jobId: context.jobId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    modelCallId: command.toolCallId,
+    toolName: command.toolName,
+    normalizedArgsDigest: normalizedArgsDigest(command.args),
+    riskTier: command.riskTier,
+    mutates: command.mutates,
+    producer: context.producer,
+  }));
+  requireApplied('start', context.engine.startToolCall({
+    toolCallId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    producer: context.producer,
+  }));
+
+  try {
+    const result = await command.execute();
+    const succeeded = command.isSuccessful?.(result) ?? true;
+    requireApplied('complete', context.engine.completeToolCall({
+      toolCallId,
+      attemptId: context.attemptId,
+      generation: context.generation,
+      fenceToken: context.fenceToken,
+      state: succeeded ? 'completed' : 'failed',
+      sideEffectState: command.mutates ? (succeeded ? 'committed' : 'unknown') : undefined,
+      resultRef: opaqueReference('tool-result', result),
+      producer: context.producer,
+    }));
+    return result;
+  } catch (error) {
+    const completion = context.engine.completeToolCall({
+      toolCallId,
+      attemptId: context.attemptId,
+      generation: context.generation,
+      fenceToken: context.fenceToken,
+      state: 'failed',
+      sideEffectState: command.mutates ? 'unknown' : undefined,
+      producer: context.producer,
+    });
+    if (!completion.applied && !completion.duplicate) {
+      throw new DurableToolCallConflictError('failure', completion);
+    }
+    throw error;
+  }
+}
+
+export function recordDurableToolVerification(toolCallId: string, verification: unknown): void {
+  const context = currentJobExecutionContext();
+  if (!context) return;
+  const persistedToolCallId = durableToolCallId(context, toolCallId);
+  requireApplied('verification', context.engine.attachToolVerification({
+    toolCallId: persistedToolCallId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    verificationRef: opaqueReference('tool-verification', verification),
+    producer: context.producer,
+  }));
+}

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { runWithJobExecutionContext } from './jobExecutionContext';
+import type { JobEngine, SubmitJobCommand } from './jobEngine';
+
+export interface DurableJobHandle {
+  jobId: string;
+  attemptId: string;
+  runId: number;
+  generation: number;
+  fenceToken: string;
+  signal: AbortSignal;
+}
+
+export interface DurableJobFinalization {
+  status: 'completed' | 'failed' | 'cancelled';
+  outcome: string;
+  finishReason: string;
+  evidence: unknown;
+  jobCard?: {
+    filesTouched?: string[];
+    sideEffects?: unknown[];
+    failureState?: unknown | null;
+    permissions?: Record<string, unknown> | null;
+    constraints?: Record<string, unknown> | null;
+  };
+}
+
+export interface DurableJobExecutionResult<T> extends DurableJobHandle {
+  value: T;
+}
+
+export class DurableJobLifecycleError extends Error {
+  constructor(message: string, readonly handle?: Partial<DurableJobHandle>) {
+    super(message);
+    this.name = 'DurableJobLifecycleError';
+  }
+}
+
+export async function executeDurableJob<T>(options: {
+  engine: JobEngine;
+  ownerId: string;
+  admission: SubmitJobCommand;
+  execute: (handle: DurableJobHandle) => Promise<T>;
+  finalize: (value: T) => DurableJobFinalization;
+  leaseTtlMs?: number;
+  onLeaseLost?: (error: DurableJobLifecycleError) => void;
+}): Promise<DurableJobExecutionResult<T>> {
+  const admitted = options.engine.submitJob(options.admission);
+  const leaseTtlMs = Math.max(3_000, options.leaseTtlMs ?? 45_000);
+  const lease = options.engine.claimAttempt({
+    attemptId: admitted.attemptId,
+    ownerId: options.ownerId,
+    ttlMs: leaseTtlMs,
+  });
+  if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
+    throw new DurableJobLifecycleError(
+      `Durable Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`,
+      admitted,
+    );
+  }
+  const leaseAbort = new AbortController();
+  const handle: DurableJobHandle = {
+    jobId: admitted.jobId,
+    attemptId: admitted.attemptId,
+    runId: admitted.runId,
+    generation: lease.generation,
+    fenceToken: lease.fenceToken,
+    signal: leaseAbort.signal,
+  };
+  let attemptStateVersion = lease.stateVersion;
+  let jobStateVersion = options.engine.getJob(handle.jobId)?.stateVersion ?? 0;
+  const attemptStarted = options.engine.transitionAttempt({
+    attemptId: handle.attemptId,
+    expectedStateVersion: attemptStateVersion,
+    generation: handle.generation,
+    fenceToken: handle.fenceToken,
+    to: 'running',
+    eventIdempotencyKey: `attempt-running:${handle.attemptId}:${handle.generation}`,
+    producer: options.admission.source,
+  });
+  if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
+    throw new DurableJobLifecycleError(
+      `Durable Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`,
+      handle,
+    );
+  }
+  attemptStateVersion = attemptStarted.stateVersion;
+  const jobStarted = options.engine.transitionJob({
+    jobId: handle.jobId,
+    attemptId: handle.attemptId,
+    generation: handle.generation,
+    fenceToken: handle.fenceToken,
+    expectedStateVersion: jobStateVersion,
+    to: 'running',
+    eventIdempotencyKey: `job-running:${handle.jobId}:${handle.generation}`,
+    producer: options.admission.source,
+  });
+  if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
+    throw new DurableJobLifecycleError(
+      `Durable Job start rejected: ${jobStarted.conflict ?? 'unknown'}`,
+      handle,
+    );
+  }
+  jobStateVersion = jobStarted.stateVersion;
+
+  let leaseLost: DurableJobLifecycleError | null = null;
+  const heartbeat = setInterval(() => {
+    const renewed = options.engine.renewAttemptLease({
+      attemptId: handle.attemptId,
+      ownerId: options.ownerId,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      ttlMs: leaseTtlMs,
+    });
+    if (!renewed.applied || renewed.stateVersion === undefined) {
+      clearInterval(heartbeat);
+      leaseLost = new DurableJobLifecycleError(
+        `Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`,
+        handle,
+      );
+      leaseAbort.abort(leaseLost);
+      options.onLeaseLost?.(leaseLost);
+      return;
+    }
+    attemptStateVersion = renewed.stateVersion;
+  }, Math.max(1_000, Math.floor(leaseTtlMs / 3)));
+  heartbeat.unref?.();
+
+  try {
+    const value = await runWithJobExecutionContext({
+      engine: options.engine,
+      jobId: handle.jobId,
+      attemptId: handle.attemptId,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      producer: options.admission.source,
+    }, () => options.execute(handle));
+    if (leaseLost) throw leaseLost;
+
+    const finalization = options.finalize(value);
+    const attemptStatus = finalization.status === 'completed'
+      ? 'succeeded'
+      : finalization.status === 'cancelled' ? 'cancelled' : 'failed';
+    const attemptFinished = options.engine.transitionAttempt({
+      attemptId: handle.attemptId,
+      expectedStateVersion: attemptStateVersion,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      to: attemptStatus,
+      eventIdempotencyKey: `attempt-${attemptStatus}:${handle.attemptId}:${handle.generation}`,
+      producer: options.admission.source,
+      finishReason: finalization.finishReason,
+    });
+    if (!attemptFinished.applied) {
+      throw new DurableJobLifecycleError(
+        `Durable Attempt finalization rejected: ${attemptFinished.conflict ?? 'unknown'}`,
+        handle,
+      );
+    }
+    const jobFinished = options.engine.finalizeJob({
+      jobId: handle.jobId,
+      attemptId: handle.attemptId,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      expectedStateVersion: jobStateVersion,
+      status: finalization.status,
+      outcome: finalization.outcome,
+      finishReason: finalization.finishReason,
+      evidence: finalization.evidence,
+      jobCard: finalization.jobCard,
+      eventIdempotencyKey: `job-finalized:${handle.jobId}:${handle.generation}`,
+      producer: options.admission.source,
+    });
+    if (!jobFinished.applied) {
+      throw new DurableJobLifecycleError(
+        `Durable Job finalization rejected: ${jobFinished.conflict ?? 'unknown'}`,
+        handle,
+      );
+    }
+    return { ...handle, value };
+  } catch (error) {
+    if (!options.engine.getAttempt(handle.attemptId)?.status.match(/^(succeeded|failed|cancelled|timed_out|crashed|unknown)$/)) {
+      const attemptFailed = options.engine.transitionAttempt({
+        attemptId: handle.attemptId,
+        expectedStateVersion: attemptStateVersion,
+        generation: handle.generation,
+        fenceToken: handle.fenceToken,
+        to: 'failed',
+        eventIdempotencyKey: `attempt-failed:${handle.attemptId}:${handle.generation}`,
+        producer: options.admission.source,
+        finishReason: 'error',
+      });
+      if (attemptFailed.applied) {
+        options.engine.finalizeJob({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          fenceToken: handle.fenceToken,
+          expectedStateVersion: jobStateVersion,
+          status: 'failed',
+          outcome: 'failed',
+          finishReason: 'error',
+          evidence: { errorClass: error instanceof Error ? error.name : 'Error' },
+          eventIdempotencyKey: `job-finalized:${handle.jobId}:${handle.generation}`,
+          producer: options.admission.source,
+        });
+      }
+    }
+    throw error;
+  } finally {
+    clearInterval(heartbeat);
+  }
+}

--- a/core/v4/daemon/jobRecoverySweep.ts
+++ b/core/v4/daemon/jobRecoverySweep.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { JobEngine } from './jobEngine';
+import type { TriggerBus } from './triggerBus';
+
+export interface DurableRecoverySweepResult {
+  expired: number;
+  retried: number;
+  needsUser: number;
+  deadLettered: number;
+  enqueued: number;
+}
+
+/**
+ * Classify expired Attempt leases, then idempotently project every queued
+ * recovery Attempt onto the existing trigger bus. Scanning all recovering
+ * Jobs closes the crash window between the authoritative recovery transaction
+ * and the compatibility queue insertion.
+ */
+export function sweepDurableJobRecovery(input: {
+  jobEngine: JobEngine;
+  triggerBus: TriggerBus;
+  instanceId: string;
+  producer: string;
+  maxCrashes?: number;
+  now?: number;
+}): DurableRecoverySweepResult {
+  const decisions = input.jobEngine.recoverExpiredAttempts({
+    now: input.now,
+    instanceId: input.instanceId,
+    producer: input.producer,
+    maxCrashes: input.maxCrashes ?? 3,
+  });
+  const result: DurableRecoverySweepResult = {
+    expired: decisions.length,
+    retried: decisions.filter((item) => item.decision === 'retry').length,
+    needsUser: decisions.filter((item) => item.decision === 'ask_user').length,
+    deadLettered: decisions.filter((item) => item.decision === 'dead_letter').length,
+    enqueued: 0,
+  };
+
+  for (const job of input.jobEngine.listJobs({ status: 'recovering' })) {
+    const attempt = job.activeAttemptId
+      ? input.jobEngine.getAttempt(job.activeAttemptId)
+      : null;
+    if (!attempt || attempt.jobId !== job.id || attempt.status !== 'queued') continue;
+
+    const queued = input.triggerBus.insert({
+      source: 'manual',
+      sourceKey: `job-recovery:${job.id}`,
+      idempotencyKey: `job-recovery:${attempt.id}`,
+      payload: {
+        resume: {
+          prompt: `A previous Attempt lost its lease. Re-evaluate current state before continuing.\n\n${job.goal}`,
+          taskId: job.id,
+          ofRunId: attempt.rowId,
+          attempt: attempt.attemptNumber,
+        },
+        durable_job: {
+          job_id: job.id,
+          attempt_id: attempt.id,
+          run_id: attempt.rowId,
+        },
+      },
+    });
+    if (queued.inserted) result.enqueued += 1;
+  }
+
+  return result;
+}

--- a/core/v4/daemon/runStore.ts
+++ b/core/v4/daemon/runStore.ts
@@ -291,28 +291,57 @@ export function createRunStore(opts: CreateRunStoreOptions): RunStore {
   // (`const { emitEvent } = store; emitEvent(...)`) still hit the
   // same implementation — `this`-bound dispatch wouldn't survive
   // that pattern.
-  const emitEventRichImpl = (eo: EmitEventOptions): number => {
+  const emitEventRichTx = db.transaction((eo: EmitEventOptions): number => {
     const now = Date.now();
 
     // session_id: prefer caller-supplied (saves a JOIN); fall back
     // to a lookup against runs. Null only if the run row vanished —
     // shouldn't happen for live runs, but we tolerate it for
     // legacy/orphan rows.
-    let sessionId: string | null = eo.sessionId ?? null;
-    if (sessionId === null) {
-      const r = db.prepare(
-        'SELECT session_id FROM runs WHERE id = ?',
-      ).get(eo.runId) as { session_id: string | null } | undefined;
-      sessionId = r?.session_id ?? null;
-    }
+    const run = db.prepare(
+      `SELECT r.session_id, r.task_id, r.attempt_id, r.generation,
+              r.status, r.lease_expires_at, t.active_attempt_id
+         FROM runs r
+         LEFT JOIN tasks t ON t.id = r.task_id
+        WHERE r.id = ?`,
+    ).get(eo.runId) as {
+      session_id: string | null;
+      task_id: string | null;
+      attempt_id: string | null;
+      generation: number | null;
+      status: string;
+      lease_expires_at: number | null;
+      active_attempt_id: string | null;
+    } | undefined;
+    const sessionId: string | null = eo.sessionId ?? run?.session_id ?? null;
+    const authoritativeJobId = run?.task_id
+      && run.attempt_id
+      && run.active_attempt_id === run.attempt_id
+      && !['succeeded', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown'].includes(run.status)
+      && run.lease_expires_at !== null
+      && run.lease_expires_at > now
+      ? run.task_id
+      : null;
 
     // seq: per-run monotonic counter. COALESCE handles the first
     // event for a run (no rows → MAX returns NULL → COALESCE to 0
     // → +1 = 1). Indexed by (run_id, seq) so this scales.
-    const seqRow = db.prepare(
-      'SELECT COALESCE(MAX(seq), 0) AS m FROM run_events WHERE run_id = ?',
-    ).get(eo.runId) as { m: number };
-    const seq = seqRow.m + 1;
+    const allocated = db.prepare(
+      `UPDATE runs
+          SET next_event_sequence = next_event_sequence + 1
+        WHERE id = ?
+        RETURNING next_event_sequence - 1 AS seq`,
+    ).get(eo.runId) as { seq: number } | undefined;
+    if (!allocated) throw new Error(`Run not found: ${eo.runId}`);
+    const seq = allocated.seq;
+    const jobSequence = authoritativeJobId
+      ? (db.prepare(
+          `UPDATE tasks
+              SET next_event_sequence = next_event_sequence + 1
+            WHERE id = ?
+            RETURNING next_event_sequence - 1 AS seq`,
+        ).get(authoritativeJobId) as { seq: number } | undefined)?.seq ?? null
+      : null;
 
     // payload: serialise once, measure full size, then slice for
     // inline storage. The truncation flag + original size let
@@ -333,8 +362,9 @@ export function createRunStore(opts: CreateRunStoreOptions): RunStore {
          tool_call_id, parent_event_id,
          status, duration_ms, summary,
          payload, payload_truncated, payload_bytes, payload_ref,
-         visibility, source
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         visibility, source,
+         job_id, attempt_id, job_sequence, producer, generation, idempotency_key
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       eo.runId,
       sessionId,
@@ -355,8 +385,28 @@ export function createRunStore(opts: CreateRunStoreOptions): RunStore {
       null,                                 // payload_ref — reserved for v4.11 external store
       eo.visibility      ?? 'model',
       (eo.source as string | null | undefined) ?? null,
+      authoritativeJobId,
+      authoritativeJobId ? run?.attempt_id ?? null : null,
+      jobSequence,
+      (eo.source as string | null | undefined) ?? null,
+      authoritativeJobId ? run?.generation ?? null : null,
+      authoritativeJobId ? `run-event:${eo.runId}:${seq}` : null,
     );
     return Number(r.lastInsertRowid);
+  }).immediate;
+  const emitEventRichImpl = (eo: EmitEventOptions): number => emitEventRichTx(eo);
+  const assertCompatibilityMutation = (runId: number, operation: string): void => {
+    const row = db.prepare(
+      `SELECT r.attempt_id, t.entry_point
+         FROM runs r
+         LEFT JOIN tasks t ON t.id = r.task_id
+        WHERE r.id = ?`,
+    ).get(runId) as { attempt_id: string | null; entry_point: string | null } | undefined;
+    if (row?.attempt_id && row.entry_point) {
+      throw new Error(
+        `RunStore.${operation} cannot mutate durable Attempt ${row.attempt_id}; use the Job transition authority`,
+      );
+    }
   };
 
   return {
@@ -384,6 +434,7 @@ export function createRunStore(opts: CreateRunStoreOptions): RunStore {
       return Number(r.lastInsertRowid);
     },
     setStatus(runId, status, opts2 = {}) {
+      assertCompatibilityMutation(runId, 'setStatus');
       const completedAt = opts2.completedAt
         ?? (status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'interrupted'
             ? Date.now()
@@ -397,17 +448,22 @@ export function createRunStore(opts: CreateRunStoreOptions): RunStore {
       ).run(status, opts2.finishReason ?? null, completedAt, runId);
     },
     markResumePending(runId, reason) {
+      assertCompatibilityMutation(runId, 'markResumePending');
       db.prepare(
         `UPDATE runs SET resume_pending = 1, resume_reason = ? WHERE id = ?`,
       ).run(reason, runId);
     },
     listResumePending() {
       const rows = db.prepare(
-        `SELECT * FROM runs WHERE resume_pending = 1 ORDER BY started_at ASC`,
+        `SELECT r.* FROM runs r
+           LEFT JOIN tasks t ON t.id = r.task_id
+          WHERE r.resume_pending = 1 AND t.entry_point IS NULL
+          ORDER BY r.started_at ASC`,
       ).all() as RunRowSql[];
       return rows.map(rowToTs);
     },
     claimResumePending(runId, reason) {
+      assertCompatibilityMutation(runId, 'claimResumePending');
       // Single-statement compare-and-clear: exactly one caller wins.
       const info = db.prepare(
         `UPDATE runs SET resume_pending = 0, resume_reason = ?

--- a/core/v4/daemon/runs/reclaim.ts
+++ b/core/v4/daemon/runs/reclaim.ts
@@ -73,14 +73,24 @@ export function reclaimStuckRuns(db: Db, opts: ReclaimOptions): ReclaimResult {
   let candidates: Array<{ id: number }>;
   if (opts.instanceId !== undefined) {
     candidates = db.prepare(
-      `SELECT id FROM runs WHERE status = 'running' AND instance_id = ?`,
+      `SELECT id FROM runs
+        WHERE status = 'running' AND instance_id = ?
+          AND NOT EXISTS (
+            SELECT 1 FROM tasks t
+             WHERE t.id = runs.task_id AND t.idempotency_namespace IS NOT NULL
+          )`,
     ).all(opts.instanceId) as Array<{ id: number }>;
   } else {
     if (!opts.currentInstanceId) {
       throw new Error('reclaimStuckRuns: currentInstanceId required when instanceId omitted');
     }
     candidates = db.prepare(
-      `SELECT id FROM runs WHERE status = 'running' AND instance_id != ?`,
+      `SELECT id FROM runs
+        WHERE status = 'running' AND instance_id != ?
+          AND NOT EXISTS (
+            SELECT 1 FROM tasks t
+             WHERE t.id = runs.task_id AND t.idempotency_namespace IS NOT NULL
+          )`,
     ).all(opts.currentInstanceId) as Array<{ id: number }>;
   }
 
@@ -101,7 +111,11 @@ export function reclaimStuckRuns(db: Db, opts: ReclaimOptions): ReclaimResult {
               completed_at   = ?,
               resume_pending = 1,
               resume_reason  = 'daemon_crashed'
-        WHERE status = 'running' AND instance_id = ?`,
+        WHERE status = 'running' AND instance_id = ?
+          AND NOT EXISTS (
+            SELECT 1 FROM tasks t
+             WHERE t.id = runs.task_id AND t.idempotency_namespace IS NOT NULL
+          )`,
     ).run(now, opts.instanceId);
   } else {
     updateResult = db.prepare(
@@ -111,7 +125,11 @@ export function reclaimStuckRuns(db: Db, opts: ReclaimOptions): ReclaimResult {
               completed_at   = ?,
               resume_pending = 1,
               resume_reason  = 'daemon_crashed'
-        WHERE status = 'running' AND instance_id != ?`,
+        WHERE status = 'running' AND instance_id != ?
+          AND NOT EXISTS (
+            SELECT 1 FROM tasks t
+             WHERE t.id = runs.task_id AND t.idempotency_namespace IS NOT NULL
+          )`,
     ).run(now, opts.currentInstanceId!);
   }
 

--- a/core/v4/daemon/taskStore.ts
+++ b/core/v4/daemon/taskStore.ts
@@ -304,6 +304,16 @@ function newTaskId(): string {
 
 export function createTaskStore(opts: CreateTaskStoreOptions): TaskStore {
   const db = opts.db;
+  const assertCompatibilityMutation = (id: string, operation: string): void => {
+    const row = db.prepare('SELECT entry_point FROM tasks WHERE id = ?').get(id) as {
+      entry_point: string | null;
+    } | undefined;
+    if (row?.entry_point) {
+      throw new Error(
+        `TaskStore.${operation} cannot mutate durable Job ${id}; use the Job transition authority`,
+      );
+    }
+  };
   return {
     create({ title, goal, sessionId, channelId, parentTaskId, status }) {
       const now = Date.now();
@@ -335,16 +345,19 @@ export function createTaskStore(opts: CreateTaskStoreOptions): TaskStore {
       return r ? rowToTask(r) : null;
     },
     setStatus(id, status) {
+      assertCompatibilityMutation(id, 'setStatus');
       db.prepare(
         `UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?`,
       ).run(status, Date.now(), id);
     },
     setGoal(id, goal) {
+      assertCompatibilityMutation(id, 'setGoal');
       db.prepare(
         `UPDATE tasks SET goal = ?, updated_at = ? WHERE id = ?`,
       ).run(goal, Date.now(), id);
     },
     finalizeVerification(id, status, evidence, jobCard) {
+      assertCompatibilityMutation(id, 'finalizeVerification');
       // Read-merge for the accumulating arrays (same discipline as
       // appendTraceId), then ONE UPDATE carrying every field — status,
       // evidence, and job-card land atomically or not at all.
@@ -424,6 +437,7 @@ export function createTaskStore(opts: CreateTaskStoreOptions): TaskStore {
       ).run(JSON.stringify(arr), Date.now(), id);
     },
     incrementResumeCount(id) {
+      assertCompatibilityMutation(id, 'incrementResumeCount');
       db.prepare(
         `UPDATE tasks SET resume_count = resume_count + 1, updated_at = ? WHERE id = ?`,
       ).run(Date.now(), id);
@@ -460,7 +474,9 @@ export function createTaskStore(opts: CreateTaskStoreOptions): TaskStore {
       const info = db.prepare(
         `UPDATE tasks
             SET status = 'interrupted', updated_at = ?
-          WHERE status IN ('active', 'pending_verification') AND created_at < ?`,
+          WHERE status IN ('active', 'pending_verification')
+            AND entry_point IS NULL
+            AND created_at < ?`,
       ).run(Date.now(), beforeMs);
       return info.changes;
     },

--- a/core/v4/hooks/toolHookGate.ts
+++ b/core/v4/hooks/toolHookGate.ts
@@ -55,6 +55,41 @@ export interface RunToolWithHooksOpts {
   ctx:          DispatchContext;
 }
 
+/** Resolve action-changing pre-hooks before policy or approval evaluation. */
+export async function runToolPreHooks(
+  opts: RunToolWithHooksOpts,
+): Promise<Record<string, unknown>> {
+  if (!opts.db) return opts.args;
+  const baseCtx: DispatchContext = { ...opts.ctx, toolName: opts.toolName, toolCallId: opts.toolCallId };
+  const pre = await dispatchHook(opts.db, 'tool.call.pre', opts.args, baseCtx);
+  if (pre.decision === 'block') {
+    throw new HookBlockedError(
+      pre.reason ?? 'tool call blocked by pre-hook',
+      pre.user_message,
+      pre.model_message,
+    );
+  }
+  return pre.payload as Record<string, unknown>;
+}
+
+/** Apply presentation-only post-hooks after the frozen action has executed. */
+export async function runToolPostHooks(
+  opts: RunToolWithHooksOpts,
+  finalArgs: Record<string, unknown>,
+  result: unknown,
+): Promise<unknown> {
+  if (!opts.db) return result;
+  const baseCtx: DispatchContext = { ...opts.ctx, toolName: opts.toolName, toolCallId: opts.toolCallId };
+  const post = await dispatchHook(
+    opts.db,
+    'tool.call.post',
+    { input: finalArgs, output: result },
+    baseCtx,
+  );
+  const patched = post.payload as Record<string, unknown>;
+  return ('output' in patched) ? patched.output : result;
+}
+
 /**
  * Wrap a tool handler call with pre/post hook dispatch. Returns
  * the (possibly transformed) handler result. Throws `HookBlockedError`

--- a/core/v4/mcp/server/stdioServer.ts
+++ b/core/v4/mcp/server/stdioServer.ts
@@ -63,6 +63,7 @@ import {
   readSkillResource,
 } from './skillBridge';
 import { AIDEN_MCP_BUILD, collectMcpDiagnostics } from './diagnostics';
+import type { JobEngine } from '../../daemon/jobEngine';
 
 export { AIDEN_MCP_BUILD } from './diagnostics';
 
@@ -82,6 +83,7 @@ export interface StdioServerOptions {
   logger?: Logger;
   /** Override env reads — tests inject fake env without mutating process.env. */
   env?: ToolBridgeEnv;
+  jobAuthority?: { engine: JobEngine; instanceId: string };
 }
 
 export interface StdioServerHandle {
@@ -112,6 +114,7 @@ export async function startStdioMcpServer(
     opts.toolContext,
     env,
     logger,
+    opts.jobAuthority,
   );
 
   // ── tools/list ──────────────────────────────────────────────

--- a/core/v4/mcp/server/toolBridge.ts
+++ b/core/v4/mcp/server/toolBridge.ts
@@ -44,6 +44,10 @@ import type {
 } from '../../../../providers/v4/types';
 import type { Logger } from '../../logger/logger';
 import { noopLogger } from '../../logger/factory';
+import { randomUUID } from 'node:crypto';
+import type { JobEngine } from '../../daemon/jobEngine';
+import { executeDurableJob } from '../../daemon/jobLifecycle';
+import { ApprovalEngine } from '../../../../moat/approvalEngine';
 
 /** MCP wire shape for a tool. Same JSON-Schema as ToolSchema.inputSchema. */
 export interface McpTool {
@@ -150,9 +154,17 @@ export function buildToolCallHandler(
   context: ToolContext,
   env: ToolBridgeEnv,
   logger: Logger = noopLogger(),
+  jobAuthority?: { engine: JobEngine; instanceId: string },
 ): (name: string, args: Record<string, unknown>) => Promise<McpToolCallResult> {
   const exposed = new Set(exposedToolNames(registry, env));
-  const execute = registry.buildExecutor(context);
+  // Direct MCP calls have no interactive approval channel. Preserve an
+  // explicitly supplied authority, but otherwise install the existing manual
+  // engine without a prompter so mutating tools fail closed after durable Job
+  // admission. Exposure is capability discovery, not execution approval.
+  const executionContext: ToolContext = context.approvalEngine
+    ? context
+    : { ...context, approvalEngine: new ApprovalEngine('manual') };
+  const execute = registry.buildExecutor(executionContext);
 
   return async (name, args) => {
     if (!exposed.has(name)) {
@@ -175,11 +187,34 @@ export function buildToolCallHandler(
       };
     }
 
-    const id = `mcp-${name}-${Date.now().toString(36)}`;
+    const id = `mcp-${name}-${randomUUID()}`;
     const call: ToolCallRequest = { id, name, arguments: args ?? {} };
     let result: ToolCallResult;
     try {
-      result = await execute(call);
+      const executeCall = () => execute(call);
+      result = jobAuthority
+        ? (await executeDurableJob({
+            engine: jobAuthority.engine,
+            ownerId: jobAuthority.instanceId,
+            admission: {
+              entryPoint: 'mcp',
+              source: 'mcp-stdio',
+              sessionId: `mcp:${jobAuthority.instanceId}`,
+              instanceId: jobAuthority.instanceId,
+              idempotencyNamespace: `mcp:${jobAuthority.instanceId}`,
+              idempotencyKey: id,
+              goal: `Execute ${name}`,
+              title: name,
+            },
+            execute: (handle) => execute(call, handle.signal),
+            finalize: (value) => ({
+              status: value.error ? 'failed' : 'completed',
+              outcome: value.error ? 'failed' : 'completed',
+              finishReason: value.error ? 'tool_error' : 'stop',
+              evidence: { toolCallId: id, toolName: name, succeeded: !value.error },
+            }),
+          })).value
+        : await executeCall();
     } catch (err) {
       // The executor itself swallows handler exceptions, but a bug in
       // the executor (or a moat layer hard-throw) would land here.

--- a/core/v4/subagent/spawnSubAgent.ts
+++ b/core/v4/subagent/spawnSubAgent.ts
@@ -42,6 +42,9 @@ import type { RunStore } from '../daemon/runStore';
 import type { Logger } from '../logger/logger';
 import { noopLogger } from '../logger/factory';
 import type { ProviderAttemptBudget } from '../../../providers/v4/types';
+import type { JobEngine } from '../daemon/jobEngine';
+import { currentJobExecutionContext, runWithJobExecutionContext } from '../daemon/jobExecutionContext';
+import { runWithProviderUsageContext } from '../../../providers/v4/providerAttemptAccounting';
 
 // ── Public types (per design doc §3) ─────────────────────────────────────
 
@@ -147,6 +150,8 @@ export interface SpawnSubAgentDeps extends ChildBuilderDeps {
   runStore: RunStore;
   /** Daemon instance id (or a REPL-sentinel) used as `runs.instance_id`. */
   instanceId: string;
+  /** Production child Job/Attempt authority. */
+  jobEngine?: JobEngine;
   /**
    * v4.6 Phase 1 observability — optional logger for spawn-side
    * traces (parsed spec, child-build summary, completion).
@@ -217,19 +222,108 @@ export async function spawnSubAgent(
 
   // ── 2. Fresh sessionId + run row ────────────────────────────────────────
   const childSessionId = randomUUID();
+  const parentJobContext = currentJobExecutionContext();
+  let childJobId: string | null = null;
+  let childAttemptId: string | null = null;
+  let childGeneration: number | null = null;
+  let childFenceToken: string | null = null;
+  let childAttemptVersion = 0;
+  let childJobVersion = 0;
+  let childLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
+  const childCtrl = new AbortController();
+  const stopChildHeartbeat = (): void => {
+    if (childLeaseHeartbeat !== null) {
+      clearInterval(childLeaseHeartbeat);
+      childLeaseHeartbeat = null;
+    }
+  };
 
   // Pre-create the child run row in 'running' state so the envelope
   // always carries a valid childRunId — even if buildChildAgent throws.
   let childRunId: number;
   try {
-    childRunId = deps.runStore.create({
-      sessionId:             childSessionId,
-      instanceId:            deps.instanceId,
-      status:                'running',
-      startedAt,
-      spawnedFromRunId:      ctx.parentRunId,
-      spawnedFromSessionId:  ctx.parentSessionId,
-    });
+    if (deps.jobEngine && parentJobContext) {
+      const parentJob = deps.jobEngine.getJob(parentJobContext.jobId);
+      if (!parentJob) throw new Error(`Parent Job not found: ${parentJobContext.jobId}`);
+      const admitted = deps.jobEngine.submitJob({
+        entryPoint: 'subagent',
+        source: 'subagent',
+        sessionId: childSessionId,
+        instanceId: deps.instanceId,
+        idempotencyNamespace: `child:${parentJobContext.jobId}`,
+        idempotencyKey: childSessionId,
+        goal: spec.goal,
+        title: spec.goal,
+        parentJobId: parentJobContext.jobId,
+        rootJobId: parentJob.rootJobId,
+      });
+      childJobId = admitted.jobId;
+      childAttemptId = admitted.attemptId;
+      childRunId = admitted.runId;
+      childJobVersion = deps.jobEngine.getJob(childJobId)?.stateVersion ?? 0;
+      const lease = deps.jobEngine.claimAttempt({
+        attemptId: childAttemptId, ownerId: deps.instanceId, ttlMs: 45_000,
+      });
+      if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
+        throw new Error(`Child Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
+      }
+      childGeneration = lease.generation;
+      childFenceToken = lease.fenceToken;
+      childAttemptVersion = lease.stateVersion;
+      const attemptStarted = deps.jobEngine.transitionAttempt({
+        attemptId: childAttemptId,
+        expectedStateVersion: childAttemptVersion,
+        generation: childGeneration,
+        fenceToken: childFenceToken,
+        to: 'running',
+        eventIdempotencyKey: `attempt-running:${childAttemptId}:${childGeneration}`,
+        producer: 'subagent',
+      });
+      if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
+        throw new Error(`Child Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`);
+      }
+      childAttemptVersion = attemptStarted.stateVersion;
+      const jobStarted = deps.jobEngine.transitionJob({
+        jobId: childJobId,
+        attemptId: childAttemptId,
+        generation: childGeneration,
+        fenceToken: childFenceToken,
+        expectedStateVersion: childJobVersion,
+        to: 'running',
+        eventIdempotencyKey: `job-running:${childJobId}:${childGeneration}`,
+        producer: 'subagent',
+      });
+      if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
+        throw new Error(`Child Job start rejected: ${jobStarted.conflict ?? 'unknown'}`);
+      }
+      childJobVersion = jobStarted.stateVersion;
+      childLeaseHeartbeat = setInterval(() => {
+        if (!deps.jobEngine || !childAttemptId || childGeneration === null || !childFenceToken) return;
+        const renewed = deps.jobEngine.renewAttemptLease({
+          attemptId: childAttemptId,
+          ownerId: deps.instanceId,
+          generation: childGeneration,
+          fenceToken: childFenceToken,
+          ttlMs: 45_000,
+        });
+        if (!renewed.applied || renewed.stateVersion === undefined) {
+          stopChildHeartbeat();
+          childCtrl.abort(new Error(`Child Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
+          return;
+        }
+        childAttemptVersion = renewed.stateVersion;
+      }, 15_000);
+      childLeaseHeartbeat.unref?.();
+    } else {
+      childRunId = deps.runStore.create({
+        sessionId: childSessionId,
+        instanceId: deps.instanceId,
+        status: 'running',
+        startedAt,
+        spawnedFromRunId: ctx.parentRunId,
+        spawnedFromSessionId: ctx.parentSessionId,
+      });
+    }
   } catch (err) {
     // Persistence failed before we even started — surface as failed
     // envelope with a synthetic id of '0' so the contract holds.
@@ -242,6 +336,42 @@ export async function spawnSubAgent(
   }
 
   // ── 3. Build child agent ────────────────────────────────────────────────
+  const finalizeChildDurable = (input: {
+    jobStatus: 'completed' | 'failed' | 'cancelled';
+    attemptStatus: 'succeeded' | 'failed' | 'cancelled' | 'timed_out';
+    outcome: string;
+    finishReason: string;
+    evidence: unknown;
+  }): void => {
+    if (!deps.jobEngine || !childJobId || !childAttemptId || childGeneration === null || !childFenceToken) return;
+    stopChildHeartbeat();
+    const attempt = deps.jobEngine.transitionAttempt({
+      attemptId: childAttemptId,
+      expectedStateVersion: childAttemptVersion,
+      generation: childGeneration,
+      fenceToken: childFenceToken,
+      to: input.attemptStatus,
+      eventIdempotencyKey: `attempt-${input.attemptStatus}:${childAttemptId}:${childGeneration}`,
+      producer: 'subagent',
+      finishReason: input.finishReason,
+    });
+    if (!attempt.applied) throw new Error(`Child Attempt finalization rejected: ${attempt.conflict ?? 'unknown'}`);
+    const job = deps.jobEngine.finalizeJob({
+      jobId: childJobId,
+      attemptId: childAttemptId,
+      generation: childGeneration,
+      fenceToken: childFenceToken,
+      expectedStateVersion: childJobVersion,
+      status: input.jobStatus,
+      outcome: input.outcome,
+      finishReason: input.finishReason,
+      evidence: input.evidence,
+      eventIdempotencyKey: `job-finalized:${childJobId}:${childGeneration}`,
+      producer: 'subagent',
+    });
+    if (!job.applied) throw new Error(`Child Job finalization rejected: ${job.conflict ?? 'unknown'}`);
+  };
+
   const logger = deps.logger ?? noopLogger();
   // v4.12.1 Pillar 2 — collect escalations the child raised to the parent
   // (destructive / external / out-of-scope ops it refused to run itself).
@@ -290,7 +420,14 @@ export async function spawnSubAgent(
     // failures (constructor throws, registry issues, etc.) collapse
     // to the generic 'error' exitReason.
     if (err instanceof ProviderNotFoundError) {
-      deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'provider_not_found' });
+      if (deps.jobEngine && childJobId) {
+        finalizeChildDurable({
+          jobStatus: 'failed', attemptStatus: 'failed', outcome: 'failed',
+          finishReason: 'provider_not_found', evidence: { errorClass: err.name },
+        });
+      } else {
+        deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'provider_not_found' });
+      }
       return {
         ok:             false,
         status:         'failed',
@@ -309,7 +446,14 @@ export async function spawnSubAgent(
         escalations:    [],
       };
     }
-    deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'error' });
+    if (deps.jobEngine && childJobId) {
+      finalizeChildDurable({
+        jobStatus: 'failed', attemptStatus: 'failed', outcome: 'failed',
+        finishReason: 'error', evidence: { errorClass: err instanceof Error ? err.name : 'Error' },
+      });
+    } else {
+      deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'error' });
+    }
     return failureEnvelope({
       childRunId:     String(childRunId),
       childSessionId,
@@ -339,7 +483,6 @@ export async function spawnSubAgent(
   //   (b) timeoutMs elapses — child aborts.
   // Track which one fired so we can label the envelope as
   // 'interrupted' vs 'timeout' (the spec distinguishes them).
-  const childCtrl = new AbortController();
   let timedOut = false;
   const timer = setTimeout(() => {
     timedOut = true;
@@ -386,7 +529,7 @@ export async function spawnSubAgent(
   // parent's spanId). Out-of-context callers (legacy paths) leave
   // the call exactly as it was pre-Slice-7.
   const parentCtx = currentContext();
-  const runChild = async (): Promise<Awaited<ReturnType<typeof agentBundle.agent.runConversation>>> =>
+  const invokeChild = async (): Promise<Awaited<ReturnType<typeof agentBundle.agent.runConversation>>> =>
     agentBundle.agent.runConversation(
       agentBundle.history,
       {
@@ -402,6 +545,28 @@ export async function spawnSubAgent(
         onUiEvent: () => { /* no-op: subagents do not render */ },
       },
     );
+  const runChild = async (): Promise<Awaited<ReturnType<typeof agentBundle.agent.runConversation>>> =>
+    runWithProviderUsageContext({
+      sessionId: childSessionId,
+      taskId: childJobId,
+      runId: childRunId,
+      jobId: childJobId,
+      attemptId: childAttemptId,
+      attemptGeneration: childGeneration,
+      entryPoint: 'subagent',
+      purpose: 'subagent',
+    }, () => (
+      deps.jobEngine && childJobId && childAttemptId && childGeneration !== null && childFenceToken
+        ? runWithJobExecutionContext({
+            engine: deps.jobEngine,
+            jobId: childJobId,
+            attemptId: childAttemptId,
+            generation: childGeneration,
+            fenceToken: childFenceToken,
+            producer: 'subagent',
+          }, invokeChild)
+        : invokeChild()
+    ));
 
   try {
     const result = await (parentCtx
@@ -470,7 +635,9 @@ export async function spawnSubAgent(
     status === 'completed'   ? 'completed'
     : status === 'interrupted' ? 'interrupted'
     : 'failed';
-  deps.runStore.setStatus(childRunId, dbStatus, { finishReason: exitReason });
+  if (!deps.jobEngine || !childJobId) {
+    deps.runStore.setStatus(childRunId, dbStatus, { finishReason: exitReason });
+  }
 
   const durationMs = Date.now() - startedAt;
 
@@ -495,6 +662,25 @@ export async function spawnSubAgent(
     reasoningOnly     = ev.reasoningOnly;
     unconfirmedRemote = ev.unconfirmedRemote;
     handles           = ev.handles;
+  }
+
+  if (deps.jobEngine && childJobId) {
+    const jobStatus = status === 'completed' && verdict !== 'verification_failed'
+      ? 'completed'
+      : status === 'interrupted' ? 'cancelled' : 'failed';
+    const attemptStatus = status === 'completed'
+      ? 'succeeded'
+      : status === 'interrupted' ? 'cancelled'
+      : status === 'timeout' ? 'timed_out' : 'failed';
+    finalizeChildDurable({
+      jobStatus,
+      attemptStatus,
+      outcome: verdict ?? status,
+      finishReason: exitReason,
+      evidence: evidence ?? { status, exitReason },
+    });
+  } else {
+    stopChildHeartbeat();
   }
 
   // Pillar 3: `ok` now means VERIFIED completion, not a clean loop exit.

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -62,7 +62,16 @@ import { classifyBrowserAction } from './browserState';
 import { pwBrowserStatus, pwDialogPendingTier } from '../playwrightBridge';
 import type { SkillLoader } from './skillLoader';
 import type { BundledManifest } from './skillBundledManifest';
-import { executeWithDurableToolCall } from './daemon/jobExecutionContext';
+import {
+  currentDurableToolCallId,
+  currentJobExecutionContext,
+  executeWithDurableToolCall,
+} from './daemon/jobExecutionContext';
+import {
+  normalizeExecutionPlan,
+  type ActionAuthority,
+  type PolicySnapshotInput,
+} from './actionAuthority';
 
 /**
  * Risk profile for a tool. Used by the Phase 9 approval engine to decide
@@ -130,6 +139,10 @@ export interface ToolContext {
   /** Phase 9: approval engine. When present, every `mutates: true`
    *  handler is gated through it before `execute` runs. */
   approvalEngine?: ApprovalEngine;
+  /** Durable exact-action approval authority for an admitted Job. */
+  actionAuthority?: ActionAuthority;
+  /** Immutable inputs used to snapshot policy for each final action. */
+  policySnapshot?: PolicySnapshotInput;
   /** Phase 9: SSRF check for any tool whose category is `network`. */
   ssrfProtection?: SSRFProtection;
   /** Phase 9: content scanner. `shell_exec` runs commands through it
@@ -440,6 +453,13 @@ export class ToolRegistry {
         executionAttempts: [],
       };
       let approvalDecision: ToolApprovalDecision | undefined;
+      let durableApproval: {
+        approvalId: string;
+        toolCallId: string;
+        actionDigest: string;
+        policySnapshotId: string;
+        riskTier: string;
+      } | undefined;
       const emit = (phase: ToolActivityUpdate['phase'], attempt?: number): void => {
         try { onActivity?.({ phase, at: Date.now(), attempt, timing }); } catch { /* observational */ }
       };
@@ -484,7 +504,7 @@ export class ToolRegistry {
         }, 'failed');
       }
 
-      const args = call.arguments ?? {};
+      let args = call.arguments ?? {};
 
       // ── Argument-shape guard — JSON that PARSES can still be garbage ───
       // A well-formed argument can carry prose where the schema declares a
@@ -501,6 +521,33 @@ export class ToolRegistry {
           error: `Invalid arguments for ${call.name}: ${argShapeError}`,
         }, 'failed');
       }
+
+      // Action-changing hooks run before policy evaluation and approval. The
+      // returned arguments become the sole frozen input for every later gate.
+      const preHookShim = sliceSpanShim();
+      const preHookContext = _identityCurrentContext();
+      if (preHookShim.db && preHookContext) {
+        try {
+          args = await preHookShim.runToolPreHooks({
+            db: preHookShim.db,
+            toolName: call.name,
+            toolCallId: call.id,
+            args,
+            ctx: {
+              runId: preHookContext.runId,
+              traceId: preHookContext.traceId,
+              spanId: preHookContext.spanId,
+              parentSpanId: preHookContext.parentSpanId,
+            },
+          });
+        } catch (error) {
+          const message = error instanceof HookBlockedError
+            ? (error.modelMessage ?? error.userMessage ?? error.message)
+            : error instanceof Error ? error.message : String(error);
+          return finish({ id: call.id, name: call.name, result: null, error: message }, 'blocked');
+        }
+      }
+      args = freezeToolArguments(args);
 
       // ── Gate 1 — approval engine for mutating tools (runs FIRST) ───
       // Fail-open ORDERING fix: approval MUST precede the SSRF check and the
@@ -522,7 +569,11 @@ export class ToolRegistry {
       // registered tool that never set it) is ASSUMED to mutate and is gated —
       // a forgotten declaration must not become a silent bypass.
       const assumeMutates = handler.mutates ?? true;
-      if (assumeMutates && context.approvalEngine && !readOnlyShell) {
+      const durableJobContext = currentJobExecutionContext();
+      if (
+        assumeMutates && !readOnlyShell &&
+        (context.approvalEngine || (context.actionAuthority && durableJobContext))
+      ) {
         // Pre-classify shell_exec commands so smart-mode has a tier.
         let riskTier: 'safe' | 'caution' | 'dangerous' | undefined;
         let reason: string | undefined;
@@ -591,6 +642,55 @@ export class ToolRegistry {
           // no extra line (graceful degradation).
           effects:  handler.effects,
         };
+        const jobContext = durableJobContext;
+        if (context.actionAuthority && jobContext) {
+          const normalized = normalizeExecutionPlan({
+            toolName: call.name,
+            args,
+            cwd: context.cwd ?? process.cwd(),
+            mutates: assumeMutates,
+            riskTier: effectiveTier ?? 'caution',
+            policy: context.policySnapshot ?? {
+              trustLevel: 'Assistant',
+              autonomyPolicy: 'ask_for_mutations',
+              approvalMode: 'smart',
+              toolMetadataVersion: 'runtime',
+              sandboxPolicy: { roots: [context.cwd ?? process.cwd()], deny: [] },
+              networkPolicy: {},
+              pluginGrants: [],
+              mcpGrants: [],
+              workspaceOverrides: {},
+              jobOverrides: {},
+            },
+          });
+          const persistedToolCallId = currentDurableToolCallId(call.id) ?? call.id;
+          const record = context.actionAuthority.request({
+            jobId: jobContext.jobId,
+            attemptId: jobContext.attemptId,
+            generation: jobContext.generation,
+            toolCallId: persistedToolCallId,
+            toolName: call.name,
+            riskTier: effectiveTier ?? 'caution',
+            riskReasons: reason ? [reason] : [],
+            normalized,
+          });
+          if (context.approvalEngine) context.actionAuthority.markDisplayed(record.approvalId);
+          durableApproval = {
+            approvalId: record.approvalId,
+            toolCallId: persistedToolCallId,
+            actionDigest: normalized.actionDigest,
+            policySnapshotId: normalized.policySnapshot.policySnapshotId,
+            riskTier: effectiveTier ?? 'caution',
+          };
+        }
+        if (!context.approvalEngine) {
+          return finish({
+            id: call.id,
+            name: call.name,
+            result: null,
+            error: `Approval required: ${durableApproval?.approvalId ?? 'interactive approval channel unavailable'}`,
+          }, 'blocked');
+        }
         timing.approvalStartedAt = Date.now();
         emit('awaiting_approval');
         let allowed: boolean;
@@ -612,12 +712,42 @@ export class ToolRegistry {
         } catch (error) {
           timing.approvalEndedAt = Date.now();
           const message = error instanceof Error ? error.message : String(error);
+          if (durableApproval && context.actionAuthority && jobContext) {
+            try {
+              context.actionAuthority.decide({
+                approvalId: durableApproval.approvalId,
+                jobId: jobContext.jobId,
+                attemptId: jobContext.attemptId,
+                generation: jobContext.generation,
+                actionDigest: durableApproval.actionDigest,
+                policySnapshotId: durableApproval.policySnapshotId,
+                decision: 'cancelled',
+                decidedBy: 'runtime',
+                decisionChannel: 'interactive',
+              });
+            } catch { /* the original prompt failure remains authoritative */ }
+          }
           const terminal = signal?.aborted
             ? 'cancelled'
             : /timed?\s*out|timeout/i.test(message) ? 'timed_out' : 'failed';
           return finish({ id: call.id, name: call.name, result: null, error: message }, terminal);
         }
         timing.approvalEndedAt = Date.now();
+        if (durableApproval && context.actionAuthority && jobContext) {
+          context.actionAuthority.decide({
+            approvalId: durableApproval.approvalId,
+            jobId: jobContext.jobId,
+            attemptId: jobContext.attemptId,
+            generation: jobContext.generation,
+            actionDigest: durableApproval.actionDigest,
+            policySnapshotId: durableApproval.policySnapshotId,
+            decision: allowed
+              ? 'approved'
+              : approvalDecision?.state === 'interrupted' ? 'cancelled' : 'denied',
+            decidedBy: 'user',
+            decisionChannel: 'interactive',
+          });
+        }
         if (!allowed) {
           if (approvalDecision?.state === 'interrupted') {
             return finish({
@@ -746,6 +876,53 @@ export class ToolRegistry {
         }
       }
 
+      // Claim execution of the exact approved action immediately before the
+      // handler boundary. A changed digest, policy, Attempt, or ToolCall fails
+      // closed and invalidates the durable Approval.
+      if (durableApproval && context.actionAuthority) {
+        const jobContext = currentJobExecutionContext();
+        if (!jobContext) {
+          return finish({ id: call.id, name: call.name, result: null, error: 'Durable approval lost its Job context' }, 'blocked');
+        }
+        const current = normalizeExecutionPlan({
+          toolName: call.name,
+          args,
+          cwd: context.cwd ?? process.cwd(),
+          mutates: assumeMutates,
+          riskTier: durableApproval.riskTier,
+          policy: context.policySnapshot ?? {
+            trustLevel: 'Assistant',
+            autonomyPolicy: 'ask_for_mutations',
+            approvalMode: 'smart',
+            toolMetadataVersion: 'runtime',
+            sandboxPolicy: { roots: [context.cwd ?? process.cwd()], deny: [] },
+            networkPolicy: {},
+            pluginGrants: [],
+            mcpGrants: [],
+            workspaceOverrides: {},
+            jobOverrides: {},
+          },
+        });
+        const authorization = context.actionAuthority.authorizeExecution({
+          approvalId: durableApproval.approvalId,
+          jobId: jobContext.jobId,
+          attemptId: jobContext.attemptId,
+          generation: jobContext.generation,
+          fenceToken: jobContext.fenceToken,
+          toolCallId: durableApproval.toolCallId,
+          actionDigest: current.actionDigest,
+          policySnapshotId: current.policySnapshot.policySnapshotId,
+        });
+        if (!authorization.authorized) {
+          return finish({
+            id: call.id,
+            name: call.name,
+            result: null,
+            error: `Approved action rejected before execution: ${authorization.reason ?? 'binding conflict'}`,
+          }, 'blocked');
+        }
+      }
+
       let result: unknown;
       const executionAttempt = {
         attempt: context.attempt ?? 1,
@@ -761,8 +938,8 @@ export class ToolRegistry {
           result = await sliced.withToolSpan(
             sliced.db,
             { toolName: call.name, inputFingerprint: inputFp, sideEffectClass: sideEffect },
-            async (childCtx) => sliced.runToolWithHooks(
-              {
+            async (childCtx) => {
+              const hookOptions = {
                 db:         sliced.db,
                 toolName:   call.name,
                 toolCallId: call.id,
@@ -773,9 +950,10 @@ export class ToolRegistry {
                   spanId:       childCtx.spanId,
                   parentSpanId: childCtx.parentSpanId,
                 },
-              },
-              dispatch,
-            ),
+              };
+              const raw = await dispatch(args);
+              return sliced.runToolPostHooks(hookOptions, args, raw);
+            },
           );
         } else {
           result = await dispatch(args);
@@ -867,7 +1045,7 @@ export class ToolRegistry {
 import { getCurrentDaemonDb } from './daemon/bootstrap';
 import { withToolSpan, shortInputFingerprint } from './daemon/spans/spanHelpers';
 import { currentContext as _identityCurrentContext } from './identity';
-import { runToolWithHooks, HookBlockedError } from './hooks/toolHookGate';
+import { runToolPostHooks, runToolPreHooks, HookBlockedError } from './hooks/toolHookGate';
 
 function classifySideEffectForHandler(h: ToolHandler): 'read' | 'write' | 'mutating' | 'destructive' {
   if (h.riskTier === 'dangerous') return 'destructive';
@@ -879,13 +1057,25 @@ function classifySideEffectForHandler(h: ToolHandler): 'read' | 'write' | 'mutat
   return 'mutating';
 }
 
+function freezeToolArguments(args: Record<string, unknown>): Record<string, unknown> {
+  const copy = structuredClone(args);
+  const freeze = (value: unknown): void => {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) return;
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) freeze(child);
+  };
+  freeze(copy);
+  return copy;
+}
+
 interface ToolSpanShim {
   db: import('./daemon/db/connection').Db | null;
   hasContext(): boolean;
   classifySideEffect(handler: ToolHandler): 'read' | 'write' | 'mutating' | 'destructive';
   fingerprint(args: Record<string, unknown>): string;
   withToolSpan: typeof withToolSpan;
-  runToolWithHooks: typeof runToolWithHooks;
+  runToolPostHooks: typeof runToolPostHooks;
+  runToolPreHooks: typeof runToolPreHooks;
 }
 const _toolSpanShim: ToolSpanShim = {
   get db()            { return getCurrentDaemonDb(); },
@@ -893,6 +1083,7 @@ const _toolSpanShim: ToolSpanShim = {
   classifySideEffect: classifySideEffectForHandler,
   fingerprint:        shortInputFingerprint,
   withToolSpan,
-  runToolWithHooks,
+  runToolPostHooks,
+  runToolPreHooks,
 };
 function sliceSpanShim(): ToolSpanShim { return _toolSpanShim; }

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -62,6 +62,7 @@ import { classifyBrowserAction } from './browserState';
 import { pwBrowserStatus, pwDialogPendingTier } from '../playwrightBridge';
 import type { SkillLoader } from './skillLoader';
 import type { BundledManifest } from './skillBundledManifest';
+import { executeWithDurableToolCall } from './daemon/jobExecutionContext';
 
 /**
  * Risk profile for a tool. Used by the Phase 9 approval engine to decide
@@ -719,7 +720,14 @@ export class ToolRegistry {
       // only when a signal is present, so a normal call allocates nothing and a
       // child agent's own signal never leaks into the shared session context.
       const dispatch = async (a: Record<string, unknown>): Promise<unknown> =>
-        handler.execute(a, signal ? { ...context, signal } : context);
+        executeWithDurableToolCall({
+          toolCallId: call.id,
+          toolName: call.name,
+          args: a,
+          riskTier: handler.riskTier ?? (handler.mutates === false ? 'safe' : 'caution'),
+          mutates: handler.mutates ?? true,
+          execute: () => handler.execute(a, signal ? { ...context, signal } : context),
+        });
 
       // ── P1B-2B — FAIL-SAFE pre-state snapshot (shadow, non-authoritative) ──
       // Post-approval, pre-spawn. In its OWN try/catch, independent of the

--- a/core/v4/usageLedger.ts
+++ b/core/v4/usageLedger.ts
@@ -53,6 +53,9 @@ export interface ProviderAttemptRecord {
   readonly sessionId: string | null;
   readonly taskId: string | null;
   readonly runId: string | null;
+  readonly jobId?: string | null;
+  readonly attemptId?: string | null;
+  readonly attemptGeneration?: number | null;
   readonly entryPoint: string;
   readonly purpose: ProviderAttemptPurpose;
   readonly providerConfigured: string | null;
@@ -108,6 +111,8 @@ export interface ProviderAttemptQuery {
   sessionId?: string;
   taskId?: string;
   runId?: string;
+  jobId?: string;
+  attemptId?: string;
   provider?: string;
   model?: string;
   purpose?: ProviderAttemptPurpose;
@@ -161,6 +166,9 @@ interface ProviderAttemptRow {
   session_id: string | null;
   task_id: string | null;
   run_id: string | null;
+  job_id: string | null;
+  attempt_id: string | null;
+  attempt_generation: number | null;
   entry_point: string;
   purpose: ProviderAttemptPurpose;
   provider_configured: string | null;
@@ -210,7 +218,7 @@ interface ProviderAttemptRow {
   loaded_skill_tokens: number | null;
 }
 
-const LEDGER_SCHEMA_VERSION = 2;
+const LEDGER_SCHEMA_VERSION = 3;
 
 const LEDGER_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS provider_attempt_ledger_meta (
@@ -224,6 +232,9 @@ CREATE TABLE IF NOT EXISTS provider_attempts (
   session_id TEXT,
   task_id TEXT,
   run_id TEXT,
+  job_id TEXT,
+  attempt_id TEXT,
+  attempt_generation INTEGER,
   entry_point TEXT NOT NULL,
   purpose TEXT NOT NULL,
   provider_configured TEXT,
@@ -289,7 +300,8 @@ CREATE INDEX IF NOT EXISTS idx_provider_attempts_purpose_status
 
 const INSERT_SQL = `
 INSERT INTO provider_attempts (
-  call_id, parent_call_id, session_id, task_id, run_id, entry_point, purpose,
+  call_id, parent_call_id, session_id, task_id, run_id,
+  job_id, attempt_id, attempt_generation, entry_point, purpose,
   provider_configured, provider_actual, model_configured, model_actual,
   api_mode, transport, attempt_index, fallback_index,
   credential_label_redacted, status, error_class, started_at, completed_at,
@@ -305,7 +317,8 @@ INSERT INTO provider_attempts (
   memory_tokens, user_profile_tokens, project_memory_tokens,
   skill_index_tokens, loaded_skill_tokens
 ) VALUES (
-  @call_id, @parent_call_id, @session_id, @task_id, @run_id, @entry_point, @purpose,
+  @call_id, @parent_call_id, @session_id, @task_id, @run_id,
+  @job_id, @attempt_id, @attempt_generation, @entry_point, @purpose,
   @provider_configured, @provider_actual, @model_configured, @model_actual,
   @api_mode, @transport, @attempt_index, @fallback_index,
   @credential_label_redacted, @status, @error_class, @started_at, @completed_at,
@@ -374,6 +387,51 @@ export class ProviderAttemptLedger {
     const { sql, params } = buildQuery(query);
     const rows = this.db.prepare(sql).all(...params) as ProviderAttemptRow[];
     return Object.freeze(rows.map(rowToRecord));
+  }
+
+  /**
+   * Fill a missing durable identity from an authoritative Job/Attempt mapping.
+   * Existing non-null linkage is never overwritten, so reconciliation cannot
+   * fabricate or move a physical provider attempt between Jobs.
+   */
+  reconcileJobLinkage(link: {
+    taskId?: string | null;
+    runId?: string | number | null;
+    jobId: string;
+    attemptId: string;
+    attemptGeneration: number;
+  }): number {
+    const identityClauses: string[] = [];
+    const identityParams: Array<string | number> = [];
+    if (link.taskId) {
+      identityClauses.push('task_id = ?');
+      identityParams.push(link.taskId);
+    }
+    if (link.runId !== undefined && link.runId !== null) {
+      identityClauses.push('run_id = ?');
+      identityParams.push(String(link.runId));
+    }
+    if (identityClauses.length === 0) return 0;
+    const result = this.db.prepare(
+      `UPDATE provider_attempts
+          SET job_id = COALESCE(job_id, ?),
+              attempt_id = COALESCE(attempt_id, ?),
+              attempt_generation = COALESCE(attempt_generation, ?)
+        WHERE ${identityClauses.join(' AND ')}
+          AND (job_id IS NULL OR job_id = ?)
+          AND (attempt_id IS NULL OR attempt_id = ?)
+          AND (attempt_generation IS NULL OR attempt_generation = ?)
+          AND (job_id IS NULL OR attempt_id IS NULL OR attempt_generation IS NULL)`,
+    ).run(
+      link.jobId,
+      link.attemptId,
+      link.attemptGeneration,
+      ...identityParams,
+      link.jobId,
+      link.attemptId,
+      link.attemptGeneration,
+    );
+    return result.changes;
   }
 
   project(query: UsageProjectionQuery = {}): ProviderUsageProjection {
@@ -483,10 +541,17 @@ function ensureLedgerColumns(db: DatabaseType): void {
     ['project_memory_tokens', 'INTEGER'],
     ['skill_index_tokens', 'INTEGER'],
     ['loaded_skill_tokens', 'INTEGER'],
+    ['job_id', 'TEXT'],
+    ['attempt_id', 'TEXT'],
+    ['attempt_generation', 'INTEGER'],
   ];
   for (const [name, sqlType] of additions) {
     if (!existing.has(name)) db.exec(`ALTER TABLE provider_attempts ADD COLUMN ${name} ${sqlType}`);
   }
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_provider_attempts_job_attempt
+      ON provider_attempts(job_id, attempt_id, started_at)
+  `);
 }
 
 function normalizeRecord(record: ProviderAttemptRecord): ProviderAttemptRecord {
@@ -513,6 +578,8 @@ function buildQuery(query: ProviderAttemptQuery): { sql: string; params: unknown
   equal('session_id', query.sessionId);
   equal('task_id', query.taskId);
   equal('run_id', query.runId);
+  equal('job_id', query.jobId);
+  equal('attempt_id', query.attemptId);
   equal('purpose', query.purpose);
   equal('status', query.status);
   if (query.provider !== undefined) {
@@ -550,6 +617,9 @@ function recordToRow(record: ProviderAttemptRecord): ProviderAttemptRow {
     session_id: record.sessionId,
     task_id: record.taskId,
     run_id: record.runId,
+    job_id: record.jobId ?? null,
+    attempt_id: record.attemptId ?? null,
+    attempt_generation: record.attemptGeneration ?? null,
     entry_point: record.entryPoint,
     purpose: record.purpose,
     provider_configured: record.providerConfigured,
@@ -607,6 +677,9 @@ function rowToRecord(row: ProviderAttemptRow): ProviderAttemptRecord {
     sessionId: row.session_id,
     taskId: row.task_id,
     runId: row.run_id,
+    jobId: row.job_id,
+    attemptId: row.attempt_id,
+    attemptGeneration: row.attempt_generation,
     entryPoint: row.entry_point,
     purpose: row.purpose,
     providerConfigured: row.provider_configured,

--- a/core/v4/workbench/bridgeServer.ts
+++ b/core/v4/workbench/bridgeServer.ts
@@ -67,6 +67,9 @@ export interface EnqueueResult {
   accepted:        boolean;
   triggerEventId?: number;
   duplicate?:      boolean;
+  jobId?:          string;
+  attemptId?:      string;
+  runId?:          number;
 }
 
 /** Optional WRITE port — enqueues a task onto the daemon's safe job path. The
@@ -430,7 +433,14 @@ export function startWorkbenchBridge(opts: WorkbenchBridgeOptions): Promise<Work
       const sessionId = typeof body?.sessionId === 'string' ? body.sessionId : undefined;
       try {
         const result = opts.enqueue.enqueue({ message, sessionId });
-        sendJson(res, 202, { accepted: result.accepted, triggerEventId: result.triggerEventId, duplicate: result.duplicate ?? false });
+        sendJson(res, 202, {
+          accepted: result.accepted,
+          triggerEventId: result.triggerEventId,
+          duplicate: result.duplicate ?? false,
+          job_id: result.jobId,
+          attempt_id: result.attemptId,
+          run_id: result.runId,
+        });
       } catch (e) {
         log(`enqueue failed: ${(e as Error).message}`);
         sendJson(res, 500, { error: 'enqueue failed' });

--- a/core/v4/workbench/bridgeServer.ts
+++ b/core/v4/workbench/bridgeServer.ts
@@ -97,6 +97,44 @@ export interface TaskCanceller {
   cancel(runId: number): CancelResult;
 }
 
+export interface TaskInputReceiver {
+  receive(runId: number, content: string, idempotencyKey?: string): {
+    accepted: boolean;
+    runId: number;
+    inputId?: string;
+    duplicate?: boolean;
+  };
+}
+
+export interface TaskController {
+  pause(runId: number, idempotencyKey?: string): {
+    accepted: boolean;
+    applied: boolean;
+    runId: number;
+    controlId?: string;
+  };
+  resume(runId: number, idempotencyKey?: string): {
+    accepted: boolean;
+    runId: number;
+    attemptId?: string;
+    generation?: number;
+  };
+}
+
+export interface ApprovalDecider {
+  decide(approvalId: string, decision: 'approved' | 'denied' | 'cancelled'): {
+    accepted: boolean;
+    approvalId: string;
+    state?: string;
+  };
+}
+
+export interface DurableJobReader {
+  getJob(jobId: string): unknown | null;
+  getAttempt(attemptId: string): unknown | null;
+  listEvents(jobId: string, afterSequence?: number): unknown[];
+}
+
 export interface WorkbenchBridgeOptions {
   /** Read port over the shared run-event store (a RunStore satisfies this). */
   reader:      RunEventReader;
@@ -107,6 +145,10 @@ export interface WorkbenchBridgeOptions {
   enqueue?:    TaskEnqueuer;
   /** Optional STEER port for the stop button. Absent → cancel is 503. */
   cancel?:     TaskCanceller;
+  input?:      TaskInputReceiver;
+  control?:    TaskController;
+  approval?:   ApprovalDecider;
+  jobs?:       DurableJobReader;
   /** Per-launch local write token. REQUIRED for any write to execute — POST
    *  /api/tasks must present it (x-workbench-token / Bearer). Absent → all
    *  writes are refused. Injected into the served page so only the local
@@ -273,6 +315,15 @@ export function startWorkbenchBridge(opts: WorkbenchBridgeOptions): Promise<Work
     if (req.method === 'POST' && url.pathname === '/api/tasks') { handlePostTask(req, res); return; }
     const cancelMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)\/cancel$/);
     if (req.method === 'POST' && cancelMatch) { handleCancelTask(req, res, cancelMatch[1]); return; }
+    const inputMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)\/input$/);
+    if (req.method === 'POST' && inputMatch) { handleTaskInput(req, res, inputMatch[1]); return; }
+    const controlMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)\/(pause|resume)$/);
+    if (req.method === 'POST' && controlMatch) {
+      handleTaskControl(req, res, controlMatch[1], controlMatch[2] as 'pause' | 'resume');
+      return;
+    }
+    const approvalMatch = url.pathname.match(/^\/api\/approvals\/([^/]+)\/decision$/);
+    if (req.method === 'POST' && approvalMatch) { handleApprovalDecision(req, res, approvalMatch[1]); return; }
     if (req.method !== 'GET') { sendJson(res, 405, { error: 'method not allowed' }); return; }
 
     // The built-in self-contained dark page. The per-launch write token is
@@ -309,6 +360,29 @@ export function startWorkbenchBridge(opts: WorkbenchBridgeOptions): Promise<Work
       return;
     }
 
+    const jobEventsMatch = url.pathname.match(/^\/api\/jobs\/([^/]+)\/events$/);
+    if (jobEventsMatch) {
+      if (!opts.jobs) { sendJson(res, 503, { error: 'durable Job query unavailable' }); return; }
+      const afterRaw = Number(url.searchParams.get('after') ?? 0);
+      const after = Number.isFinite(afterRaw) && afterRaw >= 0 ? Math.floor(afterRaw) : 0;
+      sendJson(res, 200, opts.jobs.listEvents(decodeURIComponent(jobEventsMatch[1]), after));
+      return;
+    }
+    const jobMatch = url.pathname.match(/^\/api\/jobs\/([^/]+)$/);
+    if (jobMatch) {
+      if (!opts.jobs) { sendJson(res, 503, { error: 'durable Job query unavailable' }); return; }
+      const job = opts.jobs.getJob(decodeURIComponent(jobMatch[1]));
+      sendJson(res, job ? 200 : 404, job ?? { error: 'job not found' });
+      return;
+    }
+    const attemptMatch = url.pathname.match(/^\/api\/attempts\/([^/]+)$/);
+    if (attemptMatch) {
+      if (!opts.jobs) { sendJson(res, 503, { error: 'durable Attempt query unavailable' }); return; }
+      const attempt = opts.jobs.getAttempt(decodeURIComponent(attemptMatch[1]));
+      sendJson(res, attempt ? 200 : 404, attempt ?? { error: 'attempt not found' });
+      return;
+    }
+
     // The dashboard's live feed: ALL recent events across sessions/runs, streamed
     // as plain SSE `message` frames (name is in the data) so one EventSource with
     // a single onmessage handler renders everything.
@@ -341,7 +415,7 @@ export function startWorkbenchBridge(opts: WorkbenchBridgeOptions): Promise<Work
 
     sendJson(res, 404, {
       error: 'not found',
-      endpoints: ['GET /', 'GET /plain', 'GET /api/health', 'GET /api/sessions', 'GET /api/events', 'GET /api/runs/:runId/events', 'GET /api/sessions/:sessionId/events', 'POST /api/tasks', 'POST /api/tasks/:runId/cancel'],
+      endpoints: ['GET /', 'GET /plain', 'GET /api/health', 'GET /api/sessions', 'GET /api/events', 'GET /api/runs/:runId/events', 'GET /api/sessions/:sessionId/events', 'POST /api/tasks', 'POST /api/tasks/:runId/cancel', 'POST /api/tasks/:runId/input', 'POST /api/tasks/:runId/pause', 'POST /api/tasks/:runId/resume', 'POST /api/approvals/:approvalId/decision'],
     });
   });
 
@@ -465,6 +539,59 @@ export function startWorkbenchBridge(opts: WorkbenchBridgeOptions): Promise<Work
       log(`cancel failed: ${(e as Error).message}`);
       sendJson(res, 500, { error: 'cancel failed' });
     }
+  }
+
+  function handleTaskInput(req: http.IncomingMessage, res: http.ServerResponse, rawRunId: string): void {
+    if (!passesWriteGate(req, res)) return;
+    const runId = Number(decodeURIComponent(rawRunId));
+    if (!Number.isFinite(runId)) { sendJson(res, 400, { error: 'runId must be numeric' }); return; }
+    if (!opts.input) { sendJson(res, 503, { error: 'durable input unavailable' }); return; }
+    readJsonBody(req, 64 * 1024).then((body) => {
+      const content = typeof body.message === 'string' ? stripPasteMarkers(body.message) : '';
+      if (!content.trim()) { sendJson(res, 400, { error: 'body requires a non-empty "message"' }); return; }
+      const key = typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined;
+      const result = opts.input!.receive(runId, content, key);
+      sendJson(res, result.accepted ? 202 : 409, {
+        accepted: result.accepted,
+        runId,
+        input_id: result.inputId,
+        duplicate: result.duplicate ?? false,
+      });
+    }).catch(() => sendJson(res, 400, { error: 'invalid JSON body' }));
+  }
+
+  function handleTaskControl(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    rawRunId: string,
+    kind: 'pause' | 'resume',
+  ): void {
+    if (!passesWriteGate(req, res)) return;
+    const runId = Number(decodeURIComponent(rawRunId));
+    if (!Number.isFinite(runId)) { sendJson(res, 400, { error: 'runId must be numeric' }); return; }
+    if (!opts.control) { sendJson(res, 503, { error: `${kind} unavailable` }); return; }
+    readJsonBody(req, 16 * 1024).then((body) => {
+      const key = typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined;
+      const result = kind === 'pause'
+        ? opts.control!.pause(runId, key)
+        : opts.control!.resume(runId, key);
+      sendJson(res, result.accepted ? 202 : 409, result);
+    }).catch(() => sendJson(res, 400, { error: 'invalid JSON body' }));
+  }
+
+  function handleApprovalDecision(req: http.IncomingMessage, res: http.ServerResponse, rawApprovalId: string): void {
+    if (!passesWriteGate(req, res)) return;
+    if (!opts.approval) { sendJson(res, 503, { error: 'approval decisions unavailable' }); return; }
+    const approvalId = decodeURIComponent(rawApprovalId);
+    readJsonBody(req, 16 * 1024).then((body) => {
+      const decision = body.decision;
+      if (decision !== 'approved' && decision !== 'denied' && decision !== 'cancelled') {
+        sendJson(res, 400, { error: 'decision must be approved, denied, or cancelled' });
+        return;
+      }
+      const result = opts.approval!.decide(approvalId, decision);
+      sendJson(res, result.accepted ? 202 : 409, result);
+    }).catch(() => sendJson(res, 400, { error: 'invalid JSON body' }));
   }
 
   return new Promise<WorkbenchBridge>((resolve, reject) => {

--- a/core/v4/workbench/jobCommands.ts
+++ b/core/v4/workbench/jobCommands.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+
+import type { Db } from '../daemon/db/connection';
+import type { JobEngine } from '../daemon/jobEngine';
+import type { RunStore } from '../daemon/runStore';
+import type { TriggerBus } from '../daemon/triggerBus';
+
+export function createWorkbenchJobCommands(options: {
+  db: Db;
+  triggerBus: TriggerBus;
+  jobEngine: JobEngine;
+  runStore: RunStore;
+  instanceId: string;
+  idFactory?: () => string;
+}) {
+  const nextId = options.idFactory ?? randomUUID;
+  const enqueueTx = options.db.transaction((task: { message: string; sessionId?: string }) => {
+    const idempotencyKey = nextId();
+    const fingerprint = createHash('sha256').update(task.message).digest('hex');
+    const trigger = options.triggerBus.insert({
+      source: 'manual', sourceKey: 'workbench-web', idempotencyKey,
+      payload: { body: { prompt: task.message, source: 'workbench-web' }, sessionId: task.sessionId },
+    });
+    const admission = options.jobEngine.submitJob({
+      entryPoint: 'workbench', source: 'workbench',
+      sessionId: task.sessionId ?? `workbench:${idempotencyKey}`,
+      instanceId: options.instanceId,
+      idempotencyNamespace: 'workbench-web', idempotencyKey,
+      requestFingerprint: fingerprint,
+      goal: `Workbench request ${fingerprint.slice(0, 16)}`,
+      triggerEventId: trigger.id,
+    });
+    options.db.prepare('UPDATE trigger_events SET payload_json = ? WHERE id = ?').run(JSON.stringify({
+      body: { prompt: task.message, source: 'workbench-web' },
+      sessionId: task.sessionId,
+      durable_job: {
+        job_id: admission.jobId,
+        attempt_id: admission.attemptId,
+        run_id: admission.runId,
+      },
+    }), trigger.id);
+    return { trigger, admission };
+  }).immediate;
+
+  const finalRun = new Set(['completed', 'failed', 'cancelled', 'interrupted']);
+  return {
+    enqueue: {
+      enqueue(task: { message: string; sessionId?: string }) {
+        const accepted = enqueueTx(task);
+        return {
+          accepted: true,
+          triggerEventId: accepted.trigger.id,
+          duplicate: !accepted.trigger.inserted,
+          jobId: accepted.admission.jobId,
+          attemptId: accepted.admission.attemptId,
+          runId: accepted.admission.runId,
+        };
+      },
+    },
+    cancel: {
+      cancel(runId: number): { accepted: boolean; runId: number; alreadyFinal?: boolean } {
+        const run = options.runStore.get(runId);
+        if (!run) return { accepted: false, runId };
+        if (finalRun.has(String(run.status))) return { accepted: true, runId, alreadyFinal: true };
+        if (run.taskId && options.jobEngine.getJob(run.taskId)) {
+          const result = options.jobEngine.cancelJob({
+            jobId: run.taskId,
+            reason: 'stopped from workbench web',
+            producer: 'workbench',
+            eventIdempotencyKey: `workbench-cancel:${run.taskId}`,
+          });
+          if (!result.applied && result.conflict === 'terminal_state') {
+            return { accepted: true, runId, alreadyFinal: true };
+          }
+          if (!result.applied && !result.duplicate) return { accepted: false, runId };
+          try {
+            options.runStore.emitEvent(runId, 'task_cancelled', {
+              source: 'workbench-web', reason: 'stopped from dashboard',
+            });
+          } catch { /* compatibility projection is best-effort */ }
+        } else {
+          options.runStore.setStatus(runId, 'cancelled', { finishReason: 'stopped from workbench web' });
+          options.runStore.emitEvent(runId, 'task_cancelled', {
+            source: 'workbench-web', reason: 'stopped from dashboard',
+          });
+        }
+        return { accepted: true, runId };
+      },
+    },
+  };
+}

--- a/core/v4/workbench/jobCommands.ts
+++ b/core/v4/workbench/jobCommands.ts
@@ -6,7 +6,9 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import type { Db } from '../daemon/db/connection';
+import { createActionAuthority, type ActionAuthority } from '../actionAuthority';
 import type { JobEngine } from '../daemon/jobEngine';
+import { createJobControlAuthority, type JobControlAuthority } from '../daemon/jobControlAuthority';
 import type { RunStore } from '../daemon/runStore';
 import type { TriggerBus } from '../daemon/triggerBus';
 
@@ -16,8 +18,12 @@ export function createWorkbenchJobCommands(options: {
   jobEngine: JobEngine;
   runStore: RunStore;
   instanceId: string;
+  controlAuthority?: JobControlAuthority;
+  actionAuthority?: ActionAuthority;
   idFactory?: () => string;
 }) {
+  const controlAuthority = options.controlAuthority ?? createJobControlAuthority({ db: options.db, jobEngine: options.jobEngine });
+  const actionAuthority = options.actionAuthority ?? createActionAuthority({ db: options.db, jobEngine: options.jobEngine });
   const nextId = options.idFactory ?? randomUUID;
   const enqueueTx = options.db.transaction((task: { message: string; sessionId?: string }) => {
     const idempotencyKey = nextId();
@@ -48,6 +54,14 @@ export function createWorkbenchJobCommands(options: {
   }).immediate;
 
   const finalRun = new Set(['completed', 'failed', 'cancelled', 'interrupted']);
+  const activeTarget = (runId: number) => {
+    const run = options.runStore.get(runId);
+    if (!run?.taskId) return null;
+    const job = options.jobEngine.getJob(run.taskId);
+    const attempt = job?.activeAttemptId ? options.jobEngine.getAttempt(job.activeAttemptId) : null;
+    if (!job || !attempt) return null;
+    return { run, job, attempt };
+  };
   return {
     enqueue: {
       enqueue(task: { message: string; sessionId?: string }) {
@@ -68,15 +82,17 @@ export function createWorkbenchJobCommands(options: {
         if (!run) return { accepted: false, runId };
         if (finalRun.has(String(run.status))) return { accepted: true, runId, alreadyFinal: true };
         if (run.taskId && options.jobEngine.getJob(run.taskId)) {
-          const result = options.jobEngine.cancelJob({
+          const attempt = options.jobEngine.getAttempt(options.jobEngine.getJob(run.taskId)?.activeAttemptId ?? '');
+          const result = controlAuthority.commands.request({
             jobId: run.taskId,
+            attemptId: attempt?.id,
+            generation: attempt?.generation,
+            kind: 'cancel',
             reason: 'stopped from workbench web',
-            producer: 'workbench',
-            eventIdempotencyKey: `workbench-cancel:${run.taskId}`,
+            source: 'workbench',
+            idempotencyNamespace: 'workbench-control',
+            idempotencyKey: `cancel:${run.taskId}`,
           });
-          if (!result.applied && result.conflict === 'terminal_state') {
-            return { accepted: true, runId, alreadyFinal: true };
-          }
           if (!result.applied && !result.duplicate) return { accepted: false, runId };
           try {
             options.runStore.emitEvent(runId, 'task_cancelled', {
@@ -90,6 +106,102 @@ export function createWorkbenchJobCommands(options: {
           });
         }
         return { accepted: true, runId };
+      },
+    },
+    input: {
+      receive(runId: number, content: string, idempotencyKey = nextId()) {
+        const target = activeTarget(runId);
+        if (!target) return { accepted: false, runId };
+        const received = controlAuthority.inputs.receive({
+          jobId: target.job.id,
+          targetAttemptId: target.attempt.id,
+          targetGeneration: target.attempt.generation,
+          sessionId: target.run.sessionId ?? `workbench:${target.job.id}`,
+          channelId: 'workbench',
+          source: 'workbench',
+          kind: 'message',
+          content,
+          idempotencyNamespace: 'workbench-input',
+          idempotencyKey,
+        });
+        return {
+          accepted: true,
+          runId,
+          jobId: target.job.id,
+          attemptId: target.attempt.id,
+          inputId: received.record.inputId,
+          duplicate: received.duplicate,
+        };
+      },
+    },
+    control: {
+      pause(runId: number, idempotencyKey = nextId()) {
+        const target = activeTarget(runId);
+        if (!target) return { accepted: false, applied: false, runId };
+        const result = controlAuthority.commands.request({
+          jobId: target.job.id,
+          attemptId: target.attempt.id,
+          generation: target.attempt.generation,
+          kind: 'pause',
+          source: 'workbench',
+          reason: 'paused from workbench',
+          idempotencyNamespace: 'workbench-control',
+          idempotencyKey,
+        });
+        return { accepted: true, applied: result.applied, runId, controlId: result.controlId };
+      },
+      applyPauseBoundary(runId: number) {
+        const run = options.runStore.get(runId);
+        if (!run?.taskId) return { accepted: false, applied: false };
+        const result = controlAuthority.commands.applyPendingAtBoundary({ jobId: run.taskId });
+        return { accepted: true, applied: result.applied };
+      },
+      resume(runId: number, idempotencyKey = nextId()) {
+        const run = options.runStore.get(runId);
+        if (!run?.taskId) return { accepted: false, runId };
+        const resumed = controlAuthority.commands.resume({
+          jobId: run.taskId,
+          source: 'workbench',
+          instanceId: options.instanceId,
+          idempotencyNamespace: 'workbench-control',
+          idempotencyKey,
+        });
+        const job = options.jobEngine.getJob(run.taskId)!;
+        const trigger = options.triggerBus.insert({
+          source: 'manual',
+          sourceKey: `workbench-resume:${run.taskId}`,
+          idempotencyKey: `resume:${idempotencyKey}`,
+          payload: {
+            body: { prompt: job.goal, source: 'workbench-resume' },
+            sessionId: job.sessionId,
+            durable_job: {
+              job_id: job.id,
+              attempt_id: resumed.attemptId,
+              run_id: resumed.runId,
+            },
+          },
+        });
+        options.db.prepare('UPDATE runs SET trigger_event_id = ? WHERE attempt_id = ?')
+          .run(trigger.id, resumed.attemptId);
+        return { accepted: true, runId, triggerEventId: trigger.id, ...resumed };
+      },
+    },
+    approval: {
+      decide(approvalId: string, decision: 'approved' | 'denied' | 'cancelled') {
+        const record = actionAuthority.get(approvalId);
+        if (!record) return { accepted: false, approvalId };
+        const decided = actionAuthority.decide({
+          approvalId,
+          jobId: record.jobId,
+          attemptId: record.attemptId,
+          generation: record.generation,
+          actionDigest: record.actionDigest,
+          policySnapshotId: record.policySnapshotId,
+          decision,
+          decidedBy: 'user',
+          decisionChannel: 'workbench',
+        });
+        return { accepted: true, approvalId, state: decided.state };
       },
     },
   };

--- a/providers/v4/providerAttemptAccounting.ts
+++ b/providers/v4/providerAttemptAccounting.ts
@@ -160,6 +160,9 @@ export function beginPhysicalProviderAttempt(
       runId: context?.runId === undefined || context.runId === null
         ? null
         : String(context.runId),
+      jobId: context?.jobId ?? context?.taskId ?? null,
+      attemptId: context?.attemptId ?? null,
+      attemptGeneration: context?.attemptGeneration ?? null,
       entryPoint: context?.entryPoint ?? 'unknown',
       purpose: effectivePurpose(context, metadata.attemptIndex, metadata.fallbackIndex ?? 0),
       providerConfigured: context?.providerConfigured ?? metadata.providerActual,

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -318,6 +318,9 @@ export interface ProviderCallUsageContext {
   sessionId?: string | null;
   taskId?: string | null;
   runId?: string | number | null;
+  jobId?: string | null;
+  attemptId?: string | null;
+  attemptGeneration?: number | null;
   entryPoint?: string;
   purpose?: import('../../core/v4/usageLedger').ProviderAttemptPurpose;
   providerConfigured?: string | null;

--- a/tests/v4/channels/telegramCompatibility.test.ts
+++ b/tests/v4/channels/telegramCompatibility.test.ts
@@ -170,6 +170,26 @@ describe('Telegram maintained-client compatibility', () => {
     expect(gatewayMocks.unregisterChannel).toHaveBeenCalledWith('telegram');
   });
 
+  it('waits for startup cache maintenance before shutdown completes', async () => {
+    const client = new FakeTelegramClient();
+    const adapter = new TelegramAdapter({ clientFactory: vi.fn(() => client) });
+    (adapter as any).acquireLocalLock = () => true;
+    (adapter as any).releaseLocalLock = () => undefined;
+    let releaseMaintenance!: () => void;
+    (adapter as any).runVoiceCacheJanitor = vi.fn(() => new Promise<void>((resolve) => {
+      releaseMaintenance = resolve;
+    }));
+
+    await adapter.start();
+    const stopping = adapter.stop();
+    await Promise.resolve();
+
+    expect(client.stopPolling).not.toHaveBeenCalled();
+    releaseMaintenance();
+    await stopping;
+    expect(client.stopPolling).toHaveBeenCalledWith({ cancel: true });
+  });
+
   it('handles a text update once and preserves outbound reply options', async () => {
     const client = new FakeTelegramClient();
     const { adapter } = await startAdapter(client);
@@ -289,6 +309,7 @@ describe('Telegram maintained-client compatibility', () => {
     expect(entries.join('\n')).not.toContain(token);
     expect(entries.join('\n')).not.toContain('fixture-secret-token');
     expect(entries.join('\n')).toContain('[redacted]');
+    await adapter.stop();
   });
 });
 

--- a/tests/v4/cli/activityRegistry.test.ts
+++ b/tests/v4/cli/activityRegistry.test.ts
@@ -27,11 +27,16 @@ describe('ActivityRegistry', () => {
 
   it('pauses repainting for a modal and redraws once afterward', async () => {
     const row = handle();
+    const order: string[] = [];
+    row.resume.mockImplementation(() => { order.push('activity'); });
     const registry = new ActivityRegistry(() => row);
     registry.start('c1', 'clarify', {});
-    await registry.runModal(async () => undefined);
+    await registry.runModal(async () => undefined, {
+      beforeActivityResume: () => { order.push('footer'); },
+    });
     expect(row.pause).toHaveBeenCalledTimes(1);
     expect(row.resume).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['footer', 'activity']);
   });
 
   it('turn completion dismisses orphaned rows and empties timers', () => {

--- a/tests/v4/cli/aidenPrompt.test.ts
+++ b/tests/v4/cli/aidenPrompt.test.ts
@@ -103,7 +103,7 @@ function renderPrompt(config: {
   commands:  Array<{ name: string; aliases?: string[]; description: string; hidden?: boolean }>;
   history:   string[];
   hint?: string;
-  fixedComposer?: { update: (value: string, hint: string) => void };
+  fixedComposer?: { update: (value: string, hint: string, cursorIndex: number) => void };
 }): PromptRunner {
   activeConfig = { message: '›', ...config };
   resetHookStores();
@@ -160,7 +160,7 @@ beforeEach(async () => {
 
 describe('aidenPrompt — Bug D fix via footer rendering (v4.10 Slice 10.5)', () => {
   it('renders no transient prompt rows when Display owns the fixed composer', () => {
-    const updates: Array<{ value: string; hint: string }> = [];
+    const updates: Array<{ value: string; hint: string; cursorIndex: number }> = [];
     const runner = renderPrompt({
       commands: [
         { name: 'daemon', description: 'Manage the Aiden daemon.' },
@@ -169,7 +169,9 @@ describe('aidenPrompt — Bug D fix via footer rendering (v4.10 Slice 10.5)', ()
       history: ['draft from history'],
       hint: 'Type your message · /help · /mode',
       fixedComposer: {
-        update: (value, hint) => { updates.push({ value, hint }); },
+        update: (value, hint, cursorIndex) => {
+          updates.push({ value, hint, cursorIndex });
+        },
       },
     });
 
@@ -179,7 +181,12 @@ describe('aidenPrompt — Bug D fix via footer rendering (v4.10 Slice 10.5)', ()
     expect(updates.at(-1)).toEqual({
       value: '/d',
       hint: 'Type your message · /help · /mode',
+      cursorIndex: 2,
     });
+
+    runner.state.rl.cursor = 1;
+    runner.keypress({ name: 'left' });
+    expect(updates.at(-1)?.cursorIndex).toBe(1);
   });
 
   it('ghost text renders in the footer slot, NOT inline in the prompt line', () => {

--- a/tests/v4/cli/aidenPrompt.test.ts
+++ b/tests/v4/cli/aidenPrompt.test.ts
@@ -102,6 +102,8 @@ function renderPrompt(config: {
   message?:  string;
   commands:  Array<{ name: string; aliases?: string[]; description: string; hidden?: boolean }>;
   history:   string[];
+  hint?: string;
+  fixedComposer?: { update: (value: string, hint: string) => void };
 }): PromptRunner {
   activeConfig = { message: '›', ...config };
   resetHookStores();
@@ -157,6 +159,29 @@ beforeEach(async () => {
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe('aidenPrompt — Bug D fix via footer rendering (v4.10 Slice 10.5)', () => {
+  it('renders no transient prompt rows when Display owns the fixed composer', () => {
+    const updates: Array<{ value: string; hint: string }> = [];
+    const runner = renderPrompt({
+      commands: [
+        { name: 'daemon', description: 'Manage the Aiden daemon.' },
+        { name: 'doctor', description: 'Diagnose Aiden setup.' },
+      ],
+      history: ['draft from history'],
+      hint: 'Type your message · /help · /mode',
+      fixedComposer: {
+        update: (value, hint) => { updates.push({ value, hint }); },
+      },
+    });
+
+    runner.type('/d');
+
+    expect(runner.lastRender()).toEqual({ line: '', footer: undefined });
+    expect(updates.at(-1)).toEqual({
+      value: '/d',
+      hint: 'Type your message · /help · /mode',
+    });
+  });
+
   it('ghost text renders in the footer slot, NOT inline in the prompt line', () => {
     const runner = renderPrompt({
       commands: [{ name: 'daemon', description: 'Manage the Aiden daemon.' }],

--- a/tests/v4/cli/aidenPromptFooterGhost.test.ts
+++ b/tests/v4/cli/aidenPromptFooterGhost.test.ts
@@ -76,7 +76,7 @@ afterEach(async () => {
 });
 
 describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (PTY harness, Slice 10.5)', () => {
-  it('typing a partial slash command renders ghost on a separate row, not inline', async () => {
+  it('typing a partial slash command stays exclusively in the fixed composer row', async () => {
     const cwd       = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-bugd-cwd-'));
     const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-bugd-home-'));
     cleanupDirs.push(cwd, aidenHome);
@@ -106,19 +106,14 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (P
 
     await term.waitForPrompt({ timeoutMs: 30_000 });
 
-    // Type `/d` (no Enter). Aiden's slash-command dropdown picks up
-    // matching commands; the ghost suggestion is the tail of the
-    // top match (e.g. `aemon` for `/daemon`). The dropdown also
-    // renders below — that's expected and fine.
+    // Type `/d` without submitting. In fixed-bottom-region mode the
+    // Display-owned composer is the only prompt renderer; Inquirer's
+    // ghost, helper, and dropdown footer must not create another row.
     term.type('/d');
 
-    // Wait until the rendered frame stabilises with a recognisable
-    // ghost suggestion or dropdown row. We look for any match of
-    // `aemon` (from `/daemon`) OR `octor` (from `/doctor`) somewhere
-    // in the stream — either confirms the ghost / dropdown surfaced.
     await term.waitFor(
-      (plain) => /aemon|octor/.test(plain),
-      { timeoutMs: 10_000, label: 'ghost-or-dropdown render' },
+      (plain) => plain.includes('/d'),
+      { timeoutMs: 10_000, label: 'fixed composer draft' },
     );
 
     // ── Assertions ────────────────────────────────────────────────
@@ -126,22 +121,18 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (P
     screen.write(term.raw());
     const lines = screen.lines();
 
-    // Find the prompt line — the one containing `▲ /d`.
-    const promptLineIdx = lines.findIndex((l) => l.includes('▲') && l.includes('/d'));
-    expect(promptLineIdx).toBeGreaterThanOrEqual(0);
-    const promptLine = lines[promptLineIdx];
+    const composerLine = lines.at(-2) ?? '';
+    const statusLine = lines.at(-1) ?? '';
+    expect(composerLine).toContain('▲');
+    expect(composerLine).toContain('/d');
+    expect(statusLine).toContain('groq');
+    expect(statusLine).toContain('ctx');
 
-    // ASSERTION 1: prompt line must NOT contain ghost-suggestion text
-    // inline. The ghost for `/d` should be the tail of the top
-    // matching slash command — its presence on the prompt line
-    // proves the pre-Slice-10.5 inline assembly is still in effect.
-    expect(promptLine).not.toContain('aemon');
-
-    // ASSERTION 2: the ghost suggestion (or dropdown row) remains on a
-    // separate physical row. The fixed composer is anchored below transient
-    // dropdown content, so rendered-screen position is authoritative.
-    const nonPromptLines = lines.filter((_line, index) => index !== promptLineIdx);
-    expect(nonPromptLines.some((line) => /aemon|octor/.test(line))).toBe(true);
+    const rowsAboveFooter = lines.slice(0, -2);
+    expect(rowsAboveFooter.some((line) => line.trim() === '/d')).toBe(false);
+    expect(rowsAboveFooter.some((line) => line.includes('Type your message'))).toBe(false);
+    expect(rowsAboveFooter.some((line) => /aemon|octor/.test(line))).toBe(false);
+    expect(rowsAboveFooter.some((line) => line.trimStart().startsWith('▲'))).toBe(false);
 
     // Clean exit via Ctrl+C — same rationale as the Slice 10.4 smoke.
     term.ctrl('c');

--- a/tests/v4/cli/aidenPromptFooterGhost.test.ts
+++ b/tests/v4/cli/aidenPromptFooterGhost.test.ts
@@ -49,6 +49,7 @@ import path from 'node:path';
 import os from 'node:os';
 
 import { spawnAidenTerm, type AidenTerm } from '../harness/aidenTerm';
+import { TerminalScreen } from '../harness/terminalScreen';
 
 // The PTY regression layer below is a genuinely-interactive test: it
 // spawns a real Aiden under a pseudo-terminal and waits for the
@@ -75,7 +76,7 @@ afterEach(async () => {
 });
 
 describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (PTY harness, Slice 10.5)', () => {
-  it('typing a partial slash command renders ghost in footer, NOT inline', async () => {
+  it('typing a partial slash command renders ghost on a separate row, not inline', async () => {
     const cwd       = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-bugd-cwd-'));
     const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-bugd-home-'));
     cleanupDirs.push(cwd, aidenHome);
@@ -121,8 +122,9 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (P
     );
 
     // ── Assertions ────────────────────────────────────────────────
-    const plain = term.plain();
-    const lines = plain.split('\n');
+    const screen = new TerminalScreen(120, 30);
+    screen.write(term.raw());
+    const lines = screen.lines();
 
     // Find the prompt line — the one containing `▲ /d`.
     const promptLineIdx = lines.findIndex((l) => l.includes('▲') && l.includes('/d'));
@@ -135,13 +137,11 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (P
     // proves the pre-Slice-10.5 inline assembly is still in effect.
     expect(promptLine).not.toContain('aemon');
 
-    // ASSERTION 2: the ghost suggestion (or dropdown rows including
-    // the full command name) MUST appear on a separate line below
-    // the prompt line. Scan all lines AFTER the prompt for the
-    // suggestion fragment.
-    const linesAfter = lines.slice(promptLineIdx + 1);
-    const haveGhostBelow = linesAfter.some((l) => /aemon|octor/.test(l));
-    expect(haveGhostBelow).toBe(true);
+    // ASSERTION 2: the ghost suggestion (or dropdown row) remains on a
+    // separate physical row. The fixed composer is anchored below transient
+    // dropdown content, so rendered-screen position is authoritative.
+    const nonPromptLines = lines.filter((_line, index) => index !== promptLineIdx);
+    expect(nonPromptLines.some((line) => /aemon|octor/.test(line))).toBe(true);
 
     // Clean exit via Ctrl+C — same rationale as the Slice 10.4 smoke.
     term.ctrl('c');

--- a/tests/v4/cli/aidenPromptFooterGhost.test.ts
+++ b/tests/v4/cli/aidenPromptFooterGhost.test.ts
@@ -5,43 +5,12 @@
  * Aiden — local-first agent.
  */
 /**
- * v4.10 Slice 10.5 — Bug D regression layer (PTY harness).
+ * Real-terminal regression for single ownership of the fixed composer.
+ * A partial slash command must remain inside the boxed Display-owned surface;
+ * Inquirer's prompt, helper, ghost, and dropdown output must stay suppressed.
  *
- * Two prior attempts at Bug D (cursor mis-positioning past ghost text
- * in the input prompt) shipped INERT:
- *   - v4.9.2 Slice 2 (commit 0d0668f1): inline cursorBackward escape.
- *     @inquirer/core's screen-manager.js absolute cursorTo() overrode
- *     it. Tests against the rendered string couldn't see the
- *     terminal-level effect.
- *   - v4.9.6: same shape, reframed with save/restore. Same outcome.
- *
- * Common cause of both inert ships: NO real-PTY regression layer.
- * Unit tests that inspect the returned line string can't observe what
- * the terminal actually paints because @inquirer/core mutates output
- * AFTER the prompt function returns. v4.9.1 mock-blindness pattern,
- * mirror class.
- *
- * This test fixes that gap. The Slice 10.4 node-pty harness
- * (tests/v4/harness/aidenTerm.ts) spawns a real Aiden under a real
- * pseudo-terminal and lets us observe the actual byte stream. We type
- * a partial slash command and assert two things about the rendered
- * frame:
- *
- *   1. The line containing `▲ /d` does NOT contain the ghost
- *      suggestion text (e.g. `aemon` — the tail of `/daemon`).
- *   2. The next line after the prompt line DOES contain that ghost
- *      suggestion, on its own line, dimmed.
- *
- * Path A fix (this slice): move the ghost from inline assembly into
- * the bottomContent tuple slot. Inquirer's screen-manager paints
- * bottomContent below the input line and walks the cursor back up
- * to the input line. With no embedded ghost, the cursor naturally
- * lands right after the typed value — correct by construction, no
- * library-internal coupling.
- *
- * CI cost: ~5s per run (PTY boot + Aiden init + Ctrl+C teardown).
- * Single test in this file — keep PTY tests serial; do NOT use
- * `it.concurrent`.
+ * The source-contract test at the end separately protects ghost placement on
+ * the compatibility path where Inquirer still renders the prompt.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
@@ -121,14 +90,17 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenPrompt — Bug D regression layer (P
     screen.write(term.raw());
     const lines = screen.lines();
 
-    const composerLine = lines.at(-2) ?? '';
+    const composerTop = lines.at(-4) ?? '';
+    const composerLine = lines.at(-3) ?? '';
+    const composerBottom = lines.at(-2) ?? '';
     const statusLine = lines.at(-1) ?? '';
-    expect(composerLine).toContain('▲');
+    expect(composerTop).toContain('▲ You');
     expect(composerLine).toContain('/d');
+    expect(composerBottom).toMatch(/^╰─/);
     expect(statusLine).toContain('groq');
-    expect(statusLine).toContain('ctx');
+    expect(statusLine).toContain('◉ context');
 
-    const rowsAboveFooter = lines.slice(0, -2);
+    const rowsAboveFooter = lines.slice(0, -4);
     expect(rowsAboveFooter.some((line) => line.trim() === '/d')).toBe(false);
     expect(rowsAboveFooter.some((line) => line.includes('Type your message'))).toBe(false);
     expect(rowsAboveFooter.some((line) => /aemon|octor/.test(line))).toBe(false);

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -45,7 +45,7 @@ afterEach(() => {
   else process.env.AIDEN_COMPOSER_LANE = previousLaneSetting;
 });
 
-function createDisplay(columns: number, rows = 16): {
+function createDisplay(columns: number, rows = 18): {
   display: Display;
   screen: TerminalScreen;
   stream: ScreenStream;
@@ -59,75 +59,158 @@ function createDisplay(columns: number, rows = 16): {
   return { display, screen, stream };
 }
 
-function expectFixedFooter(screen: TerminalScreen, statusNeedle: string, composerNeedle: string): void {
+function composerGeometry(screen: TerminalScreen): {
+  top: number;
+  bottom: number;
+  content: string[];
+  status: string;
+} {
   const lines = screen.lines();
-  expect(lines.at(-1)).toContain(statusNeedle);
-  expect(lines.at(-2)).toContain(composerNeedle);
-  expect(lines.slice(0, -2).filter((line) => line.includes(statusNeedle))).toHaveLength(0);
-  expect(lines.slice(0, -2).filter((line) => line.includes(composerNeedle))).toHaveLength(0);
+  const top = lines.findLastIndex((line) => line.startsWith('╭─ ▲ You'));
+  const bottom = lines.findLastIndex((line) => line.startsWith('╰─'));
+  expect(top).toBeGreaterThanOrEqual(0);
+  expect(bottom).toBeGreaterThan(top);
+  expect(bottom).toBe(lines.length - 2);
+  expect(lines.slice(top + 1, bottom).every((line) => line.startsWith('│ '))).toBe(true);
+  return {
+    top,
+    bottom,
+    content: lines.slice(top + 1, bottom),
+    status: lines.at(-1) ?? '',
+  };
 }
 
-describe.each([100, 44])('fixed two-row bottom region at %i columns', (columns) => {
-  it('keeps composer and status fixed across normal and queued submissions', () => {
+function expectExclusiveSurface(screen: TerminalScreen, statusNeedle: string): ReturnType<typeof composerGeometry> {
+  const geometry = composerGeometry(screen);
+  const lines = screen.lines();
+  expect(geometry.status).toContain('◆');
+  expect(geometry.status).toContain(statusNeedle);
+  expect(lines.slice(0, geometry.top).filter((line) => line.includes('▲ You'))).toHaveLength(0);
+  expect(lines.slice(0, geometry.top).filter((line) => line.includes(statusNeedle))).toHaveLength(0);
+  return geometry;
+}
+
+describe.each([100, 80, 44])('boxed fixed bottom region at %i columns', (columns) => {
+  it('owns empty, normal, and Unicode drafts with the hardware cursor at insertion', () => {
     delete process.env.AIDEN_COMPOSER_LANE;
     const { display, screen } = createDisplay(columns);
 
-    display.setStatusFooter('groq · selected-model · ctx 2k/32k · 4s');
-    display.setIdleComposer('', 'Type your message · /help · /mode');
-    expectFixedFooter(screen, 'groq', 'Type your message');
+    display.setStatusFooter('◆ provider · model │ ◉ context 2k/32k │ ⧖ 4s');
+    display.setIdleComposer('', 'Type your message · /help');
+    let surface = expectExclusiveSurface(screen, 'provider');
+    expect(screen.lines()[surface.top]).toContain('▲ You');
+    expect(surface.content).toHaveLength(1);
+    expect(surface.content[0]).not.toContain('Type your message');
+    expect(screen.cursorPosition()).toEqual({ row: surface.top + 1, col: 2 });
 
-    display.setIdleComposer('NORMAL ENTER', 'Type your message · /help · /mode');
-    display.submitIdleComposer('NORMAL ENTER', 'Type your message · /help · /mode');
-    expect(screen.lines().slice(0, -2).join('\n')).toContain('NORMAL ENTER');
-    expectFixedFooter(screen, 'groq', 'Type your message');
+    display.setIdleComposer('hello terminal', 'Type your message · /help', 5);
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.join('')).toContain('hello terminal');
+    expect(screen.cursorPosition().row).toBe(surface.bottom - 1);
+    expect(screen.cursorPosition().col).toBe(2 + 5);
 
-    display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
-    display.setComposer('QUEUE ONE', 'queue');
-    display.write('\n✓ queued (1 pending) · input_first\n');
-    display.setComposer('', 'queue');
-    expect(screen.lines().slice(0, -2).join('\n')).toContain('input_first');
-    expectFixedFooter(screen, 'groq', 'Enter → queue');
+    display.setIdleComposer('Unicode: नमस्ते 世界 🚀', 'Type your message · /help');
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.join('')).toContain('Unicode: नमस्ते 世界 🚀');
+    expect(screen.cursorPosition().row).toBe(surface.bottom - 1);
 
-    display.setComposer('QUEUE TWO', 'queue');
-    display.write('\n✓ queued (2 pending) · input_second\n');
-    display.setComposer('', 'queue');
-    expect(screen.lines().slice(0, -2).join('\n')).toContain('input_second');
-    expectFixedFooter(screen, 'groq', 'Enter → queue');
+    display.setIdleComposer('A世界B', 'Type your message · /help', 'A世'.length);
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.join('')).toContain('A世界B');
+    expect(screen.cursorPosition()).toEqual({
+      row: surface.bottom - 1,
+      col: 2 + 3,
+    });
   });
 
-  it('keeps tool output above the footer and restores both rows after a modal', () => {
+  it('grows upward for wrapped drafts while status remains on the final row', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(columns);
+    const draft = 'wrapped input '.repeat(12).trim();
+
+    display.setStatusFooter('◆ provider · model │ ◉ context 2k/32k │ ⧖ 8s');
+    display.setIdleComposer(draft, 'Type your message · /help');
+
+    const surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.length).toBeGreaterThan(1);
+    expect(surface.content.join(' ')).toContain('wrapped input');
+    expect(screen.lines().at(-1)).toContain('⧖');
+    expect(screen.cursorPosition().row).toBe(surface.bottom - 1);
+  });
+
+  it('labels queue mode and keeps acknowledgements above the owned surface', () => {
     delete process.env.AIDEN_COMPOSER_LANE;
     const { display, screen } = createDisplay(columns);
 
-    display.setStatusFooter('provider · model · ctx 1k/16k · 1s');
+    display.setStatusFooter('◆ provider · model │ ◉ context 1k/32k │ ⧖ 1s');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    display.setComposer('QUEUE ONE', 'queue');
+    display.write('\n✓ queued (1 pending) · input_first\n');
+    display.setComposer('QUEUE TWO', 'queue');
+
+    const surface = expectExclusiveSurface(screen, 'provider');
+    expect(screen.lines()[surface.top]).toContain('▲ You · queue mode');
+    expect(surface.content.join('')).toContain('QUEUE TWO');
+    expect(screen.lines().slice(0, surface.top).join('\n')).toContain('input_first');
+    expect(screen.lines().slice(0, surface.top).join('\n')).not.toContain('QUEUE TWO');
+  });
+
+  it('keeps streaming and tool output above the composer and restores after a modal', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(columns);
+
+    display.setStatusFooter('◆ provider · model │ ◉ context 1k/16k │ ⧖ 1s');
     display.setBusyHint('Enter → queue · Ctrl+C stop');
     const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 6' });
-    expectFixedFooter(screen, 'provider', 'Enter → queue');
+    display.write('streamed response\n');
+    let surface = expectExclusiveSurface(screen, 'provider');
+    expect(screen.lines().slice(0, surface.top).join('\n')).toContain('streamed response');
 
     display.pauseComposerSurface();
     display.write('approval prompt\n');
     display.resumeComposerSurface();
-    expectFixedFooter(screen, 'provider', 'Enter → queue');
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(screen.lines()[surface.top]).toContain('queue mode');
 
     tool.ok(6_000);
-    expectFixedFooter(screen, 'provider', 'Enter → queue');
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(screen.lines().slice(0, surface.top).join('\n')).toContain('Start-Sleep');
   });
 });
 
-describe('fixed two-row bottom region resize', () => {
-  it('preserves the complete draft and status while resizing wide to narrow and back', () => {
+describe('boxed fixed bottom region resize', () => {
+  it('makes room without overwriting the existing transcript tail', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen, stream } = createDisplay(80, 14);
+    stream.write(Array.from({ length: 8 }, (_, index) => `startup transcript ${index + 1}`).join('\n'));
+
+    display.setStatusFooter('◆ provider · model │ ◉ context 0/32k │ ⧖ 0ms');
+    display.setIdleComposer('', 'Type your message · /help');
+
+    const surface = expectExclusiveSurface(screen, 'provider');
+    const transcript = screen.lines().slice(0, surface.top).join('\n');
+    expect(transcript).toContain('startup transcript 8');
+    expect(transcript).not.toContain('startup transcr▲');
+  });
+
+  it('preserves draft, cursor, status, and single ownership across 100 → 44 → 80', () => {
     delete process.env.AIDEN_COMPOSER_LANE;
     const { display, screen, stream } = createDisplay(100);
-    const draft = 'a long draft that must survive terminal resizing exactly';
+    const draft = 'a long Unicode draft 世界 that must wrap upward and survive resizing exactly';
 
-    display.setStatusFooter('provider · selected-model · ctx 3k/32k · 9s');
-    display.setIdleComposer(draft, 'Type your message · /help · /mode');
-    expectFixedFooter(screen, 'provider', 'draft');
+    display.setStatusFooter('◆ provider · selected-model │ ◉ context 3k/32k │ ⧖ 9s');
+    display.setIdleComposer(draft, 'Type your message · /help');
+    let surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.join(' ')).toContain('Unicode draft');
 
-    stream.resize(44, 16);
-    expectFixedFooter(screen, 'provider', 'resizing exactly');
+    stream.resize(44, 18);
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.length).toBeGreaterThan(1);
+    expect(surface.content.join(' ')).toContain('survive resizing exactly');
 
-    stream.resize(100, 16);
-    expectFixedFooter(screen, 'provider', draft);
+    stream.resize(80, 18);
+    surface = expectExclusiveSurface(screen, 'provider');
+    expect(surface.content.join(' ')).toContain('Unicode draft 世界');
+    expect(screen.cursorPosition().row).toBe(surface.bottom - 1);
   });
 });

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { Writable } from 'node:stream';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+class ScreenStream extends Writable {
+  isTTY = true;
+  columns: number;
+  rows: number;
+
+  constructor(
+    readonly screen: TerminalScreen,
+    columns: number,
+    rows: number,
+  ) {
+    super({
+      write: (chunk, _encoding, callback) => {
+        screen.write(chunk);
+        callback();
+      },
+    });
+    this.columns = columns;
+    this.rows = rows;
+  }
+
+  resize(columns: number, rows: number): void {
+    this.columns = columns;
+    this.rows = rows;
+    this.screen.resize(columns, rows);
+    this.emit('resize');
+  }
+}
+
+const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
+
+afterEach(() => {
+  if (previousLaneSetting === undefined) delete process.env.AIDEN_COMPOSER_LANE;
+  else process.env.AIDEN_COMPOSER_LANE = previousLaneSetting;
+});
+
+function createDisplay(columns: number, rows = 16): {
+  display: Display;
+  screen: TerminalScreen;
+  stream: ScreenStream;
+} {
+  const screen = new TerminalScreen(columns, rows);
+  const stream = new ScreenStream(screen, columns, rows);
+  const display = new Display({
+    stdout: stream as unknown as NodeJS.WriteStream,
+    skin: new SkinEngine({ forceMono: true }),
+  });
+  return { display, screen, stream };
+}
+
+function expectFixedFooter(screen: TerminalScreen, statusNeedle: string, composerNeedle: string): void {
+  const lines = screen.lines();
+  expect(lines.at(-1)).toContain(statusNeedle);
+  expect(lines.at(-2)).toContain(composerNeedle);
+  expect(lines.slice(0, -2).filter((line) => line.includes(statusNeedle))).toHaveLength(0);
+  expect(lines.slice(0, -2).filter((line) => line.includes(composerNeedle))).toHaveLength(0);
+}
+
+describe.each([100, 44])('fixed two-row bottom region at %i columns', (columns) => {
+  it('keeps composer and status fixed across normal and queued submissions', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(columns);
+
+    display.setStatusFooter('groq · selected-model · ctx 2k/32k · 4s');
+    display.setIdleComposer('', 'Type your message · /help · /mode');
+    expectFixedFooter(screen, 'groq', 'Type your message');
+
+    display.setIdleComposer('NORMAL ENTER', 'Type your message · /help · /mode');
+    display.submitIdleComposer('NORMAL ENTER', 'Type your message · /help · /mode');
+    expect(screen.lines().slice(0, -2).join('\n')).toContain('NORMAL ENTER');
+    expectFixedFooter(screen, 'groq', 'Type your message');
+
+    display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
+    display.setComposer('QUEUE ONE', 'queue');
+    display.write('\n✓ queued (1 pending) · input_first\n');
+    display.setComposer('', 'queue');
+    expect(screen.lines().slice(0, -2).join('\n')).toContain('input_first');
+    expectFixedFooter(screen, 'groq', 'Enter → queue');
+
+    display.setComposer('QUEUE TWO', 'queue');
+    display.write('\n✓ queued (2 pending) · input_second\n');
+    display.setComposer('', 'queue');
+    expect(screen.lines().slice(0, -2).join('\n')).toContain('input_second');
+    expectFixedFooter(screen, 'groq', 'Enter → queue');
+  });
+
+  it('keeps tool output above the footer and restores both rows after a modal', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(columns);
+
+    display.setStatusFooter('provider · model · ctx 1k/16k · 1s');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 6' });
+    expectFixedFooter(screen, 'provider', 'Enter → queue');
+
+    display.pauseComposerSurface();
+    display.write('approval prompt\n');
+    display.resumeComposerSurface();
+    expectFixedFooter(screen, 'provider', 'Enter → queue');
+
+    tool.ok(6_000);
+    expectFixedFooter(screen, 'provider', 'Enter → queue');
+  });
+});
+
+describe('fixed two-row bottom region resize', () => {
+  it('preserves the complete draft and status while resizing wide to narrow and back', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen, stream } = createDisplay(100);
+    const draft = 'a long draft that must survive terminal resizing exactly';
+
+    display.setStatusFooter('provider · selected-model · ctx 3k/32k · 9s');
+    display.setIdleComposer(draft, 'Type your message · /help · /mode');
+    expectFixedFooter(screen, 'provider', 'draft');
+
+    stream.resize(44, 16);
+    expectFixedFooter(screen, 'provider', 'resizing exactly');
+
+    stream.resize(100, 16);
+    expectFixedFooter(screen, 'provider', draft);
+  });
+});

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -51,6 +51,24 @@ function quotePowerShellLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+function bottomSurface(lines: string[]): {
+  top: number;
+  content: string[];
+  status: string;
+} | null {
+  const top = lines.findLastIndex((line) => line.startsWith('╭─ ▲ You'));
+  const bottom = lines.findLastIndex((line) => line.startsWith('╰─'));
+  if (top < 0 || bottom <= top || bottom !== lines.length - 2) return null;
+  return { top, content: lines.slice(top + 1, bottom), status: lines.at(-1) ?? '' };
+}
+
+function bottomDraft(content: string[]): string {
+  return content
+    .map((line) => line.replace(/^│ ?/u, '').replace(/ ?│$/u, '').trimEnd())
+    .join('\n')
+    .trim();
+}
+
 afterEach(async () => {
   if (child) {
     try { child.kill(); } catch { /* already exited */ }
@@ -69,6 +87,7 @@ afterEach(async () => {
 describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', () => {
   it.each([
     { label: 'normal width', columns: 100 },
+    { label: 'medium width', columns: 80 },
     { label: 'narrow width', columns: 44 },
   ])('keeps idle typing exclusively inside the fixed composer at $label', async ({ columns }) => {
     const repoRoot = path.resolve(__dirname, '../../..');
@@ -115,11 +134,15 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
       },
     });
 
-    const draft = 'POWERSHELL FIXED DRAFT';
+    const initialDraft = 'POWERSHELL FIXED DRAFT';
+    const draft = 'POWERSHELL FIXED XDRAFT';
+    const insertionIndex = initialDraft.length - 'DRAFT'.length + 1;
     let output = '';
     let state = 'boot';
     let typingFrame = '';
     let restoredFrame = '';
+    let typingCursor = { row: -1, col: -1 };
+    let restoredCursor = { row: -1, col: -1 };
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error(
         `idle footer timeout (${state}):\n${screen.snapshot()}`,
@@ -131,20 +154,29 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
         if (state === 'boot' && readyCount >= 1) {
           state = 'typing';
-          typeLikeKeyboard(child!, draft, false);
+          typeLikeKeyboard(child!, initialDraft, false);
           setTimeout(() => {
-            typingFrame = screen.snapshot();
-            state = 'submitted';
-            child!.write('\r');
-          }, 750);
+            child!.write('\x1b[D'.repeat('DRAFT'.length));
+            child!.write('X');
+            setTimeout(() => {
+              typingFrame = screen.snapshot();
+              typingCursor = screen.cursorPosition();
+              state = 'submitted';
+              child!.write('\r');
+            }, 250);
+          }, 500);
         } else if (
           state === 'submitted'
           && rendered.includes('IDLE OWNER RESPONSE')
           && readyCount >= 2
         ) {
-          restoredFrame = rendered;
-          state = 'exiting';
-          typeLikeKeyboard(child!, '/exit');
+          state = 'restoring';
+          setTimeout(() => {
+            restoredFrame = screen.snapshot();
+            restoredCursor = screen.cursorPosition();
+            state = 'exiting';
+            typeLikeKeyboard(child!, '/exit');
+          }, 250);
         }
       });
       child!.onExit(({ exitCode }) => {
@@ -161,17 +193,32 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
       ['restored', restoredFrame, 'Type your message'],
     ] as const) {
       const lines = frame.split('\n');
-      expect(lines.at(-2), name).toContain(composerNeedle);
-      expect(lines.at(-1), name).toContain('custom_openai');
-      expect(lines.at(-1), name).toContain('ctx');
-      const rowsAboveFooter = lines.slice(0, -2);
+      const surface = bottomSurface(lines);
+      expect(surface, `${name}\n${frame}`).not.toBeNull();
+      if (!surface) continue;
+      if (name === 'typing') {
+        expect(surface.content.join(' '), name).toContain(composerNeedle);
+        expect(typingCursor, name).toEqual({
+          row: surface.top + surface.content.length,
+          col: 2 + insertionIndex,
+        });
+      } else {
+        expect(surface.content.join(''), name).not.toContain('Type your message');
+        expect(restoredCursor, `${name}\n${frame}`).toEqual({
+          row: surface.top + surface.content.length,
+          col: 2,
+        });
+      }
+      expect(surface.status, name).toContain('custom_openai');
+      expect(surface.status, name).toContain('◉');
+      const rowsAboveFooter = lines.slice(0, surface.top);
       expect(rowsAboveFooter.filter((line) => line.includes('Type your message')), name).toEqual([]);
-      const submittedRows = rowsAboveFooter.filter((line) => line.trimStart().startsWith('▲'));
+      const submittedRows = rowsAboveFooter.filter((line) => line.trimStart().startsWith('▲ You'));
       if (name === 'typing') {
         expect(submittedRows, name).toEqual([]);
         expect(rowsAboveFooter.filter((line) => line.includes(draft)), name).toEqual([]);
       } else {
-        expect(submittedRows, name).toHaveLength(1);
+        expect(submittedRows, `${name}\n${frame}`).toHaveLength(1);
         expect(submittedRows[0], name).toContain(draft);
       }
     }
@@ -179,6 +226,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
 
   it.each([
     { label: 'normal width', columns: 100 },
+    { label: 'medium width', columns: 80 },
     { label: 'narrow width', columns: 44 },
   ])('keeps the rendered bottom composer visible after two queued messages at $label', async ({ columns }) => {
     const repoRoot = path.resolve(__dirname, '../../..');
@@ -232,6 +280,8 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
     let secondComposer = '';
     let firstStatus = '';
     let secondStatus = '';
+    let firstCursor = { row: -1, col: -1 };
+    let secondCursor = { row: -1, col: -1 };
     let providerCallsBeforeExit = 0;
     let queuedRequestContents: Array<string | undefined> = [];
     let finishPoll: ReturnType<typeof setInterval> | null = null;
@@ -252,6 +302,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         screen.write(chunk);
         const plain = stripAnsi(output);
         const rendered = screen.snapshot();
+        const surface = bottomSurface(screen.lines());
         const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
         const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
 
@@ -265,25 +316,32 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         } else if (
           state === 'tool'
           && /running[\s\S]*Start-Sleep/i.test(plain)
-          && screen.lines().at(-2)?.includes('Enter → queue')
-          && screen.bottomLine().includes('custom_openai')
+          && surface !== null
+          && screen.lines()[surface.top]?.includes('▲ You · queue mode')
+          && surface.status.includes('custom_openai')
         ) {
           state = 'queue-one';
           frames.toolRunning = screen.snapshot();
           typeLikeKeyboard(child!, 'QUEUE ONE');
         } else if (state === 'queue-one' && ids.length >= 1) {
           state = 'queue-one-reset';
-        } else if (state === 'queue-one-reset' && screen.lines().at(-2)?.includes('Enter → queue')) {
-          firstComposer = screen.lines().at(-2) ?? '';
-          firstStatus = screen.bottomLine();
+        } else if (state === 'queue-one-reset' && surface
+          && screen.lines()[surface.top]?.includes('▲ You · queue mode')
+          && bottomDraft(surface.content) === '') {
+          firstComposer = screen.lines()[surface.top] ?? '';
+          firstStatus = surface.status;
+          firstCursor = screen.cursorPosition();
           frames.firstQueue = screen.snapshot();
           state = 'queue-two';
           typeLikeKeyboard(child!, 'QUEUE TWO');
         } else if (state === 'queue-two' && ids.length >= 2) {
           state = 'queue-two-reset';
-        } else if (state === 'queue-two-reset' && screen.lines().at(-2)?.includes('Enter → queue')) {
-          secondComposer = screen.lines().at(-2) ?? '';
-          secondStatus = screen.bottomLine();
+        } else if (state === 'queue-two-reset' && surface
+          && screen.lines()[surface.top]?.includes('▲ You · queue mode')
+          && bottomDraft(surface.content) === '') {
+          secondComposer = screen.lines()[surface.top] ?? '';
+          secondStatus = surface.status;
+          secondCursor = screen.cursorPosition();
           frames.secondQueue = screen.snapshot();
           state = 'finishing';
           finishPoll = setInterval(() => {
@@ -313,22 +371,37 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
 
     const plain = stripAnsi(output);
     const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
-    expect(firstComposer).toContain('Enter → queue');
-    expect(secondComposer).toContain('Enter → queue');
+    expect(firstComposer).toContain('▲ You · queue mode');
+    expect(secondComposer).toContain('▲ You · queue mode');
     expect(firstStatus).toContain('custom_openai');
     expect(secondStatus).toContain('custom_openai');
-    expect(firstStatus).toContain('ctx');
-    expect(secondStatus).toContain('ctx');
+    expect(firstStatus).toContain('◉');
+    expect(secondStatus).toContain('◉');
     expect(firstStatus).toMatch(/\b(?:\d+ms|\d+s)\b/);
     expect(secondStatus).toMatch(/\b(?:\d+ms|\d+s)\b/);
-    expect(frames.toolRunning.split('\n').at(-2)).toContain('Enter → queue');
-    expect(frames.toolRunning.split('\n').at(-1)).toContain('custom_openai');
+    const firstSurface = bottomSurface(frames.firstQueue.split('\n'));
+    const secondSurface = bottomSurface(frames.secondQueue.split('\n'));
+    expect(firstCursor).toEqual({
+      row: firstSurface!.top + firstSurface!.content.length,
+      col: 2,
+    });
+    expect(secondCursor).toEqual({
+      row: secondSurface!.top + secondSurface!.content.length,
+      col: 2,
+    });
+    const runningSurface = bottomSurface(frames.toolRunning.split('\n'));
+    expect(runningSurface).not.toBeNull();
+    expect(frames.toolRunning.split('\n')[runningSurface!.top]).toContain('▲ You · queue mode');
+    expect(runningSurface!.status).toContain('custom_openai');
     expect(
       frames.toolRunning.split('\n').filter((line) => line.includes('run a slow safe tool')),
     ).toHaveLength(1);
     for (const frame of Object.values(frames)) {
       const lines = frame.split('\n');
-      expect(lines.slice(0, -1).filter((line) => line.includes('custom_openai'))).toHaveLength(0);
+      const surface = bottomSurface(lines);
+      if (surface) {
+        expect(lines.slice(0, surface.top).filter((line) => line.includes('custom_openai'))).toHaveLength(0);
+      }
     }
     expect(ids).toHaveLength(2);
     expect(ids[0]).not.toBe(ids[1]);

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -47,6 +47,10 @@ function pressDownThenEnter(terminal: RunningPty, count: number): void {
   next();
 }
 
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 afterEach(async () => {
   if (child) {
     try { child.kill(); } catch { /* already exited */ }
@@ -93,9 +97,17 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
     const rows = 30;
     const screen = new TerminalScreen(columns, rows);
     const frames: Record<string, string> = {};
-    child = pty.spawn(process.execPath, [
-      '-r', path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs'),
-      path.join(repoRoot, 'dist/cli/v4/aidenCLI.js'),
+    const preloadPath = path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs');
+    const cliPath = path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
+    const powerShellCommand = [
+      '&',
+      quotePowerShellLiteral(process.execPath),
+      '-r',
+      quotePowerShellLiteral(preloadPath),
+      quotePowerShellLiteral(cliPath),
+    ].join(' ');
+    child = pty.spawn('powershell.exe', [
+      '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', powerShellCommand,
     ], {
       cwd, cols: columns, rows,
       env: { ...process.env, AIDEN_HOME: aidenHome, AIDEN_TEST_REPO_ROOT: repoRoot,
@@ -106,8 +118,10 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
 
     let output = '';
     let state = 'boot';
-    let firstBottom = '';
-    let secondBottom = '';
+    let firstComposer = '';
+    let secondComposer = '';
+    let firstStatus = '';
+    let secondStatus = '';
     let providerCallsBeforeExit = 0;
     let queuedRequestContents: Array<string | undefined> = [];
     let finishPoll: ReturnType<typeof setInterval> | null = null;
@@ -127,6 +141,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         output += chunk;
         screen.write(chunk);
         const plain = stripAnsi(output);
+        const rendered = screen.snapshot();
         const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
         const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
 
@@ -140,22 +155,25 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         } else if (
           state === 'tool'
           && /running[\s\S]*Start-Sleep/i.test(plain)
-          && screen.bottomLine().includes('Enter → queue')
+          && screen.lines().at(-2)?.includes('Enter → queue')
+          && screen.bottomLine().includes('custom_openai')
         ) {
           state = 'queue-one';
           frames.toolRunning = screen.snapshot();
           typeLikeKeyboard(child!, 'QUEUE ONE');
         } else if (state === 'queue-one' && ids.length >= 1) {
           state = 'queue-one-reset';
-        } else if (state === 'queue-one-reset' && screen.bottomLine().includes('Enter → queue')) {
-          firstBottom = screen.bottomLine();
+        } else if (state === 'queue-one-reset' && screen.lines().at(-2)?.includes('Enter → queue')) {
+          firstComposer = screen.lines().at(-2) ?? '';
+          firstStatus = screen.bottomLine();
           frames.firstQueue = screen.snapshot();
           state = 'queue-two';
           typeLikeKeyboard(child!, 'QUEUE TWO');
         } else if (state === 'queue-two' && ids.length >= 2) {
           state = 'queue-two-reset';
-        } else if (state === 'queue-two-reset' && screen.bottomLine().includes('Enter → queue')) {
-          secondBottom = screen.bottomLine();
+        } else if (state === 'queue-two-reset' && screen.lines().at(-2)?.includes('Enter → queue')) {
+          secondComposer = screen.lines().at(-2) ?? '';
+          secondStatus = screen.bottomLine();
           frames.secondQueue = screen.snapshot();
           state = 'finishing';
           finishPoll = setInterval(() => {
@@ -174,7 +192,8 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
               typeLikeKeyboard(child!, '/queue');
             }, 250);
           }, 25);
-        } else if (state === 'queue-check' && /queue is empty/i.test(plain)) {
+        } else if (state === 'queue-check' && /queue is empty/i.test(rendered)) {
+          frames.queueEmpty = rendered;
           state = 'exiting';
           typeLikeKeyboard(child!, '/exit');
         }
@@ -184,16 +203,30 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
 
     const plain = stripAnsi(output);
     const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
-    expect(firstBottom).toContain('Enter → queue');
-    expect(secondBottom).toContain('Enter → queue');
-    expect(frames.toolRunning.split('\n').at(-1)).toContain('Enter → queue');
+    expect(firstComposer).toContain('Enter → queue');
+    expect(secondComposer).toContain('Enter → queue');
+    expect(firstStatus).toContain('custom_openai');
+    expect(secondStatus).toContain('custom_openai');
+    expect(firstStatus).toContain('ctx');
+    expect(secondStatus).toContain('ctx');
+    expect(firstStatus).toMatch(/\b(?:\d+ms|\d+s)\b/);
+    expect(secondStatus).toMatch(/\b(?:\d+ms|\d+s)\b/);
+    expect(frames.toolRunning.split('\n').at(-2)).toContain('Enter → queue');
+    expect(frames.toolRunning.split('\n').at(-1)).toContain('custom_openai');
+    expect(
+      frames.toolRunning.split('\n').filter((line) => line.includes('run a slow safe tool')),
+    ).toHaveLength(1);
+    for (const frame of Object.values(frames)) {
+      const lines = frame.split('\n');
+      expect(lines.slice(0, -1).filter((line) => line.includes('custom_openai'))).toHaveLength(0);
+    }
     expect(ids).toHaveLength(2);
     expect(ids[0]).not.toBe(ids[1]);
     const queuedRuns = plain.match(/running queued: QUEUE (?:ONE|TWO)/g) ?? [];
     expect(queuedRuns).toEqual(['running queued: QUEUE ONE', 'running queued: QUEUE TWO']);
     expect(queuedRequestContents).toEqual(['QUEUE ONE', 'QUEUE TWO']);
     expect(providerCallsBeforeExit).toBe(4);
-    expect(plain).toMatch(/queue is empty/i);
+    expect(frames.queueEmpty).toMatch(/queue is empty/i);
 
     const evidenceDir = process.env.AIDEN_ACCEPTANCE_EVIDENCE_DIR;
     if (evidenceDir) {
@@ -499,6 +532,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
     });
 
     let output = '';
+    const screen = new TerminalScreen(240, 40);
     let state = 'boot';
     let queueChecks = 0;
     let queueCommandSent = false;
@@ -509,21 +543,23 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
       )), 75_000);
       child!.onData((chunk) => {
         output += chunk;
+        screen.write(chunk);
         const plain = stripAnsi(output);
+        const rendered = screen.snapshot();
         const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
         if (state === 'boot' && readyCount >= 1) {
           state = 'first-select';
           setTimeout(() => typeLikeKeyboard(child!, 'Run consecutive clarification acceptance'), 500);
         }
-        if (state === 'first-select' && plain.includes('Which format?')) {
+        if (state === 'first-select' && rendered.includes('Which format?')) {
           state = 'second-text';
           setTimeout(() => pressDownThenEnter(child!, 1), 500);
         }
-        if (state === 'second-text' && plain.includes('What topic?')) {
+        if (state === 'second-text' && rendered.includes('What topic?')) {
           state = 'clarify-final';
           setTimeout(() => typeLikeKeyboard(child!, 'P2A terminal ownership'), secondPromptDelayMs);
         }
-        if (state === 'clarify-final' && plain.includes('clarifications complete: PDF | P2A terminal ownership')) {
+        if (state === 'clarify-final' && rendered.includes('clarifications complete: PDF | P2A terminal ownership')) {
           state = 'queue-ready';
         }
         if (state === 'queue-ready' && readyCount >= 2) {
@@ -531,7 +567,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
           queueCommandSent = true;
           typeLikeKeyboard(child!, '/queue');
         }
-        const emptyQueueCount = plain.match(/queue is empty/gi)?.length ?? 0;
+        const emptyQueueCount = rendered.match(/queue is empty/gi)?.length ?? 0;
         if (state === 'queue-1' && emptyQueueCount >= 1) {
           queueChecks += 1;
           state = 'done';

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import * as pty from 'node-pty';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+import { TerminalScreen } from '../harness/terminalScreen';
 
 type RunningPty = ReturnType<typeof pty.spawn>;
 let child: RunningPty | null = null;
@@ -62,6 +63,149 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', () => {
+  it.each([
+    { label: 'normal width', columns: 100 },
+    { label: 'narrow width', columns: 44 },
+  ])('keeps the rendered bottom composer visible after two queued messages at $label', async ({ columns }) => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-pinned-queue-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-pinned-queue-cwd-'));
+    cleanup.push(aidenHome, cwd);
+    provider = await startMockProvider({
+      modelId: 'custom-default',
+      chunkDelayMs: 5,
+      script: [
+        { toolCalls: [{ id: 'slow-shell', name: 'shell_exec', arguments: {
+          command: 'Start-Sleep -Seconds 4; Write-Output TOOL-DONE',
+        } }] },
+        { content: 'ORIGINAL JOB COMPLETE' },
+        { content: 'QUEUE ONE COMPLETE' },
+        { content: 'QUEUE TWO COMPLETE' },
+      ],
+    });
+    await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'pinned-queue\n', 'utf8');
+    await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+      'model:', '  provider: custom_openai', '  modelId: custom-default',
+      'providers:', '  custom_openai:', '    apiKey: pinned-queue-key',
+      'display:', '  streaming: true', '  renderer: legacy',
+    ].join('\n') + '\n', 'utf8');
+
+    const rows = 30;
+    const screen = new TerminalScreen(columns, rows);
+    const frames: Record<string, string> = {};
+    child = pty.spawn(process.execPath, [
+      '-r', path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs'),
+      path.join(repoRoot, 'dist/cli/v4/aidenCLI.js'),
+    ], {
+      cwd, cols: columns, rows,
+      env: { ...process.env, AIDEN_HOME: aidenHome, AIDEN_TEST_REPO_ROOT: repoRoot,
+        AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl, CUSTOM_OPENAI_API_KEY: 'pinned-queue-key',
+        AIDEN_NO_UPDATE_CHECK: '1', AIDEN_TEST_COMPOSER_READY: '1', TELEGRAM_BOT_TOKEN: '',
+        FORCE_COLOR: '0', NO_COLOR: '1' },
+    });
+
+    let output = '';
+    let state = 'boot';
+    let firstBottom = '';
+    let secondBottom = '';
+    let providerCallsBeforeExit = 0;
+    let queuedRequestContents: Array<string | undefined> = [];
+    let finishPoll: ReturnType<typeof setInterval> | null = null;
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `pinned queue timeout (${state}):\n${stripAnsi(output).slice(-12000)}`,
+      )), 65_000);
+      child!.onExit(({ exitCode }) => {
+        if (state !== 'exiting') return;
+        clearTimeout(timeout);
+        if (finishPoll) clearInterval(finishPoll);
+        child = null;
+        if (exitCode === 0) resolve();
+        else reject(new Error(`pinned queue CLI exited with ${exitCode}`));
+      });
+      child!.onData((chunk) => {
+        output += chunk;
+        screen.write(chunk);
+        const plain = stripAnsi(output);
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
+
+        if (state === 'boot' && readyCount >= 1) {
+          state = 'approval';
+          typeLikeKeyboard(child!, 'run a slow safe tool');
+        } else if (state === 'approval' && plain.includes('Decision')) {
+          state = 'tool';
+          frames.approval = screen.snapshot();
+          setTimeout(() => child!.write('\r'), 250);
+        } else if (
+          state === 'tool'
+          && /running[\s\S]*Start-Sleep/i.test(plain)
+          && screen.bottomLine().includes('Enter → queue')
+        ) {
+          state = 'queue-one';
+          frames.toolRunning = screen.snapshot();
+          typeLikeKeyboard(child!, 'QUEUE ONE');
+        } else if (state === 'queue-one' && ids.length >= 1) {
+          state = 'queue-one-reset';
+        } else if (state === 'queue-one-reset' && screen.bottomLine().includes('Enter → queue')) {
+          firstBottom = screen.bottomLine();
+          frames.firstQueue = screen.snapshot();
+          state = 'queue-two';
+          typeLikeKeyboard(child!, 'QUEUE TWO');
+        } else if (state === 'queue-two' && ids.length >= 2) {
+          state = 'queue-two-reset';
+        } else if (state === 'queue-two-reset' && screen.bottomLine().includes('Enter → queue')) {
+          secondBottom = screen.bottomLine();
+          frames.secondQueue = screen.snapshot();
+          state = 'finishing';
+          finishPoll = setInterval(() => {
+            if ((provider?.callCount() ?? 0) < 4) return;
+            if (finishPoll) clearInterval(finishPoll);
+            finishPoll = null;
+            providerCallsBeforeExit = provider!.callCount();
+            queuedRequestContents = (provider!.requests().slice(2, 4) as Array<{
+              messages?: Array<{ role?: string; content?: string }>;
+            }>).map((request) => (
+              request.messages?.filter((message) => message.role === 'user').at(-1)?.content
+            ));
+            state = 'queue-check-pending';
+            setTimeout(() => {
+              state = 'queue-check';
+              typeLikeKeyboard(child!, '/queue');
+            }, 250);
+          }, 25);
+        } else if (state === 'queue-check' && /queue is empty/i.test(plain)) {
+          state = 'exiting';
+          typeLikeKeyboard(child!, '/exit');
+        }
+      });
+    });
+    await completion;
+
+    const plain = stripAnsi(output);
+    const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
+    expect(firstBottom).toContain('Enter → queue');
+    expect(secondBottom).toContain('Enter → queue');
+    expect(frames.toolRunning.split('\n').at(-1)).toContain('Enter → queue');
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).not.toBe(ids[1]);
+    const queuedRuns = plain.match(/running queued: QUEUE (?:ONE|TWO)/g) ?? [];
+    expect(queuedRuns).toEqual(['running queued: QUEUE ONE', 'running queued: QUEUE TWO']);
+    expect(queuedRequestContents).toEqual(['QUEUE ONE', 'QUEUE TWO']);
+    expect(providerCallsBeforeExit).toBe(4);
+    expect(plain).toMatch(/queue is empty/i);
+
+    const evidenceDir = process.env.AIDEN_ACCEPTANCE_EVIDENCE_DIR;
+    if (evidenceDir) {
+      await fs.mkdir(evidenceDir, { recursive: true });
+      await fs.writeFile(
+        path.join(evidenceDir, `busy-queue-${columns}-columns.txt`),
+        Object.entries(frames).map(([name, frame]) => `--- ${name} ---\n${frame}`).join('\n\n'),
+        'utf8',
+      );
+    }
+  }, 75_000);
+
   it('preserves an exact multiline busy submission through resize and provider handoff', async () => {
     const repoRoot = path.resolve(__dirname, '../../..');
     const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-busy-queue-home-'));
@@ -113,7 +257,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
           setTimeout(() => child!.resize(44, 40), 120);
           setTimeout(() => child!.resize(110, 40), 240);
           setTimeout(() => child!.write('\r'), 400);
-        } else if (state === 'queueing' && plain.includes('QUEUED TURN COMPLETE') && readyCount >= 2) {
+        } else if (state === 'queueing' && provider!.callCount() >= 2 && readyCount >= 2) {
           state = 'queue-check';
           typeLikeKeyboard(child!, '/queue');
         } else if (state === 'queue-check' && /queue is empty/i.test(plain)) {
@@ -272,7 +416,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         } else if (state === 'denying' && plain.includes('RESIZE APPROVAL COMPLETE') && readyCount >= 2) {
           state = 'normal';
           typeLikeKeyboard(child!, 'normal after resize');
-        } else if (state === 'normal' && plain.includes('NORMAL AFTER RESIZE') && readyCount >= 3) {
+        } else if (state === 'normal' && provider!.callCount() >= 3 && readyCount >= 3) {
           state = 'queue';
           typeLikeKeyboard(child!, '/queue');
         } else if (state === 'queue' && /queue is empty/i.test(plain)) {

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -70,6 +70,116 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
   it.each([
     { label: 'normal width', columns: 100 },
     { label: 'narrow width', columns: 44 },
+  ])('keeps idle typing exclusively inside the fixed composer at $label', async ({ columns }) => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-idle-footer-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-idle-footer-cwd-'));
+    cleanup.push(aidenHome, cwd);
+    provider = await startMockProvider({
+      modelId: 'custom-default',
+      script: [{ content: 'IDLE OWNER RESPONSE' }],
+    });
+    await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'idle-footer\n', 'utf8');
+    await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+      'model:', '  provider: custom_openai', '  modelId: custom-default',
+      'providers:', '  custom_openai:', '    apiKey: idle-footer-key',
+      'display:', '  streaming: true', '  renderer: legacy',
+    ].join('\n') + '\n', 'utf8');
+
+    const rows = 30;
+    const screen = new TerminalScreen(columns, rows);
+    const preloadPath = path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs');
+    const cliPath = path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
+    const powerShellCommand = [
+      '&',
+      quotePowerShellLiteral(process.execPath),
+      '-r',
+      quotePowerShellLiteral(preloadPath),
+      quotePowerShellLiteral(cliPath),
+    ].join(' ');
+    child = pty.spawn('powershell.exe', [
+      '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', powerShellCommand,
+    ], {
+      cwd, cols: columns, rows,
+      env: {
+        ...process.env,
+        AIDEN_HOME: aidenHome,
+        AIDEN_TEST_REPO_ROOT: repoRoot,
+        AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl,
+        CUSTOM_OPENAI_API_KEY: 'idle-footer-key',
+        AIDEN_NO_UPDATE_CHECK: '1',
+        AIDEN_TEST_COMPOSER_READY: '1',
+        TELEGRAM_BOT_TOKEN: '',
+        FORCE_COLOR: '0',
+        NO_COLOR: '1',
+      },
+    });
+
+    const draft = 'POWERSHELL FIXED DRAFT';
+    let output = '';
+    let state = 'boot';
+    let typingFrame = '';
+    let restoredFrame = '';
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `idle footer timeout (${state}):\n${screen.snapshot()}`,
+      )), 40_000);
+      child!.onData((chunk) => {
+        output += chunk;
+        screen.write(chunk);
+        const rendered = screen.snapshot();
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (state === 'boot' && readyCount >= 1) {
+          state = 'typing';
+          typeLikeKeyboard(child!, draft, false);
+          setTimeout(() => {
+            typingFrame = screen.snapshot();
+            state = 'submitted';
+            child!.write('\r');
+          }, 750);
+        } else if (
+          state === 'submitted'
+          && rendered.includes('IDLE OWNER RESPONSE')
+          && readyCount >= 2
+        ) {
+          restoredFrame = rendered;
+          state = 'exiting';
+          typeLikeKeyboard(child!, '/exit');
+        }
+      });
+      child!.onExit(({ exitCode }) => {
+        if (state !== 'exiting') return;
+        clearTimeout(timeout);
+        child = null;
+        if (exitCode === 0) resolve();
+        else reject(new Error(`idle footer CLI exited with ${exitCode}`));
+      });
+    });
+
+    for (const [name, frame, composerNeedle] of [
+      ['typing', typingFrame, draft],
+      ['restored', restoredFrame, 'Type your message'],
+    ] as const) {
+      const lines = frame.split('\n');
+      expect(lines.at(-2), name).toContain(composerNeedle);
+      expect(lines.at(-1), name).toContain('custom_openai');
+      expect(lines.at(-1), name).toContain('ctx');
+      const rowsAboveFooter = lines.slice(0, -2);
+      expect(rowsAboveFooter.filter((line) => line.includes('Type your message')), name).toEqual([]);
+      const submittedRows = rowsAboveFooter.filter((line) => line.trimStart().startsWith('▲'));
+      if (name === 'typing') {
+        expect(submittedRows, name).toEqual([]);
+        expect(rowsAboveFooter.filter((line) => line.includes(draft)), name).toEqual([]);
+      } else {
+        expect(submittedRows, name).toHaveLength(1);
+        expect(submittedRows[0], name).toContain(draft);
+      }
+    }
+  });
+
+  it.each([
+    { label: 'normal width', columns: 100 },
+    { label: 'narrow width', columns: 44 },
   ])('keeps the rendered bottom composer visible after two queued messages at $label', async ({ columns }) => {
     const repoRoot = path.resolve(__dirname, '../../..');
     const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-pinned-queue-home-'));

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -101,7 +101,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
       env: { ...process.env, AIDEN_HOME: aidenHome, AIDEN_TEST_REPO_ROOT: repoRoot,
         AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl, CUSTOM_OPENAI_API_KEY: 'pinned-queue-key',
         AIDEN_NO_UPDATE_CHECK: '1', AIDEN_TEST_COMPOSER_READY: '1', TELEGRAM_BOT_TOKEN: '',
-        FORCE_COLOR: '0', NO_COLOR: '1' },
+        AIDEN_SANDBOX: '0', FORCE_COLOR: '0', NO_COLOR: '1' },
     });
 
     let output = '';

--- a/tests/v4/cli/busyComposerScreen.test.ts
+++ b/tests/v4/cli/busyComposerScreen.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { Writable } from 'node:stream';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+class ScreenStream extends Writable {
+  isTTY = true;
+  columns: number;
+  rows: number;
+
+  constructor(
+    readonly screen: TerminalScreen,
+    columns: number,
+    rows: number,
+  ) {
+    super({
+      write: (chunk, _encoding, callback) => {
+        screen.write(chunk);
+        callback();
+      },
+    });
+    this.columns = columns;
+    this.rows = rows;
+  }
+}
+
+const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
+
+afterEach(() => {
+  if (previousLaneSetting === undefined) delete process.env.AIDEN_COMPOSER_LANE;
+  else process.env.AIDEN_COMPOSER_LANE = previousLaneSetting;
+});
+
+describe.each([100, 44])('busy composer rendered screen at %i columns', (columns) => {
+  it('remains pinned after two durable queue acknowledgements', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const rows = 16;
+    const screen = new TerminalScreen(columns, rows);
+    const stream = new ScreenStream(screen, columns, rows);
+    const display = new Display({
+      stdout: stream as unknown as NodeJS.WriteStream,
+      skin: new SkinEngine({ forceMono: true }),
+    });
+
+    display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
+    const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 6' });
+    expect(screen.bottomLine()).toContain('Enter → queue');
+
+    display.setComposer('QUEUE ONE', 'queue');
+    display.write('\n✓ queued (1 pending) · input_first\n');
+    display.setComposer('', 'queue');
+    expect(screen.snapshot()).toContain('input_first');
+    expect(screen.bottomLine()).toContain('Enter → queue');
+
+    display.setComposer('QUEUE TWO', 'queue');
+    display.write('\n✓ queued (2 pending) · input_second\n');
+    display.setComposer('', 'queue');
+    expect(screen.snapshot()).toContain('input_second');
+    expect(screen.bottomLine()).toContain('Enter → queue');
+
+    tool.ok(6_000);
+    display.clearComposer();
+  });
+});

--- a/tests/v4/cli/busyComposerScreen.test.ts
+++ b/tests/v4/cli/busyComposerScreen.test.ts
@@ -49,21 +49,25 @@ describe.each([100, 44])('busy composer rendered screen at %i columns', (columns
       skin: new SkinEngine({ forceMono: true }),
     });
 
+    display.setStatusFooter('provider · model · ctx 1k/32k · 1s');
     display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
     const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 6' });
-    expect(screen.bottomLine()).toContain('Enter → queue');
+    expect(screen.lines().at(-2)).toContain('Enter → queue');
+    expect(screen.bottomLine()).toContain('provider');
 
     display.setComposer('QUEUE ONE', 'queue');
     display.write('\n✓ queued (1 pending) · input_first\n');
     display.setComposer('', 'queue');
     expect(screen.snapshot()).toContain('input_first');
-    expect(screen.bottomLine()).toContain('Enter → queue');
+    expect(screen.lines().at(-2)).toContain('Enter → queue');
+    expect(screen.bottomLine()).toContain('provider');
 
     display.setComposer('QUEUE TWO', 'queue');
     display.write('\n✓ queued (2 pending) · input_second\n');
     display.setComposer('', 'queue');
     expect(screen.snapshot()).toContain('input_second');
-    expect(screen.bottomLine()).toContain('Enter → queue');
+    expect(screen.lines().at(-2)).toContain('Enter → queue');
+    expect(screen.bottomLine()).toContain('provider');
 
     tool.ok(6_000);
     display.clearComposer();

--- a/tests/v4/cli/busyComposerScreen.test.ts
+++ b/tests/v4/cli/busyComposerScreen.test.ts
@@ -52,21 +52,25 @@ describe.each([100, 44])('busy composer rendered screen at %i columns', (columns
     display.setStatusFooter('provider · model · ctx 1k/32k · 1s');
     display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
     const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 6' });
-    expect(screen.lines().at(-2)).toContain('Enter → queue');
+    expect(screen.lines().at(-4)).toContain('▲ You · queue mode');
+    expect(screen.lines().at(-3)).toMatch(/^│\s+│$/);
+    expect(screen.lines().at(-2)).toMatch(/^╰─/);
     expect(screen.bottomLine()).toContain('provider');
 
     display.setComposer('QUEUE ONE', 'queue');
     display.write('\n✓ queued (1 pending) · input_first\n');
     display.setComposer('', 'queue');
     expect(screen.snapshot()).toContain('input_first');
-    expect(screen.lines().at(-2)).toContain('Enter → queue');
+    expect(screen.lines().at(-4)).toContain('▲ You · queue mode');
+    expect(screen.lines().at(-3)).toMatch(/^│\s+│$/);
     expect(screen.bottomLine()).toContain('provider');
 
     display.setComposer('QUEUE TWO', 'queue');
     display.write('\n✓ queued (2 pending) · input_second\n');
     display.setComposer('', 'queue');
     expect(screen.snapshot()).toContain('input_second');
-    expect(screen.lines().at(-2)).toContain('Enter → queue');
+    expect(screen.lines().at(-4)).toContain('▲ You · queue mode');
+    expect(screen.lines().at(-3)).toMatch(/^│\s+│$/);
     expect(screen.bottomLine()).toContain('provider');
 
     tool.ok(6_000);

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -720,3 +720,89 @@ describe('ChatSession — v4.6 Phase 2Q-B REPL parent-run row', () => {
     expect(agent.runConversation).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('ChatSession durable Job admission', () => {
+  it('creates and leases the Job Attempt before the first provider call', async () => {
+    const order: string[] = [];
+    const { agent } = mkAgent({ finalContent: 'ok' });
+    agent.runConversation.mockImplementation(async () => {
+      order.push('provider');
+      return {
+        finalContent: 'ok', messages: [], turnCount: 1, toolCallCount: 0,
+        fallbackActivated: false, finishReason: 'stop',
+        totalUsage: { inputTokens: 0, outputTokens: 0 }, toolCallTrace: [],
+        compressionEvents: [], auxiliaryUsage: [],
+      } as never;
+    });
+    const jobEngine = {
+      submitJob: vi.fn(() => {
+        order.push('submit');
+        return { jobId: 'task_job', attemptId: 'attempt_job', runId: 41, reused: false };
+      }),
+      claimAttempt: vi.fn(() => {
+        order.push('claim');
+        return {
+          acquired: true, applied: true, leaseId: 'lease_job',
+          fenceToken: 'fence_job', generation: 1, stateVersion: 1,
+        };
+      }),
+      transitionAttempt: vi.fn((command: { to: string }) => {
+        order.push(`attempt:${command.to}`);
+        return { applied: true, stateVersion: command.to === 'running' ? 2 : 3 };
+      }),
+      transitionJob: vi.fn((command: { to: string }) => {
+        order.push(`job:${command.to}`);
+        return { applied: true, stateVersion: 1 };
+      }),
+      finalizeJob: vi.fn(() => {
+        order.push('job:finalized');
+        return { applied: true, stateVersion: 2 };
+      }),
+      renewAttemptLease: vi.fn(() => ({ applied: true, stateVersion: 3 })),
+    };
+    const ref: { runId: number | null; sessionId: string | null } = { runId: null, sessionId: null };
+    const session = new ChatSession(buildOpts({
+      agent: agent as never,
+      promptApi: mkPromptApi({ inputs: ['hello', '/quit'] }),
+      replInstanceId: 'instance_job',
+      replParentRunRef: ref,
+      jobEngine: jobEngine as never,
+    }));
+
+    await session.run();
+
+    expect(order.slice(0, 5)).toEqual([
+      'submit', 'claim', 'attempt:running', 'job:running', 'provider',
+    ]);
+    expect(jobEngine.submitJob).toHaveBeenCalledWith(expect.objectContaining({
+      entryPoint: 'interactive',
+      source: 'repl',
+      instanceId: 'instance_job',
+      goal: 'hello',
+    }));
+    expect(jobEngine.transitionAttempt).toHaveBeenCalledWith(expect.objectContaining({
+      attemptId: 'attempt_job', generation: 1, fenceToken: 'fence_job',
+    }));
+    expect(jobEngine.finalizeJob).toHaveBeenCalledTimes(1);
+    expect(ref.runId).toBeNull();
+  });
+
+  it('does not call the provider when durable admission fails', async () => {
+    const { agent } = mkAgent({ finalContent: 'must not run' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const jobEngine = {
+      submitJob: vi.fn(() => { throw new Error('durable admission unavailable'); }),
+    };
+    const session = new ChatSession(buildOpts({
+      agent: agent as never,
+      promptApi: mkPromptApi({ inputs: ['hello', '/quit'] }),
+      replInstanceId: 'instance_job',
+      jobEngine: jobEngine as never,
+    }));
+
+    await expect(session.run()).rejects.toThrow('durable admission unavailable');
+
+    expect(agent.runConversation).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/v4/cli/composerHandoff.pty.test.ts
+++ b/tests/v4/cli/composerHandoff.pty.test.ts
@@ -18,11 +18,13 @@ async function spawnBuiltCli(
 ): Promise<{
   terminal: RunningPty;
   output: () => string;
+  diagnostics: () => Promise<string>;
   cwd: string;
 }> {
   const repoRoot = path.resolve(__dirname, '../../..');
   const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-handoff-home-'));
   const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-handoff-cwd-'));
+  const diagnosticPath = path.join(aidenHome, 'turn-idle.jsonl');
   cleanup.push(aidenHome, cwd);
   provider = await startMockProvider({ modelId: 'custom-default', chunkDelayMs, headerDelayMs, script });
   await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'handoff\n', 'utf8');
@@ -53,6 +55,7 @@ async function spawnBuiltCli(
       AIDEN_NO_UPDATE_CHECK: '1',
       AIDEN_TEST_COMPOSER_READY: '1',
       AIDEN_TEST_TURN_IDLE_DIAG: '1',
+      AIDEN_TEST_TURN_IDLE_DIAG_FILE: diagnosticPath,
       TELEGRAM_BOT_TOKEN: '',
       FORCE_COLOR: '0',
       NO_COLOR: '1',
@@ -60,7 +63,12 @@ async function spawnBuiltCli(
   });
   let output = '';
   child.onData((chunk) => { output += chunk; });
-  return { terminal: child, output: () => output, cwd };
+  return {
+    terminal: child,
+    output: () => output,
+    diagnostics: () => fs.readFile(diagnosticPath, 'utf8'),
+    cwd,
+  };
 }
 
 function typeLikeKeyboard(terminal: RunningPty, text: string, submitDelayMs = 100): void {
@@ -176,14 +184,14 @@ describe.skipIf(process.platform !== 'win32')('built CLI turn-to-composer handof
     expect(plain).toContain('Reply with exactly: SECOND');
     expect(plain).toContain('Reply with exactly: THIRD');
     expect(plain).toMatch(/queue is empty/i);
-    const flattened = plain.replace(/\n/g, '');
-    const generations = [...flattened.matchAll(/"event":"composer\.ready".{0,700}?"generation":(\d+)/g)]
+    const diagnostics = await runtime.diagnostics();
+    const generations = [...diagnostics.matchAll(/"event":"composer\.ready".{0,700}?"generation":(\d+)/g)]
       .map((match) => Number(match[1]));
     expect(generations.length).toBeGreaterThanOrEqual(3);
     expect(new Set(generations).size).toBe(generations.length);
-    const thirdReadyAt = flattened.search(/"event":"composer\.ready".{0,700}"generation":3/);
-    const thirdKeyAt = flattened.indexOf('"generation":3,"key":"r"');
-    const thirdEnterAt = flattened.indexOf('"generation":3,"key":"enter"');
+    const thirdReadyAt = diagnostics.search(/"event":"composer\.ready".{0,700}"generation":3/);
+    const thirdKeyAt = diagnostics.indexOf('"generation":3,"key":"r"');
+    const thirdEnterAt = diagnostics.indexOf('"generation":3,"key":"enter"');
     expect(thirdReadyAt).toBeGreaterThanOrEqual(0);
     expect(thirdKeyAt).toBeGreaterThan(thirdReadyAt);
     expect(thirdEnterAt).toBeGreaterThan(thirdKeyAt);
@@ -256,7 +264,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI turn-to-composer handof
     });
 
     await completion;
-    const diagnosticOutput = stripAnsi(runtime.output()).replace(/\n/g, '');
+    const diagnosticOutput = await runtime.diagnostics();
     const finalReadyIndex = diagnosticOutput.lastIndexOf('"event":"composer.ready"');
     expect(finalReadyIndex).toBeGreaterThan(0);
     expect(diagnosticOutput.slice(finalReadyIndex).includes('"event":"activity.row.timer"')).toBe(false);

--- a/tests/v4/cli/composerHint.test.ts
+++ b/tests/v4/cli/composerHint.test.ts
@@ -51,7 +51,7 @@ describe('busy hint — width-safe (Issue 1)', () => {
   });
 
   it('long typed text keeps the CURSOR END (tail-fit), unlike the hint', () => {
-    const { d, chunks } = makeDisplay(80);   // avail 50; label + 48-char text overflows → tail-fit
+    const { d, chunks } = makeDisplay(50);
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setComposer('a very long message the user is typing right now', 'redirect');
@@ -75,6 +75,8 @@ describe('busy hint — single-owner ticker (Bug 1: burst bleed)', () => {
   const HINT = 'Enter → steer · /busy to change · Ctrl+C stop';
 
   it('a stale (non-owner) tool ticker does not repaint the hint into activity rows', () => {
+    const previous = process.env.AIDEN_COMPOSER_LANE;
+    process.env.AIDEN_COMPOSER_LANE = '0';
     vi.useFakeTimers();
     try {
       const { d, chunks } = makeDisplay(100);
@@ -91,6 +93,8 @@ describe('busy hint — single-owner ticker (Bug 1: burst bleed)', () => {
       a.ok(1); b.ok(1);
     } finally {
       vi.useRealTimers();
+      if (previous === undefined) delete process.env.AIDEN_COMPOSER_LANE;
+      else process.env.AIDEN_COMPOSER_LANE = previous;
     }
   });
 });

--- a/tests/v4/cli/composerHint.test.ts
+++ b/tests/v4/cli/composerHint.test.ts
@@ -5,12 +5,12 @@
  * Aiden — local-first agent.
  */
 /**
- * v4.14 composer polish:
- *   Issue 1 — the BUSY hint is width-safe: full on a wide terminal, and on a
- *   narrow one it keeps the FRONT ("Enter → …") with an ellipsis, never the
- *   wrapped tail ("…change · Ctrl+C stop") the single-line repaint used to show.
- *   Issue 2 — the persistent IDLE hint shows only when idle and nothing else
- *   owns the footer (no ghost/dropdown).
+ * Fixed-composer contract:
+ *   Issue 1 — actionable helper prose never becomes a second composer row.
+ *   The bounded surface communicates ownership through its mode label, and
+ *   typed drafts wrap upward without truncating the insertion end.
+ *   Issue 2 — the legacy Inquirer hint predicate remains available only when
+ *   the fixed Display-owned surface is not active.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { Writable } from 'node:stream';
@@ -26,38 +26,42 @@ function makeDisplay(columns: number) {
   return { d: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out as unknown as NodeJS.WriteStream }), chunks };
 }
 
-describe('busy hint — width-safe (Issue 1)', () => {
+describe('busy hint — fixed-surface ownership (Issue 1)', () => {
   const HINT = 'Enter → steer · /busy to change · Ctrl+C stop';
 
-  it('a WIDE terminal shows the FULL hint (no truncation)', () => {
+  it('a WIDE terminal uses the mode label without floating helper prose', () => {
     const { d, chunks } = makeDisplay(100);
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setBusyHint(HINT);
-    expect(stripAnsi(chunks.join(''))).toContain(HINT);   // complete, end-to-end
+    const painted = stripAnsi(chunks.join(''));
+    expect(painted).toContain('▲ You · steer mode');
+    expect(painted).not.toContain(HINT);
     ind.stop();
   });
 
-  it('a NARROW terminal keeps the FRONT with an ellipsis — never the tail-only garbage', () => {
+  it('a NARROW terminal keeps the bounded mode label and omits helper fragments', () => {
     const { d, chunks } = makeDisplay(40);
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setBusyHint(HINT);
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('Enter →');        // the important front is kept
-    expect(painted).toContain('…');              // front-fit ellipsis
-    expect(painted).not.toContain('Ctrl+C stop'); // the TAIL is dropped, not the front
+    expect(painted).toContain('▲ You · steer mode');
+    expect(painted).not.toContain('Enter →');
+    expect(painted).not.toContain('Ctrl+C stop');
     ind.stop();
   });
 
-  it('long typed text keeps the CURSOR END (tail-fit), unlike the hint', () => {
+  it('long typed text wraps upward without a truncation ellipsis', () => {
     const { d, chunks } = makeDisplay(50);
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setComposer('a very long message the user is typing right now', 'redirect');
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('…');              // ellipsis at the FRONT (tail-fit for typed text)
-    expect(painted).toContain('right now');      // most-recent chars (cursor end) kept
+    expect(painted).toContain('a very long message');
+    expect(painted).toContain('right');
+    expect(painted).toContain('now');
+    expect(painted).not.toContain('…');
     ind.stop();
   });
 });

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -46,12 +46,18 @@ describe('escape-sequence builders (pure)', () => {
 function mockSink(rows = 24, cols = 80) {
   const writes: string[] = [];
   let resizeCb: (() => void) | null = null;
-  const sink: LaneSink & { fireResize: (r: number) => void; text: () => string; setRows: (r: number) => void } = {
+  const sink: LaneSink & {
+    fireResize: (r: number) => void;
+    text: () => string;
+    setRows: (r: number) => void;
+    setCols: (c: number) => void;
+  } = {
     write: (s) => writes.push(s),
     rows: () => rows,
     cols: () => cols,
     onResize: (fn) => { resizeCb = fn; return () => { resizeCb = null; }; },
     setRows: (r) => { rows = r; },
+    setCols: (c) => { cols = c; },
     fireResize: (r) => { rows = r; resizeCb?.(); },
     text: () => writes.join(''),
   };
@@ -110,6 +116,16 @@ describe('ComposerLane — lifecycle', () => {
     expect(out).toContain(`${ESC}[30;1H`);                 // composer re-anchored to new bottom
   });
 
+  it('restores the full draft after a narrow-to-wide resize', () => {
+    const s = mockSink(24, 16);
+    const lane = new ComposerLane(s);
+    lane.activate('queue ▸ preserve the complete draft');
+    expect(s.text()).not.toContain('queue ▸ preserve');
+    s.setCols(80);
+    s.fireResize(24);
+    expect(s.text()).toContain('queue ▸ preserve the complete draft');
+  });
+
   it('deactivate restores full-screen scrolling + clears the lane (idempotent)', () => {
     const s = mockSink(24);
     const lane = new ComposerLane(s);
@@ -133,12 +149,14 @@ describe('ComposerLane — lifecycle', () => {
   });
 });
 
-describe('composerLaneEnabled — opt-in (default OFF)', () => {
+describe('composerLaneEnabled — interactive default with compatibility opt-out', () => {
   it('reads AIDEN_COMPOSER_LANE', () => {
     const prev = process.env.AIDEN_COMPOSER_LANE;
     try {
       delete process.env.AIDEN_COMPOSER_LANE;
-      expect(composerLaneEnabled()).toBe(false);   // safe default: unchanged render path
+      expect(composerLaneEnabled()).toBe(true);
+      process.env.AIDEN_COMPOSER_LANE = '0';
+      expect(composerLaneEnabled()).toBe(false);
       process.env.AIDEN_COMPOSER_LANE = '1';
       expect(composerLaneEnabled()).toBe(true);
     } finally {

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -5,7 +5,7 @@
  * Aiden — local-first agent.
  */
 /**
- * The single-owner fixed two-row bottom region. Proves
+ * The single-owner variable-height boxed bottom region. Proves
  * the pure escape-sequence builders and the owner's lifecycle: reserving the
  * region protects composer and status rows, painting is cursor-safe + de-duplicated (no
  * flicker), resize re-anchors, teardown restores full-screen scrolling. The
@@ -80,11 +80,13 @@ describe('ComposerLane — lifecycle', () => {
     lane.activate('Enter → steer · /queue · Ctrl+C stop', 'provider · model · ctx · 1s');
     expect(lane.isActive()).toBe(true);
     const out = s.text();
-    expect(out).toContain(`${ESC}[1;22r`);
-    expect(out).toContain(`${ESC}[23;1H${ESC}[2KEnter → steer`);
+    expect(out).toContain(`${ESC}[1;20r`);
+    expect(out).toContain(`${ESC}[21;1H${ESC}[2K╭─ ▲ You`);
+    expect(out).toContain(`${ESC}[22;1H${ESC}[2K│ Enter → steer`);
+    expect(out).toContain(`${ESC}[23;1H${ESC}[2K╰`);
     expect(out).toContain(`${ESC}[24;1H${ESC}[2Kprovider`);
     // reserve happens before the first paint
-    expect(out.indexOf('[1;22r')).toBeLessThan(out.indexOf('[23;1H'));
+    expect(out.indexOf('[1;20r')).toBeLessThan(out.indexOf('[21;1H'));
   });
 
   it('keeps the status row inside the physical width budget', () => {
@@ -92,22 +94,22 @@ describe('ComposerLane — lifecycle', () => {
     const lane = new ComposerLane(s);
     lane.activate(
       'Type your message',
-      '  custom_openai:custom-default │ ctx0% │ ⌛ 0ms',
+      '◆ custom_openai:custom-default │ ◉ 0% │ ⧖ 0ms',
     );
     const painted = s.text()
       .split(`${ESC}[24;1H${ESC}[2K`).at(-1)!
-      .split(ESC + '8')[0]
+      .split(`${ESC}[22;`)[0]
       .replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
-    expect(stringWidth(painted)).toBeLessThanOrEqual(46);
+    expect(stringWidth(painted)).toBeLessThanOrEqual(47);
   });
 
-  it('paint with the SAME text is a no-op — no flicker on redundant repaints', () => {
+  it('paint with the same text reasserts the cursor without duplicating the frame', () => {
     const s = mockSink();
     const lane = new ComposerLane(s);
     lane.activate('steer ▸ hi');
-    const before = s.text().length;
-    lane.paint('steer ▸ hi');   // identical
-    expect(s.text().length).toBe(before);   // nothing written
+    const before = s.text().split('╭─ ▲ You').length - 1;
+    lane.paint('steer ▸ hi');
+    expect(s.text().split('╭─ ▲ You').length - 1).toBe(before);
   });
 
   it('paint with NEW text repaints the lane (typed input updates in place)', () => {
@@ -118,16 +120,14 @@ describe('ComposerLane — lifecycle', () => {
     expect(s.text()).toContain('steer ▸ deploy');
   });
 
-  it('output written between paints never targets the lane row (region protects it)', () => {
-    // The owner only ever writes to the bottom row via paintSeq; assert every
-    // lane write is cursor-save-wrapped (so the flowing output cursor is intact).
+  it('routes transcript output through the saved scroll cursor and restores draft insertion', () => {
     const s = mockSink();
     const lane = new ComposerLane(s);
     lane.activate('Enter → steer');
-    lane.paint('steer ▸ x');
-    // Every paint is bracketed by save/restore → the output cursor is never lost.
-    const paints = s.text().split(`${ESC}7`).slice(1).filter((p) => p.includes(';1H'));
-    for (const p of paints) expect(p).toContain(ESC + '8');
+    lane.writeAbove('tool output\n');
+    const out = s.text();
+    expect(out).toContain(`${ESC}[utool output\n${ESC}[s`);
+    expect(out).toMatch(/\x1b\[22;\d+H\x1b\[\?25h$/);
   });
 
   it('resize re-reserves the region for the new height and repaints in place', () => {
@@ -136,8 +136,8 @@ describe('ComposerLane — lifecycle', () => {
     lane.activate('Enter → steer');
     (s as any).fireResize(30);   // terminal grew to 30 rows
     const out = s.text();
-    expect(out).toContain(`${ESC}[1;28r`);
-    expect(out).toContain(`${ESC}[29;1H`);
+    expect(out).toContain(`${ESC}[1;26r`);
+    expect(out).toContain(`${ESC}[27;1H`);
   });
 
   it('restores the full draft after a narrow-to-wide resize', () => {
@@ -164,9 +164,9 @@ describe('ComposerLane — lifecycle', () => {
     const s = mockSink();
     const lane = new ComposerLane(s);
     lane.activate('a');
-    const reserves1 = s.text().split('[1;22r').length - 1;
+    const reserves1 = s.text().split('[1;20r').length - 1;
     lane.activate('b');
-    const reserves2 = s.text().split('[1;22r').length - 1;
+    const reserves2 = s.text().split('[1;20r').length - 1;
     expect(reserves1).toBe(1);
     expect(reserves2).toBe(1);          // still one reserve
     expect(s.text()).toContain('b');    // repainted

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -5,9 +5,9 @@
  * Aiden — local-first agent.
  */
 /**
- * v4.14 — the single-owner FIXED bottom composer lane (scroll-region). Proves
+ * The single-owner fixed two-row bottom region. Proves
  * the pure escape-sequence builders and the owner's lifecycle: reserving the
- * region protects the bottom row, painting is cursor-safe + de-duplicated (no
+ * region protects composer and status rows, painting is cursor-safe + de-duplicated (no
  * flicker), resize re-anchors, teardown restores full-screen scrolling. The
  * live cursor behaviour on a real terminal is the Shiva smoke.
  */
@@ -20,18 +20,20 @@ import {
 const ESC = '\x1b';
 
 describe('escape-sequence builders (pure)', () => {
-  it('reserveSeq confines the scroll region to the rows ABOVE the lane, cursor-safe', () => {
-    // 24-row terminal, 1-row lane → region rows 1..23; save/restore around it.
-    expect(reserveSeq(24)).toBe(`${ESC}7${ESC}[1;23r${ESC}8`);
+  it('reserveSeq confines scrolling above the two-row region', () => {
+    expect(reserveSeq(24)).toBe(`${ESC}[1;22r${ESC}[22;1H`);
   });
   it('reserveSeq clamps a tiny terminal to a valid region', () => {
-    expect(reserveSeq(1)).toBe(`${ESC}7${ESC}[1;1r${ESC}8`);  // never a 0/negative bottom
+    expect(reserveSeq(1)).toBe(`${ESC}[1;1r${ESC}[1;1H`);
   });
-  it('paintSeq jumps to the bottom row, clears it, writes, and restores the cursor', () => {
+  it('paintSeq targets status and composer rows independently', () => {
     expect(paintSeq(24, 'Enter → steer')).toBe(`${ESC}7${ESC}[24;1H${ESC}[2KEnter → steer${ESC}8`);
+    expect(paintSeq(24, 'Enter → steer', 1)).toBe(`${ESC}7${ESC}[23;1H${ESC}[2KEnter → steer${ESC}8`);
   });
-  it('teardownSeq restores full-screen scrolling and clears the lane row', () => {
-    expect(teardownSeq(24)).toBe(`${ESC}[r${ESC}7${ESC}[24;1H${ESC}[2K${ESC}8`);
+  it('teardownSeq restores full-screen scrolling and clears both rows', () => {
+    expect(teardownSeq(24)).toBe(
+      `${ESC}[r${ESC}7${ESC}[23;1H${ESC}[2K${ESC}[24;1H${ESC}[2K${ESC}8`,
+    );
   });
   it('fitLane tail-fits with a FRONT ellipsis (keeps the cursor end visible)', () => {
     expect(fitLane('short', 80)).toBe('short');
@@ -65,16 +67,17 @@ function mockSink(rows = 24, cols = 80) {
 }
 
 describe('ComposerLane — lifecycle', () => {
-  it('activate reserves the region THEN paints the composer on the bottom row', () => {
+  it('activate reserves the region and paints composer above status', () => {
     const s = mockSink(24);
     const lane = new ComposerLane(s);
-    lane.activate('Enter → steer · /queue · Ctrl+C stop');
+    lane.activate('Enter → steer · /queue · Ctrl+C stop', 'provider · model · ctx · 1s');
     expect(lane.isActive()).toBe(true);
     const out = s.text();
-    expect(out).toContain(`${ESC}[1;23r`);                 // region reserved (protects row 24)
-    expect(out).toContain(`${ESC}[24;1H${ESC}[2KEnter → steer`); // composer painted on the lane
+    expect(out).toContain(`${ESC}[1;22r`);
+    expect(out).toContain(`${ESC}[23;1H${ESC}[2KEnter → steer`);
+    expect(out).toContain(`${ESC}[24;1H${ESC}[2Kprovider`);
     // reserve happens before the first paint
-    expect(out.indexOf('[1;23r')).toBeLessThan(out.indexOf('[24;1H'));
+    expect(out.indexOf('[1;22r')).toBeLessThan(out.indexOf('[23;1H'));
   });
 
   it('paint with the SAME text is a no-op — no flicker on redundant repaints', () => {
@@ -102,7 +105,7 @@ describe('ComposerLane — lifecycle', () => {
     lane.activate('Enter → steer');
     lane.paint('steer ▸ x');
     // Every paint is bracketed by save/restore → the output cursor is never lost.
-    const paints = s.text().split(`${ESC}7`).filter((p) => p.includes(';1H'));
+    const paints = s.text().split(`${ESC}7`).slice(1).filter((p) => p.includes(';1H'));
     for (const p of paints) expect(p).toContain(ESC + '8');
   });
 
@@ -112,8 +115,8 @@ describe('ComposerLane — lifecycle', () => {
     lane.activate('Enter → steer');
     (s as any).fireResize(30);   // terminal grew to 30 rows
     const out = s.text();
-    expect(out).toContain(`${ESC}[1;29r`);                 // region re-reserved for 30 rows
-    expect(out).toContain(`${ESC}[30;1H`);                 // composer re-anchored to new bottom
+    expect(out).toContain(`${ESC}[1;28r`);
+    expect(out).toContain(`${ESC}[29;1H`);
   });
 
   it('restores the full draft after a narrow-to-wide resize', () => {
@@ -140,9 +143,9 @@ describe('ComposerLane — lifecycle', () => {
     const s = mockSink();
     const lane = new ComposerLane(s);
     lane.activate('a');
-    const reserves1 = s.text().split('[1;23r').length - 1;
+    const reserves1 = s.text().split('[1;22r').length - 1;
     lane.activate('b');
-    const reserves2 = s.text().split('[1;23r').length - 1;
+    const reserves2 = s.text().split('[1;22r').length - 1;
     expect(reserves1).toBe(1);
     expect(reserves2).toBe(1);          // still one reserve
     expect(s.text()).toContain('b');    // repainted

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -16,6 +16,8 @@ import {
   reserveSeq, paintSeq, teardownSeq, fitLane, ComposerLane, composerLaneEnabled,
   type LaneSink,
 } from '../../../cli/v4/composerLane';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
 
 const ESC = '\x1b';
 
@@ -41,6 +43,11 @@ describe('escape-sequence builders (pure)', () => {
     expect(fit.length).toBe(10);
     expect(fit.startsWith('…')).toBe(true);
     expect(fit.endsWith('z')).toBe(true);   // most-recent chars kept
+  });
+  it('fitLane budgets wide terminal glyphs without wrapping', () => {
+    const fit = fitLane('prefix ⌛ preserve-the-end', 12);
+    expect(stringWidth(fit)).toBeLessThanOrEqual(12);
+    expect(fit).toMatch(/the-end$/);
   });
 });
 
@@ -78,6 +85,20 @@ describe('ComposerLane — lifecycle', () => {
     expect(out).toContain(`${ESC}[24;1H${ESC}[2Kprovider`);
     // reserve happens before the first paint
     expect(out.indexOf('[1;22r')).toBeLessThan(out.indexOf('[23;1H'));
+  });
+
+  it('keeps the status row inside the physical width budget', () => {
+    const s = mockSink(24, 48);
+    const lane = new ComposerLane(s);
+    lane.activate(
+      'Type your message',
+      '  custom_openai:custom-default │ ctx0% │ ⌛ 0ms',
+    );
+    const painted = s.text()
+      .split(`${ESC}[24;1H${ESC}[2K`).at(-1)!
+      .split(ESC + '8')[0]
+      .replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+    expect(stringWidth(painted)).toBeLessThanOrEqual(46);
   });
 
   it('paint with the SAME text is a no-op — no flicker on redundant repaints', () => {

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -1597,19 +1597,15 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
     });
   });
 
-  it('wide (≥120 cols): 5 separators (v4.10 Slice 10.3 — brand + session-uptime + spelled "last")', () => {
+  it('wide (≥120 cols): keeps the three runtime segments visually distinct', () => {
     withCols(140, () => {
       const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
       const out = stripAnsi(d.statusFooter(BASE));
-      // v4.9.0 pre-ship UI: turn counter retired; ⌛ hourglass remains.
       expect(out).not.toMatch(/↻/);
-      expect(out).toContain('⌛');
-      // v4.10 Slice 10.3 — full-density tier now has 6 segments:
-      //   brand · provModel │ ctxSegFull │ sessionUptime │ last <elapsed> │ stateDot
-      // => 5 separators between 6 segments.
-      expect(out).toMatch(/Aiden v\d/);
-      expect(out).toMatch(/last\s+\d+s/);
-      expect(sepCount(out)).toBe(5);
+      expect(out).toContain('◆');
+      expect(out).toContain('◉ context');
+      expect(out).toContain('⧖');
+      expect(sepCount(out)).toBe(2);
     });
   });
 
@@ -1655,8 +1651,8 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
         elapsedMs: 0,
       }));
       expect(stringWidth(out)).toBeLessThanOrEqual(46);
-      expect(out).toContain('ctx0%');
-      expect(out).toContain('⌛');
+      expect(out).toContain('◉ 0%');
+      expect(out).toContain('⧖');
     });
   });
 });

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -13,6 +13,8 @@ import {
 } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import type { ActivitySnapshot } from '../../../cli/v4/activityRegistry';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
 
 // Strip ANSI escape sequences so assertions stay terminal-agnostic.
 function stripAnsi(s: string): string {
@@ -1639,6 +1641,22 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
       const out = stripAnsi(d.statusFooter(BASE));
       // 80-col tier: no ANSI to strip in forceMono; raw len is the visible width.
       expect(out.length).toBeLessThanOrEqual(80);
+    });
+  });
+
+  it('48-col output budgets the wide timer glyph by terminal cell width', () => {
+    withCols(48, () => {
+      const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
+      const out = stripAnsi(d.statusFooter({
+        ...BASE,
+        provider: 'custom_openai',
+        model: 'custom-default',
+        ctxUsed: 0,
+        elapsedMs: 0,
+      }));
+      expect(stringWidth(out)).toBeLessThanOrEqual(46);
+      expect(out).toContain('ctx0%');
+      expect(out).toContain('⌛');
     });
   });
 });

--- a/tests/v4/cli/displayComposer.test.ts
+++ b/tests/v4/cli/displayComposer.test.ts
@@ -47,8 +47,8 @@ describe('Display composer — live during-turn paint', () => {
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setComposer('a', 'queue');
-    // Fixed-lane discipline: jump to the final row and erase it in place.
-    expect(chunks.join('')).toMatch(/\x1b\[24;1H\x1b\[2K/);
+    // Fixed-region discipline: composer is the second-last row.
+    expect(chunks.join('')).toMatch(/\x1b\[23;1H\x1b\[2K/);
     expect(stripAnsi(chunks.join(''))).toContain('queue ▸ a');
     ind.stop();
   });
@@ -194,8 +194,8 @@ describe('Display composer — fixed bottom lane (opt-in) reserves + pins the ro
       chunks.length = 0;
       d.setBusyHint('Enter → steer · /queue · Ctrl+C stop');
       const raw = chunks.join('');
-      expect(raw).toContain('\x1b[1;23r');                 // scroll region reserved (row 24 protected)
-      expect(raw).toContain('\x1b[24;1H');                 // composer pinned to the bottom row
+      expect(raw).toContain('\x1b[1;22r');                 // final two rows protected
+      expect(raw).toContain('\x1b[23;1H');                 // composer above status row
       expect(raw).toContain('Enter → steer');              // …with the plain-language hint
       // turn end tears the region back down.
       d.clearComposer();
@@ -217,7 +217,7 @@ describe('Display composer — fixed bottom lane (opt-in) reserves + pins the ro
 
     chunks.length = 0;
     d.resumeComposerSurface();
-    expect(chunks.join('')).toContain('\x1b[1;23r');
+    expect(chunks.join('')).toContain('\x1b[1;22r');
     expect(stripAnsi(chunks.join(''))).toContain('draft survives');
     d.clearComposer();
   });

--- a/tests/v4/cli/displayComposer.test.ts
+++ b/tests/v4/cli/displayComposer.test.ts
@@ -5,10 +5,9 @@
  * Aiden — local-first agent.
  */
 /**
- * v4.12.1 Pillar 4 Slice 2c — the live during-turn composer woven into the
- * owned bottom row. Verifies: setComposer paints the buffer + mode label into
- * the live indicator; it survives (and repaints) a tool call; clearComposer
- * removes it; and it never fires without a live owner (no stray writes).
+ * The live during-turn composer uses one owned bottom surface. Verifies:
+ * setComposer paints the draft + mode label, tool calls do not swallow the
+ * input surface, and clearing removes it without stray writes.
  */
 import { describe, it, expect } from 'vitest';
 import { Writable } from 'node:stream';
@@ -38,7 +37,8 @@ describe('Display composer — live during-turn paint', () => {
     chunks.length = 0;
     d.setComposer('deploy now', 'redirect');
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('steer ▸ deploy now');
+    expect(painted).toContain('▲ You · steer mode');
+    expect(painted).toContain('│ deploy now');
     ind.stop();
   });
 
@@ -47,9 +47,10 @@ describe('Display composer — live during-turn paint', () => {
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setComposer('a', 'queue');
-    // Fixed-region discipline: composer is the second-last row.
-    expect(chunks.join('')).toMatch(/\x1b\[23;1H\x1b\[2K/);
-    expect(stripAnsi(chunks.join(''))).toContain('queue ▸ a');
+    // Fixed-region discipline: the draft is inside the boxed content row.
+    expect(chunks.join('')).toMatch(/\x1b\[22;1H\x1b\[2K/);
+    expect(stripAnsi(chunks.join(''))).toContain('▲ You · queue mode');
+    expect(stripAnsi(chunks.join(''))).toContain('│ a');
     ind.stop();
   });
 
@@ -63,7 +64,7 @@ describe('Display composer — live during-turn paint', () => {
     ind.stop();
   });
 
-  it('SURVIVES a tool call — the tool row carries the composer suffix', () => {
+  it('survives a tool call without moving the composer into the tool row', () => {
     const { d, chunks } = makeDisplay();
     const ind = d.activityIndicator('thinking');
     d.setComposer('hold on', 'queue');
@@ -75,7 +76,8 @@ describe('Display composer — live during-turn paint', () => {
     // is paused) — this is the whole point of Slice 2c.
     d.setComposer('hold on!', 'queue');
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('queue ▸ hold on!');
+    expect(painted).toContain('▲ You · queue mode');
+    expect(painted).toContain('│ hold on!');
     row.ok(120);
     ind.stop();
   });
@@ -89,7 +91,8 @@ describe('Display composer — live during-turn paint', () => {
     ind.resume();          // indicator reclaims the bottom
     chunks.length = 0;
     d.setComposer('back', 'redirect');
-    expect(stripAnsi(chunks.join(''))).toContain('steer ▸ back');
+    expect(stripAnsi(chunks.join(''))).toContain('▲ You · steer mode');
+    expect(stripAnsi(chunks.join(''))).toContain('│ back');
     ind.stop();
   });
 
@@ -101,7 +104,7 @@ describe('Display composer — live during-turn paint', () => {
     d.clearComposer();
     const painted = stripAnsi(chunks.join(''));
     expect(painted).not.toContain('typing…');
-    expect(painted).not.toContain('queue ▸');
+    expect(painted).not.toContain('▲ You');
     ind.stop();
   });
 
@@ -120,7 +123,8 @@ describe('Display composer — live during-turn paint', () => {
     ind.stop();
     chunks.length = 0;
     d.setComposer('next message', 'queue');
-    expect(stripAnsi(chunks.join(''))).toContain('queue ▸ next message');
+    expect(stripAnsi(chunks.join(''))).toContain('▲ You · queue mode');
+    expect(stripAnsi(chunks.join(''))).toContain('│ next message');
   });
 
   it('pasted text shows clean (no paste markers reach the row)', () => {
@@ -130,7 +134,8 @@ describe('Display composer — live during-turn paint', () => {
     // chatSession passes an already-stripped buffer; the row shows it verbatim.
     d.setComposer('npm run build', 'redirect');
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('steer ▸ npm run build');
+    expect(painted).toContain('▲ You · steer mode');
+    expect(painted).toContain('│ npm run build');
     expect(painted).not.toContain('[200~');
     expect(painted).not.toContain('[201~');
     ind.stop();
@@ -139,36 +144,41 @@ describe('Display composer — live during-turn paint', () => {
 
 // ── v4.14 BUG 2 — the ALWAYS-visible input lane (persistent hint) ────────────
 describe('Display composer — persistent busy hint (input lane always visible)', () => {
-  it('setBusyHint shows the plain-language hint in the row BEFORE any keystroke', () => {
+  it('setBusyHint shows a labeled empty composer before any keystroke', () => {
     const { d, chunks } = makeDisplay();
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setBusyHint('Enter → steer · /busy to change · Ctrl+C stop');   // turn start, nothing typed
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('Enter → steer');   // input lane visible with zero typing
+    expect(painted).toContain('▲ You · steer mode');
+    expect(painted).not.toContain('Enter → steer');
+    expect(painted).toContain('│ ');
     ind.stop();
   });
 
-  it('typing OVERRIDES the hint with the live buffer; clearing the buffer falls BACK to the hint', () => {
+  it('typing fills the box; clearing restores a labeled empty composer', () => {
     const { d, chunks } = makeDisplay();
     const ind = d.activityIndicator('thinking');
     d.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
     d.setComposer('hello', 'queue');
-    expect(stripAnsi(chunks.join(''))).toContain('queue ▸ hello');   // typed text wins
+    expect(stripAnsi(chunks.join(''))).toContain('│ hello');
     chunks.length = 0;
     d.setComposer('', 'queue');                                       // user cleared their line
-    expect(stripAnsi(chunks.join(''))).toContain('Enter → queue');   // hint returns (lane stays visible)
+    expect(stripAnsi(chunks.join(''))).toContain('▲ You · queue mode');
+    expect(stripAnsi(chunks.join(''))).not.toContain('Enter → queue');
+    expect(stripAnsi(chunks.join(''))).not.toContain('hello');
     ind.stop();
   });
 
-  it('the hint SURVIVES a tool call (rides the tool row, like the typed composer)', () => {
+  it('the labeled empty composer survives a tool call without helper text', () => {
     const { d, chunks } = makeDisplay();
     const ind = d.activityIndicator('thinking');
     d.setBusyHint('Enter → steer · /busy to change · Ctrl+C stop');
     ind.pause();
     const row = d.toolRow('web_research', { query: 'q' });
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('Enter → steer');   // visible + typeable during a long tool call
+    expect(painted).toContain('▲ You · steer mode');
+    expect(painted).not.toContain('Enter → steer');
     row.ok(120);
     ind.stop();
   });
@@ -184,9 +194,9 @@ describe('Display composer — persistent busy hint (input lane always visible)'
   });
 });
 
-// ── v4.14 — the FIXED bottom lane routing (opt-in AIDEN_COMPOSER_LANE=1) ──────
-describe('Display composer — fixed bottom lane (opt-in) reserves + pins the row', () => {
-  it('setBusyHint reserves the scroll region and pins the composer to the bottom row', () => {
+// ── Fixed bottom surface with compatibility opt-out ───────────────────────
+describe('Display composer — fixed bottom surface compatibility opt-out', () => {
+  it('setBusyHint reserves the scroll region and pins the boxed composer', () => {
     const prev = process.env.AIDEN_COMPOSER_LANE;
     process.env.AIDEN_COMPOSER_LANE = '1';
     try {
@@ -194,9 +204,11 @@ describe('Display composer — fixed bottom lane (opt-in) reserves + pins the ro
       chunks.length = 0;
       d.setBusyHint('Enter → steer · /queue · Ctrl+C stop');
       const raw = chunks.join('');
-      expect(raw).toContain('\x1b[1;22r');                 // final two rows protected
-      expect(raw).toContain('\x1b[23;1H');                 // composer above status row
-      expect(raw).toContain('Enter → steer');              // …with the plain-language hint
+      expect(raw).toContain('\x1b[1;20r');                 // boxed composer + status protected
+      expect(raw).toContain('\x1b[21;1H');                 // labeled top border
+      expect(raw).toContain('\x1b[22;1H');                 // composer content row
+      expect(raw).toContain('▲ You · queue mode');
+      expect(raw).not.toContain('Enter → steer');
       // turn end tears the region back down.
       d.clearComposer();
       expect(chunks.join('')).toContain('\x1b[r');          // full-screen scrolling restored
@@ -217,7 +229,7 @@ describe('Display composer — fixed bottom lane (opt-in) reserves + pins the ro
 
     chunks.length = 0;
     d.resumeComposerSurface();
-    expect(chunks.join('')).toContain('\x1b[1;22r');
+    expect(chunks.join('')).toContain('\x1b[1;20r');
     expect(stripAnsi(chunks.join(''))).toContain('draft survives');
     d.clearComposer();
   });

--- a/tests/v4/cli/displayComposer.test.ts
+++ b/tests/v4/cli/displayComposer.test.ts
@@ -47,8 +47,8 @@ describe('Display composer — live during-turn paint', () => {
     const ind = d.activityIndicator('thinking');
     chunks.length = 0;
     d.setComposer('a', 'queue');
-    // owned-row discipline: repaint starts with up-one-line + erase.
-    expect(chunks.join('')).toMatch(/\x1b\[1A\x1b\[2K/);
+    // Fixed-lane discipline: jump to the final row and erase it in place.
+    expect(chunks.join('')).toMatch(/\x1b\[24;1H\x1b\[2K/);
     expect(stripAnsi(chunks.join(''))).toContain('queue ▸ a');
     ind.stop();
   });
@@ -114,13 +114,13 @@ describe('Display composer — live during-turn paint', () => {
     ind.stop();
   });
 
-  it('after the indicator stops, setComposer does NOT write (no owner to repaint)', () => {
+  it('after the indicator stops, the independent composer lane still repaints', () => {
     const { d, chunks } = makeDisplay();
     const ind = d.activityIndicator('thinking');
     ind.stop();
     chunks.length = 0;
-    d.setComposer('ghost', 'queue');   // no live owner
-    expect(chunks.join('')).toBe('');
+    d.setComposer('next message', 'queue');
+    expect(stripAnsi(chunks.join(''))).toContain('queue ▸ next message');
   });
 
   it('pasted text shows clean (no paste markers reach the row)', () => {
@@ -203,5 +203,22 @@ describe('Display composer — fixed bottom lane (opt-in) reserves + pins the ro
     } finally {
       if (prev === undefined) delete process.env.AIDEN_COMPOSER_LANE; else process.env.AIDEN_COMPOSER_LANE = prev;
     }
+  });
+
+  it('releases the reserved row for a modal and restores the exact draft afterward', () => {
+    const { d, chunks } = makeDisplay();
+    d.setBusyHint('Enter → queue · /queue · Ctrl+C stop');
+    d.setComposer('draft survives', 'queue');
+    chunks.length = 0;
+
+    d.pauseComposerSurface();
+    expect(chunks.join('')).toContain('\x1b[r');
+    expect(stripAnsi(chunks.join(''))).not.toContain('draft survives');
+
+    chunks.length = 0;
+    d.resumeComposerSurface();
+    expect(chunks.join('')).toContain('\x1b[1;23r');
+    expect(stripAnsi(chunks.join(''))).toContain('draft survives');
+    d.clearComposer();
   });
 });

--- a/tests/v4/cli/interactionDecision.pty.test.ts
+++ b/tests/v4/cli/interactionDecision.pty.test.ts
@@ -192,7 +192,12 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
             child!.write('\x1b[B');
             setTimeout(() => child!.write('\r'), 150);
           }, 250);
-        } else if (state === 'single-denial-settle' && plain.includes('SINGLE DENIAL COMPLETE') && readyCount >= 3) {
+        } else if (
+          state === 'single-denial-settle'
+          && provider!.callCount() >= 3
+          && plain.slice(turnStart).includes('Denied · Task:')
+          && readyCount >= 3
+        ) {
           settled.denial = plain.slice(turnStart);
           state = 'clear-before-allow';
           typeLine(child!, '/clear');
@@ -203,7 +208,12 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (state === 'single-allow-prompt' && plain.slice(turnStart).includes('Decision')) {
           state = 'single-allow-settle';
           setTimeout(() => child!.write('\r'), 250);
-        } else if (state === 'single-allow-settle' && plain.includes('SINGLE ALLOW COMPLETE') && readyCount >= 5) {
+        } else if (
+          state === 'single-allow-settle'
+          && provider!.callCount() >= 5
+          && plain.slice(turnStart).includes('Completed · Task:')
+          && readyCount >= 5
+        ) {
           settled.allow = plain.slice(turnStart);
           state = 'clear-after-single';
           typeLine(child!, '/clear');
@@ -217,7 +227,12 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (state === 'batch-valid-retry' && plain.includes('Could not parse')) {
           state = 'batch-valid-settle';
           setTimeout(() => typeLine(child!, '1'), 200);
-        } else if (state === 'batch-valid-settle' && plain.includes('BATCH RETRY COMPLETE') && readyCount >= 7) {
+        } else if (
+          state === 'batch-valid-settle'
+          && provider!.callCount() >= 8
+          && /(?:Partially completed|Verified) · Task:/.test(plain.slice(turnStart))
+          && readyCount >= 7
+        ) {
           settled.retry = plain.slice(turnStart);
           state = 'clear-after-retry';
           typeLine(child!, '/clear');
@@ -228,7 +243,12 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (state === 'batch-cancel-prompt' && plain.includes('Cancel this write')) {
           state = 'batch-cancel-settle';
           setTimeout(() => child!.write('\x03'), 250);
-        } else if (state === 'batch-cancel-settle' && plain.includes('BATCH CANCELLATION COMPLETE') && readyCount >= 9) {
+        } else if (
+          state === 'batch-cancel-settle'
+          && provider!.callCount() >= 10
+          && plain.slice(turnStart).includes('Cancelled · Task:')
+          && readyCount >= 9
+        ) {
           settled.cancel = plain.slice(turnStart);
           state = 'clear-after-cancel';
           typeLine(child!, '/clear');
@@ -239,7 +259,12 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (state === 'batch-none-prompt' && plain.includes('Deny this write')) {
           state = 'batch-none-settle';
           setTimeout(() => typeLine(child!, 'none'), 200);
-        } else if (state === 'batch-none-settle' && plain.includes('BATCH NONE COMPLETE') && readyCount >= 11) {
+        } else if (
+          state === 'batch-none-settle'
+          && provider!.callCount() >= 12
+          && plain.slice(turnStart).includes('Denied · Task:')
+          && readyCount >= 11
+        ) {
           settled.none = plain.slice(turnStart);
           state = 'queue';
           typeLine(child!, '/queue');

--- a/tests/v4/cli/oneShotJobIdentity.test.ts
+++ b/tests/v4/cli/oneShotJobIdentity.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { executeOneShotTurn } from '../../../cli/v4/aidenCLI';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+describe('headless durable Job admission', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance_oneshot', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    engine = createJobEngine({ db });
+  });
+
+  afterEach(() => db.close());
+
+  it('creates identity before the first provider-facing agent call', async () => {
+    const agent = {
+      runConversation: vi.fn(async () => {
+        expect(engine.listJobs({ sessionId: 'session_oneshot' })).toHaveLength(1);
+        expect(engine.listAttempts(engine.listJobs({ sessionId: 'session_oneshot' })[0]!.id)[0]).toMatchObject({
+          status: 'running',
+        });
+        return { finalContent: 'ok', finishReason: 'stop', toolCallTrace: [] };
+      }),
+    };
+
+    expect(await executeOneShotTurn({
+      agent,
+      prompt: 'headless work',
+      writeOut: () => {},
+      writeErr: () => {},
+      jobEngine: engine,
+      instanceId: 'instance_oneshot',
+      sessionId: 'session_oneshot',
+    })).toBe(0);
+
+    expect(agent.runConversation).toHaveBeenCalledOnce();
+    expect(engine.listJobs({ sessionId: 'session_oneshot' })[0]).toMatchObject({ status: 'completed' });
+  });
+});

--- a/tests/v4/cli/render/promptBoundary.test.ts
+++ b/tests/v4/cli/render/promptBoundary.test.ts
@@ -30,7 +30,7 @@ describe('prompt-zone rule boundaries', () => {
   it('chatSession.ts emits BOTTOM rule immediately before runAgentTurn', () => {
     const src = readFileSync(path.join(__dirname, '../../../../cli/v4/chatSession.ts'), 'utf8');
     const lines = src.split('\n');
-    const idx = lines.findIndex((l) => /await this\.runAgentTurn\(input\)/.test(l));
+    const idx = lines.findIndex((l) => /await this\.runAgentTurn\(input(?:,\s*inputAlreadyPersisted)?\)/.test(l));
     expect(idx).toBeGreaterThan(0);
     const preceding = lines.slice(Math.max(0, idx - 8), idx).join('\n');
     expect(preceding).toMatch(/display\.write\(\s*`\s+\$\{this\.opts\.display\.rule\(\)\}\\n`\s*\)/);

--- a/tests/v4/cli/render/welcomeChrome.test.ts
+++ b/tests/v4/cli/render/welcomeChrome.test.ts
@@ -16,7 +16,7 @@ describe('renderStartupCard closing-line order', () => {
     expect(SRC.indexOf('display.rule(Math.max(1, columns - 4))', h)).toBeGreaterThan(h);
   });
   it('turn loop does not emit bottomPromptHint per turn', () => {
-    const slice = SRC.slice(SRC.indexOf('while (iter < max)'), SRC.indexOf('await this.runAgentTurn(input)'));
+    const slice = SRC.slice(SRC.indexOf('while (iter < max)'), SRC.indexOf('private async runAgentTurn'));
     expect(slice).not.toMatch(/bottomPromptHint/);
   });
 });

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -6,6 +6,7 @@ import * as pty from 'node-pty';
 
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
+import { TerminalScreen } from '../harness/terminalScreen';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
@@ -43,6 +44,7 @@ async function launch(columns: number, paused = false): Promise<{
   child: RunningPty;
   raw: () => string;
   plain: () => string;
+  rendered: () => string;
 }> {
   const repoRoot = path.resolve(__dirname, '../../..');
   const home = await fs.mkdtemp(path.join(os.tmpdir(), `aiden-startup-${columns}-home-`));
@@ -82,12 +84,21 @@ async function launch(columns: number, paused = false): Promise<{
   });
   children.push(child);
   let output = '';
-  child.onData((chunk) => { output += chunk; });
+  const screen = new TerminalScreen(columns, 50);
+  child.onData((chunk) => {
+    output += chunk;
+    screen.write(chunk);
+  });
   await waitFor(
     () => output.includes(COMPOSER_READY_TOKEN),
     () => stripAnsi(output),
   );
-  return { child, raw: () => output, plain: () => stripAnsi(output) };
+  return {
+    child,
+    raw: () => output,
+    plain: () => stripAnsi(output),
+    rendered: () => screen.snapshot(),
+  };
 }
 
 function dashboardLines(output: string): string[] {
@@ -153,14 +164,21 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     }
 
     const narrow = await launch(48);
-    expect(narrow.plain()).toMatch(/\bAIDEN\b/);
-    expect(narrow.plain()).toMatch(/Assistant\s+·\s+custom-default/i);
-    expect(narrow.plain()).toMatch(/built solo/i);
-    expect(narrow.plain()).not.toContain('Environment');
-    expect(narrow.plain()).not.toContain('Capabilities');
-    expect(narrow.plain()).not.toContain('╭');
-    for (const line of dashboardLines(narrow.plain())) {
+    const narrowRendered = narrow.rendered();
+    expect(narrowRendered).toMatch(/\bAIDEN\b/);
+    expect(narrowRendered).toMatch(/Assistant\s+·\s+custom-default/i);
+    expect(narrowRendered).toMatch(/built solo/i);
+    expect(narrowRendered).not.toContain('Environment');
+    expect(narrowRendered).not.toContain('Capabilities');
+    expect(narrowRendered).not.toContain('╭');
+    for (const line of dashboardLines(narrowRendered)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(46);
     }
+    const narrowRows = narrowRendered.split('\n');
+    expect(narrowRows.at(-2)).toContain('Type your message');
+    expect(narrowRows.at(-1)).toContain('ctx');
+    expect(stringWidth(narrowRows.at(-2) ?? '')).toBeLessThanOrEqual(46);
+    expect(stringWidth(narrowRows.at(-1) ?? '')).toBeLessThanOrEqual(46);
+    expect(narrowRows.slice(0, -2).filter((line) => line.includes('Type your message'))).toEqual([]);
   }, 75_000);
 });

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -104,10 +104,10 @@ async function launch(columns: number, paused = false): Promise<{
 function dashboardLines(output: string): string[] {
   const lines = output.split(/\r?\n/);
   const start = lines.findIndex((line) => line.includes('█████╗') || /^\s*AIDEN\s*$/.test(line));
-  const end = lines.findIndex((line, index) => index >= start && /Type (?:your message|· \/help)/.test(line));
+  const end = lines.findIndex((line, index) => index >= start && line.startsWith('╭─ ▲ You'));
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
-  return lines.slice(start, end + 1);
+  return lines.slice(start, end);
 }
 
 afterEach(async () => {
@@ -158,7 +158,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     expect(medium.plain()).toContain('Environment');
     expect(medium.plain()).toContain('Capabilities');
     expect(medium.plain()).toContain('github.com/taracodlabs/aiden');
-    expect(medium.plain()).not.toContain('╭');
+    expect(dashboardLines(medium.plain()).join('\n')).not.toContain('╭');
     for (const line of dashboardLines(medium.plain())) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(78);
     }
@@ -170,15 +170,18 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     expect(narrowRendered).toMatch(/built solo/i);
     expect(narrowRendered).not.toContain('Environment');
     expect(narrowRendered).not.toContain('Capabilities');
-    expect(narrowRendered).not.toContain('╭');
+    expect(dashboardLines(narrowRendered).join('\n')).not.toContain('╭');
     for (const line of dashboardLines(narrowRendered)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(46);
     }
     const narrowRows = narrowRendered.split('\n');
-    expect(narrowRows.at(-2)).toContain('Type your message');
-    expect(narrowRows.at(-1)).toContain('ctx');
-    expect(stringWidth(narrowRows.at(-2) ?? '')).toBeLessThanOrEqual(46);
+    expect(narrowRows.at(-4)).toContain('▲ You');
+    expect(narrowRows.at(-3)).toMatch(/^│\s+│$/);
+    expect(narrowRows.at(-2)).toMatch(/^╰─/);
+    expect(narrowRows.at(-1)).toContain('◉');
+    expect(stringWidth(narrowRows.at(-4) ?? '')).toBeLessThanOrEqual(47);
+    expect(stringWidth(narrowRows.at(-3) ?? '')).toBeLessThanOrEqual(47);
     expect(stringWidth(narrowRows.at(-1) ?? '')).toBeLessThanOrEqual(46);
-    expect(narrowRows.slice(0, -2).filter((line) => line.includes('Type your message'))).toEqual([]);
+    expect(narrowRows.slice(0, -4).filter((line) => line.includes('▲ You'))).toEqual([]);
   }, 75_000);
 });

--- a/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
+++ b/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
@@ -7,6 +7,7 @@ import * as pty from 'node-pty';
 import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
+import { TerminalScreen } from '../harness/terminalScreen';
 
 type RunningPty = ReturnType<typeof pty.spawn>;
 let child: RunningPty | null = null;
@@ -86,19 +87,22 @@ describe.skipIf(process.platform !== 'win32')('built CLI token-efficiency accept
     });
 
     let output = '';
+    const screen = new TerminalScreen(110, 40);
     let state = 'boot';
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error(
-        `token-efficiency acceptance timeout (${state}):\n${plain(output).slice(-12_000)}`,
+        `token-efficiency acceptance timeout (${state}):\n${screen.snapshot()}`,
       )), 45_000);
       child!.onData((chunk) => {
         output += chunk;
-        const text = plain(output);
+        screen.write(chunk);
+        const text = screen.snapshot();
+        const rawText = plain(output);
         const ready = output.split(COMPOSER_READY_TOKEN).length - 1;
         if (state === 'boot' && ready >= 1) {
           state = 'estimate';
           submit(child!, '/estimate --json inspect one file');
-        } else if (state === 'estimate' && text.includes('"selectedMode":"balanced"') && ready >= 2) {
+        } else if (state === 'estimate' && rawText.includes('"selectedMode":"balanced"') && ready >= 2) {
           expect(provider!.callCount()).toBe(0);
           state = 'mode'; submit(child!, '/mode economy');
         } else if (state === 'mode' && text.includes('Usage mode: economy') && ready >= 3) {
@@ -107,7 +111,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI token-efficiency accept
           state = 'turn'; submit(child!, 'reply with the acceptance phrase');
         } else if (state === 'turn' && text.includes('TOKEN EFFICIENCY ACCEPTANCE') && ready >= 5) {
           state = 'usage-json'; submit(child!, '/usage --json');
-        } else if (state === 'usage-json' && text.includes('"physicalAttempts":1') && ready >= 6) {
+        } else if (state === 'usage-json' && rawText.includes('"physicalAttempts":1') && ready >= 6) {
           state = 'usage-human'; submit(child!, '/usage');
         } else if (state === 'usage-human' && text.includes('Usage — Current session') && ready >= 7) {
           expect(text).toContain('cumulative exposures');
@@ -117,7 +121,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI token-efficiency accept
           expect(text).toContain('Providers and models');
           expect(text).toContain('Purposes');
           state = 'budget-json'; submit(child!, '/budget --json');
-        } else if (state === 'budget-json' && text.includes('"tokenBudget":100000') && ready >= 9) {
+        } else if (state === 'budget-json' && rawText.includes('"tokenBudget":100000') && ready >= 9) {
           state = 'queue'; submit(child!, '/queue');
         } else if (state === 'queue' && /queue is empty/i.test(text) && ready >= 10) {
           state = 'quit'; submit(child!, '/quit');

--- a/tests/v4/core/actionAuthority.test.ts
+++ b/tests/v4/core/actionAuthority.test.ts
@@ -120,7 +120,9 @@ describe('final action and durable Approval authority', () => {
         riskTier: 'caution',
         policy,
       });
-      expect(normalized.plan.affectedResources).toEqual([path.join(target, 'result.txt')]);
+      expect(normalized.plan.affectedResources).toEqual([
+        path.join(fs.realpathSync.native(target), 'result.txt'),
+      ]);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/tests/v4/core/actionAuthority.test.ts
+++ b/tests/v4/core/actionAuthority.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type AdmissionResult, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import {
+  createActionAuthority,
+  normalizeExecutionPlan,
+  type ActionAuthority,
+  type PolicySnapshotInput,
+} from '../../../core/v4/actionAuthority';
+
+describe('final action and durable Approval authority', () => {
+  let db: Database.Database;
+  let jobs: JobEngine;
+  let actions: ActionAuthority;
+  let admission: AdmissionResult;
+  let fenceToken: string;
+  const policy: PolicySnapshotInput = {
+    trustLevel: 'Assistant',
+    autonomyPolicy: 'ask_for_mutations',
+    approvalMode: 'smart',
+    toolMetadataVersion: '1',
+    sandboxPolicy: { roots: ['C:/workspace'], deny: ['C:/Windows'] },
+    networkPolicy: { allow: ['example.test'] },
+    pluginGrants: [],
+    mcpGrants: [],
+    workspaceOverrides: {},
+    jobOverrides: {},
+  };
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance-1', 1, 'test', 1, 1, 'test')`,
+    ).run();
+    jobs = createJobEngine({ db });
+    admission = jobs.submitJob({
+      entryPoint: 'interactive',
+      source: 'test',
+      sessionId: 'session-1',
+      instanceId: 'instance-1',
+      idempotencyNamespace: 'test',
+      idempotencyKey: 'job-approval',
+      goal: 'approval test',
+    });
+    const lease = jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'test', ttlMs: 60_000 });
+    fenceToken = lease.fenceToken!;
+    const attemptRunning = jobs.transitionAttempt({
+      attemptId: admission.attemptId,
+      expectedStateVersion: lease.stateVersion!,
+      generation: 1,
+      fenceToken,
+      to: 'running',
+      eventIdempotencyKey: 'approval-attempt-running',
+      producer: 'test',
+    });
+    jobs.transitionJob({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      fenceToken,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'approval-job-running',
+      producer: 'test',
+    });
+    expect(attemptRunning.applied).toBe(true);
+    actions = createActionAuthority({ db, jobEngine: jobs });
+  });
+
+  afterEach(() => db.close());
+
+  it('normalizes transformed arguments before producing the action digest', () => {
+    const first = normalizeExecutionPlan({
+      toolName: 'shell_exec',
+      args: { command: 'echo one', cwd: 'C:/workspace/.' },
+      cwd: 'C:/workspace',
+      mutates: true,
+      riskTier: 'caution',
+      policy,
+    });
+    const transformed = normalizeExecutionPlan({
+      toolName: 'shell_exec',
+      args: { command: 'echo two', cwd: 'C:/workspace/.' },
+      cwd: 'C:/workspace',
+      mutates: true,
+      riskTier: 'caution',
+      policy,
+    });
+    expect(first.plan.cwd).toMatch(/workspace$/i);
+    expect(first.plan.executable).toBeTruthy();
+    expect(first.actionDigest).not.toBe(transformed.actionDigest);
+    expect(first.policySnapshot.digest).toBe(transformed.policySnapshot.digest);
+  });
+
+  it('binds affected paths to their canonical symlink or junction target', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'aiden-action-'));
+    const target = path.join(root, 'target');
+    const link = path.join(root, 'link');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir');
+    try {
+      const normalized = normalizeExecutionPlan({
+        toolName: 'file_write',
+        args: { path: path.join(link, 'result.txt') },
+        cwd: root,
+        mutates: true,
+        riskTier: 'caution',
+        policy,
+      });
+      expect(normalized.plan.affectedResources).toEqual([path.join(target, 'result.txt')]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('binds approval to exact Job, Attempt, generation, ToolCall, plan, and policy', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write',
+      args: { path: 'result.txt', content: 'ok' },
+      cwd: 'C:/workspace',
+      mutates: true,
+      riskTier: 'caution',
+      policy,
+    });
+    const approval = actions.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      toolCallId: 'tool-call-1',
+      toolName: 'file_write',
+      riskTier: 'caution',
+      riskReasons: ['filesystem write'],
+      normalized,
+      expiresAt: Date.now() + 60_000,
+    });
+    expect(actions.listPending(admission.jobId)).toHaveLength(1);
+    expect(actions.decide({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+      decision: 'approved',
+      decidedBy: 'user',
+      decisionChannel: 'tui',
+    }).state).toBe('approved');
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      fenceToken,
+      toolCallId: 'tool-call-1',
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+    }).authorized).toBe(true);
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      fenceToken,
+      toolCallId: 'tool-call-1',
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+    })).toMatchObject({ authorized: false, duplicate: true });
+  });
+
+  it('replays approval lifecycle from reference-only Job events', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write',
+      args: { path: 'event-result.txt', content: 'private approval content' },
+      cwd: 'C:/workspace',
+      mutates: true,
+      riskTier: 'caution',
+      policy,
+    });
+    const approval = actions.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      toolCallId: 'tool-call-events',
+      toolName: 'file_write',
+      riskTier: 'caution',
+      riskReasons: ['filesystem write'],
+      normalized,
+    });
+    actions.markDisplayed(approval.approvalId);
+    actions.decide({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+      decision: 'approved',
+      decidedBy: 'user',
+      decisionChannel: 'tui',
+    });
+    actions.authorizeExecution({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      fenceToken,
+      toolCallId: 'tool-call-events',
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+    });
+
+    const events = jobs.listEvents(admission.jobId).filter((event) => event.type.startsWith('approval.'));
+    expect(events.map((event) => event.type)).toEqual([
+      'approval.created', 'approval.displayed', 'approval.approved', 'approval.executed',
+    ]);
+    expect(events.every((event) => event.payload?.approvalId === approval.approvalId)).toBe(true);
+    expect(JSON.stringify(events)).not.toContain('private approval content');
+    expect(JSON.stringify(events)).not.toContain('normalized_execution_plan');
+  });
+
+  it.each([
+    ['command', { command: 'echo changed' }],
+    ['path', { path: 'other.txt' }],
+    ['cwd', { cwd: 'C:/other' }],
+    ['environment', { env: { MODE: 'changed' } }],
+    ['network target', { url: 'https://other.test/' }],
+  ])('rejects a changed %s after approval', (_label, changedArgs) => {
+    const original = normalizeExecutionPlan({
+      toolName: 'shell_exec',
+      args: { command: 'echo one', path: 'result.txt', env: { MODE: 'safe' }, url: 'https://example.test/' },
+      cwd: 'C:/workspace',
+      mutates: true,
+      riskTier: 'dangerous',
+      policy,
+    });
+    const approval = actions.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      toolCallId: 'tool-call-change',
+      toolName: 'shell_exec',
+      riskTier: 'dangerous',
+      riskReasons: [],
+      normalized: original,
+    });
+    actions.decide({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      actionDigest: original.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+      decision: 'approved',
+      decidedBy: 'user',
+      decisionChannel: 'tui',
+    });
+    const changed = normalizeExecutionPlan({
+      toolName: 'shell_exec',
+      args: { command: 'echo one', path: 'result.txt', env: { MODE: 'safe' }, url: 'https://example.test/', ...changedArgs },
+      cwd: typeof changedArgs.cwd === 'string' ? changedArgs.cwd : 'C:/workspace',
+      mutates: true,
+      riskTier: 'dangerous',
+      policy,
+    });
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      fenceToken,
+      toolCallId: 'tool-call-change',
+      actionDigest: changed.actionDigest,
+      policySnapshotId: changed.policySnapshot.policySnapshotId,
+    })).toMatchObject({ authorized: false, reason: expect.stringMatching(/changed|mismatch|invalid/i) });
+  });
+
+  it('does not interpret normal text as an approval and rejects stale or terminal decisions', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write',
+      args: { path: 'result.txt', content: 'ok' },
+      cwd: 'C:/workspace',
+      mutates: true,
+      riskTier: 'caution',
+      policy,
+    });
+    const approval = actions.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      toolCallId: 'tool-call-2',
+      toolName: 'file_write',
+      riskTier: 'caution',
+      riskReasons: [],
+      normalized,
+    });
+    expect(() => actions.decideFromInput({ approvalId: approval.approvalId, inputKind: 'message', content: 'yes' }))
+      .toThrow(/explicit approval decision/i);
+    expect(() => actions.decide({
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 2,
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+      decision: 'approved',
+      decidedBy: 'user',
+      decisionChannel: 'tui',
+    })).toThrow(/stale generation/i);
+  });
+
+  it('rejects an approved action when the execution fence is stale', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'stale.txt' }, cwd: 'C:/workspace',
+      mutates: true, riskTier: 'caution', policy,
+    });
+    const approval = actions.request({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      toolCallId: 'tool-call-stale-fence', toolName: 'file_write', riskTier: 'caution',
+      riskReasons: [], normalized,
+    });
+    actions.decide({
+      approvalId: approval.approvalId, jobId: admission.jobId,
+      attemptId: admission.attemptId, generation: 1,
+      actionDigest: normalized.actionDigest, policySnapshotId: approval.policySnapshotId,
+      decision: 'approved', decidedBy: 'user', decisionChannel: 'tui',
+    });
+
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId, jobId: admission.jobId,
+      attemptId: admission.attemptId, generation: 1, fenceToken: 'stale-fence',
+      toolCallId: 'tool-call-stale-fence', actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+    })).toMatchObject({ authorized: false, reason: expect.stringMatching(/fence/i) });
+    expect(actions.get(approval.approvalId)?.state).toBe('invalidated');
+  });
+
+  it('restores pending approvals by exact ID after authority restart', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'restart.txt', content: 'ok' }, cwd: 'C:/workspace',
+      mutates: true, riskTier: 'caution', policy,
+    });
+    const created = actions.request({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      toolCallId: 'tool-restart', toolName: 'file_write', riskTier: 'caution',
+      riskReasons: ['filesystem write'], normalized, expiresAt: 10_000, now: 1_000,
+    });
+    actions.markDisplayed(created.approvalId, 2_000);
+
+    const restarted = createActionAuthority({ db, jobEngine: jobs });
+    expect(restarted.listPending(admission.jobId)).toEqual([
+      expect.objectContaining({
+        approvalId: created.approvalId,
+        actionDigest: normalized.actionDigest,
+        state: 'displayed',
+        expiresAt: 10_000,
+      }),
+    ]);
+  });
+
+  it('makes duplicate decisions idempotent but rejects a conflicting decision', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'once.txt' }, cwd: 'C:/workspace',
+      mutates: true, riskTier: 'caution', policy,
+    });
+    const approval = actions.request({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      toolCallId: 'tool-decision', toolName: 'file_write', riskTier: 'caution',
+      riskReasons: [], normalized,
+    });
+    const decision = {
+      approvalId: approval.approvalId,
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId,
+      decision: 'approved' as const,
+      decidedBy: 'user',
+      decisionChannel: 'tui',
+    };
+    expect(actions.decide(decision).state).toBe('approved');
+    expect(actions.decide(decision).state).toBe('approved');
+    expect(() => actions.decide({ ...decision, decision: 'denied' })).toThrow(/conflicting decision/i);
+  });
+
+  it('expires approvals and rejects decisions after the Job becomes terminal', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'late.txt' }, cwd: 'C:/workspace',
+      mutates: true, riskTier: 'caution', policy,
+    });
+    const expired = actions.request({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      toolCallId: 'tool-expired', toolName: 'file_write', riskTier: 'caution',
+      riskReasons: [], normalized, expiresAt: 2, now: 1,
+    });
+    expect(() => actions.decide({
+      approvalId: expired.approvalId, jobId: admission.jobId,
+      attemptId: admission.attemptId, generation: 1,
+      actionDigest: normalized.actionDigest, policySnapshotId: expired.policySnapshotId,
+      decision: 'approved', decidedBy: 'user', decisionChannel: 'tui', now: 3,
+    })).toThrow(/expired/i);
+    expect(actions.get(expired.approvalId)?.state).toBe('expired');
+
+    const pending = actions.request({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      toolCallId: 'tool-terminal', toolName: 'file_write', riskTier: 'caution',
+      riskReasons: [], normalized,
+    });
+    jobs.cancelJob({ jobId: admission.jobId, producer: 'test', reason: 'stop', eventIdempotencyKey: 'stop' });
+    expect(() => actions.decide({
+      approvalId: pending.approvalId, jobId: admission.jobId,
+      attemptId: admission.attemptId, generation: 1,
+      actionDigest: normalized.actionDigest, policySnapshotId: pending.policySnapshotId,
+      decision: 'approved', decidedBy: 'user', decisionChannel: 'tui',
+    })).toThrow(/terminal Job/i);
+  });
+
+  it('keeps multiple approvals independent and never persists raw secret values', () => {
+    const make = (toolCallId: string, filePath: string) => actions.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      toolCallId,
+      toolName: 'file_write',
+      riskTier: 'caution',
+      riskReasons: [],
+      normalized: normalizeExecutionPlan({
+        toolName: 'file_write',
+        args: { path: filePath, apiKey: 'private-fixture-value' },
+        cwd: 'C:/workspace',
+        mutates: true,
+        riskTier: 'caution',
+        policy: { ...policy, jobOverrides: { accessToken: 'private-fixture-value' } },
+      }),
+    });
+    const first = make('tool-one', 'one.txt');
+    const second = make('tool-two', 'two.txt');
+    expect(actions.listPending(admission.jobId).map((entry) => entry.approvalId)).toEqual([
+      first.approvalId,
+      second.approvalId,
+    ]);
+    const persisted = db.prepare(
+      'SELECT normalized_execution_plan AS plan FROM approvals ORDER BY request_sequence',
+    ).all() as Array<{ plan: string }>;
+    const policies = db.prepare('SELECT job_overrides_json AS value FROM policy_snapshots').all() as Array<{ value: string }>;
+    expect(JSON.stringify({ persisted, policies })).not.toContain('private-fixture-value');
+  });
+});

--- a/tests/v4/core/approvalDecisionProjection.test.ts
+++ b/tests/v4/core/approvalDecisionProjection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
 import { AidenAgent, type ToolExecutor } from '../../../core/v4/aidenAgent';
 import { MockProviderAdapter } from '../../../core/v4/__mocks__/mockProvider';
 import { ToolRegistry, type ToolHandler } from '../../../core/v4/toolRegistry';
@@ -10,6 +11,9 @@ import {
 import { ApprovalEngine } from '../../../moat/approvalEngine';
 import { HonestyEnforcement } from '../../../moat/honestyEnforcement';
 import { resolveAidenPaths } from '../../../core/v4/paths';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { runWithJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
 
 describe('approval decision projection', () => {
   it('reconciles contradictory final prose from the existing trace without another provider call', async () => {
@@ -184,7 +188,32 @@ describe('approval decision projection', () => {
       honestyEnforcement: new HonestyEnforcement('enforce'),
     });
 
-    const result = await agent.runConversation([{ role: 'user', content: 'run the command' }]);
+    const db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('approval_instance', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    const engine = createJobEngine({ db });
+    const admitted = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'approval_session',
+      instanceId: 'approval_instance', idempotencyNamespace: 'approval-test',
+      idempotencyKey: 'interrupted', goal: 'interrupt approval',
+    });
+    const lease = engine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'approval_instance', ttlMs: 30_000,
+    });
+    const result = await runWithJobExecutionContext({
+      engine,
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      producer: 'test',
+    }, () => agent.runConversation([{ role: 'user', content: 'run the command' }]));
+    db.close();
     const presentation = mapTaskOutcomePresentation(taskOutcomeInputFromFinalization({
       finalization: computeTaskFinalization({
         finishReason: result.finishReason,

--- a/tests/v4/core/toolRegistry.jobIdentity.test.ts
+++ b/tests/v4/core/toolRegistry.jobIdentity.test.ts
@@ -14,6 +14,8 @@ import {
 import type { JobEngine } from '../../../core/v4/daemon/jobEngine';
 import { resolveAidenPaths } from '../../../core/v4/paths';
 import { ToolRegistry } from '../../../core/v4/toolRegistry';
+import type { ActionAuthority, NormalizedAction, PolicySnapshotInput } from '../../../core/v4/actionAuthority';
+import { ApprovalEngine } from '../../../moat/approvalEngine';
 
 describe('ToolRegistry durable execution identity', () => {
   it('persists and starts a mutating ToolCall before the handler executes', async () => {
@@ -153,5 +155,103 @@ describe('ToolRegistry durable execution identity', () => {
     expect(handler).not.toHaveBeenCalled();
     expect(result.result).toBeNull();
     expect(result.error).toContain('stale_fence');
+  });
+
+  it('persists approval_required and denies safely when no interactive channel exists', async () => {
+    const handler = vi.fn(async () => ({ ok: true }));
+    const engine = {
+      prepareToolCall: vi.fn(() => ({ applied: true })),
+      startToolCall: vi.fn(),
+      completeToolCall: vi.fn(() => ({ applied: true })),
+    } as unknown as JobEngine;
+    const actionAuthority = {
+      request: vi.fn(() => ({
+        approvalId: 'approval_exact', policySnapshotId: 'policy_exact',
+      })),
+      markDisplayed: vi.fn(),
+    } as unknown as ActionAuthority;
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'unattended_write', description: 'writes', inputSchema: { type: 'object' } },
+      category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc', execute: handler,
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(),
+      paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+      actionAuthority,
+      policySnapshot: {
+        trustLevel: 'Observer', autonomyPolicy: 'deny_without_interactive_channel', approvalMode: 'manual',
+        toolMetadataVersion: 'test', sandboxPolicy: {}, networkPolicy: {}, pluginGrants: [],
+        mcpGrants: [], workspaceOverrides: {}, jobOverrides: {},
+      },
+    });
+
+    const result = await runWithJobExecutionContext({
+      engine, jobId: 'job_1', attemptId: 'attempt_1', generation: 1,
+      fenceToken: 'fence_1', producer: 'mcp',
+    }, () => execute({ id: 'tool_unattended', name: 'unattended_write', arguments: {} }));
+
+    expect(actionAuthority.request).toHaveBeenCalledOnce();
+    expect(actionAuthority.markDisplayed).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.error).toContain('approval_exact');
+  });
+
+  it('recomputes policy and action identity immediately before execution', async () => {
+    const handler = vi.fn(async () => ({ ok: true }));
+    const engine = {
+      prepareToolCall: vi.fn(() => ({ applied: true })),
+      startToolCall: vi.fn(),
+      completeToolCall: vi.fn(() => ({ applied: true })),
+    } as unknown as JobEngine;
+    const policy: PolicySnapshotInput = {
+      trustLevel: 'Assistant', autonomyPolicy: 'ask_for_mutations', approvalMode: 'manual',
+      toolMetadataVersion: 'test', sandboxPolicy: {}, networkPolicy: {}, pluginGrants: [],
+      mcpGrants: [], workspaceOverrides: {}, jobOverrides: {},
+    };
+    let approvedAction: NormalizedAction | undefined;
+    const actionAuthority = {
+      request: vi.fn((command: { normalized: NormalizedAction }) => {
+        approvedAction = command.normalized;
+        return {
+          approvalId: 'approval_policy',
+          policySnapshotId: command.normalized.policySnapshot.policySnapshotId,
+        };
+      }),
+      markDisplayed: vi.fn(),
+      decide: vi.fn(),
+      authorizeExecution: vi.fn((command: { actionDigest: string; policySnapshotId: string }) => ({
+        authorized: command.actionDigest === approvedAction?.actionDigest
+          && command.policySnapshotId === approvedAction?.policySnapshot.policySnapshotId,
+        reason: 'approved action changed or binding mismatch',
+      })),
+    } as unknown as ActionAuthority;
+    const approvalEngine = new ApprovalEngine('manual', {
+      promptUser: async () => {
+        policy.trustLevel = 'Observer';
+        return 'allow';
+      },
+    });
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'policy_bound_write', description: 'writes', inputSchema: { type: 'object' } },
+      category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc', execute: handler,
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(),
+      paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+      actionAuthority,
+      approvalEngine,
+      policySnapshot: policy,
+    });
+
+    const result = await runWithJobExecutionContext({
+      engine, jobId: 'job_1', attemptId: 'attempt_1', generation: 1,
+      fenceToken: 'fence_1', producer: 'test',
+    }, () => execute({ id: 'tool_policy', name: 'policy_bound_write', arguments: { path: 'result.txt' } }));
+
+    expect(actionAuthority.authorizeExecution).toHaveBeenCalledOnce();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.error).toContain('binding mismatch');
   });
 });

--- a/tests/v4/core/toolRegistry.jobIdentity.test.ts
+++ b/tests/v4/core/toolRegistry.jobIdentity.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  recordDurableToolVerification,
+  runWithJobExecutionContext,
+} from '../../../core/v4/daemon/jobExecutionContext';
+import type { JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ToolRegistry } from '../../../core/v4/toolRegistry';
+
+describe('ToolRegistry durable execution identity', () => {
+  it('persists and starts a mutating ToolCall before the handler executes', async () => {
+    const order: string[] = [];
+    const engine = {
+      prepareToolCall: vi.fn(() => { order.push('prepared'); return { applied: true }; }),
+      startToolCall: vi.fn(() => { order.push('started'); return { applied: true }; }),
+      completeToolCall: vi.fn(() => { order.push('completed'); return { applied: true }; }),
+    } as unknown as JobEngine;
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: {
+        name: 'durable_write',
+        description: 'writes durable state',
+        inputSchema: { type: 'object', properties: { value: { type: 'string' } } },
+      },
+      category: 'write',
+      riskTier: 'caution',
+      mutates: true,
+      toolset: 'misc',
+      async execute() {
+        order.push('handler');
+        return { ok: true };
+      },
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(),
+      paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+    });
+
+    await runWithJobExecutionContext({
+      engine,
+      jobId: 'job_1',
+      attemptId: 'attempt_1',
+      generation: 3,
+      fenceToken: 'fence_1',
+      producer: 'test',
+    }, () => execute({
+      id: 'tool_call_1',
+      name: 'durable_write',
+      arguments: { value: 'exact' },
+    }));
+
+    expect(order).toEqual(['prepared', 'started', 'handler', 'completed']);
+    const persistedToolCallId = `tool-call:sha256:${createHash('sha256')
+      .update(['attempt_1', '3', 'tool_call_1'].join('\0'))
+      .digest('hex')}`;
+    expect(engine.prepareToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      toolCallId: persistedToolCallId,
+      modelCallId: 'tool_call_1',
+      jobId: 'job_1',
+      attemptId: 'attempt_1',
+      generation: 3,
+      fenceToken: 'fence_1',
+      toolName: 'durable_write',
+      mutates: true,
+      normalizedArgsDigest: createHash('sha256').update('{"value":"exact"}').digest('hex'),
+    }));
+    expect(engine.completeToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      toolCallId: persistedToolCallId,
+      state: 'completed',
+      sideEffectState: 'committed',
+      resultRef: expect.stringMatching(/^tool-result:sha256:[a-f0-9]{64}$/),
+    }));
+  });
+
+  it('scopes a repeated provider ToolCall id to each durable Attempt', async () => {
+    const persisted = new Map<string, { attemptId: string; verification?: string }>();
+    const engine = {
+      prepareToolCall: vi.fn((command: { toolCallId: string; attemptId: string }) => {
+        if (persisted.has(command.toolCallId)) return { applied: false, conflict: 'illegal_transition' };
+        persisted.set(command.toolCallId, { attemptId: command.attemptId });
+        return { applied: true };
+      }),
+      startToolCall: vi.fn(() => ({ applied: true })),
+      completeToolCall: vi.fn(() => ({ applied: true })),
+      attachToolVerification: vi.fn((command: {
+        toolCallId: string; attemptId: string; verificationRef: string;
+      }) => {
+        const row = persisted.get(command.toolCallId);
+        if (!row || row.attemptId !== command.attemptId) return { applied: false, conflict: 'stale_fence' };
+        row.verification = command.verificationRef;
+        return { applied: true };
+      }),
+    } as unknown as JobEngine;
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'repeatable_read', description: 'reads durable state', inputSchema: { type: 'object' } },
+      category: 'read', riskTier: 'safe', mutates: false, toolset: 'misc',
+      async execute() { return { ok: true }; },
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(),
+      paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+    });
+
+    for (const [jobId, attemptId] of [['job_1', 'attempt_1'], ['job_2', 'attempt_2']]) {
+      await runWithJobExecutionContext({
+        engine, jobId, attemptId, generation: 1, fenceToken: `fence_${attemptId}`, producer: 'test',
+      }, async () => {
+        await execute({ id: 'provider-reused-id', name: 'repeatable_read', arguments: {} });
+        recordDurableToolVerification('provider-reused-id', { ok: true });
+      });
+    }
+
+    expect(persisted).toHaveLength(2);
+    expect(new Set([...persisted.values()].map((row) => row.attemptId))).toEqual(
+      new Set(['attempt_1', 'attempt_2']),
+    );
+    expect([...persisted.values()].every((row) => row.verification?.startsWith('tool-verification:sha256:')))
+      .toBe(true);
+  });
+
+  it('does not execute when durable preparation rejects a stale fence', async () => {
+    const handler = vi.fn(async () => ({ ok: true }));
+    const engine = {
+      prepareToolCall: vi.fn(() => ({ applied: false, conflict: 'stale_fence' })),
+      startToolCall: vi.fn(),
+      completeToolCall: vi.fn(),
+    } as unknown as JobEngine;
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'guarded_write', description: 'guarded', inputSchema: { type: 'object' } },
+      category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc', execute: handler,
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(),
+      paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+    });
+
+    const result = await runWithJobExecutionContext({
+      engine,
+      jobId: 'job_1', attemptId: 'attempt_1', generation: 1,
+      fenceToken: 'stale', producer: 'test',
+    }, () => execute({ id: 'tool_call_stale', name: 'guarded_write', arguments: {} }));
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.result).toBeNull();
+    expect(result.error).toContain('stale_fence');
+  });
+});

--- a/tests/v4/core/usageLedger.test.ts
+++ b/tests/v4/core/usageLedger.test.ts
@@ -109,6 +109,47 @@ describe('ProviderAttemptLedger', () => {
     expect(Object.isFrozen(records[0])).toBe(true);
   });
 
+  it('links each physical attempt to the durable Job, Attempt, and generation', () => {
+    ledger.append(attempt({
+      callId: 'call-linked-1',
+      jobId: 'task_job',
+      attemptId: 'attempt_job',
+      attemptGeneration: 3,
+    }));
+
+    const records = ledger.query({ jobId: 'task_job', attemptId: 'attempt_job' });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      callId: 'call-linked-1',
+      jobId: 'task_job',
+      attemptId: 'attempt_job',
+      attemptGeneration: 3,
+    });
+  });
+
+  it('reconciles only missing linkage from an exact authoritative task/run mapping', () => {
+    ledger.append(attempt({ callId: 'call-gap', jobId: null, attemptId: null, attemptGeneration: null }));
+    ledger.append(attempt({
+      callId: 'call-other-run', runId: 'run-2', jobId: null, attemptId: null, attemptGeneration: null,
+    }));
+    ledger.append(attempt({
+      callId: 'call-conflict', jobId: 'task-other', attemptId: 'attempt-other', attemptGeneration: 9,
+    }));
+
+    expect(ledger.reconcileJobLinkage({
+      taskId: 'task-1', runId: 'run-1',
+      jobId: 'task-job', attemptId: 'attempt-job', attemptGeneration: 3,
+    })).toBe(1);
+    expect(ledger.query({ callId: 'call-gap' })[0]).toMatchObject({
+      jobId: 'task-job', attemptId: 'attempt-job', attemptGeneration: 3,
+    });
+    expect(ledger.query({ callId: 'call-other-run' })[0]?.jobId).toBeNull();
+    expect(ledger.query({ callId: 'call-conflict' })[0]).toMatchObject({
+      jobId: 'task-other', attemptId: 'attempt-other', attemptGeneration: 9,
+    });
+  });
+
   it('keeps failed attempts and unknown spend explicit instead of recording zero', () => {
     ledger.append(attempt({
       callId: 'call-failed-1',

--- a/tests/v4/daemon/api/runControls.test.ts
+++ b/tests/v4/daemon/api/runControls.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import http from 'node:http';
+
+import Database from 'better-sqlite3';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mountRunsRoutes } from '../../../../core/v4/daemon/api/runs';
+import { runMigrations } from '../../../../core/v4/daemon/db/migrations';
+import { createJobControlAuthority, type JobControlAuthority } from '../../../../core/v4/daemon/jobControlAuthority';
+import { createJobEngine, type AdmissionResult, type JobEngine } from '../../../../core/v4/daemon/jobEngine';
+import { createTriggerBus } from '../../../../core/v4/daemon/triggerBus';
+
+describe('daemon API durable run controls', () => {
+  let db: Database.Database;
+  let server: http.Server;
+  let port: number;
+  let jobs: JobEngine;
+  let controls: JobControlAuthority;
+  let admission: AdmissionResult;
+
+  const post = async (url: string, body: unknown, key?: string) => {
+    const response = await fetch(`http://127.0.0.1:${port}${url}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(key ? { 'idempotency-key': key } : {}) },
+      body: JSON.stringify(body),
+    });
+    return { status: response.status, body: await response.json() as Record<string, unknown> };
+  };
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('api-test', 1, 'test', 1, 1, '4.15.1')`,
+    ).run();
+    jobs = createJobEngine({ db });
+    controls = createJobControlAuthority({ db, jobEngine: jobs });
+    admission = jobs.submitJob({
+      entryPoint: 'daemon_api', source: 'test', sessionId: 'api-session', instanceId: 'api-test',
+      idempotencyNamespace: 'test', idempotencyKey: 'job', goal: 'control test',
+    });
+    const app = express();
+    mountRunsRoutes({
+      app, db, jobEngine: jobs, jobControlAuthority: controls,
+      triggerBus: createTriggerBus({ db }), instanceId: 'api-test', log: () => {},
+    });
+    server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    db.close();
+  });
+
+  it('persists exact ordinary input before acknowledgment and deduplicates delivery', async () => {
+    const first = await post(`/api/runs/${admission.attemptId}/input`, { message: 'yes\n' }, 'input-exact');
+    const duplicate = await post(`/api/runs/${admission.attemptId}/input`, { message: 'yes\n' }, 'input-exact');
+    expect(first).toMatchObject({ status: 202, body: { accepted: true, duplicate: false } });
+    expect(duplicate).toMatchObject({
+      status: 202,
+      body: { accepted: true, duplicate: true, input_id: first.body.input_id },
+    });
+    expect(controls.inputs.get(String(first.body.input_id))).toMatchObject({ kind: 'message', content: 'yes\n' });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM approvals').get()).toEqual({ count: 0 });
+  });
+
+  it('persists pause for a safe boundary and resumes with a new generation', async () => {
+    const lease = jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 30_000 });
+    jobs.transitionAttempt({
+      attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      producer: 'test', eventIdempotencyKey: 'attempt-running',
+    });
+    jobs.transitionJob({
+      jobId: admission.jobId, attemptId: admission.attemptId, expectedStateVersion: 0,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      producer: 'test', eventIdempotencyKey: 'job-running',
+    });
+
+    const paused = await post(`/api/runs/${admission.attemptId}/pause`, {}, 'pause-exact');
+    expect(paused).toMatchObject({ status: 202, body: { persisted: true, applied: false } });
+    expect(jobs.getJob(admission.jobId)?.status).toBe('running');
+    expect(controls.commands.applyPendingAtBoundary({ jobId: admission.jobId }).applied).toBe(true);
+    const resumed = await post(`/api/runs/${admission.attemptId}/resume`, {}, 'resume-exact');
+    expect(resumed).toMatchObject({
+      status: 202,
+      body: {
+        accepted: true,
+        generation: 2,
+        attempt_id: expect.any(String),
+        trigger_event_id: expect.any(Number),
+      },
+    });
+    expect(resumed.body.attempt_id).not.toBe(admission.attemptId);
+    expect(db.prepare('SELECT trigger_event_id FROM runs WHERE attempt_id = ?').get(resumed.body.attempt_id))
+      .toEqual({ trigger_event_id: resumed.body.trigger_event_id });
+  });
+
+  it('physically aborts the exact active runtime after durable cancellation wins', async () => {
+    const controller = new AbortController();
+    controls.runtime.attach(admission.attemptId, controller);
+    const cancelled = await post(`/api/runs/${admission.attemptId}/cancel`, {}, 'cancel-exact');
+    expect(cancelled).toMatchObject({ status: 202, body: { persisted: true, applied: true } });
+    expect(controller.signal.aborted).toBe(true);
+    expect(jobs.getJob(admission.jobId)?.status).toBe('cancelled');
+  });
+});

--- a/tests/v4/daemon/api/runsTraceAdoption.test.ts
+++ b/tests/v4/daemon/api/runsTraceAdoption.test.ts
@@ -123,6 +123,16 @@ describe('Slice 7 inbound trace adoption + 7 captured smoke scenarios', () => {
     expect(r1.status).toBe(202);
     expect(String(r1.body.trace_id)).toMatch(/^trc_[0-9a-f]{32}$/);
     expect(r1.body.external_trace_id).toBeNull();
+    expect(String(r1.body.job_id)).toMatch(/^task_/);
+    expect(String(r1.body.attempt_id)).toMatch(/^attempt_/);
+    expect(typeof r1.body.run_id).toBe('number');
+    const db = getCurrentDaemonDb()!;
+    expect(db.prepare(
+      'SELECT task_id, attempt_id FROM runs WHERE id = ?',
+    ).get(r1.body.run_id)).toEqual({
+      task_id: r1.body.job_id,
+      attempt_id: r1.body.attempt_id,
+    });
 
     // smoke 2 — valid traceparent
     const r2 = await postJson(basePort, '/api/runs',
@@ -153,6 +163,28 @@ describe('Slice 7 inbound trace adoption + 7 captured smoke scenarios', () => {
       { body: { args: { p: 2 } }, headers: { 'x-request-id': garbage } });
     console.log(`[smoke 5] response: status=${r5.status} (8000-char X-Request-Id dropped, request still accepted)`);
     expect(r5.status).toBe(202);
+
+    const sameKeyHeaders = { 'idempotency-key': 'same-request-key' };
+    const firstKeyed = await postJson(basePort, '/api/runs', {
+      body: { prompt: 'first body' }, headers: sameKeyHeaders,
+    });
+    const duplicate = await postJson(basePort, '/api/runs', {
+      body: { prompt: 'first body' }, headers: sameKeyHeaders,
+    });
+    const conflicting = await postJson(basePort, '/api/runs', {
+      body: { prompt: 'different body' }, headers: sameKeyHeaders,
+    });
+    expect(firstKeyed.status).toBe(202);
+    expect(duplicate).toMatchObject({
+      status: 202,
+      body: {
+        job_id: firstKeyed.body.job_id,
+        attempt_id: firstKeyed.body.attempt_id,
+        run_id: firstKeyed.body.run_id,
+        duplicate: true,
+      },
+    });
+    expect(conflicting).toMatchObject({ status: 409, body: { error: 'idempotency_conflict' } });
   });
 
   it('smoke 6: spawn child process via shell-exec → child sees AIDEN_* env', async () => {
@@ -208,4 +240,5 @@ describe('Slice 7 inbound trace adoption + 7 captured smoke scenarios', () => {
     expect(headers['X-Aiden-Run-Id']).toBe(ctx.runId);
     expect(headers['User-Agent']).toBe('test/1.0');
   });
+
 });

--- a/tests/v4/daemon/bootstrap-two-phase.test.ts
+++ b/tests/v4/daemon/bootstrap-two-phase.test.ts
@@ -5,8 +5,8 @@
  *   1. bootstrapDaemonFoundation boots without an agentBuilder
  *   2. installDaemonAgentBuilder swaps placeholder → real runner
  *   3. installDaemonAgentBuilder returns false when handle inactive
- *   4. Foundation can serve trigger claims with placeholder before
- *      real runner is installed (rails work without provider config)
+ *   4. Foundation admits work durably but cannot falsely complete it before
+ *      the real runner is installed
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
@@ -116,8 +116,8 @@ describe('installDaemonAgentBuilder', () => {
   });
 });
 
-describe('foundation serves claims with placeholder before install', () => {
-  it('placeholder handles a claim end-to-end before installDaemonAgentBuilder is called', async () => {
+describe('foundation admission before runner install', () => {
+  it('placeholder leaves admitted work retryable instead of reporting false success', async () => {
     const handle = bootstrapDaemonFoundation();
     expect(handle.dispatcher!.runnerKind()).toBe('placeholder');
 
@@ -128,7 +128,7 @@ describe('foundation serves claims with placeholder before install', () => {
     });
     await handle.dispatcher!._pumpOnce();
     const ev = handle.triggerBus!.get(inserted.id);
-    expect(ev?.status).toBe('done');
-    expect(ev?.runId).not.toBeNull();
+    expect(ev?.status).toBe('pending');
+    expect(ev?.runId).toBeNull();
   });
 });

--- a/tests/v4/daemon/cleanShutdown.test.ts
+++ b/tests/v4/daemon/cleanShutdown.test.ts
@@ -13,6 +13,7 @@ import {
   consumeCleanShutdownMarker,
   evaluateBootState,
 } from '../../../core/v4/daemon/cleanShutdown';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 
 let db: Database.Database;
 let tmpDir: string;
@@ -109,5 +110,31 @@ describe('evaluateBootState', () => {
     ).run('new', process.pid, 'test', Date.now(), Date.now(), 'test');
     const r = evaluateBootState({ db, markerPath, instanceId: 'new' });
     expect(r.crashDetected).toBe(false);
+  });
+
+  it('leaves Job-managed Attempts for the lease recovery authority', () => {
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('new', ?, 'test', ?, ?, 'test')`,
+    ).run(process.pid, now, now);
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('crashed', 99999, 'test', ?, ?, 'test')`,
+    ).run(now - 60_000, now - 60_000);
+    const engine = createJobEngine({ db });
+    const admitted = engine.submitJob({
+      entryPoint: 'daemon', source: 'test', sessionId: 'durable-session',
+      instanceId: 'crashed', idempotencyNamespace: 'durable-test',
+      idempotencyKey: 'durable-job', requestFingerprint: 'durable-fingerprint',
+      goal: 'recover through lease authority',
+    });
+    db.prepare("UPDATE runs SET status = 'running' WHERE attempt_id = ?").run(admitted.attemptId);
+
+    expect(evaluateBootState({ db, markerPath, instanceId: 'new' }).crashDetected).toBe(true);
+    expect(engine.getAttempt(admitted.attemptId)?.status).toBe('running');
+    expect(engine.getJob(admitted.jobId)?.status).toBe('queued');
   });
 });

--- a/tests/v4/daemon/db/jobControlMigration.test.ts
+++ b/tests/v4/daemon/db/jobControlMigration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  LATEST_SCHEMA_VERSION,
+  MIGRATIONS_FOR_TESTS,
+  runMigrations,
+} from '../../../../core/v4/daemon/db/migrations';
+
+let db: Database.Database;
+
+function applyThrough(version: number): void {
+  for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= version)) {
+    db.transaction(() => {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare(
+        'INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)',
+      ).run(migration.version, Date.now());
+    })();
+  }
+}
+
+function tableNames(): string[] {
+  return (db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all() as Array<{ name: string }>)
+    .map((row) => row.name);
+}
+
+describe('durable input and approval migration', () => {
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+  });
+
+  afterEach(() => db.close());
+
+  it('upgrades the exact previous schema additively without creating another Job or Attempt authority', () => {
+    applyThrough(20);
+    const before = tableNames();
+
+    expect(runMigrations(db)).toEqual({ from: 20, to: LATEST_SCHEMA_VERSION });
+    expect(tableNames()).toEqual(expect.arrayContaining([
+      ...before,
+      'durable_inputs',
+      'steering_commands',
+      'job_control_commands',
+      'policy_snapshots',
+      'approvals',
+    ]));
+    expect(tableNames()).not.toContain('jobs');
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 21 });
+  });
+
+  it('is idempotent when the additive migration is applied repeatedly', () => {
+    applyThrough(20);
+    const migration = MIGRATIONS_FOR_TESTS.find((entry) => entry.version === 21)!;
+    migration.apply!(db);
+    const first = tableNames();
+    migration.apply!(db);
+    expect(tableNames()).toEqual(first);
+  });
+
+  it('rolls back all Phase 4 tables when schema-version persistence is interrupted', () => {
+    applyThrough(20);
+    db.exec(`
+      CREATE TRIGGER reject_phase_four_version
+      BEFORE INSERT ON schema_version
+      WHEN NEW.version = 21
+      BEGIN
+        SELECT RAISE(ABORT, 'phase four fixture interruption');
+      END;
+    `);
+
+    expect(() => runMigrations(db)).toThrow(/Migration 21 .*fixture interruption/i);
+    expect(tableNames()).not.toContain('durable_inputs');
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 20 });
+  });
+
+  it('contains no credential columns or seeded secret values', () => {
+    runMigrations(db);
+    const schema = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type = 'table' AND name IN ('durable_inputs','policy_snapshots','approvals') ORDER BY name",
+    ).all() as Array<{ sql: string }>;
+    expect(schema.map((row) => row.sql).join('\n')).not.toMatch(/api_key|access_token|refresh_token|password/i);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM durable_inputs').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM approvals').get()).toEqual({ count: 0 });
+  });
+});

--- a/tests/v4/daemon/db/jobEngineMigration.test.ts
+++ b/tests/v4/daemon/db/jobEngineMigration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import {
+  LATEST_SCHEMA_VERSION,
+  MIGRATIONS_FOR_TESTS,
+  runMigrations,
+} from '../../../../core/v4/daemon/db/migrations';
+
+let db: Database.Database;
+
+function applyThrough(version: number): void {
+  for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= version)) {
+    db.transaction(() => {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare(
+        'INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)',
+      ).run(migration.version, Date.now());
+    })();
+  }
+}
+
+function columns(table: string): Set<string> {
+  return new Set(
+    (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name),
+  );
+}
+
+function seedV4151Rows(): { taskId: string; runIds: [number, number] } {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('instance_fixture', 1, 'localhost', now, now, '4.15.1');
+  db.prepare(
+    `INSERT INTO tasks
+       (id, title, goal, status, created_at, updated_at, session_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run('task_fixture', 'Fixture', 'Exercise migration', 'active', now, now, 'session_fixture');
+
+  const insertRun = db.prepare(
+    `INSERT INTO runs
+       (session_id, instance_id, status, started_at, task_id)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  const first = Number(insertRun.run('session_fixture', 'instance_fixture', 'completed', now, 'task_fixture').lastInsertRowid);
+  const second = Number(insertRun.run('session_fixture', 'instance_fixture', 'running', now + 1, 'task_fixture').lastInsertRowid);
+
+  const insertEvent = db.prepare(
+    `INSERT INTO run_events
+       (run_id, session_id, seq, ts, category, kind, payload)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  insertEvent.run(first, 'session_fixture', 1, now, 'legacy', 'first', '{}');
+  insertEvent.run(second, 'session_fixture', 1, now + 1, 'legacy', 'second', '{}');
+  return { taskId: 'task_fixture', runIds: [first, second] };
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* already closed */ }
+});
+
+describe('durable Job and Attempt migration', () => {
+  it('promotes a v4.15.1 database without replacing tasks, runs, or historic records', () => {
+    applyThrough(19);
+    const seeded = seedV4151Rows();
+
+    const result = runMigrations(db);
+
+    expect(result).toEqual({ from: 19, to: LATEST_SCHEMA_VERSION });
+    expect(LATEST_SCHEMA_VERSION).toBeGreaterThanOrEqual(20);
+    expect(db.prepare('SELECT id FROM tasks WHERE id = ?').get(seeded.taskId)).toEqual({ id: seeded.taskId });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 2 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM run_events').get()).toEqual({ count: 2 });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='jobs'").get()).toBeUndefined();
+  });
+
+  it('adds the Job, Attempt, event, ToolCall, and SideEffect authority fields', () => {
+    runMigrations(db);
+
+    expect([...columns('tasks')]).toEqual(expect.arrayContaining([
+      'state_version', 'active_attempt_id', 'root_job_id',
+      'idempotency_namespace', 'idempotency_key', 'request_fingerprint',
+      'entry_point', 'source', 'terminal_at', 'terminal_outcome',
+      'finish_reason', 'recovery_state', 'crash_count',
+      'next_event_sequence', 'policy_snapshot_id',
+    ]));
+    expect([...columns('runs')]).toEqual(expect.arrayContaining([
+      'attempt_id', 'attempt_number', 'generation', 'state_version',
+      'lease_id', 'lease_owner', 'lease_expires_at', 'lease_heartbeat_at',
+      'fence_token', 'recovery_of_attempt_id', 'trigger_reason',
+      'provider_route_snapshot', 'budget_snapshot', 'ended_at',
+    ]));
+    expect([...columns('run_events')]).toEqual(expect.arrayContaining([
+      'job_id', 'attempt_id', 'job_sequence', 'producer', 'generation',
+      'causation_id', 'correlation_id', 'idempotency_key',
+    ]));
+    expect([...columns('tool_calls')]).toEqual(expect.arrayContaining([
+      'tool_call_id', 'job_id', 'attempt_id', 'generation', 'model_call_id',
+      'tool_name', 'normalized_args_digest', 'risk_tier', 'mutates', 'state',
+      'started_at', 'ended_at', 'result_ref', 'side_effect_id', 'verification_ref',
+    ]));
+    expect([...columns('side_effect_ledger')]).toEqual(expect.arrayContaining([
+      'job_id', 'attempt_id', 'generation', 'tool_call_id', 'effect_state',
+    ]));
+  });
+
+  it('backfills stable Attempt identities and deterministic per-Job event order', () => {
+    applyThrough(19);
+    const seeded = seedV4151Rows();
+
+    runMigrations(db);
+
+    const attempts = db.prepare(
+      'SELECT id, attempt_id, attempt_number, generation FROM runs ORDER BY id',
+    ).all() as Array<{ id: number; attempt_id: string; attempt_number: number; generation: number }>;
+    expect(attempts).toEqual([
+      { id: seeded.runIds[0], attempt_id: `attempt_legacy_${seeded.runIds[0]}`, attempt_number: 1, generation: 1 },
+      { id: seeded.runIds[1], attempt_id: `attempt_legacy_${seeded.runIds[1]}`, attempt_number: 2, generation: 1 },
+    ]);
+
+    const events = db.prepare(
+      'SELECT job_id, attempt_id, job_sequence FROM run_events ORDER BY id',
+    ).all();
+    expect(events).toEqual([
+      { job_id: seeded.taskId, attempt_id: `attempt_legacy_${seeded.runIds[0]}`, job_sequence: 1 },
+      { job_id: seeded.taskId, attempt_id: `attempt_legacy_${seeded.runIds[1]}`, job_sequence: 2 },
+    ]);
+  });
+
+  it('recovers safely from a partially materialized additive schema', () => {
+    applyThrough(19);
+    db.exec('ALTER TABLE tasks ADD COLUMN state_version INTEGER NOT NULL DEFAULT 0');
+
+    expect(() => runMigrations(db)).not.toThrow();
+    expect(columns('tasks').has('active_attempt_id')).toBe(true);
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({
+      version: LATEST_SCHEMA_VERSION,
+    });
+  });
+
+  it('rolls back an interrupted migration and succeeds on retry', () => {
+    applyThrough(19);
+    db.exec(`
+      CREATE TRIGGER reject_job_engine_version
+      BEFORE INSERT ON schema_version
+      WHEN NEW.version >= 20
+      BEGIN
+        SELECT RAISE(ABORT, 'fixture interruption');
+      END;
+    `);
+
+    expect(() => runMigrations(db)).toThrow(/fixture interruption/);
+    expect(columns('tasks').has('state_version')).toBe(false);
+
+    db.exec('DROP TRIGGER reject_job_engine_version');
+    expect(() => runMigrations(db)).not.toThrow();
+    expect(columns('tasks').has('state_version')).toBe(true);
+  });
+
+  it('is stable when the additive migration is applied repeatedly', () => {
+    applyThrough(19);
+    const seeded = seedV4151Rows();
+    const migration = MIGRATIONS_FOR_TESTS.find((entry) => entry.version === 20)!;
+
+    migration.apply!(db);
+    const first = db.prepare(
+      'SELECT attempt_id, attempt_number FROM runs ORDER BY id',
+    ).all();
+    migration.apply!(db);
+
+    expect(db.prepare('SELECT attempt_id, attempt_number FROM runs ORDER BY id').all()).toEqual(first);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 2 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM run_events').get()).toEqual({ count: 2 });
+    expect(first).toEqual([
+      { attempt_id: `attempt_legacy_${seeded.runIds[0]}`, attempt_number: 1 },
+      { attempt_id: `attempt_legacy_${seeded.runIds[1]}`, attempt_number: 2 },
+    ]);
+  });
+
+  it('fails a malformed partial migration transaction with an actionable version', () => {
+    applyThrough(19);
+    const seeded = seedV4151Rows();
+    db.exec('ALTER TABLE runs ADD COLUMN attempt_id TEXT');
+    db.prepare('UPDATE runs SET attempt_id = ? WHERE id IN (?, ?)')
+      .run('duplicate_attempt', ...seeded.runIds);
+
+    expect(() => runMigrations(db)).toThrow(/Migration 20 .*UNIQUE constraint failed/i);
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 19 });
+    expect(columns('tasks').has('state_version')).toBe(false);
+  });
+});

--- a/tests/v4/daemon/dispatcher/deliverOnly.test.ts
+++ b/tests/v4/daemon/dispatcher/deliverOnly.test.ts
@@ -10,6 +10,7 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '../../../../core/v4/daemon/db/migrations';
 import { createTriggerBus } from '../../../../core/v4/daemon/triggerBus';
 import { createRunStore } from '../../../../core/v4/daemon/runStore';
+import { createJobEngine } from '../../../../core/v4/daemon/jobEngine';
 import {
   createDispatcher,
   makeRunner,
@@ -81,5 +82,31 @@ describe('dispatcher — deliver_only stub', () => {
     const parsed = JSON.parse(ev.payload);
     expect(parsed.deliverOnly).toBe(true);
     expect(parsed.messageBytes).toBeGreaterThan(0);
+  });
+
+  it('uses one authoritative Job and Attempt when the durable authority is available', async () => {
+    const bus = createTriggerBus({ db });
+    const runStore = createRunStore({ db });
+    const jobEngine = createJobEngine({ db });
+    db.prepare(`INSERT INTO triggers (id, source, name, spec_json, enabled, prompt_template, deliver_only, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('t3', 'manual', 'durable-notify', '{}', 1, 'Durable delivery', 1, Date.now(), Date.now());
+    const trigger = bus.insert({ source: 'manual', sourceKey: 't3', idempotencyKey: 'durable', payload: {} });
+    const dispatcher = createDispatcher({
+      triggerBus: bus, runStore, jobEngine, db,
+      ownerId: 'inst-1', instanceId: 'inst-1', workerCount: 1,
+      runnerFactory: () => makeRunner(async () => ({ runId: 0, finishReason: 'stop' })),
+    });
+
+    await dispatcher._pumpOnce();
+
+    const row = bus.get(trigger.id)!;
+    const jobs = jobEngine.listJobs();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({ status: 'completed', terminalOutcome: 'delivered' });
+    expect(jobEngine.listAttempts(jobs[0]!.id)).toEqual([
+      expect.objectContaining({ rowId: row.runId, status: 'succeeded' }),
+    ]);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 1 });
   });
 });

--- a/tests/v4/daemon/dispatcher/realAgentRunner.test.ts
+++ b/tests/v4/daemon/dispatcher/realAgentRunner.test.ts
@@ -15,6 +15,7 @@ import { runMigrations } from '../../../../core/v4/daemon/db/migrations';
 import { createRunStore } from '../../../../core/v4/daemon/runStore';
 import { createTaskStore } from '../../../../core/v4/daemon/taskStore';
 import { createJobEngine } from '../../../../core/v4/daemon/jobEngine';
+import { createJobControlAuthority } from '../../../../core/v4/daemon/jobControlAuthority';
 import {
   createRealAgentRunner,
 } from '../../../../core/v4/daemon/dispatcher/realAgentRunner';
@@ -109,6 +110,65 @@ describe('createRealAgentRunner durable identity', () => {
     expect(result.runId).toBe(jobEngine.listAttempts(job.id)[0]!.rowId);
     expect(job.status).toBe('completed');
     expect(jobEngine.listAttempts(job.id)[0]!.status).toBe('succeeded');
+  });
+
+  it('applies durable pause only at the loop safe boundary without terminalizing the Job', async () => {
+    const jobEngine = createJobEngine({ db });
+    const controls = createJobControlAuthority({ db, jobEngine });
+    const agent = {
+      runConversation: async (
+        _history: unknown,
+        options: { waitForResumeIfPaused?: () => Promise<void> },
+      ) => {
+        const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+        const attempt = jobEngine.getAttempt(job.activeAttemptId!)!;
+        controls.commands.request({
+          jobId: job.id, attemptId: attempt.id, generation: attempt.generation,
+          kind: 'pause', source: 'api', idempotencyNamespace: 'test', idempotencyKey: 'pause-boundary',
+        });
+        await options.waitForResumeIfPaused?.();
+        throw new Error('pause boundary unexpectedly resumed');
+      },
+    } as unknown as AidenAgent;
+    const runner = createRealAgentRunner({
+      db, runStore, jobEngine, taskStore: createTaskStore({ db }),
+      agentBuilder: () => agent, persistedDefault: PERSISTED,
+    });
+
+    const result = await runner.invoke(mkInput());
+    const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+    expect(result).toMatchObject({ finishReason: 'interrupted', error: 'paused' });
+    expect(job.status).toBe('paused');
+    expect(jobEngine.getAttempt(job.activeAttemptId!)?.status).toBe('waiting');
+    expect(runStore.listEvents(result.runId).map((event) => event.name)).toContain('dispatcher:paused');
+  });
+
+  it('observes cross-process cancellation, aborts the active invocation, and rejects late finalization', async () => {
+    const jobEngine = createJobEngine({ db });
+    const controls = createJobControlAuthority({ db, jobEngine });
+    const agent = {
+      runConversation: async (_history: unknown, options: { signal?: AbortSignal }) => {
+        const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+        const attempt = jobEngine.getAttempt(job.activeAttemptId!)!;
+        controls.commands.request({
+          jobId: job.id, attemptId: attempt.id, generation: attempt.generation,
+          kind: 'cancel', source: 'workbench', idempotencyNamespace: 'test', idempotencyKey: 'cancel-active',
+        });
+        await new Promise<void>((resolve) => options.signal?.addEventListener('abort', () => resolve(), { once: true }));
+        throw options.signal?.reason ?? new Error('cancelled');
+      },
+    } as unknown as AidenAgent;
+    const runner = createRealAgentRunner({
+      db, runStore, jobEngine, taskStore: createTaskStore({ db }),
+      agentBuilder: () => agent, persistedDefault: PERSISTED,
+    });
+
+    const result = await runner.invoke(mkInput());
+    const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+    expect(result.finishReason).toBe('interrupted');
+    expect(job.status).toBe('cancelled');
+    expect(jobEngine.listAttempts(job.id)).toHaveLength(1);
+    expect(jobEngine.listEvents(job.id).filter((event) => event.type === 'job.cancelled')).toHaveLength(1);
   });
 });
 

--- a/tests/v4/daemon/dispatcher/realAgentRunner.test.ts
+++ b/tests/v4/daemon/dispatcher/realAgentRunner.test.ts
@@ -14,6 +14,7 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '../../../../core/v4/daemon/db/migrations';
 import { createRunStore } from '../../../../core/v4/daemon/runStore';
 import { createTaskStore } from '../../../../core/v4/daemon/taskStore';
+import { createJobEngine } from '../../../../core/v4/daemon/jobEngine';
 import {
   createRealAgentRunner,
 } from '../../../../core/v4/daemon/dispatcher/realAgentRunner';
@@ -82,6 +83,34 @@ function mkResult(over: Partial<{ finishReason: string; usage: { totalTokens: nu
     ...over,
   } as unknown as AidenAgentResult;
 }
+
+describe('createRealAgentRunner durable identity', () => {
+  it('creates and starts the Job and Attempt before invoking the agent', async () => {
+    const jobEngine = createJobEngine({ db });
+    const agent = stubAgent({
+      ...mkResult(), turnCount: 1, toolCallTrace: [],
+    } as AidenAgentResult);
+    const original = agent.runConversation.bind(agent);
+    agent.runConversation = async (...args: Parameters<AidenAgent['runConversation']>) => {
+      const jobs = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' });
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]).toMatchObject({ status: 'running' });
+      expect(jobEngine.listAttempts(jobs[0]!.id)[0]).toMatchObject({ status: 'running' });
+      return original(...args);
+    };
+    const runner = createRealAgentRunner({
+      db, runStore, jobEngine, taskStore: createTaskStore({ db }),
+      agentBuilder: () => agent, persistedDefault: PERSISTED,
+    });
+
+    const result = await runner.invoke(mkInput());
+
+    const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+    expect(result.runId).toBe(jobEngine.listAttempts(job.id)[0]!.rowId);
+    expect(job.status).toBe('completed');
+    expect(jobEngine.listAttempts(job.id)[0]!.status).toBe('succeeded');
+  });
+});
 
 describe('createRealAgentRunner — builder invocation', () => {
   it('calls builder with sessionId + resolvedModel + approvalPolicy', async () => {
@@ -252,6 +281,45 @@ describe('createRealAgentRunner — failure paths', () => {
     expect(result.error).toMatch(/cannot construct agent/);
     const events = runStore.listEvents(result.runId);
     expect(events.some((e) => e.name === 'dispatcher:builder_failed')).toBe(true);
+  });
+
+  it('treats an unknown agent finish reason as failure rather than success', async () => {
+    const jobEngine = createJobEngine({ db });
+    const builder: AgentBuilder = () => stubAgent({
+      finishReason: 'future_unhandled_reason',
+      turnCount: 1,
+      toolCallTrace: [],
+    } as unknown as AidenAgentResult);
+    const runner = createRealAgentRunner({
+      db, runStore, jobEngine, taskStore: createTaskStore({ db }),
+      agentBuilder: builder, persistedDefault: PERSISTED,
+    });
+
+    const result = await runner.invoke(mkInput());
+
+    expect(result.finishReason).toBe('error');
+    expect(runStore.get(result.runId)?.status).toBe('failed');
+    const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+    expect(job.status).toBe('failed');
+    expect(job.terminalOutcome).not.toBe('verified');
+  });
+
+  it('preserves an interrupted turn as cancellation instead of failure or success', async () => {
+    const jobEngine = createJobEngine({ db });
+    const runner = createRealAgentRunner({
+      db, runStore, jobEngine, taskStore: createTaskStore({ db }),
+      agentBuilder: () => stubAgent({
+        finishReason: 'interrupted', turnCount: 1, toolCallTrace: [],
+      } as unknown as AidenAgentResult),
+      persistedDefault: PERSISTED,
+    });
+
+    const result = await runner.invoke(mkInput());
+
+    expect(result.finishReason).toBe('interrupted');
+    const job = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' })[0]!;
+    expect(job.status).toBe('cancelled');
+    expect(jobEngine.listAttempts(job.id)[0]?.status).toBe('cancelled');
   });
 
   it('a zero-iteration turn (turnCount 0) is NOT reported as verified-completed', async () => {

--- a/tests/v4/daemon/httpJobIngress.test.ts
+++ b/tests/v4/daemon/httpJobIngress.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import http from 'node:http';
+
+import Database from 'better-sqlite3';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createHttpJobCoordinator } from '../../../core/v4/daemon/httpJobIngress';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { currentJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
+import { executeTool } from '../../../core/toolRegistry';
+
+describe('HTTP durable Job ingress', () => {
+  let db: Database.Database;
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('http_test', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    const engine = createJobEngine({ db });
+    const coordinator = createHttpJobCoordinator({ engine, instanceId: 'http_test' });
+    const app = express();
+    app.use(express.json());
+    app.post('/direct', coordinator.middleware({ entryPoint: 'compatibility_api', source: 'test' }), async (_req, res) => {
+      const context = currentJobExecutionContext();
+      await executeTool('respond', { message: 'ok' });
+      res.json({ seen_job_id: context?.jobId, seen_attempt_id: context?.attemptId });
+    });
+    app.post('/outer', coordinator.middleware({ entryPoint: 'openai_compatible_api', source: 'test' }), async (_req, res) => {
+      const outer = currentJobExecutionContext();
+      const response = await fetch(`http://127.0.0.1:${port}/inner`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...coordinator.internalHeaders(coordinator.internalToken(res)) },
+        body: JSON.stringify({ message: 'internal' }),
+      });
+      const inner = await response.json() as Record<string, unknown>;
+      res.json({ outer_job_id: outer?.jobId, inner_job_id: inner.seen_job_id });
+    });
+    app.post('/outer-reuse', coordinator.middleware({ entryPoint: 'openai_compatible_api', source: 'test' }), async (_req, res) => {
+      const headers = { 'content-type': 'application/json', ...coordinator.internalHeaders(coordinator.internalToken(res)) };
+      const first = await fetch(`http://127.0.0.1:${port}/inner`, {
+        method: 'POST', headers, body: JSON.stringify({ message: 'first' }),
+      });
+      const second = await fetch(`http://127.0.0.1:${port}/inner`, {
+        method: 'POST', headers, body: JSON.stringify({ message: 'second' }),
+      });
+      res.json({ first: first.status, second: second.status });
+    });
+    app.post('/inner', coordinator.middleware({ entryPoint: 'compatibility_api', source: 'test' }), (_req, res) => {
+      res.json({ seen_job_id: currentJobExecutionContext()?.jobId });
+    });
+    server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    db.close();
+  });
+
+  it('persists and starts identity before the route, then finalizes after the response', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/direct`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'hello' }),
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body.job_id).toBe(body.seen_job_id);
+    expect(body.attempt_id).toBe(body.seen_attempt_id);
+    expect(typeof body.run_id).toBe('number');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(db.prepare('SELECT status, active_attempt_id FROM tasks WHERE id = ?').get(body.job_id)).toEqual({
+      status: 'completed',
+      active_attempt_id: null,
+    });
+    expect(db.prepare('SELECT status FROM runs WHERE id = ?').get(body.run_id)).toEqual({ status: 'succeeded' });
+    expect(db.prepare('SELECT job_id, attempt_id, state FROM tool_calls').get()).toEqual({
+      job_id: body.job_id,
+      attempt_id: body.attempt_id,
+      state: 'completed',
+    });
+  });
+
+  it('borrows the outer identity for the internal compatibility hop', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/outer`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'hello' }),
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(body.inner_job_id).toBe(body.outer_job_id);
+    expect(body.job_id).toBe(body.outer_job_id);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 1 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 1 });
+  });
+
+  it('allows an internal identity loan token to be consumed only once', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/outer-reuse`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'hello' }),
+    });
+    expect(await response.json()).toMatchObject({ first: 200, second: 409 });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 1 });
+  });
+});

--- a/tests/v4/daemon/jobAuthorityCompatibility.test.ts
+++ b/tests/v4/daemon/jobAuthorityCompatibility.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createRunStore } from '../../../core/v4/daemon/runStore';
+import { createTaskStore } from '../../../core/v4/daemon/taskStore';
+
+describe('durable Job compatibility boundaries', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('compat_instance', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    engine = createJobEngine({ db });
+  });
+
+  afterEach(() => db.close());
+
+  function admit() {
+    return engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'compat_session',
+      instanceId: 'compat_instance', idempotencyNamespace: 'compat',
+      idempotencyKey: 'compat_job', goal: 'Protect durable authority',
+    });
+  }
+
+  it('rejects legacy status and resume writers for promoted Jobs and Attempts', () => {
+    const admitted = admit();
+    const taskStore = createTaskStore({ db });
+    const runStore = createRunStore({ db });
+
+    expect(() => taskStore.setStatus(admitted.jobId, 'completed')).toThrow(/Job transition authority/);
+    expect(() => taskStore.setGoal(admitted.jobId, 'replacement')).toThrow(/Job transition authority/);
+    expect(() => taskStore.incrementResumeCount(admitted.jobId)).toThrow(/Job transition authority/);
+    expect(() => runStore.setStatus(admitted.runId, 'completed')).toThrow(/Job transition authority/);
+    expect(() => runStore.markResumePending(admitted.runId, 'legacy')).toThrow(/Job transition authority/);
+    expect(() => runStore.claimResumePending(admitted.runId, 'legacy')).toThrow(/Job transition authority/);
+
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'queued', goal: 'Protect durable authority' });
+    expect(engine.getAttempt(admitted.attemptId)).toMatchObject({ status: 'queued' });
+  });
+
+  it('keeps expired-worker diagnostic events out of the authoritative Job sequence', () => {
+    const admitted = admit();
+    const base = 1;
+    engine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'old_worker', ttlMs: 10, now: base,
+    });
+    const before = engine.listEvents(admitted.jobId).map((event) => event.jobSequence);
+
+    const eventId = createRunStore({ db }).emitEventRich({
+      runId: admitted.runId,
+      category: 'dispatcher',
+      kind: 'late.worker.output',
+      source: 'old_worker',
+      payload: { accepted: false },
+    });
+
+    expect(engine.listEvents(admitted.jobId).map((event) => event.jobSequence)).toEqual(before);
+    expect(db.prepare(
+      'SELECT job_id, attempt_id, job_sequence FROM run_events WHERE id = ?',
+    ).get(eventId)).toEqual({ job_id: null, attempt_id: null, job_sequence: null });
+  });
+
+  it('does not let the legacy orphan sweep transition a promoted Job', () => {
+    const admitted = admit();
+    db.prepare("UPDATE tasks SET status = 'active', created_at = 1 WHERE id = ?").run(admitted.jobId);
+
+    expect(createTaskStore({ db }).sweepOrphaned(Date.now())).toBe(0);
+    expect(engine.getJob(admitted.jobId)?.status).toBe('active');
+  });
+});

--- a/tests/v4/daemon/jobControlAuthority.test.ts
+++ b/tests/v4/daemon/jobControlAuthority.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type AdmissionResult, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import {
+  createJobControlAuthority,
+  type JobControlAuthority,
+} from '../../../core/v4/daemon/jobControlAuthority';
+
+describe('durable Job input and control authority', () => {
+  let db: Database.Database;
+  let jobs: JobEngine;
+  let controls: JobControlAuthority;
+  let admission: AdmissionResult;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (
+         instance_id, pid, hostname, started_at, last_heartbeat, version
+       ) VALUES ('instance-1', 1, 'test', 1, 1, 'test')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO daemon_instances (
+         instance_id, pid, hostname, started_at, last_heartbeat, version
+       ) VALUES ('instance-2', 2, 'test', 1, 1, 'test')`,
+    ).run();
+    jobs = createJobEngine({ db });
+    controls = createJobControlAuthority({ db, jobEngine: jobs });
+    admission = jobs.submitJob({
+      entryPoint: 'interactive',
+      source: 'test',
+      sessionId: 'session-1',
+      instanceId: 'instance-1',
+      idempotencyNamespace: 'test',
+      idempotencyKey: 'job-1',
+      goal: 'test durable input',
+    });
+  });
+
+  afterEach(() => db.close());
+
+  it('persists before acknowledging, preserves order, and consumes exactly once', () => {
+    const first = controls.inputs.receive({
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      targetGeneration: 1,
+      sessionId: 'session-1',
+      source: 'tui',
+      kind: 'message',
+      content: '  FIRST\n',
+      idempotencyNamespace: 'tui:session-1',
+      idempotencyKey: 'input-1',
+    });
+    const second = controls.inputs.receive({
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      targetGeneration: 1,
+      sessionId: 'session-1',
+      source: 'api',
+      kind: 'message',
+      content: 'SECOND',
+      idempotencyNamespace: 'api:session-1',
+      idempotencyKey: 'input-2',
+    });
+
+    expect(first.persisted).toBe(true);
+    expect(first.record.content).toBe('  FIRST\n');
+    expect([first.record.sequence, second.record.sequence]).toEqual([1, 2]);
+    expect(controls.inputs.listPending(admission.jobId).map((entry) => entry.inputId))
+      .toEqual([first.record.inputId, second.record.inputId]);
+
+    const claim = controls.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    });
+    expect(claim?.inputId).toBe(first.record.inputId);
+    expect(controls.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    })?.inputId).toBe(second.record.inputId);
+    expect(controls.inputs.consume({
+      inputId: first.record.inputId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    }).applied).toBe(true);
+    expect(controls.inputs.consume({
+      inputId: first.record.inputId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    })).toMatchObject({ applied: false, duplicate: true });
+  });
+
+  it('deduplicates delivery, rejects stale generations, and excludes credentials', () => {
+    const command = {
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      targetGeneration: 1,
+      sessionId: 'session-1',
+      source: 'channel',
+      kind: 'message' as const,
+      content: 'hello',
+      idempotencyNamespace: 'channel:one',
+      idempotencyKey: 'delivery-7',
+    };
+    const first = controls.inputs.receive(command);
+    const duplicate = controls.inputs.receive(command);
+    expect(duplicate).toMatchObject({ persisted: true, duplicate: true });
+    expect(duplicate.record.inputId).toBe(first.record.inputId);
+
+    expect(() => controls.inputs.receive({ ...command, idempotencyKey: 'stale', targetGeneration: 2 }))
+      .toThrow(/stale generation/i);
+    expect(() => controls.inputs.receive({ ...command, idempotencyKey: 'secret', kind: 'credential', content: 'secret' }))
+      .toThrow(/credential/i);
+    expect(JSON.stringify(controls.inputs.listPending(admission.jobId))).not.toContain('secret');
+  });
+
+  it('rejects new input addressed to a terminal Job', () => {
+    controls.commands.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      kind: 'cancel',
+      source: 'test',
+      idempotencyNamespace: 'test-control',
+      idempotencyKey: 'terminal-input-cancel',
+    });
+    expect(() => controls.inputs.receive({
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      targetGeneration: 1,
+      sessionId: 'session-1',
+      source: 'api',
+      kind: 'message',
+      content: 'do not reopen',
+      idempotencyNamespace: 'api:session-1',
+      idempotencyKey: 'terminal-input',
+    })).toThrow(/terminal.*new Job|continuation/i);
+  });
+
+  it('persists steering and applies it once at a safe boundary', () => {
+    const steer = controls.steering.submit({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      sessionId: 'session-1',
+      source: 'tui',
+      action: 'redirect',
+      payload: 'use the narrower scope',
+      idempotencyNamespace: 'steer:session-1',
+      idempotencyKey: 'steer-1',
+    });
+    expect(steer.state).toBe('pending');
+    expect(controls.steering.applyNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      safeBoundarySequence: 8,
+    })).toMatchObject({ steeringId: steer.steeringId, state: 'applied', safeBoundarySequence: 8 });
+    expect(controls.steering.applyNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      safeBoundarySequence: 9,
+    })).toBeNull();
+  });
+
+  it('creates a new Attempt for goal-changing steering at a safe boundary', () => {
+    const lease = jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 30_000 });
+    jobs.transitionAttempt({
+      attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      producer: 'test', eventIdempotencyKey: 'goal-attempt-running',
+    });
+    jobs.transitionJob({
+      jobId: admission.jobId, attemptId: admission.attemptId, expectedStateVersion: 0,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      producer: 'test', eventIdempotencyKey: 'goal-job-running',
+    });
+    controls.steering.submit({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      sessionId: 'session-1', source: 'tui', action: 'replace_goal', payload: 'new durable goal',
+      idempotencyNamespace: 'steer:session-1', idempotencyKey: 'replace-goal',
+    });
+
+    expect(controls.steering.applyNext({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      safeBoundarySequence: 12, instanceId: 'instance-2',
+    })).toMatchObject({ action: 'replace_goal', state: 'applied' });
+    const current = jobs.getJob(admission.jobId)!;
+    expect(current.activeAttemptId).not.toBe(admission.attemptId);
+    expect(jobs.getAttempt(current.activeAttemptId!)?.generation).toBe(2);
+  });
+
+  it('rejects stale steering after a newer Attempt becomes active', () => {
+    const steer = controls.steering.submit({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      sessionId: 'session-1', source: 'tui', action: 'skip',
+      idempotencyNamespace: 'steer:session-1', idempotencyKey: 'stale-steer',
+    });
+    db.prepare("UPDATE steering_commands SET generation = 2 WHERE steering_id = ?").run(steer.steeringId);
+    expect(controls.steering.applyNext({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 2,
+      safeBoundarySequence: 4,
+    })).toMatchObject({ steeringId: steer.steeringId, state: 'rejected', rejectionReason: 'stale generation' });
+  });
+
+  it('does not let a queued steering record displace the next chat message claim', () => {
+    controls.steering.submit({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      sessionId: 'session-1',
+      source: 'tui',
+      action: 'redirect',
+      payload: 'narrow the result',
+      idempotencyNamespace: 'steer:session-1',
+      idempotencyKey: 'steer-before-message',
+    });
+    const message = controls.inputs.receive({
+      jobId: admission.jobId,
+      sessionId: 'session-1',
+      source: 'tui',
+      kind: 'message',
+      content: 'next user turn',
+      idempotencyNamespace: 'tui:session-1',
+      idempotencyKey: 'message-after-steer',
+    });
+
+    expect(controls.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      kinds: ['message'],
+    })?.inputId).toBe(message.record.inputId);
+  });
+
+  it('restores an exact claimed input after authority reconstruction', () => {
+    const received = controls.inputs.receive({
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      targetGeneration: 1,
+      sessionId: 'session-1',
+      source: 'tui',
+      kind: 'message',
+      content: 'survive restart',
+      idempotencyNamespace: 'tui:session-1',
+      idempotencyKey: 'restart-claim',
+    });
+    expect(controls.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      inputId: received.record.inputId,
+      kinds: ['message'],
+    })?.state).toBe('claimed');
+
+    const restored = createJobControlAuthority({ db, jobEngine: createJobEngine({ db }) });
+    expect(restored.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      inputId: received.record.inputId,
+      kinds: ['message'],
+    })?.inputId).toBe(received.record.inputId);
+    expect(restored.inputs.consume({
+      inputId: received.record.inputId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    }).applied).toBe(true);
+  });
+
+  it('projects input lifecycle by reference without copying content into Job events', () => {
+    const secretLikeContent = 'ordinary input with private material';
+    const received = controls.inputs.receive({
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      targetGeneration: 1,
+      sessionId: 'session-1',
+      source: 'api',
+      kind: 'message',
+      content: secretLikeContent,
+      idempotencyNamespace: 'api:session-1',
+      idempotencyKey: 'event-projection',
+    });
+    controls.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      inputId: received.record.inputId,
+    });
+    controls.inputs.consume({
+      inputId: received.record.inputId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    });
+
+    const events = jobs.listEvents(admission.jobId).filter((event) => event.type.startsWith('input.'));
+    expect(events.map((event) => event.type)).toEqual(['input.queued', 'input.claimed', 'input.consumed']);
+    expect(events.every((event) => event.payload?.inputId === received.record.inputId)).toBe(true);
+    expect(JSON.stringify(events)).not.toContain(secretLikeContent);
+  });
+
+  it('persists cancellation before physically aborting and makes races idempotent', () => {
+    const abort = new AbortController();
+    controls.runtime.attach(admission.attemptId, abort);
+    const result = controls.commands.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      kind: 'cancel',
+      source: 'api',
+      reason: 'user requested stop',
+      idempotencyNamespace: 'api-control',
+      idempotencyKey: 'cancel-1',
+    });
+    expect(result.persisted).toBe(true);
+    expect(abort.signal.aborted).toBe(true);
+    expect(jobs.getJob(admission.jobId)?.status).toBe('cancelled');
+    expect(controls.commands.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      kind: 'cancel',
+      source: 'api',
+      reason: 'duplicate',
+      idempotencyNamespace: 'api-control',
+      idempotencyKey: 'cancel-1',
+    }).duplicate).toBe(true);
+  });
+
+  it('cascades parent cancellation to active child Jobs and runtimes', () => {
+    const child = jobs.submitJob({
+      entryPoint: 'subagent',
+      source: 'parent',
+      sessionId: 'session-1',
+      instanceId: 'instance-1',
+      idempotencyNamespace: 'test-child',
+      idempotencyKey: 'child-1',
+      goal: 'child work',
+      parentJobId: admission.jobId,
+      rootJobId: admission.jobId,
+    });
+    const parentAbort = new AbortController();
+    const childAbort = new AbortController();
+    controls.runtime.attach(admission.attemptId, parentAbort);
+    controls.runtime.attach(child.attemptId, childAbort);
+
+    expect(controls.commands.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      kind: 'cancel',
+      source: 'api',
+      reason: 'cancel family',
+      idempotencyNamespace: 'api-control',
+      idempotencyKey: 'cancel-family',
+    }).applied).toBe(true);
+    expect(jobs.getJob(admission.jobId)?.status).toBe('cancelled');
+    expect(jobs.getJob(child.jobId)?.status).toBe('cancelled');
+    expect(parentAbort.signal.aborted).toBe(true);
+    expect(childAbort.signal.aborted).toBe(true);
+  });
+
+  it('persists pause and creates a new attempt on resume', () => {
+    const claimed = jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 30_000 });
+    expect(claimed.acquired).toBe(true);
+    const startedAttempt = jobs.transitionAttempt({
+      attemptId: admission.attemptId,
+      expectedStateVersion: claimed.stateVersion!,
+      generation: claimed.generation!,
+      fenceToken: claimed.fenceToken!,
+      to: 'running',
+      producer: 'test',
+      eventIdempotencyKey: 'attempt-running',
+    });
+    const startedJob = jobs.transitionJob({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      expectedStateVersion: 0,
+      generation: claimed.generation!,
+      fenceToken: claimed.fenceToken!,
+      to: 'running',
+      producer: 'test',
+      eventIdempotencyKey: 'job-running',
+    });
+    expect(startedAttempt.applied && startedJob.applied).toBe(true);
+
+    const paused = controls.commands.request({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      kind: 'pause',
+      source: 'tui',
+      reason: 'user pause',
+      idempotencyNamespace: 'tui-control',
+      idempotencyKey: 'pause-1',
+    });
+    expect(paused.persisted).toBe(true);
+    expect(paused.applied).toBe(false);
+    expect(controls.commands.applyPendingAtBoundary({ jobId: admission.jobId })).toEqual({ applied: true, kind: 'pause' });
+    expect(jobs.getJob(admission.jobId)?.status).toBe('paused');
+
+    const resumed = controls.commands.resume({
+      jobId: admission.jobId,
+      source: 'tui',
+      instanceId: 'instance-2',
+      idempotencyNamespace: 'tui-control',
+      idempotencyKey: 'resume-1',
+    });
+    expect(resumed.attemptId).not.toBe(admission.attemptId);
+    expect(resumed.generation).toBe(2);
+    expect(jobs.getJob(admission.jobId)?.activeAttemptId).toBe(resumed.attemptId);
+  });
+
+  it('keeps runtime signal registration scoped to the exact attempt', () => {
+    const first = new AbortController();
+    const second = new AbortController();
+    const detachFirst = controls.runtime.attach(admission.attemptId, first);
+    controls.runtime.attach(admission.attemptId, second);
+    detachFirst();
+    controls.runtime.cancel(admission.attemptId, 'cancel current');
+    expect(first.signal.aborted).toBe(false);
+    expect(second.signal.aborted).toBe(true);
+  });
+});

--- a/tests/v4/daemon/jobEngine.process.test.ts
+++ b/tests/v4/daemon/jobEngine.process.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { fork, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+
+type WorkerMessage = { type: string; result?: Record<string, unknown>; error?: string };
+
+const fixture = resolve(__dirname, '../harness/jobEngineProcessFixture.ts');
+let directory: string;
+let dbPath: string;
+let children: ChildProcess[];
+
+function startWorker(payload: Record<string, unknown>): ChildProcess {
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const child = fork(fixture, [dbPath, encoded], {
+    execArgv: ['-r', 'ts-node/register/transpile-only'],
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+  });
+  children.push(child);
+  return child;
+}
+
+function message(child: ChildProcess, type: string): Promise<WorkerMessage> {
+  return new Promise((resolveMessage, reject) => {
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => { stderr += String(chunk); });
+    const onMessage = (value: unknown): void => {
+      const parsed = value as WorkerMessage;
+      if (parsed.type === 'error') {
+        cleanup();
+        reject(new Error(parsed.error ?? 'worker failed'));
+        return;
+      }
+      if (parsed.type !== type) return;
+      cleanup();
+      resolveMessage(parsed);
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`worker exited before ${type} with code ${code}: ${stderr.trim()}`));
+    };
+    const cleanup = (): void => {
+      child.off('message', onMessage);
+      child.off('exit', onExit);
+    };
+    child.on('message', onMessage);
+    child.on('exit', onExit);
+  });
+}
+
+function seed(): { jobId: string; attemptId: string } {
+  const db = new Database(dbPath);
+  runMigrations(db);
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES ('process_instance', 1, 'localhost', ?, ?, '4.15.1')`,
+  ).run(now, now);
+  const admitted = createJobEngine({ db }).submitJob({
+    entryPoint: 'process-test',
+    source: 'process-test',
+    sessionId: 'process-session',
+    instanceId: 'process_instance',
+    idempotencyNamespace: 'process-test',
+    idempotencyKey: 'process-job',
+    requestFingerprint: 'process-fingerprint',
+    goal: 'Exercise process-level lease arbitration',
+  });
+  db.close();
+  return admitted;
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'aiden-job-process-'));
+  dbPath = join(directory, 'daemon.db');
+  children = [];
+});
+
+afterEach(() => {
+  for (const child of children) child.kill();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe('Job engine process arbitration', () => {
+  it('allows exactly one of two real processes to claim an Attempt', async () => {
+    const admitted = seed();
+    const first = startWorker({ action: 'claim', attemptId: admitted.attemptId, ownerId: 'process_a' });
+    const second = startWorker({ action: 'claim', attemptId: admitted.attemptId, ownerId: 'process_b' });
+    await Promise.all([message(first, 'ready'), message(second, 'ready')]);
+    const results = [message(first, 'result'), message(second, 'result')];
+    first.send('go');
+    second.send('go');
+
+    const resolved = (await Promise.all(results)).map((entry) => entry.result);
+    expect(resolved.filter((entry) => entry?.acquired === true)).toHaveLength(1);
+    expect(resolved.filter((entry) => entry?.conflict === 'lease_held')).toHaveLength(1);
+  });
+
+  it('rejects a late result from a real process after another process reclaims the lease', async () => {
+    const admitted = seed();
+    const base = Date.now();
+    const stale = startWorker({
+      action: 'claim_then_write', attemptId: admitted.attemptId,
+      ownerId: 'process_stale', ttlMs: 10, now: base,
+    });
+    const staleClaim = await message(stale, 'claimed');
+    expect(staleClaim.result?.acquired).toBe(true);
+
+    const recoveryDb = new Database(dbPath);
+    const recovery = createJobEngine({ db: recoveryDb }).recoverExpiredAttempts({
+      now: base + 11,
+      instanceId: 'process_instance',
+      producer: 'process-recovery',
+      maxCrashes: 3,
+    })[0]!;
+    recoveryDb.close();
+    const current = startWorker({
+      action: 'claim', attemptId: recovery.recoveryAttemptId!,
+      ownerId: 'process_current', ttlMs: 30_000, now: base + 11,
+    });
+    await message(current, 'ready');
+    const currentResult = message(current, 'result');
+    current.send('go');
+    expect((await currentResult).result).toMatchObject({ acquired: true, generation: 2 });
+
+    const lateResult = message(stale, 'result');
+    stale.send('write');
+    expect((await lateResult).result).toMatchObject({ applied: false, conflict: 'terminal_state' });
+  });
+
+  it('recovers a crashed process into a new Attempt after reopening the database', async () => {
+    const admitted = seed();
+    const base = Date.now();
+    const crashing = startWorker({
+      action: 'claim_and_crash', attemptId: admitted.attemptId,
+      ownerId: 'process_crash', ttlMs: 10, now: base,
+    });
+    const claim = await message(crashing, 'claimed');
+    expect(claim.result).toMatchObject({
+      lease: { acquired: true, generation: 1 },
+      started: { applied: true },
+    });
+    if (crashing.exitCode === null) {
+      await new Promise<void>((resolveExit) => crashing.once('exit', () => resolveExit()));
+    }
+
+    const recovering = startWorker({
+      action: 'recover', attemptId: admitted.attemptId,
+      ownerId: 'process_instance', now: base + 11,
+    });
+    const recovered = await message(recovering, 'result');
+    expect(recovered.result?.recovered).toEqual([expect.objectContaining({
+      jobId: admitted.jobId,
+      expiredAttemptId: admitted.attemptId,
+      recoveryAttemptId: expect.stringMatching(/^attempt_/),
+    })]);
+
+    const reopened = new Database(dbPath);
+    const engine = createJobEngine({ db: reopened });
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'recovering' });
+    expect(engine.listAttempts(admitted.jobId)).toEqual([
+      expect.objectContaining({ id: admitted.attemptId, status: 'crashed', generation: 1 }),
+      expect.objectContaining({ status: 'queued', generation: 2, recoveryOfAttemptId: admitted.attemptId }),
+    ]);
+    reopened.close();
+  });
+
+  it.each([
+    { mutates: false, expectedDecision: 'retry', expectedJobStatus: 'recovering', expectedAttempts: 2 },
+    { mutates: true, expectedDecision: 'ask_user', expectedJobStatus: 'blocked', expectedAttempts: 1 },
+  ])('recovers conservatively after a real process crashes during tool execution ($expectedDecision)', async ({
+    mutates, expectedDecision, expectedJobStatus, expectedAttempts,
+  }) => {
+    const admitted = seed();
+    const base = Date.now();
+    const crashing = startWorker({
+      action: 'start_tool_and_crash',
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      toolCallId: mutates ? 'tool_process_write' : 'tool_process_read',
+      mutates,
+      ownerId: 'process_tool_crash',
+      ttlMs: 10,
+      now: base,
+    });
+    const started = await message(crashing, 'tool_started');
+    expect(started.result).toMatchObject({
+      lease: { acquired: true, generation: 1 },
+      attempt: { applied: true },
+      prepared: { applied: true },
+      started: { applied: true },
+    });
+    if (crashing.exitCode === null) {
+      await new Promise<void>((resolveExit) => crashing.once('exit', () => resolveExit()));
+    }
+
+    const recovering = startWorker({
+      action: 'recover', attemptId: admitted.attemptId,
+      ownerId: 'process_instance', now: base + 11,
+    });
+    const recovered = await message(recovering, 'result');
+    expect(recovered.result?.recovered).toEqual([expect.objectContaining({
+      jobId: admitted.jobId,
+      expiredAttemptId: admitted.attemptId,
+      decision: expectedDecision,
+    })]);
+
+    const reopened = new Database(dbPath);
+    const engine = createJobEngine({ db: reopened });
+    expect(engine.getJob(admitted.jobId)?.status).toBe(expectedJobStatus);
+    expect(engine.listAttempts(admitted.jobId)).toHaveLength(expectedAttempts);
+    if (mutates) {
+      expect(engine.getAttempt(admitted.attemptId)?.status).toBe('unknown');
+    } else {
+      expect(engine.listAttempts(admitted.jobId)[1]).toMatchObject({
+        status: 'queued', generation: 2, recoveryOfAttemptId: admitted.attemptId,
+      });
+    }
+    reopened.close();
+  });
+
+  it('allocates unique replayable Job event sequences under concurrent process writes', async () => {
+    const admitted = seed();
+    const db = new Database(dbPath);
+    const engine = createJobEngine({ db });
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'event_owner', ttlMs: 30_000 });
+    db.close();
+
+    const first = startWorker({
+      action: 'prepare_tool', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: lease.generation, fenceToken: lease.fenceToken, toolCallId: 'tool_process_a',
+    });
+    const second = startWorker({
+      action: 'prepare_tool', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: lease.generation, fenceToken: lease.fenceToken, toolCallId: 'tool_process_b',
+    });
+    await Promise.all([message(first, 'ready'), message(second, 'ready')]);
+    const results = [message(first, 'result'), message(second, 'result')];
+    first.send('go');
+    second.send('go');
+    expect((await Promise.all(results)).map((entry) => entry.result?.applied)).toEqual([true, true]);
+
+    const reopened = new Database(dbPath);
+    const replay = createJobEngine({ db: reopened }).listEvents(admitted.jobId, 0);
+    const sequences = replay.map((event) => event.jobSequence);
+    expect(new Set(sequences).size).toBe(sequences.length);
+    expect(sequences).toEqual([...sequences].sort((a, b) => a - b));
+    const cursor = sequences.at(-2) ?? 0;
+    expect(createJobEngine({ db: reopened }).listEvents(admitted.jobId, cursor).map((event) => event.jobSequence))
+      .toEqual(sequences.filter((sequence) => sequence > cursor));
+    reopened.close();
+  });
+});

--- a/tests/v4/daemon/jobEngine.process.test.ts
+++ b/tests/v4/daemon/jobEngine.process.test.ts
@@ -59,6 +59,18 @@ function message(child: ChildProcess, type: string): Promise<WorkerMessage> {
   });
 }
 
+function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise<void>((resolveExit) => {
+    const onExit = (): void => { resolveExit(); };
+    child.once('exit', onExit);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      child.off('exit', onExit);
+      resolveExit();
+    }
+  });
+}
+
 function seed(): { jobId: string; attemptId: string } {
   const db = new Database(dbPath);
   runMigrations(db);
@@ -88,9 +100,12 @@ beforeEach(() => {
   children = [];
 });
 
-afterEach(() => {
-  for (const child of children) child.kill();
-  rmSync(directory, { recursive: true, force: true });
+afterEach(async () => {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
+  await Promise.all(children.map(waitForExit));
+  rmSync(directory, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 describe('Job engine process arbitration', () => {
@@ -147,14 +162,13 @@ describe('Job engine process arbitration', () => {
       action: 'claim_and_crash', attemptId: admitted.attemptId,
       ownerId: 'process_crash', ttlMs: 10, now: base,
     });
+    const exited = waitForExit(crashing);
     const claim = await message(crashing, 'claimed');
     expect(claim.result).toMatchObject({
       lease: { acquired: true, generation: 1 },
       started: { applied: true },
     });
-    if (crashing.exitCode === null) {
-      await new Promise<void>((resolveExit) => crashing.once('exit', () => resolveExit()));
-    }
+    await exited;
 
     const recovering = startWorker({
       action: 'recover', attemptId: admitted.attemptId,
@@ -195,6 +209,7 @@ describe('Job engine process arbitration', () => {
       ttlMs: 10,
       now: base,
     });
+    const exited = waitForExit(crashing);
     const started = await message(crashing, 'tool_started');
     expect(started.result).toMatchObject({
       lease: { acquired: true, generation: 1 },
@@ -202,9 +217,7 @@ describe('Job engine process arbitration', () => {
       prepared: { applied: true },
       started: { applied: true },
     });
-    if (crashing.exitCode === null) {
-      await new Promise<void>((resolveExit) => crashing.once('exit', () => resolveExit()));
-    }
+    await exited;
 
     const recovering = startWorker({
       action: 'recover', attemptId: admitted.attemptId,

--- a/tests/v4/daemon/jobEngine.test.ts
+++ b/tests/v4/daemon/jobEngine.test.ts
@@ -1,0 +1,596 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import {
+  IdempotencyConflictError,
+  createJobEngine,
+  type JobEngine,
+} from '../../../core/v4/daemon/jobEngine';
+
+let db: Database.Database;
+let engine: JobEngine;
+
+function seedInstance(instanceId = 'instance_test'): void {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(instanceId, 1, 'localhost', now, now, '4.15.1');
+}
+
+function submit(overrides: Partial<Parameters<JobEngine['submitJob']>[0]> = {}) {
+  return engine.submitJob({
+    entryPoint: 'test',
+    source: 'unit',
+    sessionId: 'session_test',
+    workspaceId: 'workspace_test',
+    principalId: 'principal_test',
+    instanceId: 'instance_test',
+    idempotencyNamespace: 'test',
+    idempotencyKey: 'submission_1',
+    requestFingerprint: 'fingerprint_1',
+    goal: 'Exercise the durable Job engine',
+    ...overrides,
+  });
+}
+
+function claimJob(admitted: ReturnType<typeof submit>, ownerId = 'owner_a') {
+  const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId, ttlMs: 30_000 });
+  if (!lease.acquired || lease.generation === undefined || !lease.fenceToken) {
+    throw new Error(`test lease unavailable: ${lease.conflict ?? 'unknown'}`);
+  }
+  return {
+    attemptId: admitted.attemptId,
+    generation: lease.generation,
+    fenceToken: lease.fenceToken,
+  };
+}
+
+function recoverExpired(now: number) {
+  return engine.recoverExpiredAttempts({
+    now,
+    instanceId: 'instance_test',
+    producer: 'test-recovery',
+    maxCrashes: 3,
+  });
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  seedInstance();
+  engine = createJobEngine({ db });
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* already closed */ }
+});
+
+describe('Job admission', () => {
+  it('durably creates exactly one Job and Attempt before returning', () => {
+    const admitted = submit();
+
+    expect(admitted.reused).toBe(false);
+    expect(admitted.jobId).toMatch(/^task_/);
+    expect(admitted.attemptId).toMatch(/^attempt_/);
+    expect(engine.getJob(admitted.jobId)).toMatchObject({
+      id: admitted.jobId,
+      status: 'queued',
+      activeAttemptId: admitted.attemptId,
+      stateVersion: 0,
+    });
+    expect(engine.getAttempt(admitted.attemptId)).toMatchObject({
+      id: admitted.attemptId,
+      jobId: admitted.jobId,
+      status: 'queued',
+      attemptNumber: 1,
+      generation: 1,
+    });
+    expect(engine.listEvents(admitted.jobId, 0).map((event) => event.type)).toEqual([
+      'job.submitted',
+      'attempt.created',
+    ]);
+  });
+
+  it('reuses the existing Job for the same idempotency key and fingerprint', () => {
+    const first = submit();
+    const duplicate = submit();
+
+    expect(duplicate).toEqual({ ...first, reused: true });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 1 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 1 });
+  });
+
+  it('rejects the same idempotency key with a different fingerprint', () => {
+    submit();
+    expect(() => submit({ requestFingerprint: 'different' })).toThrow(IdempotencyConflictError);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 1 });
+  });
+
+  it('persists an internal idempotency key when the client supplies none', () => {
+    const admitted = submit({ idempotencyKey: undefined });
+    const row = db.prepare(
+      'SELECT idempotency_key FROM tasks WHERE id = ?',
+    ).get(admitted.jobId) as { idempotency_key: string };
+    expect(row.idempotency_key).toMatch(/^internal_/);
+  });
+});
+
+describe('transactional transitions', () => {
+  it('commits Job state and its event together with compare-and-set versioning', () => {
+    const admitted = submit();
+    const authority = claimJob(admitted);
+    const result = engine.transitionJob({
+      jobId: admitted.jobId,
+      ...authority,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'job-running',
+      producer: 'test',
+    });
+
+    expect(result).toMatchObject({ applied: true, stateVersion: 1 });
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'running', stateVersion: 1 });
+    expect(engine.listEvents(admitted.jobId, 0).at(-1)).toMatchObject({
+      type: 'job.running',
+      jobSequence: 4,
+    });
+  });
+
+  it('rolls back state when event append fails', () => {
+    const admitted = submit();
+    const authority = claimJob(admitted);
+    db.exec(`
+      CREATE TRIGGER reject_transition_event
+      BEFORE INSERT ON run_events
+      WHEN NEW.kind = 'job.running'
+      BEGIN
+        SELECT RAISE(ABORT, 'event rejected');
+      END;
+    `);
+
+    expect(() => engine.transitionJob({
+      jobId: admitted.jobId,
+      ...authority,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'job-running',
+      producer: 'test',
+    })).toThrow(/event rejected/);
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'queued', stateVersion: 0 });
+    expect(engine.listEvents(admitted.jobId, 0)).toHaveLength(3);
+  });
+
+  it('rejects stale versions and never overwrites terminal truth', () => {
+    const admitted = submit();
+    const authority = claimJob(admitted);
+    expect(engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: 0,
+      generation: authority.generation,
+      fenceToken: authority.fenceToken,
+      to: 'running',
+      eventIdempotencyKey: 'stale-attempt-version',
+      producer: 'test',
+    })).toMatchObject({ applied: false, conflict: 'state_version' });
+    expect(engine.transitionJob({
+      jobId: admitted.jobId,
+      ...authority,
+      expectedStateVersion: 0,
+      to: 'cancelled',
+      eventIdempotencyKey: 'cancel',
+      producer: 'test',
+    }).applied).toBe(true);
+
+    const stale = engine.transitionJob({
+      jobId: admitted.jobId,
+      ...authority,
+      expectedStateVersion: 0,
+      to: 'completed',
+      eventIdempotencyKey: 'late-success',
+      producer: 'test',
+    });
+    expect(stale).toMatchObject({ applied: false, conflict: 'terminal_state' });
+
+    const terminal = engine.transitionJob({
+      jobId: admitted.jobId,
+      ...authority,
+      expectedStateVersion: 1,
+      to: 'completed',
+      eventIdempotencyKey: 'late-success-2',
+      producer: 'test',
+    });
+    expect(terminal).toMatchObject({ applied: false, conflict: 'terminal_state' });
+    expect(engine.getJob(admitted.jobId)?.status).toBe('cancelled');
+  });
+
+  it('makes duplicate transition commands idempotent', () => {
+    const admitted = submit();
+    const authority = claimJob(admitted);
+    const command = {
+      jobId: admitted.jobId,
+      ...authority,
+      expectedStateVersion: 0,
+      to: 'running' as const,
+      eventIdempotencyKey: 'same-command',
+      producer: 'test',
+    };
+    const first = engine.transitionJob(command);
+    const duplicate = engine.transitionJob(command);
+
+    expect(first.applied).toBe(true);
+    expect(duplicate).toMatchObject({ applied: false, duplicate: true });
+    expect(engine.listEvents(admitted.jobId, 0).filter((event) => event.type === 'job.running')).toHaveLength(1);
+  });
+
+  it('finalizes lifecycle, verification evidence, and its event in one transaction', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({
+      attemptId: admitted.attemptId,
+      ownerId: 'owner_a',
+      ttlMs: 30_000,
+    });
+    engine.transitionJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'job-running',
+      producer: 'test',
+    });
+
+    const result = engine.finalizeJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      expectedStateVersion: 1,
+      status: 'completed',
+      outcome: 'completed_unverified',
+      finishReason: 'stop',
+      evidence: { version: 1, verdict: 'unverified' },
+      jobCard: { filesTouched: ['result.txt'] },
+      eventIdempotencyKey: 'job-finalized',
+      producer: 'test',
+    });
+
+    expect(result).toMatchObject({ applied: true, stateVersion: 2 });
+    expect(engine.getJob(admitted.jobId)).toMatchObject({
+      status: 'completed',
+      terminalOutcome: 'completed_unverified',
+      finishReason: 'stop',
+    });
+    expect(db.prepare('SELECT evidence, files_touched FROM tasks WHERE id = ?').get(admitted.jobId)).toEqual({
+      evidence: JSON.stringify({
+        version: 1,
+        verdict: 'unverified',
+        durableExecution: {
+          jobId: admitted.jobId,
+          attemptId: admitted.attemptId,
+          generation: lease.generation,
+          toolCallIds: [],
+        },
+      }),
+      files_touched: JSON.stringify(['result.txt']),
+    });
+    expect(engine.listEvents(admitted.jobId, 0).at(-1)?.type).toBe('job.finalized');
+  });
+
+  it('rejects stale evidence and completion from a reclaimed Attempt fence', () => {
+    const admitted = submit();
+    const base = Date.now();
+    const first = engine.claimAttempt({
+      attemptId: admitted.attemptId,
+      ownerId: 'owner_a',
+      ttlMs: 10,
+      now: base,
+    });
+    engine.transitionJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: first.generation!,
+      fenceToken: first.fenceToken!,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'stale-job-running',
+      producer: 'test',
+      now: base,
+    });
+    const recovery = recoverExpired(base + 11)[0]!;
+    const reclaimed = engine.claimAttempt({
+      attemptId: recovery.recoveryAttemptId!,
+      ownerId: 'owner_b',
+      ttlMs: 30_000,
+      now: base + 11,
+    });
+    expect(reclaimed).toMatchObject({ acquired: true, generation: 2 });
+
+    const stale = engine.finalizeJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: first.generation!,
+      fenceToken: first.fenceToken!,
+      expectedStateVersion: 1,
+      status: 'completed',
+      outcome: 'verified',
+      finishReason: 'stop',
+      evidence: { verdict: 'verified', stale: true },
+      eventIdempotencyKey: 'stale-job-finalized',
+      producer: 'test',
+    });
+
+    expect(stale).toMatchObject({ applied: false, conflict: 'stale_fence' });
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'recovering', activeAttemptId: recovery.recoveryAttemptId });
+    expect(db.prepare('SELECT evidence FROM tasks WHERE id = ?').get(admitted.jobId)).toEqual({ evidence: null });
+    expect(engine.listEvents(admitted.jobId).some((event) => event.idempotencyKey === 'stale-job-finalized')).toBe(false);
+  });
+
+  it('lets cancellation win atomically and rejects the late worker result', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    const attemptRunning = engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'running',
+      eventIdempotencyKey: 'cancel-race-attempt-running',
+      producer: 'test',
+    });
+    engine.transitionJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'cancel-race-job-running',
+      producer: 'test',
+    });
+
+    expect(engine.cancelJob({
+      jobId: admitted.jobId,
+      reason: 'user_cancelled',
+      producer: 'test',
+      eventIdempotencyKey: 'cancel-race-winner',
+    })).toMatchObject({ applied: true, stateVersion: 2 });
+    expect(engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: attemptRunning.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'succeeded',
+      eventIdempotencyKey: 'cancel-race-late-attempt',
+      producer: 'test',
+    })).toMatchObject({ applied: false, conflict: 'terminal_state' });
+    expect(engine.finalizeJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      expectedStateVersion: 1,
+      status: 'completed',
+      outcome: 'verified',
+      finishReason: 'stop',
+      evidence: { stale: true },
+      eventIdempotencyKey: 'cancel-race-late-job',
+      producer: 'test',
+    })).toMatchObject({ applied: false, conflict: 'terminal_state' });
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'cancelled', terminalOutcome: 'cancelled' });
+    expect(engine.getAttempt(admitted.attemptId)?.status).toBe('cancelled');
+  });
+});
+
+describe('Attempt leases and fencing', () => {
+  it('allows only one owner to claim an Attempt', () => {
+    const admitted = submit();
+    const first = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    const second = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_b', ttlMs: 30_000 });
+
+    expect(first.acquired).toBe(true);
+    expect(first.leaseId).toMatch(/^lease_/);
+    expect(first.fenceToken).toMatch(/^fence_/);
+    expect(second).toMatchObject({ acquired: false, conflict: 'lease_held' });
+  });
+
+  it('rejects stale fence writes after lease expiry and reclaim', () => {
+    const admitted = submit();
+    const first = engine.claimAttempt({
+      attemptId: admitted.attemptId,
+      ownerId: 'owner_a',
+      ttlMs: 10,
+      now: 1_000,
+    });
+    const recovery = recoverExpired(1_011)[0]!;
+    const reclaimed = engine.claimAttempt({
+      attemptId: recovery.recoveryAttemptId!,
+      ownerId: 'owner_b',
+      ttlMs: 10_000,
+      now: 1_011,
+    });
+    expect(reclaimed).toMatchObject({ acquired: true, generation: 2 });
+
+    const stale = engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: first.stateVersion!,
+      generation: first.generation!,
+      fenceToken: first.fenceToken!,
+      to: 'succeeded',
+      eventIdempotencyKey: 'stale-success',
+      producer: 'test',
+    });
+    expect(stale).toMatchObject({ applied: false, conflict: 'terminal_state' });
+    expect(engine.getAttempt(admitted.attemptId)?.generation).toBe(1);
+    expect(engine.getAttempt(recovery.recoveryAttemptId!)?.generation).toBe(2);
+  });
+
+  it('creates a new Attempt for recovery instead of resurrecting a terminal Attempt', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    expect(engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'failed',
+      eventIdempotencyKey: 'attempt-failed',
+      producer: 'test',
+    }).applied).toBe(true);
+
+    const recovery = engine.createRecoveryAttempt({
+      jobId: admitted.jobId,
+      recoveryOfAttemptId: admitted.attemptId,
+      instanceId: 'instance_test',
+      triggerReason: 'retry',
+      eventIdempotencyKey: 'attempt-recovery',
+      producer: 'test',
+    });
+    expect(recovery.attemptId).not.toBe(admitted.attemptId);
+    expect(recovery).toMatchObject({ attemptNumber: 2, generation: 2 });
+    expect(engine.getAttempt(admitted.attemptId)?.status).toBe('failed');
+    expect(engine.getJob(admitted.jobId)).toMatchObject({
+      activeAttemptId: recovery.attemptId,
+      status: 'recovering',
+      stateVersion: 1,
+    });
+  });
+});
+
+describe('ToolCall and SideEffect identity', () => {
+  it('persists prepared, started, and committed mutating execution under the active fence', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'running',
+      eventIdempotencyKey: 'attempt-running',
+      producer: 'test',
+    });
+
+    expect(engine.prepareToolCall({
+      toolCallId: 'tool_call_1',
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      toolName: 'file_write',
+      normalizedArgsDigest: 'digest_1',
+      riskTier: 'caution',
+      mutates: true,
+      producer: 'test',
+    }).applied).toBe(true);
+    expect(engine.startToolCall({
+      toolCallId: 'tool_call_1',
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      producer: 'test',
+    }).applied).toBe(true);
+    expect(engine.completeToolCall({
+      toolCallId: 'tool_call_1',
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      state: 'completed',
+      sideEffectState: 'committed',
+      resultRef: 'tool-result:sha256:result',
+      producer: 'test',
+    }).applied).toBe(true);
+
+    expect(engine.attachToolVerification({
+      toolCallId: 'tool_call_1',
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      verificationRef: 'tool-verification:sha256:verification',
+      producer: 'test',
+    }).applied).toBe(true);
+
+    expect(db.prepare(
+      'SELECT state, side_effect_id, result_ref, verification_ref FROM tool_calls WHERE tool_call_id = ?',
+    ).get('tool_call_1')).toMatchObject({
+      state: 'completed',
+      side_effect_id: 'side_effect:tool_call_1',
+      result_ref: 'tool-result:sha256:result',
+      verification_ref: 'tool-verification:sha256:verification',
+    });
+    expect(db.prepare('SELECT effect_state FROM side_effect_ledger WHERE tool_call_id = ?').get('tool_call_1')).toEqual({
+      effect_state: 'committed',
+    });
+  });
+
+  it('rejects a stale ToolCall result after the Attempt is reclaimed', () => {
+    const admitted = submit();
+    const base = Date.now();
+    const first = engine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 10, now: base,
+    });
+    engine.prepareToolCall({
+      toolCallId: 'tool_call_stale',
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: first.generation!,
+      fenceToken: first.fenceToken!,
+      toolName: 'file_write',
+      normalizedArgsDigest: 'digest_stale',
+      riskTier: 'caution',
+      mutates: true,
+      producer: 'test',
+    });
+    recoverExpired(base + 11);
+
+    expect(engine.completeToolCall({
+      toolCallId: 'tool_call_stale',
+      attemptId: admitted.attemptId,
+      generation: first.generation!,
+      fenceToken: first.fenceToken!,
+      state: 'completed',
+      sideEffectState: 'committed',
+      producer: 'test',
+    })).toMatchObject({ applied: false, conflict: 'stale_fence' });
+    expect(db.prepare('SELECT state FROM tool_calls WHERE tool_call_id = ?').get('tool_call_stale')).toEqual({ state: 'prepared' });
+  });
+
+  it('rejects authoritative writes after the active lease expires', () => {
+    const admitted = submit();
+    const base = Date.now();
+    const lease = engine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 10, now: base,
+    });
+
+    expect(engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'running',
+      eventIdempotencyKey: 'expired-write',
+      producer: 'test',
+      now: base + 11,
+    })).toMatchObject({ applied: false, conflict: 'lease_expired' });
+  });
+});
+
+describe('Job queries', () => {
+  it('lists Jobs by session and status without exposing a second authority', () => {
+    const first = submit({ sessionId: 'session_a' });
+    submit({ sessionId: 'session_b', idempotencyKey: 'submission_2', requestFingerprint: 'fingerprint_2' });
+
+    expect(engine.listJobs({ sessionId: 'session_a', status: 'queued' }).map((job) => job.id)).toEqual([
+      first.jobId,
+    ]);
+  });
+});

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { executeDurableJob } from '../../../core/v4/daemon/jobLifecycle';
+import { currentJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
+
+describe('executeDurableJob', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance_lifecycle', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    engine = createJobEngine({ db });
+  });
+
+  afterEach(() => db.close());
+
+  it('creates, leases, starts, executes, and finalizes one Job and Attempt', async () => {
+    let identityDuringWork: ReturnType<typeof currentJobExecutionContext>;
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_lifecycle',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_1', requestFingerprint: 'fingerprint_1', goal: 'run work',
+      },
+      execute: async () => {
+        identityDuringWork = currentJobExecutionContext();
+        return { value: 42 };
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: { verified: true },
+      }),
+    });
+
+    expect(identityDuringWork!).toMatchObject({
+      jobId: execution.jobId,
+      attemptId: execution.attemptId,
+      generation: 1,
+    });
+    expect(engine.getJob(execution.jobId)).toMatchObject({ status: 'completed', activeAttemptId: null });
+    expect(engine.getAttempt(execution.attemptId)?.status).toBe('succeeded');
+    expect(engine.listEvents(execution.jobId).map((event) => event.type)).toEqual([
+      'job.submitted', 'attempt.created', 'attempt.leased', 'attempt.running',
+      'job.running', 'attempt.succeeded', 'job.finalized',
+    ]);
+  });
+
+  it('persists failure and never reports an unknown thrown operation as success', async () => {
+    const result = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_lifecycle',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_failure', requestFingerprint: 'fingerprint_failure', goal: 'fail work',
+      },
+      execute: async () => { throw new Error('failure'); },
+      finalize: () => ({ status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {} }),
+    }).catch((error: Error & { jobId?: string; attemptId?: string }) => error);
+
+    expect(result).toBeInstanceOf(Error);
+    const job = engine.listJobs({ sessionId: 'session_lifecycle' })[0];
+    expect(job.status).toBe('failed');
+    expect(engine.getAttempt(job.activeAttemptId!)?.status ?? engine.listAttempts(job.id)[0]?.status).toBe('failed');
+  });
+
+  it('aborts active work when lease renewal loses authority', async () => {
+    let sawAbort = false;
+    const execution = executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      leaseTtlMs: 3_000,
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_lease_loss',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_lease_loss', requestFingerprint: 'fingerprint_lease_loss', goal: 'wait',
+      },
+      execute: async (handle) => new Promise<{ value: number }>((resolve) => {
+        handle.signal.addEventListener('abort', () => {
+          sawAbort = true;
+          resolve({ value: 0 });
+        }, { once: true });
+      }),
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const job = engine.listJobs({ sessionId: 'session_lease_loss' })[0]!;
+    engine.cancelJob({
+      jobId: job.id,
+      reason: 'test cancellation',
+      producer: 'test',
+      eventIdempotencyKey: 'cancel-lease-loss',
+    });
+
+    await expect(execution).rejects.toThrow(/lease renewal failed/i);
+    expect(sawAbort).toBe(true);
+    expect(engine.getJob(job.id)?.status).toBe('cancelled');
+  });
+});

--- a/tests/v4/daemon/jobRecovery.test.ts
+++ b/tests/v4/daemon/jobRecovery.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+describe('durable Job recovery', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let sequence = 0;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('recovery_instance', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    engine = createJobEngine({ db });
+  });
+
+  afterEach(() => db.close());
+
+  function expiredAttempt() {
+    sequence += 1;
+    const admitted = engine.submitJob({
+      entryPoint: 'daemon', source: 'daemon', sessionId: `session_${sequence}`,
+      instanceId: 'recovery_instance', idempotencyNamespace: 'recovery',
+      idempotencyKey: `job_${sequence}`, requestFingerprint: `fingerprint_${sequence}`,
+      goal: 'recover safely',
+    });
+    const base = Date.now();
+    const lease = engine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'old_worker', ttlMs: 10, now: base,
+    });
+    return { ...admitted, ...lease, base };
+  }
+
+  it('creates a new Attempt instead of resurrecting an expired generation', () => {
+    const expired = expiredAttempt();
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11,
+      instanceId: 'recovery_instance',
+      producer: 'recovery',
+      maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ jobId: expired.jobId, decision: 'retry' })]);
+
+    const attempts = engine.listAttempts(expired.jobId);
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]).toMatchObject({ id: expired.attemptId, status: 'crashed' });
+    expect(attempts[1]).toMatchObject({ status: 'queued', attemptNumber: 2, generation: 2 });
+    expect(engine.getJob(expired.jobId)).toMatchObject({ status: 'recovering', activeAttemptId: attempts[1]!.id });
+  });
+
+  it('does not replay an unknown mutating side effect', () => {
+    const expired = expiredAttempt();
+    engine.prepareToolCall({
+      toolCallId: 'tool_unknown', jobId: expired.jobId, attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      toolName: 'external_send', normalizedArgsDigest: 'digest', riskTier: 'dangerous',
+      mutates: true, producer: 'test', now: expired.base + 1,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_unknown', attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!, producer: 'test',
+      now: expired.base + 2,
+    });
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11,
+      instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ decision: 'ask_user' })]);
+    expect(engine.listAttempts(expired.jobId)).toHaveLength(1);
+    expect(engine.getAttempt(expired.attemptId)?.status).toBe('unknown');
+    expect(engine.getJob(expired.jobId)?.status).toBe('blocked');
+  });
+
+  it('retries a read-only tool interrupted after start', () => {
+    const expired = expiredAttempt();
+    engine.prepareToolCall({
+      toolCallId: 'tool_read_started', jobId: expired.jobId, attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      toolName: 'file_read', normalizedArgsDigest: 'read-digest', riskTier: 'safe',
+      mutates: false, producer: 'test', now: expired.base + 1,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_read_started', attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!, producer: 'test',
+      now: expired.base + 2,
+    });
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11, instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ decision: 'retry' })]);
+    expect(engine.listAttempts(expired.jobId)).toHaveLength(2);
+  });
+
+  it('retries a mutating tool that was prepared but never started', () => {
+    const expired = expiredAttempt();
+    engine.prepareToolCall({
+      toolCallId: 'tool_prepared_only', jobId: expired.jobId, attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      toolName: 'file_write', normalizedArgsDigest: 'prepared-digest', riskTier: 'caution',
+      mutates: true, producer: 'test', now: expired.base + 1,
+    });
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11, instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ decision: 'retry' })]);
+  });
+
+  it('does not replay a committed mutating side effect when final Job confirmation is missing', () => {
+    const expired = expiredAttempt();
+    engine.prepareToolCall({
+      toolCallId: 'tool_committed', jobId: expired.jobId, attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      toolName: 'file_write', normalizedArgsDigest: 'committed-digest', riskTier: 'caution',
+      mutates: true, producer: 'test', now: expired.base + 1,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_committed', attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!, producer: 'test',
+      now: expired.base + 2,
+    });
+    engine.completeToolCall({
+      toolCallId: 'tool_committed', attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      state: 'completed', sideEffectState: 'committed', resultRef: 'tool-result:sha256:known',
+      producer: 'test', now: expired.base + 3,
+    });
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11, instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ decision: 'ask_user' })]);
+    expect(engine.listAttempts(expired.jobId)).toHaveLength(1);
+    expect(engine.getJob(expired.jobId)).toMatchObject({ status: 'blocked', finishReason: 'unknown_side_effect' });
+  });
+
+  it('can retry after a completed read-only tool result but before terminal Job state', () => {
+    const expired = expiredAttempt();
+    engine.prepareToolCall({
+      toolCallId: 'tool_read_complete', jobId: expired.jobId, attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      toolName: 'file_read', normalizedArgsDigest: 'read-complete-digest', riskTier: 'safe',
+      mutates: false, producer: 'test', now: expired.base + 1,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_read_complete', attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!, producer: 'test',
+      now: expired.base + 2,
+    });
+    engine.completeToolCall({
+      toolCallId: 'tool_read_complete', attemptId: expired.attemptId,
+      generation: expired.generation!, fenceToken: expired.fenceToken!,
+      state: 'completed', resultRef: 'tool-result:sha256:read', producer: 'test', now: expired.base + 3,
+    });
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11, instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ decision: 'retry' })]);
+  });
+
+  it('dead-letters a crash loop at the configured threshold', () => {
+    const expired = expiredAttempt();
+    db.prepare('UPDATE tasks SET crash_count = 2 WHERE id = ?').run(expired.jobId);
+
+    expect(engine.recoverExpiredAttempts({
+      now: expired.base + 11,
+      instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ decision: 'dead_letter' })]);
+    expect(engine.getJob(expired.jobId)?.status).toBe('dead_letter');
+    expect(engine.listAttempts(expired.jobId)).toHaveLength(1);
+  });
+
+  it('is idempotent after the first scan resolves an expired Attempt', () => {
+    const expired = expiredAttempt();
+    const command = {
+      now: expired.base + 11,
+      instanceId: 'recovery_instance', producer: 'recovery', maxCrashes: 3,
+    };
+    expect(engine.recoverExpiredAttempts(command)).toHaveLength(1);
+    expect(engine.recoverExpiredAttempts(command)).toEqual([]);
+  });
+});

--- a/tests/v4/daemon/jobRecoverySweep.test.ts
+++ b/tests/v4/daemon/jobRecoverySweep.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { openDaemonDb, type Db } from '../../../core/v4/daemon/db/connection';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { sweepDurableJobRecovery } from '../../../core/v4/daemon/jobRecoverySweep';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+
+describe('durable Job recovery sweep', () => {
+  let db: Db | null = null;
+
+  afterEach(() => {
+    db?.close();
+    db = null;
+  });
+
+  it('enqueues an expired read-only Attempt exactly once and repairs the recovery-to-queue crash window', () => {
+    db = openDaemonDb(':memory:');
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('instance-old', 1, 'localhost', 1, 1, '4.15.1');
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('instance-new', 2, 'localhost', 2, 2, '4.15.1');
+    const engine = createJobEngine({ db });
+    const bus = createTriggerBus({ db });
+    const admitted = engine.submitJob({
+      entryPoint: 'schedule', source: 'schedule', sessionId: 'session-recovery',
+      instanceId: 'instance-old', idempotencyNamespace: 'schedule:test',
+      idempotencyKey: 'tick-1', goal: 'Read the current status',
+    });
+    const lease = engine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'worker-old', ttlMs: 10, now: 100,
+    });
+    expect(lease.acquired).toBe(true);
+    expect(engine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: 1,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'running',
+      eventIdempotencyKey: 'attempt-started',
+      producer: 'worker-old',
+      now: 101,
+    }).applied).toBe(true);
+
+    const first = sweepDurableJobRecovery({
+      jobEngine: engine, triggerBus: bus, instanceId: 'instance-new',
+      producer: 'recovery-sweep', now: 111,
+    });
+    expect(first).toMatchObject({ expired: 1, retried: 1, enqueued: 1 });
+
+    const recovery = engine.listAttempts(admitted.jobId)[1]!;
+    const event = bus.claim({ ownerId: 'dispatcher' });
+    expect(event?.payload).toMatchObject({
+      durable_job: {
+        job_id: admitted.jobId,
+        attempt_id: recovery.id,
+        run_id: recovery.rowId,
+      },
+      resume: { taskId: admitted.jobId, ofRunId: recovery.rowId },
+    });
+    if (event) bus.release(event.id, event.claimToken);
+
+    const second = sweepDurableJobRecovery({
+      jobEngine: engine, triggerBus: bus, instanceId: 'instance-new',
+      producer: 'recovery-sweep', now: 112,
+    });
+    expect(second).toMatchObject({ expired: 0, enqueued: 0 });
+    expect(db.prepare("SELECT COUNT(*) AS count FROM trigger_events WHERE source_key = ?")
+      .get(`job-recovery:${admitted.jobId}`)).toEqual({ count: 1 });
+  });
+});

--- a/tests/v4/daemon/runs/reclaim.test.ts
+++ b/tests/v4/daemon/runs/reclaim.test.ts
@@ -124,4 +124,20 @@ describe('reclaimStuckRuns — v4.9.0 Slice 3', () => {
       expect(readRun(id).status).toBe('interrupted');
     }
   });
+
+  it('does not bypass the Job lease recovery authority for durable Attempts', () => {
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO tasks
+         (id, title, goal, status, created_at, updated_at, session_id,
+          idempotency_namespace, idempotency_key)
+       VALUES ('task-durable', 'durable', 'durable', 'running', ?, ?, 'sess-durable',
+               'durable-test', 'durable-key')`,
+    ).run(now, now);
+    const runId = seedRun({ instanceId: 'inst-dead', status: 'running', sessionId: 'sess-durable' });
+    db.prepare("UPDATE runs SET task_id = 'task-durable' WHERE id = ?").run(runId);
+
+    expect(reclaimStuckRuns(db, { instanceId: 'inst-dead' })).toEqual({ reclaimed: 0, runIds: [] });
+    expect(readRun(runId).status).toBe('running');
+  });
 });

--- a/tests/v4/daemon/taskStore.test.ts
+++ b/tests/v4/daemon/taskStore.test.ts
@@ -264,27 +264,29 @@ describe('v14 migration — Slice 10.8 tasks table', () => {
     const cols = db.prepare(`PRAGMA table_info(tasks)`).all() as Array<{ name: string }>;
     const colNames = cols.map((c) => c.name).sort();
     expect(colNames).toEqual([
-      'artifact_ids', 'channel_id',
+      'active_attempt_id', 'artifact_ids', 'channel_id',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
-      'constraints',
-      'created_at',
+      'constraints', 'crash_count', 'created_at', 'entry_point',
       // v4.13 Gap 1 (v16 migration) — verify-before-done evidence envelope.
       'evidence',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
-      'failure_state', 'files_touched',
-      'goal', 'id',
-      'parent_task_id',
+      'failure_state', 'files_touched', 'finish_reason',
+      'goal', 'id', 'idempotency_key', 'idempotency_namespace',
+      'next_event_sequence', 'parent_task_id',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
-      'permissions',
+      'permissions', 'policy_snapshot_id', 'principal_id', 'recovery_state',
+      'request_fingerprint',
       // v4.13 Gap 4 (v18 migration) — wake-loop cap.
-      'resume_count',
-      'session_id',
+      'resume_count', 'root_job_id', 'session_id',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
-      'side_effects',
-      'status', 'title', 'trace_ids', 'updated_at',
+      'side_effects', 'source', 'state_version', 'status',
+      'terminal_at', 'terminal_outcome', 'title', 'trace_ids', 'updated_at',
+      'workspace_id',
     ]);
     const idx = db.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tasks' AND name NOT LIKE 'sqlite_%'`).all() as Array<{ name: string }>;
     expect(idx.map((i) => i.name).sort()).toEqual([
+      'idx_tasks_idempotency',
+      'idx_tasks_root_job',
       'idx_tasks_session_created',
       'idx_tasks_status',
     ]);

--- a/tests/v4/daemon/taskStore.test.ts
+++ b/tests/v4/daemon/taskStore.test.ts
@@ -272,7 +272,7 @@ describe('v14 migration — Slice 10.8 tasks table', () => {
       // v4.13 Gap 3 (v17 migration) — job-card columns.
       'failure_state', 'files_touched', 'finish_reason',
       'goal', 'id', 'idempotency_key', 'idempotency_namespace',
-      'next_event_sequence', 'parent_task_id',
+      'next_event_sequence', 'next_input_sequence', 'parent_task_id',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
       'permissions', 'policy_snapshot_id', 'principal_id', 'recovery_state',
       'request_fingerprint',

--- a/tests/v4/harness/jobEngineProcessFixture.ts
+++ b/tests/v4/harness/jobEngineProcessFixture.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+
+type Payload = {
+  action: 'claim' | 'claim_then_write' | 'claim_and_crash' | 'start_tool_and_crash' | 'recover' | 'prepare_tool';
+  attemptId: string;
+  ownerId?: string;
+  ttlMs?: number;
+  now?: number;
+  jobId?: string;
+  expectedStateVersion?: number;
+  generation?: number;
+  fenceToken?: string;
+  toolCallId?: string;
+  mutates?: boolean;
+};
+
+function send(message: Record<string, unknown>): void {
+  process.send?.(message);
+}
+
+function finish(message: Record<string, unknown>): void {
+  if (!process.send) return;
+  process.send(message, () => process.disconnect());
+}
+
+async function waitForGo(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    process.once('message', (message) => {
+      if (message === 'go') resolve();
+    });
+    send({ type: 'ready' });
+  });
+}
+
+async function main(): Promise<void> {
+  const dbPath = process.argv[2];
+  const encoded = process.argv[3];
+  if (!dbPath || !encoded) throw new Error('database path and payload are required');
+  const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as Payload;
+  const db = new Database(dbPath);
+  db.pragma('busy_timeout = 5000');
+  const engine = createJobEngine({ db });
+  try {
+    if (payload.action === 'claim') {
+      await waitForGo();
+      const result = engine.claimAttempt({
+        attemptId: payload.attemptId,
+        ownerId: payload.ownerId ?? 'process_worker',
+        ttlMs: payload.ttlMs ?? 30_000,
+        now: payload.now,
+      });
+      finish({ type: 'result', result });
+      return;
+    }
+
+    if (payload.action === 'claim_then_write') {
+      const lease = engine.claimAttempt({
+        attemptId: payload.attemptId,
+        ownerId: payload.ownerId ?? 'stale_process',
+        ttlMs: payload.ttlMs ?? 10,
+        now: payload.now,
+      });
+      send({ type: 'claimed', result: lease });
+      await new Promise<void>((resolve) => process.once('message', () => resolve()));
+      const result = engine.transitionAttempt({
+        attemptId: payload.attemptId,
+        expectedStateVersion: lease.stateVersion ?? -1,
+        generation: lease.generation ?? -1,
+        fenceToken: lease.fenceToken ?? '',
+        to: 'succeeded',
+        eventIdempotencyKey: `late-process-result:${payload.ownerId ?? 'stale_process'}`,
+        producer: 'process-test',
+        now: (payload.now ?? Date.now()) + (payload.ttlMs ?? 10) + 1,
+      });
+      finish({ type: 'result', result });
+      return;
+    }
+
+    if (payload.action === 'claim_and_crash') {
+      const lease = engine.claimAttempt({
+        attemptId: payload.attemptId,
+        ownerId: payload.ownerId ?? 'crashing_process',
+        ttlMs: payload.ttlMs ?? 10,
+        now: payload.now,
+      });
+      if (!lease.acquired || lease.stateVersion === undefined || lease.generation === undefined || !lease.fenceToken) {
+        finish({ type: 'error', error: `claim failed: ${lease.conflict ?? 'unknown'}` });
+        return;
+      }
+      const started = engine.transitionAttempt({
+        attemptId: payload.attemptId,
+        expectedStateVersion: lease.stateVersion,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        to: 'running',
+        eventIdempotencyKey: `crashing-process-running:${payload.attemptId}`,
+        producer: 'process-test',
+        now: payload.now,
+      });
+      send({ type: 'claimed', result: { lease, started } });
+      process.exit(17);
+    }
+
+    if (payload.action === 'start_tool_and_crash') {
+      const lease = engine.claimAttempt({
+        attemptId: payload.attemptId,
+        ownerId: payload.ownerId ?? 'crashing_tool_process',
+        ttlMs: payload.ttlMs ?? 10,
+        now: payload.now,
+      });
+      if (!lease.acquired || lease.stateVersion === undefined || lease.generation === undefined || !lease.fenceToken) {
+        finish({ type: 'error', error: `claim failed: ${lease.conflict ?? 'unknown'}` });
+        return;
+      }
+      const attempt = engine.transitionAttempt({
+        attemptId: payload.attemptId,
+        expectedStateVersion: lease.stateVersion,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        to: 'running',
+        eventIdempotencyKey: `crashing-tool-attempt:${payload.attemptId}`,
+        producer: 'process-test',
+        now: payload.now,
+      });
+      const toolCallId = payload.toolCallId ?? 'tool_process_crash';
+      const prepared = engine.prepareToolCall({
+        toolCallId,
+        jobId: payload.jobId ?? '',
+        attemptId: payload.attemptId,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        toolName: payload.mutates ? 'file_write' : 'file_read',
+        normalizedArgsDigest: `${toolCallId}-digest`,
+        riskTier: payload.mutates ? 'caution' : 'safe',
+        mutates: payload.mutates ?? false,
+        producer: 'process-test',
+        now: (payload.now ?? Date.now()) + 1,
+      });
+      const started = engine.startToolCall({
+        toolCallId,
+        attemptId: payload.attemptId,
+        generation: lease.generation,
+        fenceToken: lease.fenceToken,
+        producer: 'process-test',
+        now: (payload.now ?? Date.now()) + 2,
+      });
+      send({ type: 'tool_started', result: { lease, attempt, prepared, started } });
+      process.exit(17);
+    }
+
+    if (payload.action === 'recover') {
+      const result = engine.recoverExpiredAttempts({
+        now: payload.now,
+        instanceId: payload.ownerId ?? 'process_instance',
+        producer: 'process-recovery',
+        maxCrashes: 3,
+      });
+      finish({ type: 'result', result: { recovered: result } });
+      return;
+    }
+
+    await waitForGo();
+    const result = engine.prepareToolCall({
+      toolCallId: payload.toolCallId ?? 'tool_process',
+      jobId: payload.jobId ?? '',
+      attemptId: payload.attemptId,
+      generation: payload.generation ?? -1,
+      fenceToken: payload.fenceToken ?? '',
+      toolName: 'file_read',
+      normalizedArgsDigest: payload.toolCallId ?? 'tool_process',
+      riskTier: 'safe',
+      mutates: false,
+      producer: 'process-test',
+    });
+    finish({ type: 'result', result });
+  } finally {
+    db.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  finish({ type: 'error', error: error instanceof Error ? error.message : String(error) });
+  process.exitCode = 1;
+});

--- a/tests/v4/harness/mockProvider.ts
+++ b/tests/v4/harness/mockProvider.ts
@@ -63,6 +63,8 @@ export interface MockProvider {
   callCount(): number;
   /** Last seen request body (parsed JSON). */
   lastRequest(): unknown | null;
+  /** All request bodies in physical arrival order. */
+  requests(): readonly unknown[];
   /** Stop the server + wait for close. */
   stop(): Promise<void>;
 }
@@ -81,6 +83,7 @@ export async function startMockProvider(
 
   let callCount = 0;
   let lastRequest: unknown | null = null;
+  const requests: unknown[] = [];
 
   const server = http.createServer(async (req, res) => {
     if (req.method === 'GET' && (req.url?.startsWith('/v1/models') || req.url?.startsWith('/models'))) {
@@ -105,6 +108,7 @@ export async function startMockProvider(
     } catch {
       lastRequest = body;
     }
+    requests.push(lastRequest);
     const scriptedTurn = script?.[callCount];
     callCount += 1;
 
@@ -185,6 +189,7 @@ export async function startMockProvider(
     port,
     callCount:    () => callCount,
     lastRequest:  () => lastRequest,
+    requests:     () => [...requests],
     stop: () => new Promise<void>((resolve) => server.close(() => resolve())),
   };
 }

--- a/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
+++ b/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
@@ -22,8 +22,20 @@ function plain(value) {
     .replace(/\r/g, '');
 }
 
-function submit(terminal, value) {
-  terminal.write(`${value}\r`);
+function submit(terminal, value, onComplete) {
+  let index = 0;
+  const writeNext = () => {
+    if (index < value.length) {
+      terminal.write(value[index++]);
+      setTimeout(writeNext, 10);
+    } else {
+      setTimeout(() => {
+        terminal.write('\r');
+        onComplete();
+      }, 100);
+    }
+  };
+  writeNext();
 }
 
 function runFirstSession() {
@@ -38,48 +50,60 @@ function runFirstSession() {
     let state = 'boot';
     let historyTurns = 0;
     let historyReadyTarget = 0;
+    let submitting = false;
+    const send = (value, afterSent) => {
+      submitting = true;
+      submit(terminal, value, () => {
+        submitting = false;
+        afterSent?.();
+      });
+    };
     const timeout = setTimeout(() => {
       terminal.kill();
       reject(new Error(`First packaged interactive session timed out (${state}):\n${plain(output).slice(-12_000)}`));
     }, 90_000);
     terminal.onData((chunk) => {
       output += chunk;
+      if (submitting) return;
       const text = plain(output);
       const readyCount = output.split(readyToken).length - 1;
       if (state === 'boot' && readyCount >= 1) {
-        state = 'mode'; submit(terminal, '/mode economy');
+        state = 'mode'; send('/mode economy');
       } else if (state === 'mode' && text.includes('Usage mode: economy')) {
-        state = 'budget-set'; submit(terminal, '/budget 120');
+        state = 'budget-set'; send('/budget 120');
       } else if (state === 'budget-set' && text.includes('Session token cap set')) {
-        state = 'first-turn'; submit(terminal, 'package history turn 1');
+        state = 'first-turn'; send('package history turn 1');
       } else if (state === 'first-turn' && text.includes('PACKAGED SIMPLE PASS') && readyCount >= 4) {
-        state = 'budget-warning'; submit(terminal, '/budget');
+        state = 'budget-warning'; send('/budget');
       } else if (state === 'budget-warning' && text.includes('Budget warning.')) {
-        state = 'budget-expand'; submit(terminal, '/budget 100000');
+        state = 'budget-expand'; send('/budget 100000');
       } else if (state === 'budget-expand' && text.includes('Session token cap set to 100,000')) {
         historyTurns = 1;
-        historyReadyTarget = readyCount + 1;
-        state = 'history'; submit(terminal, `use a tool for package history ${historyTurns}`);
+        state = 'history';
+        send(`use a tool for package history ${historyTurns}`, () => {
+          historyReadyTarget = output.split(readyToken).length;
+        });
       } else if (state === 'history' && readyCount >= historyReadyTarget) {
         if (historyTurns < 4) {
           historyTurns += 1;
-          historyReadyTarget = readyCount + 1;
-          submit(terminal, `use a tool for package history ${historyTurns}`);
+          send(`use a tool for package history ${historyTurns}`, () => {
+            historyReadyTarget = output.split(readyToken).length;
+          });
         } else {
-          state = 'usage-json'; submit(terminal, '/usage --json');
+          state = 'usage-json'; send('/usage --json');
         }
       } else if (state === 'usage-json' && text.includes('"physicalAttempts":9')) {
-        state = 'usage-human'; submit(terminal, '/usage');
+        state = 'usage-human'; send('/usage');
       } else if (state === 'usage-human' && text.includes('Usage — Current session')) {
         if (!text.includes('cumulative exposures')) throw new Error('Human usage summary omitted schema exposure context.');
-        state = 'usage-details'; submit(terminal, '/usage details');
+        state = 'usage-details'; send('/usage details');
       } else if (state === 'usage-details' && text.includes('Usage details — Current session')) {
         if (!text.includes('Providers and models') || !text.includes('Purposes')) {
           throw new Error('Detailed usage output omitted required sections.');
         }
-        state = 'compress'; submit(terminal, '/compress');
+        state = 'compress'; send('/compress');
       } else if (state === 'compress' && /Compressed \d+ .* \d+ messages/.test(text)) {
-        state = 'quit'; submit(terminal, '/quit');
+        state = 'quit'; send('/quit');
       }
     });
     terminal.onExit(({ exitCode }) => {
@@ -103,20 +127,26 @@ function runRestartSession() {
     });
     let output = '';
     let state = 'boot';
+    let submitting = false;
+    const send = (value) => {
+      submitting = true;
+      submit(terminal, value, () => { submitting = false; });
+    };
     const timeout = setTimeout(() => {
       terminal.kill();
       reject(new Error(`Restarted packaged session timed out (${state}):\n${plain(output).slice(-12_000)}\nRequest trace:\n${requestTrace()}`));
     }, 60_000);
     terminal.onData((chunk) => {
       output += chunk;
+      if (submitting) return;
       const text = plain(output);
       const readyCount = output.split(readyToken).length - 1;
       if (state === 'boot' && readyCount >= 1) {
-        state = 'usage'; submit(terminal, '/usage --json');
+        state = 'usage'; send('/usage --json');
       } else if (state === 'usage' && text.includes('"compression":{"physicalAttempts":1')) {
-        state = 'turn'; submit(terminal, 'RESTART');
+        state = 'turn'; send('RESTART');
       } else if (state === 'turn' && text.includes('PACKAGED RESTART PASS') && readyCount >= 3) {
-        state = 'quit'; submit(terminal, '/quit');
+        state = 'quit'; send('/quit');
       }
     });
     terminal.onExit(({ exitCode }) => {

--- a/tests/v4/harness/terminalScreen.ts
+++ b/tests/v4/harness/terminalScreen.ts
@@ -120,6 +120,10 @@ export class TerminalScreen {
     return this.lines()[this.height - 1] ?? '';
   }
 
+  cursorPosition(): { row: number; col: number } {
+    return { row: this.row, col: this.col };
+  }
+
   snapshot(): string {
     const lines = this.lines();
     while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();

--- a/tests/v4/harness/terminalScreen.ts
+++ b/tests/v4/harness/terminalScreen.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+
+/**
+ * Small ANSI terminal screen model for CLI acceptance tests.
+ *
+ * It intentionally implements only the cursor, erase, scroll-region and resize
+ * operations emitted by the v4 CLI. Assertions use the rendered screen rather
+ * than treating terminal control bytes as an append-only transcript.
+ */
+export class TerminalScreen {
+  private cells: string[][];
+  private row = 0;
+  private col = 0;
+  private savedRow = 0;
+  private savedCol = 0;
+  private scrollTop = 0;
+  private scrollBottom: number;
+  private pending = '';
+
+  constructor(
+    private width: number,
+    private height: number,
+  ) {
+    this.width = Math.max(1, width);
+    this.height = Math.max(1, height);
+    this.scrollBottom = this.height - 1;
+    this.cells = this.blankScreen();
+  }
+
+  write(chunk: string | Buffer): void {
+    const input = this.pending + chunk.toString();
+    this.pending = '';
+
+    for (let i = 0; i < input.length;) {
+      const ch = input[i];
+
+      if (ch === '\x1b') {
+        if (i + 1 >= input.length) {
+          this.pending = input.slice(i);
+          break;
+        }
+
+        const next = input[i + 1];
+        if (next === '[') {
+          const match = /^\x1b\[([?0-9;]*)([A-Za-z])/u.exec(input.slice(i));
+          if (!match) {
+            this.pending = input.slice(i);
+            break;
+          }
+          this.applyCsi(match[1], match[2]);
+          i += match[0].length;
+          continue;
+        }
+
+        if (next === ']') {
+          const bell = input.indexOf('\x07', i + 2);
+          const stringTerminator = input.indexOf('\x1b\\', i + 2);
+          const end = bell >= 0 && (stringTerminator < 0 || bell < stringTerminator)
+            ? bell + 1
+            : stringTerminator >= 0
+              ? stringTerminator + 2
+              : -1;
+          if (end < 0) {
+            this.pending = input.slice(i);
+            break;
+          }
+          i = end;
+          continue;
+        }
+
+        if (next === '7') {
+          this.savedRow = this.row;
+          this.savedCol = this.col;
+        } else if (next === '8') {
+          this.row = this.savedRow;
+          this.col = this.savedCol;
+          this.clampCursor();
+        }
+        i += 2;
+        continue;
+      }
+
+      if (ch === '\r') {
+        this.col = 0;
+      } else if (ch === '\n') {
+        this.lineFeed();
+      } else if (ch === '\b') {
+        this.col = Math.max(0, this.col - 1);
+      } else if (ch >= ' ') {
+        this.put(ch);
+      }
+      i += 1;
+    }
+  }
+
+  resize(width: number, height: number): void {
+    const nextWidth = Math.max(1, width);
+    const nextHeight = Math.max(1, height);
+    const next = Array.from({ length: nextHeight }, (_, row) => (
+      Array.from({ length: nextWidth }, (_, col) => this.cells[row]?.[col] ?? ' ')
+    ));
+    this.width = nextWidth;
+    this.height = nextHeight;
+    this.cells = next;
+    this.scrollTop = 0;
+    this.scrollBottom = nextHeight - 1;
+    this.clampCursor();
+  }
+
+  lines(): string[] {
+    return this.cells.map((line) => line.join('').trimEnd());
+  }
+
+  bottomLine(): string {
+    return this.lines()[this.height - 1] ?? '';
+  }
+
+  snapshot(): string {
+    const lines = this.lines();
+    while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+    return lines.join('\n');
+  }
+
+  private blankScreen(): string[][] {
+    return Array.from(
+      { length: this.height },
+      () => Array.from({ length: this.width }, () => ' '),
+    );
+  }
+
+  private applyCsi(rawParams: string, final: string): void {
+    const params = rawParams.replace(/^\?/u, '').split(';').map((value) => (
+      value === '' ? 0 : Number.parseInt(value, 10)
+    ));
+    const first = params[0] ?? 0;
+    const amount = Math.max(1, first || 1);
+
+    switch (final) {
+      case 'A':
+        this.row -= amount;
+        break;
+      case 'B':
+        this.row += amount;
+        break;
+      case 'C':
+        this.col += amount;
+        break;
+      case 'D':
+        this.col -= amount;
+        break;
+      case 'G':
+        this.col = Math.max(0, amount - 1);
+        break;
+      case 'H':
+      case 'f':
+        this.row = Math.max(0, (params[0] || 1) - 1);
+        this.col = Math.max(0, (params[1] || 1) - 1);
+        break;
+      case 'J':
+        if (first === 2 || first === 3) this.cells = this.blankScreen();
+        break;
+      case 'K':
+        this.eraseLine(first);
+        break;
+      case 'r':
+        if (rawParams === '') {
+          this.scrollTop = 0;
+          this.scrollBottom = this.height - 1;
+        } else {
+          this.scrollTop = Math.max(0, (params[0] || 1) - 1);
+          this.scrollBottom = Math.min(this.height - 1, (params[1] || this.height) - 1);
+          if (this.scrollBottom < this.scrollTop) {
+            this.scrollTop = 0;
+            this.scrollBottom = this.height - 1;
+          }
+        }
+        this.row = 0;
+        this.col = 0;
+        break;
+      case 's':
+        this.savedRow = this.row;
+        this.savedCol = this.col;
+        break;
+      case 'u':
+        this.row = this.savedRow;
+        this.col = this.savedCol;
+        break;
+      default:
+        break;
+    }
+    this.clampCursor();
+  }
+
+  private eraseLine(mode: number): void {
+    const start = mode === 1 || mode === 2 ? 0 : this.col;
+    const end = mode === 0 || mode === 2 ? this.width : this.col + 1;
+    for (let col = start; col < end; col += 1) this.cells[this.row][col] = ' ';
+  }
+
+  private put(ch: string): void {
+    if (this.col >= this.width) {
+      this.col = 0;
+      this.lineFeed();
+    }
+    this.cells[this.row][this.col] = ch;
+    this.col += 1;
+  }
+
+  private lineFeed(): void {
+    // Windows ConPTY applies output newline processing for CLI writes, so LF
+    // advances to the next line at column one.
+    this.col = 0;
+    if (this.row === this.scrollBottom) {
+      this.cells.splice(this.scrollTop, 1);
+      this.cells.splice(
+        this.scrollBottom,
+        0,
+        Array.from({ length: this.width }, () => ' '),
+      );
+      return;
+    }
+    this.row = Math.min(this.height - 1, this.row + 1);
+  }
+
+  private clampCursor(): void {
+    this.row = Math.min(this.height - 1, Math.max(0, this.row));
+    this.col = Math.min(this.width - 1, Math.max(0, this.col));
+  }
+}

--- a/tests/v4/mcp/server/toolBridgeJobIdentity.test.ts
+++ b/tests/v4/mcp/server/toolBridgeJobIdentity.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../../core/v4/daemon/jobEngine';
+import { buildToolCallHandler } from '../../../../core/v4/mcp/server/toolBridge';
+import { resolveAidenPaths } from '../../../../core/v4/paths';
+import { ToolRegistry } from '../../../../core/v4/toolRegistry';
+
+describe('MCP direct durable identity', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('mcp_instance', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+    engine = createJobEngine({ db });
+  });
+
+  afterEach(() => db.close());
+
+  it('creates a resolvable Job and Attempt before executing the tool', async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'mcp_read', description: 'read', inputSchema: { type: 'object' } },
+      category: 'read', mutates: false, riskTier: 'safe', toolset: 'misc',
+      execute: async () => {
+        const job = engine.listJobs({ sessionId: 'mcp:mcp_instance' })[0];
+        expect(job).toMatchObject({ status: 'running', entryPoint: 'mcp' });
+        expect(engine.listAttempts(job!.id)[0]).toMatchObject({ status: 'running' });
+        return { ok: true };
+      },
+    });
+    const call = buildToolCallHandler(
+      registry,
+      { cwd: process.cwd(), paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-mcp-job' }) },
+      { allowDestructive: false, allowlist: null },
+      undefined,
+      { engine, instanceId: 'mcp_instance' },
+    );
+
+    expect(await call('mcp_read', {})).toMatchObject({ isError: false });
+    const job = engine.listJobs({ sessionId: 'mcp:mcp_instance' })[0]!;
+    expect(job.status).toBe('completed');
+    expect(engine.listAttempts(job.id)[0]!.status).toBe('succeeded');
+  });
+
+  it('durably records a deterministic denial when a mutating call has no approval channel', async () => {
+    const registry = new ToolRegistry();
+    let executed = false;
+    registry.register({
+      schema: { name: 'mcp_write', description: 'write', inputSchema: { type: 'object' } },
+      category: 'write', mutates: true, riskTier: 'caution', toolset: 'misc',
+      execute: async () => {
+        executed = true;
+        return { ok: true };
+      },
+    });
+    const call = buildToolCallHandler(
+      registry,
+      { cwd: process.cwd(), paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-mcp-job' }) },
+      { allowDestructive: true, allowlist: null },
+      undefined,
+      { engine, instanceId: 'mcp_instance' },
+    );
+
+    const result = await call('mcp_write', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('denied by approval engine');
+    expect(executed).toBe(false);
+    const job = engine.listJobs({ sessionId: 'mcp:mcp_instance' })[0]!;
+    expect(job).toMatchObject({ status: 'failed', terminalOutcome: 'failed', finishReason: 'tool_error' });
+    expect(engine.listAttempts(job.id)[0]).toMatchObject({ status: 'failed' });
+  });
+});

--- a/tests/v4/subagent/spawnSubAgent.test.ts
+++ b/tests/v4/subagent/spawnSubAgent.test.ts
@@ -28,6 +28,8 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createRunStore } from '../../../core/v4/daemon/runStore';
 import type { RunStore } from '../../../core/v4/daemon/runStore';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { runWithJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
 import { ToolRegistry } from '../../../core/v4/toolRegistry';
 import type { ToolContext, ToolHandler } from '../../../core/v4/toolRegistry';
 import { MockProviderAdapter } from '../../../core/v4/__mocks__/mockProvider';
@@ -131,6 +133,39 @@ describe('spawnSubAgent — v4.6 Phase 1 contract', () => {
     expect(result.metrics.durationMs).toBeGreaterThanOrEqual(0);
     expect(result.childRunId).toMatch(/^\d+$/);
     expect(result.childSessionId).toMatch(/^[a-f0-9-]{36}$/);
+  });
+
+  it('creates a durable child Job and Attempt linked to the parent/root identity', async () => {
+    const jobEngine = createJobEngine({ db });
+    const parent = jobEngine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'parent_session',
+      instanceId: INST, idempotencyNamespace: 'parent', idempotencyKey: 'parent_1',
+      requestFingerprint: 'parent_fingerprint', goal: 'parent goal',
+    });
+    const lease = jobEngine.claimAttempt({ attemptId: parent.attemptId, ownerId: INST, ttlMs: 30_000 });
+    const started = jobEngine.transitionAttempt({
+      attemptId: parent.attemptId, expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      eventIdempotencyKey: 'parent-attempt-running', producer: 'test',
+    });
+    jobEngine.transitionJob({
+      jobId: parent.jobId, attemptId: parent.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!,
+      expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'parent-job-running', producer: 'test',
+    });
+
+    const result = await runWithJobExecutionContext({
+      engine: jobEngine, jobId: parent.jobId, attemptId: parent.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+    }, () => spawnSubAgent({ goal: 'durable child' }, { ...makeDeps(), jobEngine }, {}));
+
+    const children = jobEngine.listJobs({ rootJobId: parent.jobId }).filter((job) => job.id !== parent.jobId);
+    expect(started.applied).toBe(true);
+    expect(result.status).toBe('completed');
+    expect(children).toHaveLength(1);
+    expect(children[0]).toMatchObject({ parentJobId: parent.jobId, rootJobId: parent.jobId, status: 'completed' });
+    expect(jobEngine.listAttempts(children[0]!.id)[0]).toMatchObject({ status: 'succeeded' });
   });
 
   // ──────────────────────────────────────────────────────────────────────

--- a/tests/v4/workbench/bridgeServer.test.ts
+++ b/tests/v4/workbench/bridgeServer.test.ts
@@ -414,6 +414,105 @@ describe('Workbench steer — token-gated POST /api/tasks/:runId/cancel', () => 
   });
 });
 
+describe('Workbench durable input, pause, resume, and approval commands', () => {
+  const TOKEN = 'durable-command-token';
+
+  it('routes every command through its injected durable authority port', async () => {
+    const calls: string[] = [];
+    const b = await startWorkbenchBridge({
+      reader: runStore,
+      token: TOKEN,
+      input: {
+        receive: (id, content, key) => {
+          calls.push(`input:${id}:${content}:${key}`);
+          return { accepted: true, runId: id, inputId: 'input_exact' };
+        },
+      },
+      control: {
+        pause: (id, key) => {
+          calls.push(`pause:${id}:${key}`);
+          return { accepted: true, applied: false, runId: id, controlId: 'pause_exact' };
+        },
+        resume: (id, key) => {
+          calls.push(`resume:${id}:${key}`);
+          return { accepted: true, runId: id, attemptId: 'attempt_new', generation: 2 };
+        },
+      },
+      approval: {
+        decide: (id, decision) => {
+          calls.push(`approval:${id}:${decision}`);
+          return { accepted: true, approvalId: id, state: decision };
+        },
+      },
+      port: 0,
+    });
+    const headers = { 'x-workbench-token': TOKEN };
+
+    expect((await httpPost(b.port, `/api/tasks/${runId}/input`, {
+      message: 'next exact input', idempotencyKey: 'input-key',
+    }, headers)).status).toBe(202);
+    expect((await httpPost(b.port, `/api/tasks/${runId}/pause`, {
+      idempotencyKey: 'pause-key',
+    }, headers)).status).toBe(202);
+    expect((await httpPost(b.port, `/api/tasks/${runId}/resume`, {
+      idempotencyKey: 'resume-key',
+    }, headers)).status).toBe(202);
+    expect((await httpPost(b.port, '/api/approvals/approval_exact/decision', {
+      decision: 'approved',
+    }, headers)).status).toBe(202);
+
+    expect(calls).toEqual([
+      `input:${runId}:next exact input:input-key`,
+      `pause:${runId}:pause-key`,
+      `resume:${runId}:resume-key`,
+      'approval:approval_exact:approved',
+    ]);
+    await b.close();
+  });
+
+  it('does not treat ordinary input as an approval decision', async () => {
+    const approvals: string[] = [];
+    const b = await startWorkbenchBridge({
+      reader: runStore,
+      token: TOKEN,
+      input: { receive: (id) => ({ accepted: true, runId: id, inputId: 'input_yes' }) },
+      approval: {
+        decide: (id, decision) => {
+          approvals.push(`${id}:${decision}`);
+          return { accepted: true, approvalId: id, state: decision };
+        },
+      },
+      port: 0,
+    });
+    const response = await httpPost(b.port, `/api/tasks/${runId}/input`, { message: 'yes' }, {
+      'x-workbench-token': TOKEN,
+    });
+    expect(response.status).toBe(202);
+    expect(approvals).toEqual([]);
+    await b.close();
+  });
+});
+
+describe('Workbench durable Job projections', () => {
+  it('queries Job and Attempt identity and replays events from a Job sequence cursor', async () => {
+    const jobs = {
+      getJob: (id: string) => id === 'job_exact' ? { id, status: 'waiting', activeAttemptId: 'attempt_exact' } : null,
+      getAttempt: (id: string) => id === 'attempt_exact' ? { id, jobId: 'job_exact', generation: 3 } : null,
+      listEvents: (id: string, after: number) => id === 'job_exact'
+        ? [{ jobId: id, jobSequence: after + 1, type: 'approval.created' }]
+        : [],
+    };
+    const b = await startWorkbenchBridge({ reader: runStore, jobs, port: 0 });
+    const job = await httpGet(b.port, '/api/jobs/job_exact');
+    const attempt = await httpGet(b.port, '/api/attempts/attempt_exact');
+    const events = await httpGet(b.port, '/api/jobs/job_exact/events?after=7');
+    expect(JSON.parse(job.body)).toMatchObject({ id: 'job_exact', status: 'waiting' });
+    expect(JSON.parse(attempt.body)).toMatchObject({ id: 'attempt_exact', generation: 3 });
+    expect(JSON.parse(events.body)).toEqual([{ jobId: 'job_exact', jobSequence: 8, type: 'approval.created' }]);
+    await b.close();
+  });
+});
+
 // ── Serving the built React dashboard (dashboard-next/out) ────────────────────
 
 describe('Workbench bridge — static React dashboard', () => {

--- a/tests/v4/workbench/jobCommands.test.ts
+++ b/tests/v4/workbench/jobCommands.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createActionAuthority, normalizeExecutionPlan } from '../../../core/v4/actionAuthority';
 import { createRunStore } from '../../../core/v4/daemon/runStore';
 import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
 import { createWorkbenchJobCommands } from '../../../core/v4/workbench/jobCommands';
@@ -101,5 +102,73 @@ describe('Workbench durable Job commands', () => {
       producer: 'test',
     }).applied).toBe(false);
     expect(jobEngine.listEvents(admitted.jobId).map((event) => event.type)).toContain('job.cancelled');
+  });
+
+  it('persists queued input and pause before acknowledging, then resumes with a new Attempt', () => {
+    const { enqueue, input, control, jobEngine } = commands();
+    const admitted = enqueue.enqueue({ message: 'long work', sessionId: 'workbench-session' });
+    const lease = jobEngine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'workbench-runner', ttlMs: 30_000,
+    });
+    jobEngine.transitionAttempt({
+      attemptId: admitted.attemptId, expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      eventIdempotencyKey: 'input-attempt-running', producer: 'test',
+    });
+    jobEngine.transitionJob({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, expectedStateVersion: 0,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, to: 'running',
+      eventIdempotencyKey: 'input-job-running', producer: 'test',
+    });
+
+    const queued = input.receive(admitted.runId, 'follow up', 'input-key');
+    expect(queued).toMatchObject({ accepted: true, inputId: expect.stringMatching(/^input_/) });
+    expect(control.pause(admitted.runId, 'pause-key')).toMatchObject({ accepted: true, applied: false });
+    expect(jobEngine.getJob(admitted.jobId)?.status).toBe('running');
+    expect(control.applyPauseBoundary(admitted.runId)).toEqual({ accepted: true, applied: true });
+    expect(jobEngine.getJob(admitted.jobId)?.status).toBe('paused');
+
+    const resumed = control.resume(admitted.runId, 'resume-key');
+    expect(resumed).toMatchObject({
+      accepted: true,
+      attemptId: expect.any(String),
+      generation: 2,
+      triggerEventId: expect.any(Number),
+    });
+    expect(resumed.attemptId).not.toBe(admitted.attemptId);
+    expect(db.prepare('SELECT trigger_event_id FROM runs WHERE attempt_id = ?').get(resumed.attemptId))
+      .toEqual({ trigger_event_id: resumed.triggerEventId });
+  });
+
+  it('resolves a durable approval by exact ID without treating ordinary input as consent', () => {
+    const value = commands();
+    const admitted = value.enqueue.enqueue({ message: 'write a file', sessionId: 'workbench-session' });
+    const actionAuthority = createActionAuthority({ db, jobEngine: value.jobEngine });
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'result.txt' }, cwd: process.cwd(),
+      mutates: true, riskTier: 'caution',
+      policy: {
+        trustLevel: 'Assistant', autonomyPolicy: 'ask_for_mutations', approvalMode: 'smart',
+        toolMetadataVersion: 'test', sandboxPolicy: {}, networkPolicy: {}, pluginGrants: [],
+        mcpGrants: [], workspaceOverrides: {}, jobOverrides: {},
+      },
+    });
+    const pending = actionAuthority.request({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1,
+      toolCallId: 'workbench-tool', toolName: 'file_write', riskTier: 'caution',
+      riskReasons: [], normalized,
+    });
+    const commandsWithApproval = createWorkbenchJobCommands({
+      db, triggerBus: createTriggerBus({ db }), jobEngine: value.jobEngine,
+      runStore: value.runStore, instanceId: 'workbench_test',
+      actionAuthority, idFactory: () => 'approval-command-key',
+    });
+
+    expect(commandsWithApproval.approval.decide(pending.approvalId, 'approved')).toMatchObject({
+      accepted: true, approvalId: pending.approvalId, state: 'approved',
+    });
+    expect(() => commandsWithApproval.input.receive(admitted.runId, 'yes', 'ordinary-yes'))
+      .not.toThrow();
+    expect(actionAuthority.get(pending.approvalId)?.state).toBe('approved');
   });
 });

--- a/tests/v4/workbench/jobCommands.test.ts
+++ b/tests/v4/workbench/jobCommands.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createRunStore } from '../../../core/v4/daemon/runStore';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { createWorkbenchJobCommands } from '../../../core/v4/workbench/jobCommands';
+
+describe('Workbench durable Job commands', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('workbench_test', 1, 'localhost', ?, ?, '4.15.1')`,
+    ).run(now, now);
+  });
+
+  afterEach(() => db.close());
+
+  function commands() {
+    const jobEngine = createJobEngine({ db });
+    const runStore = createRunStore({ db });
+    const value = createWorkbenchJobCommands({
+      db,
+      triggerBus: createTriggerBus({ db }),
+      jobEngine,
+      runStore,
+      instanceId: 'workbench_test',
+      idFactory: () => 'workbench-idempotency-key',
+    });
+    return { ...value, jobEngine, runStore };
+  }
+
+  it('returns authoritative Job and Attempt identities before acknowledging enqueue', () => {
+    const { enqueue, jobEngine } = commands();
+    const result = enqueue.enqueue({ message: 'read the project notes', sessionId: 'workbench-session' });
+
+    expect(result).toMatchObject({ accepted: true, duplicate: false });
+    expect(jobEngine.getJob(result.jobId)).toMatchObject({
+      id: result.jobId, activeAttemptId: result.attemptId, entryPoint: 'workbench',
+    });
+    expect(jobEngine.getAttempt(result.attemptId)).toMatchObject({
+      rowId: result.runId, jobId: result.jobId, status: 'queued',
+    });
+    const trigger = db.prepare('SELECT payload_json FROM trigger_events WHERE id = ?')
+      .get(result.triggerEventId) as { payload_json: string };
+    expect(JSON.parse(trigger.payload_json).durable_job).toEqual({
+      job_id: result.jobId,
+      attempt_id: result.attemptId,
+      run_id: result.runId,
+    });
+  });
+
+  it('cancels through the Job authority and rejects the active worker late result', () => {
+    const { enqueue, cancel, jobEngine } = commands();
+    const admitted = enqueue.enqueue({ message: 'wait for cancellation' });
+    const lease = jobEngine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'workbench-runner', ttlMs: 30_000,
+    });
+    const attemptRunning = jobEngine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: lease.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'running',
+      eventIdempotencyKey: 'workbench-attempt-running',
+      producer: 'test',
+    });
+    jobEngine.transitionJob({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      expectedStateVersion: 0,
+      to: 'running',
+      eventIdempotencyKey: 'workbench-job-running',
+      producer: 'test',
+    });
+
+    expect(cancel.cancel(admitted.runId)).toEqual({ accepted: true, runId: admitted.runId });
+    expect(jobEngine.getJob(admitted.jobId)).toMatchObject({ status: 'cancelled', activeAttemptId: null });
+    expect(jobEngine.getAttempt(admitted.attemptId)?.status).toBe('cancelled');
+    expect(jobEngine.transitionAttempt({
+      attemptId: admitted.attemptId,
+      expectedStateVersion: attemptRunning.stateVersion!,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      to: 'succeeded',
+      eventIdempotencyKey: 'workbench-late-success',
+      producer: 'test',
+    }).applied).toBe(false);
+    expect(jobEngine.listEvents(admitted.jobId).map((event) => event.type)).toContain('job.cancelled');
+  });
+});


### PR DESCRIPTION
## Summary

- promotes the existing `tasks` and `runs` records into the durable Job and Attempt authorities;
- adds transactional lifecycle events, compare-and-set versions, leases, generations, fencing, and conservative recovery;
- admits interactive, one-shot, channel, daemon, schedule, API, Workbench, MCP, and child work before execution;
- persists ordinary input, steering, pause, resume, cancel, and interrupt commands beneath the existing terminal input owner;
- restores queued and claimed input after restart with exact ordering, claim, consume, idempotency, and stale-generation checks;
- physically propagates cancellation to active runtimes and descendant Jobs;
- adds immutable policy snapshots and durable approvals bound to the final normalized action, ToolCall, Attempt, generation, and lease fence;
- runs action-changing hooks before approval and revalidates canonical paths and policy immediately before execution;
- makes unattended mutating MCP execution return a durable approval requirement instead of bypassing policy;
- exposes Job, Attempt, event replay, durable input, control, and exact approval commands through the existing API and Workbench bridge.

## Safety properties

- terminal Job and Attempt states are immutable;
- stale generations, leases, tool results, evidence, approval decisions, and completion writes are rejected;
- authoritative state changes and their events commit in the same SQLite transaction;
- credentials remain outside durable input, approval, policy, Job, and event records;
- events reference input and approval identities without copying their content or normalized execution plans;
- normal text cannot become consent;
- denied, cancelled, expired, invalidated, stale, and executed approvals remain distinct;
- parent cancellation durably cancels active child Jobs and aborts attached runtimes;
- no version, package, release, or public compatibility schema was changed.

## Validation

- Node 22 deterministic suite: 6,796 passed, 39 skipped;
- integration suite: 39 passed, 7 skipped;
- durable input/control/daemon/Workbench focused matrix: 133 passed, 1 skipped;
- approval normalization and policy matrix: 106 passed;
- CLI/daemon/MCP/Workbench wiring matrix: 70 passed;
- Windows ConPTY matrices passed;
- copied v4.15.1 database migration, interruption rollback, and idempotent rerun passed;
- packed global, local package-runner, and literal fresh-tarball package-runner smokes passed;
- packaged plain response, harmless tool call, restart, interactive usage, compression, and state restoration passed;
- packaged accounting recorded exactly 19 controlled physical provider calls with no credential sentinel leakage;
- typecheck and production build passed;
- diff, NUL, secret, license, attribution, and package-content scans passed.

## Performance

- simple controlled turns retain one physical provider attempt;
- token, schema, retry, fallback, child, compression, and usage accounting remain unchanged;
- large tool-result externalization and repeated-file-read deduplication remain effective;
- Job, event, input, approval, and policy state is not injected into model context.