### PR TITLE
feat(kernel): complete durable autonomy foundation

### DIFF
--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -1808,7 +1808,15 @@ export async function buildAgentRuntime(
   await pluginLoader.fireHook('onActivate');
   for (const plugin of pluginLoader.getRegistry().list()) {
     if (plugin.status === 'pending-grant' || plugin.status === 'suspended') {
-      recordStartupNotice(buildPluginGrantNotice(plugin.manifest.name));
+      recordStartupNotice(buildPluginGrantNotice(plugin.manifest.name, {
+        activeProvider: providerId,
+        providedProviders: plugin.manifest.providers,
+        capabilities: [
+          ...plugin.manifest.tools,
+          ...plugin.manifest.skills,
+          ...plugin.manifest.providers.filter((candidate) => candidate !== providerId),
+        ],
+      }));
     }
   }
 

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -81,9 +81,11 @@ import type { RuntimeResolver } from '../../providers/v4/runtimeResolver';
 import type { ConfigManager } from '../../core/v4/config';
 import type { PersonalityManager } from '../../core/v4/personality';
 import {
-  runWithJobExecutionContext,
-  type JobExecutionContext,
-} from '../../core/v4/daemon/jobExecutionContext';
+  executeDurableJob,
+  DurableJobAuthorityLostError,
+  type DurableJobDisposition,
+  type DurableJobHandle,
+} from '../../core/v4/daemon/jobLifecycle';
 import type { ProviderCallUsageContext } from '../../providers/v4/types';
 import type { PluginLoader } from '../../core/v4/plugins/pluginLoader';
 import { ModelMetadata } from '../../core/v4/modelMetadata';
@@ -147,6 +149,11 @@ import {
   renderStartupNoticeLines,
   type StartupNotice,
 } from './startupNotices';
+
+interface ChatTurnLifecycleContext {
+  handle: DurableJobHandle;
+  finalization?: DurableJobDisposition;
+}
 
 /**
  * v4.10 Slice 10.2 / 10.2b — extracted onUiEvent factory. Builds the
@@ -1682,6 +1689,71 @@ export class ChatSession implements ChatSessionLike {
   }
 
   private async runAgentTurn(userInput: string, inputAlreadyPersisted = false): Promise<void> {
+    const jobEngine = this.opts.jobEngine;
+    if (!jobEngine || this.opts.unconfigured) {
+      await this.runAgentTurnBody(userInput, inputAlreadyPersisted);
+      return;
+    }
+    const instanceId = this.opts.replInstanceId;
+    const sessionId = this.sessionId;
+    if (!instanceId || !sessionId) {
+      throw new Error('Durable Job admission requires an instance and session identity');
+    }
+
+    let lifecycleContext: ChatTurnLifecycleContext | null = null;
+    try {
+      await executeDurableJob({
+        engine: jobEngine,
+        ownerId: instanceId,
+        controlAuthority: this.opts.jobControlAuthority,
+        admission: {
+          entryPoint: 'interactive',
+          source: 'repl',
+          sessionId,
+          workspaceId: process.cwd(),
+          instanceId,
+          idempotencyNamespace: `interactive:${sessionId}`,
+          goal: userInput,
+          title: userInput,
+          channelId: 'repl',
+        },
+        initialInput: !inputAlreadyPersisted && this.opts.jobControlAuthority
+          ? {
+            sessionId,
+            channelId: 'repl',
+            source: 'tui',
+            kind: 'message',
+            content: userInput,
+            idempotencyNamespace: `interactive-input:${sessionId}`,
+            idempotencyKey: `initial:${this.durableInputOrdinal++}`,
+          }
+          : undefined,
+        execute: async (handle) => {
+          lifecycleContext = { handle };
+          await this.runAgentTurnBody(userInput, inputAlreadyPersisted, lifecycleContext);
+          return lifecycleContext;
+        },
+        finalize: (context) => context.finalization ?? ({
+          status: 'failed',
+          outcome: 'failed',
+          finishReason: 'missing_finalization',
+          evidence: { reason: 'turn completed without an authoritative finalization' },
+        }),
+      });
+    } catch (error) {
+      if (error instanceof DurableJobAuthorityLostError && lifecycleContext) {
+        const status = jobEngine.getJob(lifecycleContext.handle.jobId)?.status;
+        if (status === 'cancelled' || status === 'paused') return;
+      }
+      throw error;
+    }
+  }
+
+  private async runAgentTurnBody(
+    userInput: string,
+    inputAlreadyPersisted = false,
+    lifecycleContext?: ChatTurnLifecycleContext,
+  ): Promise<void> {
     // v4.11 Slice B — snapshot pre-turn history for /undo (in-memory,
     // bounded). Captured before any mutation; `this.history` is only
     // reassigned at end-of-turn, so this copy is the true pre-turn state.
@@ -1757,6 +1829,11 @@ export class ChatSession implements ChatSessionLike {
     const turnId    = ++this.nextTurnId;
     this.queueGuidanceShown = false;
     const turnAbort = new AbortController();
+    const abortFromLifecycle = (): void => {
+      if (!turnAbort.signal.aborted) turnAbort.abort(lifecycleContext?.handle.signal.reason);
+    };
+    if (lifecycleContext?.handle.signal.aborted) abortFromLifecycle();
+    else lifecycleContext?.handle.signal.addEventListener('abort', abortFromLifecycle, { once: true });
     this.currentAbortController = turnAbort;
     this.activeTurnId           = turnId;
 
@@ -1802,7 +1879,7 @@ export class ChatSession implements ChatSessionLike {
           if (word === '/resume') {
             let durableResumed = true;
             const target = this.activeDurableTarget;
-            if (target && this.opts.jobControlAuthority && jobEngine && replInstanceId) {
+            if (target && this.opts.jobControlAuthority && lifecycleContext && replInstanceId) {
               try {
                 const resumed = this.opts.jobControlAuthority.commands.resume({
                   jobId: target.jobId,
@@ -1811,64 +1888,25 @@ export class ChatSession implements ChatSessionLike {
                   idempotencyNamespace: `tui-control:${this.sessionId}`,
                   idempotencyKey: `resume:${target.attemptId}:${++this.durableInputOrdinal}`,
                 });
-                const lease = jobEngine.claimAttempt({
-                  attemptId: resumed.attemptId,
-                  ownerId: replInstanceId,
-                  ttlMs: 45_000,
-                });
-                if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
-                  throw new Error(`resumed Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
-                }
-                const attemptRunning = jobEngine.transitionAttempt({
-                  attemptId: resumed.attemptId,
-                  expectedStateVersion: lease.stateVersion,
-                  generation: lease.generation,
-                  fenceToken: lease.fenceToken,
-                  to: 'running',
-                  eventIdempotencyKey: `attempt-running:${resumed.attemptId}:${lease.generation}`,
-                  producer: 'repl',
-                });
-                const resumedJob = jobEngine.getJob(target.jobId);
-                if (!attemptRunning.applied || attemptRunning.stateVersion === undefined || !resumedJob) {
-                  throw new Error('resumed Attempt start rejected');
-                }
-                const jobRunning = jobEngine.transitionJob({
+                lifecycleContext.handle.resumeAttempt({
                   jobId: target.jobId,
                   attemptId: resumed.attemptId,
-                  generation: lease.generation,
-                  fenceToken: lease.fenceToken,
-                  expectedStateVersion: resumedJob.stateVersion,
-                  to: 'running',
-                  eventIdempotencyKey: `job-running:${target.jobId}:${lease.generation}`,
-                  producer: 'repl',
+                  runId: resumed.runId,
+                  reused: resumed.duplicate,
                 });
-                if (!jobRunning.applied || jobRunning.stateVersion === undefined) {
-                  throw new Error('resumed Job start rejected');
-                }
-                detachRuntimeControl?.();
-                jobAttemptId = resumed.attemptId;
-                replRunId = resumed.runId;
-                jobGeneration = lease.generation;
-                jobFenceToken = lease.fenceToken;
-                attemptStateVersion = attemptRunning.stateVersion;
-                jobStateVersion = jobRunning.stateVersion;
+                jobAttemptId = lifecycleContext.handle.attemptId;
+                replRunId = lifecycleContext.handle.runId;
+                jobGeneration = lifecycleContext.handle.generation;
                 this.activeDurableTarget = {
                   jobId: target.jobId,
-                  attemptId: resumed.attemptId,
-                  generation: lease.generation,
+                  attemptId: lifecycleContext.handle.attemptId,
+                  generation: lifecycleContext.handle.generation,
                 };
-                detachRuntimeControl = this.opts.jobControlAuthority.runtime.attach(resumed.attemptId, turnAbort);
-                if (jobExecutionContextRef) {
-                  jobExecutionContextRef.attemptId = resumed.attemptId;
-                  jobExecutionContextRef.generation = lease.generation;
-                  jobExecutionContextRef.fenceToken = lease.fenceToken;
-                }
                 if (providerUsageContextRef) {
-                  providerUsageContextRef.runId = resumed.runId;
-                  providerUsageContextRef.attemptId = resumed.attemptId;
-                  providerUsageContextRef.attemptGeneration = lease.generation;
+                  providerUsageContextRef.runId = lifecycleContext.handle.runId;
+                  providerUsageContextRef.attemptId = lifecycleContext.handle.attemptId;
+                  providerUsageContextRef.attemptGeneration = lifecycleContext.handle.generation;
                 }
-                startJobLeaseHeartbeat();
               } catch (error) {
                 durableResumed = false;
                 try { this.opts.display.warn(`  resume failed: ${error instanceof Error ? error.message : String(error)}`); } catch { /* defensive */ }
@@ -2023,154 +2061,27 @@ export class ChatSession implements ChatSessionLike {
     // etc.) must NOT crash the REPL — every persistence call here is
     // wrapped in try/catch and reduces to a logged warning. The
     // user-facing turn still runs.
-    let replRunId: number | null = null;
-    let replTaskId: string | null = null;
+    let replRunId: number | null = lifecycleContext?.handle.runId ?? null;
+    let replTaskId: string | null = lifecycleContext?.handle.jobId ?? null;
     const replRunStore       = this.opts.replRunStore;
     const replInstanceId     = this.opts.replInstanceId;
     const replParentRunRef   = this.opts.replParentRunRef;
     const jobEngine          = this.opts.jobEngine;
-    let jobAttemptId: string | null = null;
-    let jobGeneration: number | null = null;
-    let jobFenceToken: string | null = null;
-    let jobStateVersion = 0;
-    let attemptStateVersion = 0;
-    let detachRuntimeControl: (() => void) | null = null;
-    let jobExecutionContextRef: JobExecutionContext | null = null;
+    let jobAttemptId: string | null = lifecycleContext?.handle.attemptId ?? null;
+    let jobGeneration: number | null = lifecycleContext?.handle.generation ?? null;
     let providerUsageContextRef: ProviderCallUsageContext | null = null;
-    let jobLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
-    const stopJobLeaseHeartbeat = (): void => {
-      if (jobLeaseHeartbeat !== null) {
-        clearInterval(jobLeaseHeartbeat);
-        jobLeaseHeartbeat = null;
-      }
-    };
-    const startJobLeaseHeartbeat = (): void => {
-      stopJobLeaseHeartbeat();
-      if (!jobEngine || !replInstanceId) return;
-      jobLeaseHeartbeat = setInterval(() => {
-        if (!jobAttemptId || jobGeneration === null || !jobFenceToken || turnAbort.signal.aborted) return;
-        const renewed = jobEngine.renewAttemptLease({
-          attemptId: jobAttemptId,
-          ownerId: replInstanceId,
-          generation: jobGeneration,
-          fenceToken: jobFenceToken,
-          ttlMs: 45_000,
-        });
-        if (!renewed.applied || renewed.stateVersion === undefined) {
-          stopJobLeaseHeartbeat();
-          turnAbort.abort(new Error(`Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
-          return;
-        }
-        attemptStateVersion = renewed.stateVersion;
-      }, 15_000);
-      jobLeaseHeartbeat.unref?.();
-    };
+    void inputAlreadyPersisted;
 
-    if (jobEngine) {
-      if (!replInstanceId || !this.sessionId) {
-        throw new Error('Durable Job admission requires an instance and session identity');
-      }
-      const admitted = jobEngine.submitJob({
-        entryPoint: 'interactive',
-        source: 'repl',
-        sessionId: this.sessionId,
-        workspaceId: process.cwd(),
-        instanceId: replInstanceId,
-        idempotencyNamespace: `interactive:${this.sessionId}`,
-        goal: userInput,
-        title: userInput,
-        channelId: 'repl',
-      });
-      replRunId = admitted.runId;
-      replTaskId = admitted.jobId;
-      jobAttemptId = admitted.attemptId;
-      if (this.opts.jobControlAuthority && !inputAlreadyPersisted) {
-        const durableInput = this.opts.jobControlAuthority.inputs.receive({
-          jobId: admitted.jobId,
-          targetAttemptId: admitted.attemptId,
-          targetGeneration: 1,
-          sessionId: this.sessionId,
-          channelId: 'repl',
-          source: 'tui',
-          kind: 'message',
-          content: userInput,
-          idempotencyNamespace: `interactive-input:${this.sessionId}`,
-          idempotencyKey: `job:${admitted.jobId}:initial`,
-        });
-        const claimed = this.opts.jobControlAuthority.inputs.claimNext({
-          jobId: admitted.jobId,
-          attemptId: admitted.attemptId,
-          generation: 1,
-          inputId: durableInput.record.inputId,
-          kinds: ['message'],
-        });
-        if (!claimed) throw new Error(`Initial durable input claim failed: ${durableInput.record.inputId}`);
-        const consumed = this.opts.jobControlAuthority.inputs.consume({
-          inputId: durableInput.record.inputId,
-          attemptId: admitted.attemptId,
-          generation: 1,
-        });
-        if (!consumed.applied && !consumed.duplicate) {
-          throw new Error(`Initial durable input consume failed: ${durableInput.record.inputId}`);
-        }
-      }
+    if (lifecycleContext) {
       if (replParentRunRef) {
         replParentRunRef.runId = replRunId;
         replParentRunRef.sessionId = this.sessionId;
       }
-      const lease = jobEngine.claimAttempt({
-        attemptId: admitted.attemptId,
-        ownerId: replInstanceId,
-        ttlMs: 45_000,
-      });
-      if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
-        throw new Error(`Durable Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
-      }
-      jobFenceToken = lease.fenceToken;
-      jobGeneration = lease.generation;
-      attemptStateVersion = lease.stateVersion;
-      const attemptRunning = jobEngine.transitionAttempt({
-        attemptId: admitted.attemptId,
-        expectedStateVersion: attemptStateVersion,
-        generation: jobGeneration,
-        fenceToken: jobFenceToken,
-        to: 'running',
-        eventIdempotencyKey: `attempt-running:${admitted.attemptId}:${jobGeneration}`,
-        producer: 'repl',
-      });
-      if (!attemptRunning.applied || attemptRunning.stateVersion === undefined) {
-        throw new Error(`Durable Attempt start rejected: ${attemptRunning.conflict ?? 'unknown'}`);
-      }
-      attemptStateVersion = attemptRunning.stateVersion;
-      const jobRunning = jobEngine.transitionJob({
-        jobId: admitted.jobId,
-        attemptId: admitted.attemptId,
-        generation: jobGeneration,
-        fenceToken: jobFenceToken,
-        expectedStateVersion: jobStateVersion,
-        to: 'running',
-        eventIdempotencyKey: `job-running:${admitted.jobId}:${jobGeneration}`,
-        producer: 'repl',
-      });
-      if (!jobRunning.applied || jobRunning.stateVersion === undefined) {
-        throw new Error(`Durable Job start rejected: ${jobRunning.conflict ?? 'unknown'}`);
-      }
-      jobStateVersion = jobRunning.stateVersion;
       this.activeDurableTarget = {
-        jobId: admitted.jobId,
-        attemptId: admitted.attemptId,
-        generation: jobGeneration,
+        jobId: lifecycleContext.handle.jobId,
+        attemptId: lifecycleContext.handle.attemptId,
+        generation: lifecycleContext.handle.generation,
       };
-      jobExecutionContextRef = {
-        engine: jobEngine,
-        jobId: admitted.jobId,
-        attemptId: admitted.attemptId,
-        generation: jobGeneration,
-        fenceToken: jobFenceToken,
-        producer: 'repl',
-      };
-      detachRuntimeControl = this.opts.jobControlAuthority?.runtime.attach(admitted.attemptId, turnAbort) ?? null;
-      startJobLeaseHeartbeat();
     } else if (replRunStore && replInstanceId && this.sessionId) {
       try {
         replRunId = replRunStore.create({
@@ -2577,7 +2488,7 @@ export class ChatSession implements ChatSessionLike {
           const target = this.activeDurableTarget;
           if (target && this.opts.jobControlAuthority && this.duringTurnInput.isPaused()) {
             const paused = this.opts.jobControlAuthority.commands.applyPendingAtBoundary({ jobId: target.jobId });
-            if (paused.applied) stopJobLeaseHeartbeat();
+            if (paused.applied) lifecycleContext?.handle.pauseAtBoundary();
           }
           await this.duringTurnInput.waitWhilePaused(sig);
         },
@@ -2705,11 +2616,7 @@ export class ChatSession implements ChatSessionLike {
             })
           : undefined,
       }));
-      const result = await (
-        jobExecutionContextRef
-          ? runWithJobExecutionContext(jobExecutionContextRef, runAgent)
-          : runAgent()
-      );
+      const result = await runAgent();
       if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && replRunId !== null) {
         currentProviderAttemptLedger()?.reconcileJobLinkage({
           taskId: replTaskId,
@@ -2860,48 +2767,17 @@ export class ChatSession implements ChatSessionLike {
           err instanceof Error ? err.message : String(err));
       }
 
-      if (jobEngine && replTaskId !== null && jobAttemptId && jobGeneration !== null && jobFenceToken && _fin) {
-        stopJobLeaseHeartbeat();
-        const attemptTerminal =
-          result.finishReason === 'stop' ? 'succeeded' :
-          result.finishReason === 'interrupted' ? 'cancelled' :
-          'failed';
-        const attemptFinal = jobEngine.transitionAttempt({
-          attemptId: jobAttemptId,
-          expectedStateVersion: attemptStateVersion,
-          generation: jobGeneration,
-          fenceToken: jobFenceToken,
-          to: attemptTerminal,
-          eventIdempotencyKey: `attempt-final:${jobAttemptId}:${jobGeneration}`,
-          producer: 'repl',
-          finishReason: result.finishReason,
-        });
-        if (!attemptFinal.applied || attemptFinal.stateVersion === undefined) {
-          throw new Error(`Durable Attempt finalization rejected: ${attemptFinal.conflict ?? 'unknown'}`);
-        }
-        attemptStateVersion = attemptFinal.stateVersion;
-        const jobStatus =
-          result.finishReason === 'interrupted' ? 'cancelled' :
-          _fin.status === 'completed' || _fin.status === 'completed_unverified' ? 'completed' :
-          'failed';
-        const jobFinal = jobEngine.finalizeJob({
-          jobId: replTaskId,
-          attemptId: jobAttemptId,
-          generation: jobGeneration,
-          fenceToken: jobFenceToken,
-          expectedStateVersion: jobStateVersion,
-          status: jobStatus,
+      if (lifecycleContext && _fin) {
+        const cancelled = result.finishReason === 'interrupted';
+        const completed = _fin.status === 'completed' || _fin.status === 'completed_unverified';
+        lifecycleContext.finalization = {
+          status: cancelled ? 'cancelled' : completed ? 'completed' : 'failed',
+          attemptStatus: cancelled ? 'cancelled' : completed ? 'succeeded' : 'failed',
           outcome: _fin.status,
           finishReason: result.finishReason,
           evidence: _fin.evidence,
           jobCard: _fin.jobCard,
-          eventIdempotencyKey: `job-final:${replTaskId}:${jobGeneration}`,
-          producer: 'repl',
-        });
-        if (!jobFinal.applied || jobFinal.stateVersion === undefined) {
-          throw new Error(`Durable Job finalization rejected: ${jobFinal.conflict ?? 'unknown'}`);
-        }
-        jobStateVersion = jobFinal.stateVersion;
+        };
       }
 
       if (!jobEngine && replTaskStore && replTaskId !== null && _fin) {
@@ -3181,7 +3057,15 @@ export class ChatSession implements ChatSessionLike {
         (err instanceof Error && err.name === 'AbortError') ||
         turnAbort.signal.aborted;
       if (_abortHit) {
-        stopJobLeaseHeartbeat();
+        if (lifecycleContext) {
+          lifecycleContext.finalization = {
+            status: 'cancelled',
+            attemptStatus: 'cancelled',
+            outcome: 'cancelled',
+            finishReason: 'interrupted',
+            evidence: { reason: 'interrupted' },
+          };
+        }
         // v4.11 regression patch — stop the indicator BEFORE printing
         // the dim line so the setInterval can't paint a stray
         // "calling provider… (Ns)" line on top of our cancel
@@ -3196,36 +3080,6 @@ export class ChatSession implements ChatSessionLike {
         if (replParentRunRef) {
           replParentRunRef.runId     = null;
           replParentRunRef.sessionId = null;
-        }
-        if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && jobFenceToken) {
-          const attemptCancelled = jobEngine.transitionAttempt({
-            attemptId: jobAttemptId,
-            expectedStateVersion: attemptStateVersion,
-            generation: jobGeneration,
-            fenceToken: jobFenceToken,
-            to: 'cancelled',
-            eventIdempotencyKey: `attempt-cancelled:${jobAttemptId}:${jobGeneration}`,
-            producer: 'repl',
-            finishReason: 'interrupted',
-          });
-          if (attemptCancelled.applied && attemptCancelled.stateVersion !== undefined) {
-            attemptStateVersion = attemptCancelled.stateVersion;
-          }
-          const jobCancelled = jobEngine.transitionJob({
-            jobId: replTaskId,
-            attemptId: jobAttemptId,
-            generation: jobGeneration,
-            fenceToken: jobFenceToken,
-            expectedStateVersion: jobStateVersion,
-            to: 'cancelled',
-            eventIdempotencyKey: `job-cancelled:${replTaskId}:${jobGeneration}`,
-            producer: 'repl',
-            finishReason: 'interrupted',
-            terminalOutcome: 'cancelled',
-          });
-          if (jobCancelled.applied && jobCancelled.stateVersion !== undefined) {
-            jobStateVersion = jobCancelled.stateVersion;
-          }
         }
         if (!jobEngine && replRunStore && replRunId !== null) {
           try {
@@ -3251,36 +3105,14 @@ export class ChatSession implements ChatSessionLike {
       // Visible in `aiden runs list` as a failed top-level row so
       // operators can correlate a chat error with whatever children
       // it had already kicked off this turn.
-      stopJobLeaseHeartbeat();
-      if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && jobFenceToken) {
-        const attemptFailed = jobEngine.transitionAttempt({
-          attemptId: jobAttemptId,
-          expectedStateVersion: attemptStateVersion,
-          generation: jobGeneration,
-          fenceToken: jobFenceToken,
-          to: 'failed',
-          eventIdempotencyKey: `attempt-failed:${jobAttemptId}:${jobGeneration}`,
-          producer: 'repl',
+      if (lifecycleContext) {
+        lifecycleContext.finalization = {
+          status: 'failed',
+          attemptStatus: 'failed',
+          outcome: 'failed',
           finishReason: 'error',
-        });
-        if (attemptFailed.applied && attemptFailed.stateVersion !== undefined) {
-          attemptStateVersion = attemptFailed.stateVersion;
-        }
-        const jobFailed = jobEngine.transitionJob({
-          jobId: replTaskId,
-          attemptId: jobAttemptId,
-          generation: jobGeneration,
-          fenceToken: jobFenceToken,
-          expectedStateVersion: jobStateVersion,
-          to: 'failed',
-          eventIdempotencyKey: `job-failed:${replTaskId}:${jobGeneration}`,
-          producer: 'repl',
-          finishReason: 'error',
-          terminalOutcome: 'failed',
-        });
-        if (jobFailed.applied && jobFailed.stateVersion !== undefined) {
-          jobStateVersion = jobFailed.stateVersion;
-        }
+          evidence: { errorClass: err instanceof Error ? err.name : 'Error' },
+        };
       }
       if (!jobEngine && replRunStore && replRunId !== null) {
         try {
@@ -3367,7 +3199,6 @@ export class ChatSession implements ChatSessionLike {
         }
       } catch { /* defensive */ }
     } finally {
-      stopJobLeaseHeartbeat();
       if (p2aHeartbeat) clearInterval(p2aHeartbeat);
       emitP2aDiag('turn.finally.start', {
         aborted: turnAbort.signal.aborted,
@@ -3383,8 +3214,7 @@ export class ChatSession implements ChatSessionLike {
         activityTimers: this.opts.callbacks.activityTimerCount?.() ?? 0,
         modalPauseDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
       });
-      detachRuntimeControl?.();
-      detachRuntimeControl = null;
+      lifecycleContext?.handle.signal.removeEventListener('abort', abortFromLifecycle);
       if (this.activeDurableTarget?.attemptId === jobAttemptId) this.activeDurableTarget = null;
       // v4.11 Slice 3 — release the per-turn cancel handles. ORDER
       // MATTERS:

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -81,8 +81,10 @@ import type { RuntimeResolver } from '../../providers/v4/runtimeResolver';
 import type { ConfigManager } from '../../core/v4/config';
 import type { PersonalityManager } from '../../core/v4/personality';
 import {
+  admitDurableJob,
   executeDurableJob,
   DurableJobAuthorityLostError,
+  type DurableJobAdmission,
   type DurableJobDisposition,
   type DurableJobHandle,
 } from '../../core/v4/daemon/jobLifecycle';
@@ -696,7 +698,24 @@ export class ChatSession implements ChatSessionLike {
   getBusyMode(): BusyEnterMode { return this.duringTurnInput.getMode(); }
   listQueue(): string[] { return this.duringTurnInput.peek(); }
   clearQueue(): number {
-    if (this.sessionId) this.opts.jobControlAuthority?.inputs.cancelPendingForSession(this.sessionId);
+    if (this.sessionId && this.opts.jobControlAuthority) {
+      const pending = this.opts.jobControlAuthority.inputs.listPendingForSession(this.sessionId);
+      this.opts.jobControlAuthority.inputs.cancelPendingForSession(this.sessionId);
+      for (const record of pending) {
+        const job = this.opts.jobEngine?.getJob(record.jobId);
+        if (job?.status !== 'queued') continue;
+        this.opts.jobControlAuthority.commands.request({
+          jobId: record.jobId,
+          attemptId: record.targetAttemptId,
+          generation: record.targetGeneration,
+          kind: 'cancel',
+          source: 'tui',
+          reason: 'queued input cleared',
+          idempotencyNamespace: `queue-clear:${this.sessionId}`,
+          idempotencyKey: record.inputId,
+        });
+      }
+    }
     this.durableQueueInputIds.length = 0;
     return this.duringTurnInput.clear();
   }
@@ -1133,6 +1152,7 @@ export class ChatSession implements ChatSessionLike {
         if (iter > 1) this.opts.display.printTurnSeparator();
         let input: string;
         let inputAlreadyPersisted = false;
+        let queuedDurableInputId: string | undefined;
         // v4.12.1 Slice 2a — idle boundary: run a message the user queued
         // WHILE the previous turn was busy before blocking on fresh input.
         // Echo it so a queued message never fires invisibly.
@@ -1140,29 +1160,7 @@ export class ChatSession implements ChatSessionLike {
         if (queuedNext !== null) {
           inputAlreadyPersisted = true;
           const durableInputId = this.durableQueueInputIds.shift();
-          if (durableInputId && this.opts.jobControlAuthority) {
-            const record = this.opts.jobControlAuthority.inputs.get(durableInputId);
-            if (record?.targetAttemptId && record.targetGeneration !== null) {
-              const claimed = this.opts.jobControlAuthority.inputs.claimNext({
-                jobId: record.jobId,
-                attemptId: record.targetAttemptId,
-                generation: record.targetGeneration,
-                inputId: durableInputId,
-                kinds: ['message'],
-              });
-              if (!claimed || claimed.inputId !== durableInputId) {
-                throw new Error(`Durable queued input claim failed: ${durableInputId}`);
-              }
-              const consumed = this.opts.jobControlAuthority.inputs.consume({
-                inputId: durableInputId,
-                attemptId: record.targetAttemptId,
-                generation: record.targetGeneration,
-              });
-              if (!consumed.applied && !consumed.duplicate) {
-                throw new Error(`Durable queued input consume failed: ${durableInputId}`);
-              }
-            }
-          }
+          queuedDurableInputId = durableInputId;
           try { this.opts.display.dim(`▸ running queued: ${queuedNext}`); } catch { /* defensive */ }
           input = queuedNext;
           // Fall through to the slash/agent dispatch below with this input.
@@ -1271,7 +1269,7 @@ export class ChatSession implements ChatSessionLike {
         // slash commands + empty input + /quit all `continue` above and
         // never reach this line, matching the task's edge-case spec.
         this.opts.display.write(`  ${this.opts.display.rule()}\n`);
-        await this.runAgentTurn(input, inputAlreadyPersisted);
+        await this.runAgentTurn(input, inputAlreadyPersisted, queuedDurableInputId);
       }
     } finally {
       try { this.opts.display.releaseBottomRegion(); } catch { /* defensive */ }
@@ -1688,7 +1686,11 @@ export class ChatSession implements ChatSessionLike {
     }
   }
 
-  private async runAgentTurn(userInput: string, inputAlreadyPersisted = false): Promise<void> {
+  private async runAgentTurn(
+    userInput: string,
+    inputAlreadyPersisted = false,
+    queuedDurableInputId?: string,
+  ): Promise<void> {
     const jobEngine = this.opts.jobEngine;
     if (!jobEngine || this.opts.unconfigured) {
       await this.runAgentTurnBody(userInput, inputAlreadyPersisted);
@@ -1701,22 +1703,67 @@ export class ChatSession implements ChatSessionLike {
     }
 
     let lifecycleContext: ChatTurnLifecycleContext | null = null;
-    try {
-      await executeDurableJob({
-        engine: jobEngine,
-        ownerId: instanceId,
-        controlAuthority: this.opts.jobControlAuthority,
-        admission: {
+    let admission: DurableJobAdmission = {
+      entryPoint: 'interactive',
+      source: 'repl',
+      sessionId,
+      workspaceId: process.cwd(),
+      instanceId,
+      idempotencyNamespace: `interactive:${sessionId}`,
+      goal: userInput,
+      title: userInput,
+      channelId: 'repl',
+    };
+    if (queuedDurableInputId) {
+      const controls = this.opts.jobControlAuthority;
+      let record = controls?.inputs.get(queuedDurableInputId);
+      if (!controls || !record) {
+        throw new Error(`Durable queued input admission is unavailable: ${queuedDurableInputId}`);
+      }
+      let attempt = record.targetAttemptId
+        ? jobEngine.getAttempt(record.targetAttemptId)
+        : null;
+      const targetJob = jobEngine.getJob(record.jobId);
+      if (!attempt || attempt.jobId !== record.jobId || targetJob?.activeAttemptId !== attempt.id) {
+        const continued = admitDurableJob(jobEngine, {
           entryPoint: 'interactive',
           source: 'repl',
           sessionId,
           workspaceId: process.cwd(),
           instanceId,
-          idempotencyNamespace: `interactive:${sessionId}`,
+          idempotencyNamespace: `interactive-queue-recovery:${sessionId}`,
+          idempotencyKey: `queued-input:${queuedDurableInputId}`,
           goal: userInput,
           title: userInput,
           channelId: 'repl',
+        });
+        record = controls.inputs.retarget({
+          inputId: queuedDurableInputId,
+          jobId: continued.jobId,
+          attemptId: continued.attemptId,
+          source: 'repl',
+        }).record;
+        attempt = jobEngine.getAttempt(continued.attemptId);
+      }
+      if (!attempt || attempt.jobId !== record.jobId) {
+        throw new Error(`Durable queued input continuation is unavailable: ${queuedDurableInputId}`);
+      }
+      admission = {
+        existing: {
+          jobId: record.jobId,
+          attemptId: attempt.id,
+          runId: attempt.rowId,
+          reused: true,
         },
+        source: 'repl',
+      };
+    }
+    try {
+      await executeDurableJob({
+        engine: jobEngine,
+        ownerId: instanceId,
+        controlAuthority: this.opts.jobControlAuthority,
+        admission,
         initialInput: !inputAlreadyPersisted && this.opts.jobControlAuthority
           ? {
             sessionId,
@@ -1728,6 +1775,7 @@ export class ChatSession implements ChatSessionLike {
             idempotencyKey: `initial:${this.durableInputOrdinal++}`,
           }
           : undefined,
+        existingInitialInputId: queuedDurableInputId,
         execute: async (handle) => {
           lifecycleContext = { handle };
           await this.runAgentTurnBody(userInput, inputAlreadyPersisted, lifecycleContext);
@@ -1943,10 +1991,24 @@ export class ChatSession implements ChatSessionLike {
                 idempotencyKey: `interrupt:${target.attemptId}:${ordinal}`,
               });
             } else {
+              const queuedAdmission = jobEngine && replInstanceId && this.sessionId
+                ? admitDurableJob(jobEngine, {
+                  entryPoint: 'interactive',
+                  source: 'repl',
+                  sessionId: this.sessionId,
+                  workspaceId: process.cwd(),
+                  instanceId: replInstanceId,
+                  idempotencyNamespace: `interactive-queue:${this.sessionId}`,
+                  idempotencyKey: `queued:${target.jobId}:${target.attemptId}:${ordinal}`,
+                  goal: submission,
+                  title: submission,
+                  channelId: 'repl',
+                })
+                : null;
               const received = this.opts.jobControlAuthority.inputs.receive({
-                jobId: target.jobId,
-                targetAttemptId: target.attemptId,
-                targetGeneration: target.generation,
+                jobId: queuedAdmission?.jobId ?? target.jobId,
+                targetAttemptId: queuedAdmission?.attemptId ?? target.attemptId,
+                targetGeneration: queuedAdmission ? null : target.generation,
                 sessionId: this.sessionId!,
                 channelId: 'repl',
                 source: 'tui',

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -697,6 +697,12 @@ export class ChatSession implements ChatSessionLike {
   setBusyMode(mode: BusyEnterMode): void { this.duringTurnInput.setMode(mode); }
   getBusyMode(): BusyEnterMode { return this.duringTurnInput.getMode(); }
   listQueue(): string[] { return this.duringTurnInput.peek(); }
+  listQueueEntries(): Array<{ inputId: string | null; message: string }> {
+    return this.duringTurnInput.peek().map((message, index) => ({
+      inputId: this.durableQueueInputIds[index] ?? null,
+      message,
+    }));
+  }
   clearQueue(): number {
     if (this.sessionId && this.opts.jobControlAuthority) {
       const pending = this.opts.jobControlAuthority.inputs.listPendingForSession(this.sessionId);
@@ -1147,9 +1153,7 @@ export class ChatSession implements ChatSessionLike {
     try {
       while (iter < max) {
         iter += 1;
-        // Phase 26.2.3 — turn boundary rule. The boot card already ends
-        // with a rule + blank, so suppress on the very first iteration.
-        if (iter > 1) this.opts.display.printTurnSeparator();
+        // Composer acquisition intentionally emits no transition rule.
         let input: string;
         let inputAlreadyPersisted = false;
         let queuedDurableInputId: string | undefined;
@@ -1219,6 +1223,7 @@ export class ChatSession implements ChatSessionLike {
             prompt: (msg: string) => promptApi.readLine(msg),
           });
           if (result.exit) {
+            this.opts.display.dim('Finalizing session…');
             // Phase v4.1.2 alive-core / Phase v4.1.2-memory-AB:
             // auto-trigger session distillation on /quit when the
             // session was substantive (≥3 user turns). SIGINT and
@@ -1247,28 +1252,22 @@ export class ChatSession implements ChatSessionLike {
             }
             // v4.12 PM.1 — /quit is session-end: reap background spawns too.
             try { this.opts.processRegistry?.cleanup(); } catch { /* best-effort reap */ }
+            this.opts.display.dim('Goodbye.');
             break;
           }
           if (result.clearHistory) this.history = [];
-          // v4.11 Slice C — /retry re-dispatch. The command already
-          // reverted the last turn and handed back its prompt; run it as
-          // a normal fresh turn (with the same bottom rule the direct
-          // chat path emits below).
+          // /retry re-dispatches a normal turn. Completed output owns the
+          // separator; acquiring another composer never adds one.
           if (typeof result.rerun === 'string' && result.rerun.length > 0) {
-            this.opts.display.write(`  ${this.opts.display.rule()}\n`);
             await this.runAgentTurn(result.rerun);
+          } else {
+            this.opts.display.printTurnSeparator();
           }
           // Phase 23.6 — v3 doesn't print a status footer after slash
           // commands; the footer belongs to agent turns only.
           continue;
         }
 
-        // v4.9.0 pre-ship UI: BOTTOM rule of the prompt zone. The TOP
-        // rule fires at `printTurnSeparator()` above (iter > 1). This
-        // bottom rule fires only when actual content goes to the LLM —
-        // slash commands + empty input + /quit all `continue` above and
-        // never reach this line, matching the task's edge-case spec.
-        this.opts.display.write(`  ${this.opts.display.rule()}\n`);
         await this.runAgentTurn(input, inputAlreadyPersisted, queuedDurableInputId);
       }
     } finally {
@@ -1354,9 +1353,16 @@ export class ChatSession implements ChatSessionLike {
       userTurns,
       unconfigured: !!this.opts.unconfigured,
       memoryPath,
+      disabled:
+        process.env.AIDEN_SESSION_DISTILLATION === '0'
+        || (this.opts.config as { getValue?: <T>(key: string, fallback?: T) => T })
+          .getValue?.<boolean>('memory.session_distillation', true) === false,
     });
     if (gate.fire === false) {
       switch (gate.reason) {
+        case 'disabled':
+          this.opts.display.dim('Skipping session summary — disabled by configuration.');
+          return;
         case 'short':
           this.opts.display.dim(
             `Skipping session summary — only ${userTurns} user turn(s), need ${SESSION_SUMMARY_MIN_TURNS}+.`,
@@ -2798,6 +2804,7 @@ export class ChatSession implements ChatSessionLike {
           : null;
       let _fin: ReturnType<typeof computeTaskFinalization> | undefined;
       let _taskOutcome: TaskOutcomePresentation | undefined;
+      let durableProofVerdict: ReturnType<NonNullable<typeof jobEngine>['proof']['finalize']> | undefined;
       try {
         _fin = computeTaskFinalization(
           {
@@ -2816,12 +2823,56 @@ export class ChatSession implements ChatSessionLike {
             },
           },
         );
-        _taskOutcome = mapTaskOutcomePresentation(taskOutcomeInputFromFinalization({
-          finalization: _fin,
-          trace: result.toolCallTrace,
-          finishReason: result.finishReason,
-          ...(replTaskId != null ? { taskId: String(replTaskId) } : {}),
-        }));
+        if (lifecycleContext && jobEngine?.proof.hasRequiredClaims(lifecycleContext.handle.jobId)) {
+          durableProofVerdict = jobEngine.proof.finalize({
+            jobId: lifecycleContext.handle.jobId,
+            attemptId: lifecycleContext.handle.attemptId,
+            generation: lifecycleContext.handle.generation,
+            fenceToken: lifecycleContext.handle.fenceToken,
+            cancelled: result.finishReason === 'interrupted',
+          });
+          const summary = durableProofVerdict.summary as {
+            verifiedClaims?: number; failedClaims?: number; unknownClaims?: number;
+          };
+          const proofEvidence = jobEngine.proof.listEvidence(lifecycleContext.handle.jobId)
+            .filter((item) => item.attemptId === lifecycleContext!.handle.attemptId
+              && item.generation === lifecycleContext!.handle.generation
+              && !item.late);
+          const verifiedHandle = {
+            tool: 'durable_proof', kind: 'note' as const,
+            value: `${proofEvidence.length} linked evidence record${proofEvidence.length === 1 ? '' : 's'}`,
+            verified: true,
+          };
+          const proofOutcome = durableProofVerdict.verdict === 'verified'
+            ? { kind: 'verified' as const, handles: [verifiedHandle] as const }
+            : durableProofVerdict.verdict === 'failed'
+              ? { kind: 'failed' as const, failures: [{ tool: 'durable_proof', reason: 'a required claim failed' }] as const }
+              : { kind: 'unverifiable' as const, reason: 'required claims remain unresolved' };
+          _taskOutcome = mapTaskOutcomePresentation({
+            status: durableProofVerdict.verdict === 'failed' ? 'verification_failed'
+              : durableProofVerdict.verdict === 'verified' ? 'completed' : 'completed_unverified',
+            outcome: proofOutcome,
+            finishReason: result.finishReason,
+            ...(replTaskId != null ? { taskId: String(replTaskId) } : {}),
+            evidenceCount: proofEvidence.filter((item) => item.verificationResult === 'verified').length,
+            toolCallCount: result.toolCallTrace?.length ?? 0,
+            executionStarted: true,
+            cancelled: durableProofVerdict.verdict === 'cancelled',
+            partial: durableProofVerdict.verdict === 'partially_verified',
+            requiredEvidenceGap: durableProofVerdict.verdict === 'unknown',
+            meaningfulEvidenceRequirement: true,
+            requiredCompletedCount: summary.verifiedClaims ?? 0,
+            requiredFailedCount: summary.failedClaims ?? 0,
+            requiredUnresolvedCount: summary.unknownClaims ?? 0,
+          });
+        } else {
+          _taskOutcome = mapTaskOutcomePresentation(taskOutcomeInputFromFinalization({
+            finalization: _fin,
+            trace: result.toolCallTrace,
+            finishReason: result.finishReason,
+            ...(replTaskId != null ? { taskId: String(replTaskId) } : {}),
+          }));
+        }
         result.taskOutcome = _taskOutcome;
       } catch (err) {
         // eslint-disable-next-line no-console
@@ -2831,13 +2882,20 @@ export class ChatSession implements ChatSessionLike {
 
       if (lifecycleContext && _fin) {
         const cancelled = result.finishReason === 'interrupted';
-        const completed = _fin.status === 'completed' || _fin.status === 'completed_unverified';
+        const proofVerdict = durableProofVerdict?.verdict;
+        const completed = proofVerdict === 'verified'
+          || (!proofVerdict && (_fin.status === 'completed' || _fin.status === 'completed_unverified'));
+        const uncertain = proofVerdict === 'unknown' || proofVerdict === 'partially_verified';
         lifecycleContext.finalization = {
-          status: cancelled ? 'cancelled' : completed ? 'completed' : 'failed',
-          attemptStatus: cancelled ? 'cancelled' : completed ? 'succeeded' : 'failed',
-          outcome: _fin.status,
+          status: cancelled || proofVerdict === 'cancelled' ? 'cancelled'
+            : uncertain ? 'unknown' : completed ? 'completed' : 'failed',
+          attemptStatus: cancelled || proofVerdict === 'cancelled' ? 'cancelled'
+            : uncertain ? 'unknown' : completed ? 'succeeded' : 'failed',
+          outcome: proofVerdict ?? _fin.status,
           finishReason: result.finishReason,
-          evidence: _fin.evidence,
+          evidence: durableProofVerdict
+            ? jobEngine?.proof.exportJson(lifecycleContext.handle.jobId) ?? _fin.evidence
+            : _fin.evidence,
           jobCard: _fin.jobCard,
         };
       }

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -1772,7 +1772,7 @@ export class ChatSession implements ChatSessionLike {
             kind: 'message',
             content: userInput,
             idempotencyNamespace: `interactive-input:${sessionId}`,
-            idempotencyKey: `initial:${this.durableInputOrdinal++}`,
+            idempotencyKey: `initial:${instanceId}:${this.durableInputOrdinal++}`,
           }
           : undefined,
         existingInitialInputId: queuedDurableInputId,

--- a/cli/v4/commandRegistry.ts
+++ b/cli/v4/commandRegistry.ts
@@ -67,6 +67,8 @@ export interface ChatSessionLike {
   getBusyMode?(): 'queue' | 'interrupt' | 'redirect';
   /** The pending type-next queue (copy). */
   listQueue?(): string[];
+  /** Pending messages paired with their durable identities when available. */
+  listQueueEntries?(): Array<{ inputId: string | null; message: string }>;
   /** Empty the queue; returns how many were dropped. */
   clearQueue?(): number;
   queueCount?(): number;

--- a/cli/v4/commands/queue.ts
+++ b/cli/v4/commands/queue.ts
@@ -38,13 +38,17 @@ export const queue: SlashCommand = {
       ctx.display.success(n > 0 ? `Cleared ${n} queued message${n === 1 ? '' : 's'}.` : 'Queue was already empty.');
       return {};
     }
-    const items = session.listQueue();
+    const items = session.listQueueEntries?.()
+      ?? session.listQueue().map((message) => ({ inputId: null, message }));
     if (items.length === 0) {
       ctx.display.info('Type-next queue is empty. Type while a turn runs to queue a message (see /busy).');
       return {};
     }
     ctx.display.info(`Type-next queue (${items.length}) — runs in order after the current turn:`);
-    items.forEach((m, i) => ctx.display.write(`  ${i + 1}. ${formatQueuePreview(m)}\n`));
+    items.forEach((entry, i) => {
+      const identity = entry.inputId ? `[${entry.inputId}] ` : '';
+      ctx.display.write(`  ${i + 1}. ${identity}${formatQueuePreview(entry.message)}\n`);
+    });
     ctx.display.dim('Run /queue clear to empty it.');
     return {};
   },

--- a/cli/v4/commands/quit.ts
+++ b/cli/v4/commands/quit.ts
@@ -16,8 +16,5 @@ export const quit: SlashCommand = {
   category: 'system',
   icon: '🚪',
   aliases: ['q', 'exit'],
-  handler: async (ctx) => {
-    ctx.display.dim('Goodbye.');
-    return { exit: true };
-  },
+  handler: async () => ({ exit: true }),
 };

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -1684,7 +1684,16 @@ export class Display {
     const outcomeRow = (suffix: string, kind: ColorKindForBracket): string => {
       const failed = kind === 'error' || kind === 'warn' || /^(?:cancelled|denied|blocked|timed out|fail)/u.test(suffix);
       const outcomeGlyph = failed ? '!' : '✓';
-      const prefix = `${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(verb)} `;
+      const terminalVerb = /^denied\b/u.test(suffix) ? 'denied'
+        : /^cancelled\b/u.test(suffix) ? 'cancelled'
+        : /^timed out\b/u.test(suffix) ? 'timed out'
+        : /^unknown\b/u.test(suffix) ? 'unknown'
+        : /^blocked\b/u.test(suffix) ? 'blocked'
+        : /^fail(?:ed)?\b/u.test(suffix) ? 'failed'
+        : /^partial\b/u.test(suffix) ? 'partial'
+        : /^empty (?:fail|retry)\b/u.test(suffix) ? 'failed'
+        : 'completed';
+      const prefix = `${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(terminalVerb)} `;
       const suffixText = suffix ? `  ${suffix}` : '';
       const width = terminalRowWidth();
       const availableDetail = width === null
@@ -1853,6 +1862,9 @@ export class Display {
             break;
           case 'degraded':
             writeFinal(`partial ${execution}${waited}`, 'degraded');
+            break;
+          case 'unknown':
+            writeFinal(snapshot.executionDurationMs > 0 ? `unknown after ${execution}` : 'unknown', 'warn');
             break;
           default:
             writeFinal(`done ${execution}${attempts}${waited}${backoff}`, 'muted');

--- a/cli/v4/replyRenderer.ts
+++ b/cli/v4/replyRenderer.ts
@@ -421,7 +421,7 @@ export function getReplyRenderer(): { render: (text: string) => string } {
     // line wrap, the bg painting may show a visual seam at the wrap
     // point. Acceptable for v4.1.3 — revertable to Path A (no bg) if
     // visual smoke surfaces a real problem.
-    codespan:     (text: string) => `${CODE_BG_ON} ${paint('accent')(decodeColonToken(text))} ${CODE_BG_OFF}`,
+    codespan:     (text: string) => `${CODE_BG_ON}${paint('accent')(decodeColonToken(text))}${CODE_BG_OFF}`,
     del:          paint('muted'),
     // marked-terminal calls opts.link with the ASSEMBLED visual
     // (already OSC8-wrapped when the host terminal supports it),

--- a/cli/v4/sessionSummaryGate.ts
+++ b/cli/v4/sessionSummaryGate.ts
@@ -31,11 +31,12 @@ export interface SessionSummaryGateInput {
   userTurns:     number;
   unconfigured:  boolean;
   memoryPath:    string | undefined;
+  disabled?:     boolean;
 }
 
 export type SessionSummaryGateResult =
   | { fire: true }
-  | { fire: false; reason: 'short' | 'unconfigured' | 'no-paths' };
+  | { fire: false; reason: 'short' | 'unconfigured' | 'no-paths' | 'disabled' };
 
 /**
  * Decide whether the /quit auto-summary should fire. Threshold lives
@@ -45,6 +46,7 @@ export type SessionSummaryGateResult =
 export function shouldAutoSummarize(
   input: SessionSummaryGateInput,
 ): SessionSummaryGateResult {
+  if (input.disabled) return { fire: false, reason: 'disabled' };
   if (input.userTurns < SESSION_SUMMARY_MIN_TURNS) {
     return { fire: false, reason: 'short' };
   }

--- a/cli/v4/startupNotices.ts
+++ b/cli/v4/startupNotices.ts
@@ -299,12 +299,25 @@ export function buildMcpAuthNotice(serverName: string): StartupNotice {
   });
 }
 
-export function buildPluginGrantNotice(pluginName: string): StartupNotice {
+export function buildPluginGrantNotice(
+  pluginName: string,
+  options: { activeProvider?: string; providedProviders?: readonly string[]; capabilities?: readonly string[] } = {},
+): StartupNotice | null {
   const plugin = clean(pluginName) ?? 'plugin';
+  if (
+    options.activeProvider
+    && options.providedProviders?.includes(options.activeProvider)
+  ) {
+    return null;
+  }
+  const capabilities = options.capabilities?.filter((value) => clean(value)) ?? [];
   return notice({
     id: `plugin:grant:${plugin}`,
     severity: 'action',
-    title: `${plugin} plugin grant required`,
+    title: `${plugin} plugin capability requires a grant`,
+    detail: capabilities.length > 0
+      ? `Grant only to enable: ${capabilities.join(', ')}.`
+      : 'Grant only if you want to enable this optional plugin capability.',
     command: `/plugins grant ${plugin}`,
     source: 'plugin',
     blocking: false,

--- a/core/v4/actionAuthority.ts
+++ b/core/v4/actionAuthority.ts
@@ -55,6 +55,7 @@ export interface ApprovalRecord {
   attemptId: string;
   generation: number;
   toolCallId: string;
+  effectId: string | null;
   requestSequence: number;
   toolName: string;
   riskTier: string;
@@ -76,6 +77,7 @@ export interface ActionAuthority {
     attemptId: string;
     generation: number;
     toolCallId: string;
+    effectId?: string | null;
     toolName: string;
     riskTier: string;
     riskReasons: string[];
@@ -121,6 +123,7 @@ interface ApprovalRow {
   attempt_id: string;
   generation: number;
   tool_call_id: string;
+  effect_id: string | null;
   request_sequence: number;
   tool_name: string;
   risk_tier: string;
@@ -277,6 +280,7 @@ function mapApproval(row: ApprovalRow): ApprovalRecord {
     attemptId: row.attempt_id,
     generation: row.generation,
     toolCallId: row.tool_call_id,
+    effectId: row.effect_id,
     requestSequence: row.request_sequence,
     toolName: row.tool_name,
     riskTier: row.risk_tier,
@@ -337,6 +341,7 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
       payload: {
         approvalId: record.approvalId,
         toolCallId: record.toolCallId,
+        effectId: record.effectId,
         actionDigest: record.actionDigest,
         policySnapshotId: record.policySnapshotId,
         state: record.state,
@@ -358,6 +363,22 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
       ) {
         throw new Error('Approval target has a stale generation');
       }
+      if (command.effectId) {
+        const effect = db.prepare(
+          `SELECT se.key
+             FROM side_effect_ledger se
+             JOIN tool_calls tc ON tc.tool_call_id = se.tool_call_id
+            WHERE se.key = ? AND se.job_id = ? AND se.attempt_id = ?
+              AND se.generation = ? AND tc.tool_call_id = ?`,
+        ).get(
+          command.effectId,
+          command.jobId,
+          command.attemptId,
+          command.generation,
+          command.toolCallId,
+        ) as { key: string } | undefined;
+        if (!effect) throw new Error('Approval Effect binding mismatch or stale generation');
+      }
       const now = command.now ?? Date.now();
       const transaction = db.transaction(() => {
         persistPolicy(command.normalized.policySnapshot, now);
@@ -367,17 +388,18 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
         const approvalId = makeId('approval');
         db.prepare(
           `INSERT INTO approvals (
-             approval_id, job_id, attempt_id, generation, tool_call_id,
+             approval_id, job_id, attempt_id, generation, tool_call_id, effect_id,
              request_sequence, tool_name, risk_tier, risk_reasons_json,
              normalized_execution_plan, action_digest, policy_snapshot_id,
              state, requested_at, expires_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created', ?, ?)`,
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created', ?, ?)`,
         ).run(
           approvalId,
           command.jobId,
           command.attemptId,
           command.generation,
           command.toolCallId,
+          command.effectId ?? null,
           sequence,
           command.toolName,
           command.riskTier,

--- a/core/v4/actionAuthority.ts
+++ b/core/v4/actionAuthority.ts
@@ -49,6 +49,8 @@ export interface NormalizedAction {
   policySnapshot: PolicySnapshot;
 }
 
+export type ApprovalScope = 'once' | 'session' | 'permanent';
+
 export interface ApprovalRecord {
   approvalId: string;
   jobId: string;
@@ -61,8 +63,10 @@ export interface ApprovalRecord {
   riskTier: string;
   actionDigest: string;
   policySnapshotId: string;
+  fenceDigest: string | null;
   state: 'created' | 'displayed' | 'approved' | 'denied' | 'expired' | 'cancelled' | 'invalidated' | 'executed' | 'stale_rejected';
   decision: string | null;
+  decisionScope: ApprovalScope | null;
   requestedAt: number;
   displayedAt: number | null;
   decidedAt: number | null;
@@ -76,6 +80,7 @@ export interface ActionAuthority {
     jobId: string;
     attemptId: string;
     generation: number;
+    fenceToken: string;
     toolCallId: string;
     effectId?: string | null;
     toolName: string;
@@ -97,7 +102,7 @@ export interface ActionAuthority {
     policySnapshotId: string;
     decision: 'approved' | 'denied' | 'cancelled';
     decisionInputId?: string | null;
-    decisionScope?: string | null;
+    decisionScope?: ApprovalScope | null;
     decidedBy: string;
     decisionChannel: string;
     now?: number;
@@ -110,6 +115,7 @@ export interface ActionAuthority {
     generation: number;
     fenceToken: string;
     toolCallId: string;
+    effectId: string | null;
     actionDigest: string;
     policySnapshotId: string;
     now?: number;
@@ -129,8 +135,10 @@ interface ApprovalRow {
   risk_tier: string;
   action_digest: string;
   policy_snapshot_id: string;
+  fence_token_digest: string | null;
   state: ApprovalRecord['state'];
   decision: string | null;
+  decision_scope: ApprovalScope | null;
   requested_at: number;
   displayed_at: number | null;
   decided_at: number | null;
@@ -286,8 +294,10 @@ function mapApproval(row: ApprovalRow): ApprovalRecord {
     riskTier: row.risk_tier,
     actionDigest: row.action_digest,
     policySnapshotId: row.policy_snapshot_id,
+    fenceDigest: row.fence_token_digest,
     state: row.state,
     decision: row.decision,
+    decisionScope: row.decision_scope,
     requestedAt: row.requested_at,
     displayedAt: row.displayed_at,
     decidedAt: row.decided_at,
@@ -354,14 +364,16 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
 
   return {
     request(command) {
+      const now = command.now ?? Date.now();
       const job = jobEngine.getJob(command.jobId);
       const attempt = jobEngine.getAttempt(command.attemptId);
       if (
         !job || !attempt || job.activeAttemptId !== command.attemptId ||
         attempt.jobId !== command.jobId || attempt.generation !== command.generation ||
-        ['cancelled', 'completed', 'failed', 'dead_letter'].includes(job.status)
+        attempt.fenceToken !== command.fenceToken || attempt.leaseExpiresAt === null || attempt.leaseExpiresAt <= now ||
+        ['cancelled', 'completed', 'failed', 'dead_letter', 'completed_unverified', 'verification_failed', 'abandoned'].includes(job.status)
       ) {
-        throw new Error('Approval target has a stale generation');
+        throw new Error('Approval target has a stale generation or fence');
       }
       if (command.effectId) {
         const effect = db.prepare(
@@ -379,7 +391,6 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
         ) as { key: string } | undefined;
         if (!effect) throw new Error('Approval Effect binding mismatch or stale generation');
       }
-      const now = command.now ?? Date.now();
       const transaction = db.transaction(() => {
         persistPolicy(command.normalized.policySnapshot, now);
         const sequence = (db.prepare(
@@ -390,9 +401,9 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
           `INSERT INTO approvals (
              approval_id, job_id, attempt_id, generation, tool_call_id, effect_id,
              request_sequence, tool_name, risk_tier, risk_reasons_json,
-             normalized_execution_plan, action_digest, policy_snapshot_id,
+             normalized_execution_plan, action_digest, policy_snapshot_id, fence_token_digest,
              state, requested_at, expires_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created', ?, ?)`,
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created', ?, ?)`,
         ).run(
           approvalId,
           command.jobId,
@@ -407,6 +418,7 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
           stableJson(command.normalized.plan),
           command.normalized.actionDigest,
           command.normalized.policySnapshot.policySnapshotId,
+          sha(command.fenceToken),
           now,
           command.expiresAt ?? null,
         );
@@ -443,7 +455,7 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
         if (!record) throw new Error('Approval not found');
         const job = jobEngine.getJob(command.jobId);
         const attempt = jobEngine.getAttempt(command.attemptId);
-        if (!job || ['cancelled', 'completed', 'failed', 'dead_letter'].includes(job.status)) {
+        if (!job || ['cancelled', 'completed', 'failed', 'dead_letter', 'completed_unverified', 'verification_failed', 'abandoned'].includes(job.status)) {
           throw new Error('Terminal Job rejects approval decisions');
         }
         if (
@@ -522,10 +534,24 @@ export function createActionAuthority(options: { db: Db; jobEngine: JobEngine })
         if (
           record.jobId !== command.jobId || record.attemptId !== command.attemptId ||
           record.generation !== command.generation || record.toolCallId !== command.toolCallId ||
+          record.effectId !== command.effectId || record.fenceDigest !== sha(command.fenceToken) ||
           record.actionDigest !== command.actionDigest || record.policySnapshotId !== command.policySnapshotId
         ) {
           this.invalidate(command.approvalId, 'approved action changed or binding mismatch', command.now);
           return { authorized: false, reason: 'approved action changed or binding mismatch' };
+        }
+        if (record.effectId) {
+          const effect = db.prepare(
+            `SELECT se.key
+               FROM side_effect_ledger se
+               JOIN tool_calls tc ON tc.tool_call_id = se.tool_call_id
+              WHERE se.key = ? AND se.job_id = ? AND se.attempt_id = ?
+                AND se.generation = ? AND tc.tool_call_id = ? AND tc.side_effect_id = se.key`,
+          ).get(record.effectId, record.jobId, record.attemptId, record.generation, record.toolCallId);
+          if (!effect) {
+            this.invalidate(command.approvalId, 'approval Effect binding changed', command.now);
+            return { authorized: false, reason: 'approval Effect binding changed' };
+          }
         }
         if (record.expiresAt !== null && record.expiresAt <= now) {
           db.prepare(`UPDATE approvals SET state = 'expired', invalidated_at = ? WHERE approval_id = ? AND state = 'approved'`)

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -55,7 +55,7 @@ import {
   type ToolResultArtifactStore,
 } from './toolResultBoundary';
 import { selectEconomyTools } from './usagePolicy';
-import { recordDurableToolVerification } from './daemon/jobExecutionContext';
+import { currentJobExecutionContext, recordDurableToolVerification } from './daemon/jobExecutionContext';
 import {
   createLogicalProviderCallId,
   currentProviderAttemptLedger,
@@ -2664,6 +2664,23 @@ export class AidenAgent {
         ? { attemptBudgets: runOptions.providerAttemptBudgets }
         : {}),
     };
+    const durableJob = currentJobExecutionContext();
+    if (
+      durableJob
+      && durableJob.engine.resources.getBudgets(durableJob.jobId).some((budget) => budget.kind === 'model_calls')
+    ) {
+      const debit = durableJob.engine.resources.debit({
+        jobId: durableJob.jobId,
+        attemptId: durableJob.attemptId,
+        generation: durableJob.generation,
+        fenceToken: durableJob.fenceToken,
+        kind: 'model_calls',
+        amount: 1,
+        certainty: 'confirmed',
+        idempotencyKey: `model-call:${usageContext.logicalCallId}`,
+      });
+      if (debit.exhausted) throw new Error('Model-call budget exhausted');
+    }
     if (!wantStream) {
       // v4.6 prep — forward the abort signal into the provider call so
       // an in-flight HTTP request can be cancelled mid-flight.

--- a/core/v4/daemon/api/runs.ts
+++ b/core/v4/daemon/api/runs.ts
@@ -33,6 +33,7 @@ import express from 'express';
 import type { TriggerBus } from '../triggerBus';
 import type { Db } from '../db/connection';
 import { IdempotencyConflictError, type JobEngine } from '../jobEngine';
+import { admitDurableJob } from '../jobLifecycle';
 import { createJobControlAuthority, type JobControlAuthority } from '../jobControlAuthority';
 import { fingerprintCanonical } from '../idempotency/runIdempotencyStore';
 // v4.9.0 Slice 7 — inbound trace adoption.
@@ -148,7 +149,7 @@ export function mountRunsRoutes(opts: MountRunsRoutesOptions): MountedRunsRoutes
               },
             });
             const sessionId = `api:${sourceKey}:${idempotencyKey.slice(0, 24)}`;
-            const admission = opts.jobEngine.submitJob({
+            const admission = admitDurableJob(opts.jobEngine, {
               entryPoint: 'daemon_api',
               source: 'api',
               sessionId,

--- a/core/v4/daemon/db/connection.ts
+++ b/core/v4/daemon/db/connection.ts
@@ -28,7 +28,7 @@ import Database from 'better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { runMigrations } from './migrations';
+import { LATEST_SCHEMA_VERSION, runMigrations } from './migrations';
 
 export type Db = Database.Database;
 
@@ -44,6 +44,7 @@ const _open: Map<string, Db> = new Map();
 export function openDaemonDb(dbPath: string): Db {
   const cached = _open.get(dbPath);
   if (cached && cached.open) return cached;
+  const existedBeforeOpen = dbPath !== ':memory:' && fs.existsSync(dbPath) && fs.statSync(dbPath).size > 0;
   if (dbPath !== ':memory:') {
     try { fs.mkdirSync(path.dirname(dbPath), { recursive: true }); }
     catch { /* tolerate — open will surface a clearer error */ }
@@ -53,7 +54,29 @@ export function openDaemonDb(dbPath: string): Db {
   db.pragma('synchronous = NORMAL');
   db.pragma('foreign_keys = ON');
   db.pragma('busy_timeout = 5000');
-  runMigrations(db);
+  const versionTable = db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'",
+  ).get();
+  const fromVersion = versionTable
+    ? ((db.prepare('SELECT version FROM schema_version WHERE id = 1').get() as { version?: number } | undefined)?.version ?? 0)
+    : 0;
+  if (existedBeforeOpen && fromVersion < LATEST_SCHEMA_VERSION) {
+    const backupPath = `${dbPath}.pre-schema-v${fromVersion}.bak`;
+    if (!fs.existsSync(backupPath)) {
+      try {
+        db.prepare('VACUUM INTO ?').run(backupPath);
+      } catch (error) {
+        try { db.close(); } catch { /* preserve original migration error */ }
+        throw new Error(`Database backup before migration failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+  try {
+    runMigrations(db);
+  } catch (error) {
+    try { db.close(); } catch { /* preserve migration error */ }
+    throw error;
+  }
   _open.set(dbPath, db);
   // v4.5 Phase 3 — daemon.db stores webhook secrets (raw, required
   // for HMAC computation). Lock the file mode to user-only on POSIX

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1434,6 +1434,24 @@ function applyV30(db: Database.Database): void {
   `);
 }
 
+/** Cover the ordered kernel projection and active-Job query paths. */
+function applyV31(db: Database.Database): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_tasks_status_created_id
+      ON tasks(status, created_at, id);
+    CREATE INDEX IF NOT EXISTS idx_tasks_session_created_id
+      ON tasks(session_id, created_at, id);
+    CREATE INDEX IF NOT EXISTS idx_side_effect_job_created
+      ON side_effect_ledger(job_id, attempted_at, key);
+    CREATE INDEX IF NOT EXISTS idx_child_job_contracts_parent_created
+      ON child_job_contracts(parent_job_id, created_at, child_job_id);
+    CREATE INDEX IF NOT EXISTS idx_job_claims_job_created
+      ON job_claims(job_id, created_at, claim_id);
+    CREATE INDEX IF NOT EXISTS idx_job_evidence_job_created
+      ON job_evidence(job_id, captured_at, evidence_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1465,6 +1483,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 28, name: 'durable budgets and capabilities', apply: applyV28 },
   { version: 29, name: 'durable claims evidence and verdicts', apply: applyV29 },
   { version: 30, name: 'durable Job event cursors', apply: applyV30 },
+  { version: 31, name: 'kernel projection query indexes', apply: applyV31 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1418,6 +1418,22 @@ function applyV29(db: Database.Database): void {
   `);
 }
 
+/** Durable cursors for replayable Job-event consumers. */
+function applyV30(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_event_cursors (
+      consumer_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      last_sequence INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (consumer_id, job_id),
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_event_cursors_job
+      ON job_event_cursors(job_id, last_sequence);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1448,6 +1464,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 27, name: 'durable child Job contracts', apply: applyV27 },
   { version: 28, name: 'durable budgets and capabilities', apply: applyV28 },
   { version: 29, name: 'durable claims evidence and verdicts', apply: applyV29 },
+  { version: 30, name: 'durable Job event cursors', apply: applyV30 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1103,6 +1103,40 @@ function applyV22(db: Database.Database): void {
   `);
 }
 
+/** Append-only reconciliation history for uncertain real-world Effects. */
+function applyV23(db: Database.Database): void {
+  addMissingColumns(db, 'side_effect_ledger', [
+    ['reconciliation_data_json', 'TEXT'],
+    ['reconciliation_outcome', 'TEXT'],
+    ['reconciliation_required', 'INTEGER NOT NULL DEFAULT 0'],
+    ['last_reconciled_at', 'INTEGER'],
+  ]);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS effect_reconciliations (
+      reconciliation_id TEXT PRIMARY KEY,
+      effect_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      outcome TEXT NOT NULL,
+      confidence TEXT NOT NULL,
+      evidence_json TEXT NOT NULL,
+      retry_recommendation TEXT NOT NULL,
+      human_resolution_required INTEGER NOT NULL,
+      producer TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (effect_id) REFERENCES side_effect_ledger(key) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (effect_id, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_effect_reconciliations_effect
+      ON effect_reconciliations(effect_id, created_at, reconciliation_id);
+    CREATE INDEX IF NOT EXISTS idx_effect_reconciliation_required
+      ON side_effect_ledger(job_id, reconciliation_required, effect_state);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1126,6 +1160,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 20, name: 'v4.15.1 — durable Job and Attempt foundation',    apply: applyV20 },
   { version: 21, name: 'v4.15.1 - durable input and approval authority', apply: applyV21 },
   { version: 22, name: 'durable effect contracts', apply: applyV22 },
+  { version: 23, name: 'append-only effect reconciliation', apply: applyV23 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1305,6 +1305,52 @@ function applyV27(db: Database.Database): void {
   `);
 }
 
+/** Durable budget balances, debits, and least-privilege capability snapshots. */
+function applyV28(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_budgets (
+      job_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      limit_value REAL,
+      used_value REAL NOT NULL DEFAULT 0,
+      has_unknown_usage INTEGER NOT NULL DEFAULT 0,
+      state_version INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (job_id, kind),
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS job_budget_debits (
+      debit_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      amount REAL,
+      certainty TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (job_id, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_budget_debits_attempt
+      ON job_budget_debits(attempt_id, generation, created_at);
+    CREATE TABLE IF NOT EXISTS job_capability_sets (
+      job_id TEXT PRIMARY KEY,
+      allowed_tools_json TEXT NOT NULL,
+      allowed_paths_json TEXT NOT NULL,
+      allowed_hosts_json TEXT NOT NULL,
+      allowed_applications_json TEXT NOT NULL,
+      allowed_connections_json TEXT NOT NULL,
+      allowed_accounts_json TEXT NOT NULL,
+      allowed_workers_json TEXT NOT NULL,
+      allowed_effect_kinds_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1333,6 +1379,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 25, name: 'durable waits and continuations', apply: applyV25 },
   { version: 26, name: 'exact approval fence binding', apply: applyV26 },
   { version: 27, name: 'durable child Job contracts', apply: applyV27 },
+  { version: 28, name: 'durable budgets and capabilities', apply: applyV28 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1222,6 +1222,56 @@ function applyV24(db: Database.Database): void {
   `);
 }
 
+/** Durable waits and their append-only resolution history. */
+function applyV25(db: Database.Database): void {
+  addMissingColumns(db, 'tasks', [
+    ['next_wait_sequence', 'INTEGER NOT NULL DEFAULT 1'],
+  ]);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_waits (
+      wait_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      sequence INTEGER NOT NULL,
+      graph_node_key TEXT,
+      kind TEXT NOT NULL,
+      state TEXT NOT NULL,
+      deadline_at INTEGER,
+      external_key TEXT,
+      payload_ref TEXT,
+      resolved_by_input_id TEXT,
+      resolution_ref TEXT,
+      idempotency_namespace TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      resolved_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (resolved_by_input_id) REFERENCES durable_inputs(input_id) ON DELETE SET NULL,
+      UNIQUE (idempotency_namespace, idempotency_key),
+      UNIQUE (job_id, sequence)
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_waits_pending
+      ON job_waits(job_id, state, deadline_at, sequence);
+    CREATE INDEX IF NOT EXISTS idx_job_waits_external
+      ON job_waits(job_id, external_key, state) WHERE external_key IS NOT NULL;
+    CREATE TABLE IF NOT EXISTS job_wait_events (
+      wait_event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      wait_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      producer TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (wait_id) REFERENCES job_waits(wait_id) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (wait_id, idempotency_key)
+    );
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1247,6 +1297,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 22, name: 'durable effect contracts', apply: applyV22 },
   { version: 23, name: 'append-only effect reconciliation', apply: applyV23 },
   { version: 24, name: 'durable execution graph', apply: applyV24 },
+  { version: 25, name: 'durable waits and continuations', apply: applyV25 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1062,6 +1062,47 @@ function applyV21(db: Database.Database): void {
   `);
 }
 
+/** Extend the existing SideEffect ledger with explicit execution contracts. */
+function applyV22(db: Database.Database): void {
+  addMissingColumns(db, 'side_effect_ledger', [
+    ['effect_classification',      "TEXT NOT NULL DEFAULT 'unknown_mutation'"],
+    ['effect_kind',                "TEXT NOT NULL DEFAULT 'unknown'"],
+    ['retry_safety',               "TEXT NOT NULL DEFAULT 'never_automatic'"],
+    ['idempotency_key',            'TEXT'],
+    ['idempotency_supported',      'INTEGER NOT NULL DEFAULT 0'],
+    ['reconciliation_supported',   'INTEGER NOT NULL DEFAULT 0'],
+    ['verification_supported',     'INTEGER NOT NULL DEFAULT 0'],
+    ['approval_requirement',       "TEXT NOT NULL DEFAULT 'always'"],
+    ['approval_state',             "TEXT NOT NULL DEFAULT 'not_required'"],
+    ['approval_id',                'TEXT'],
+    ['action_digest',              'TEXT'],
+    ['sensitive_fields_json',      "TEXT NOT NULL DEFAULT '[]'"],
+    ['redaction_rules_json',       "TEXT NOT NULL DEFAULT '[]'"],
+    ['result_ref',                 'TEXT'],
+    ['updated_at',                 'INTEGER'],
+  ]);
+  addMissingColumns(db, 'approvals', [
+    ['effect_id', 'TEXT'],
+  ]);
+  db.exec(`
+    UPDATE side_effect_ledger
+       SET updated_at = COALESCE(updated_at, confirmed_at, attempted_at),
+           effect_classification = CASE
+             WHEN effect_classification = 'unknown_mutation' AND effect_state IN ('committed','started')
+               THEN 'unsafe_mutation'
+             ELSE effect_classification
+           END;
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_side_effect_job_idempotency
+      ON side_effect_ledger(job_id, idempotency_key)
+      WHERE job_id IS NOT NULL AND idempotency_key IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_side_effect_recovery
+      ON side_effect_ledger(effect_state, retry_safety, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_approvals_effect
+      ON approvals(effect_id, state)
+      WHERE effect_id IS NOT NULL;
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1084,6 +1125,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 19, name: 'v4.12.1 — side-effect idempotency ledger',        sql: V19_SQL },
   { version: 20, name: 'v4.15.1 — durable Job and Attempt foundation',    apply: applyV20 },
   { version: 21, name: 'v4.15.1 - durable input and approval authority', apply: applyV21 },
+  { version: 22, name: 'durable effect contracts', apply: applyV22 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1493,6 +1493,19 @@ function getCurrentVersion(db: Database.Database): number {
   return verRow?.version ?? 0;
 }
 
+function tableExists(db: Database.Database, name: string): boolean {
+  return db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !== undefined;
+}
+
+function validateLatestSchema(db: Database.Database): void {
+  const required = ['tasks', 'runs', 'run_events', 'side_effect_ledger', 'durable_inputs'];
+  const missing = required.filter((table) => !tableExists(db, table));
+  if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
+  if (!tableExists(db, 'job_event_cursors')) {
+    db.transaction(() => applyV30(db)).immediate();
+  }
+}
+
 /**
  * Apply every pending migration. Idempotent: re-running a database
  * already at the latest version is a no-op.
@@ -1500,7 +1513,10 @@ function getCurrentVersion(db: Database.Database): number {
 export function runMigrations(db: Database.Database): { from: number; to: number } {
   const from = getCurrentVersion(db);
   const pending = MIGRATIONS.filter((m) => m.version > from);
-  if (pending.length === 0) return { from, to: from };
+  if (pending.length === 0) {
+    validateLatestSchema(db);
+    return { from, to: from };
+  }
   const apply = db.transaction((m: Migration): void => {
     if (m.apply) m.apply(db);
     else db.exec(m.sql ?? '');
@@ -1520,5 +1536,6 @@ export function runMigrations(db: Database.Database): { from: number; to: number
     }
     to = m.version;
   }
+  validateLatestSchema(db);
   return { from, to };
 }

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1137,6 +1137,91 @@ function applyV23(db: Database.Database): void {
   `);
 }
 
+/** Durable dependency graph and append-only node execution history. */
+function applyV24(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS execution_graphs (
+      graph_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL UNIQUE,
+      plan_digest TEXT NOT NULL,
+      state TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      next_event_sequence INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS execution_graph_nodes (
+      node_id TEXT PRIMARY KEY,
+      node_key TEXT NOT NULL,
+      graph_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      state TEXT NOT NULL,
+      label TEXT,
+      input_ref TEXT,
+      output_ref TEXT,
+      verification_ref TEXT,
+      requires_verification INTEGER NOT NULL DEFAULT 0,
+      ordinal INTEGER NOT NULL,
+      state_version INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (graph_id) REFERENCES execution_graphs(graph_id) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (graph_id, node_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_execution_graph_nodes_state
+      ON execution_graph_nodes(graph_id, state, ordinal);
+    CREATE TABLE IF NOT EXISTS execution_graph_edges (
+      graph_id TEXT NOT NULL,
+      from_node_id TEXT NOT NULL,
+      to_node_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (graph_id, from_node_id, to_node_id),
+      FOREIGN KEY (graph_id) REFERENCES execution_graphs(graph_id) ON DELETE CASCADE,
+      FOREIGN KEY (from_node_id) REFERENCES execution_graph_nodes(node_id) ON DELETE CASCADE,
+      FOREIGN KEY (to_node_id) REFERENCES execution_graph_nodes(node_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_execution_graph_edges_target
+      ON execution_graph_edges(graph_id, to_node_id);
+    CREATE TABLE IF NOT EXISTS execution_node_attempts (
+      node_execution_id TEXT PRIMARY KEY,
+      graph_id TEXT NOT NULL,
+      node_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      state TEXT NOT NULL,
+      output_ref TEXT,
+      verification_ref TEXT,
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      FOREIGN KEY (graph_id) REFERENCES execution_graphs(graph_id) ON DELETE CASCADE,
+      FOREIGN KEY (node_id) REFERENCES execution_graph_nodes(node_id) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (node_id, attempt_id, generation)
+    );
+    CREATE INDEX IF NOT EXISTS idx_execution_node_attempts_active
+      ON execution_node_attempts(job_id, state, started_at);
+    CREATE TABLE IF NOT EXISTS execution_graph_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      graph_id TEXT NOT NULL,
+      graph_sequence INTEGER NOT NULL,
+      job_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      producer TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (graph_id) REFERENCES execution_graphs(graph_id) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (graph_id, graph_sequence),
+      UNIQUE (graph_id, idempotency_key)
+    );
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1161,6 +1246,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 21, name: 'v4.15.1 - durable input and approval authority', apply: applyV21 },
   { version: 22, name: 'durable effect contracts', apply: applyV22 },
   { version: 23, name: 'append-only effect reconciliation', apply: applyV23 },
+  { version: 24, name: 'durable execution graph', apply: applyV24 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1279,6 +1279,32 @@ function applyV26(db: Database.Database): void {
   ]);
 }
 
+/** Durable execution contract and attributed result for delegated child Jobs. */
+function applyV27(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS child_job_contracts (
+      child_job_id TEXT PRIMARY KEY,
+      parent_job_id TEXT NOT NULL,
+      required INTEGER NOT NULL DEFAULT 1,
+      worker_id TEXT NOT NULL,
+      capabilities_json TEXT NOT NULL,
+      allowed_resources_json TEXT NOT NULL,
+      budget_json TEXT NOT NULL,
+      result_attempt_id TEXT,
+      result_generation INTEGER,
+      result_status TEXT,
+      evidence_json TEXT,
+      evidence_handles_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (parent_job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_child_job_contracts_parent
+      ON child_job_contracts(parent_job_id, required, child_job_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1306,6 +1332,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 24, name: 'durable execution graph', apply: applyV24 },
   { version: 25, name: 'durable waits and continuations', apply: applyV25 },
   { version: 26, name: 'exact approval fence binding', apply: applyV26 },
+  { version: 27, name: 'durable child Job contracts', apply: applyV27 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1272,6 +1272,13 @@ function applyV25(db: Database.Database): void {
   `);
 }
 
+/** Bind each durable Approval to the exact lease fence that requested it. */
+function applyV26(db: Database.Database): void {
+  addMissingColumns(db, 'approvals', [
+    ['fence_token_digest', 'TEXT'],
+  ]);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1298,6 +1305,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 23, name: 'append-only effect reconciliation', apply: applyV23 },
   { version: 24, name: 'durable execution graph', apply: applyV24 },
   { version: 25, name: 'durable waits and continuations', apply: applyV25 },
+  { version: 26, name: 'exact approval fence binding', apply: applyV26 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1351,6 +1351,73 @@ function applyV28(db: Database.Database): void {
   `);
 }
 
+/** Attempt-attributed claims, evidence, immutable verdicts, and late-review history. */
+function applyV29(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_claims (
+      claim_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT,
+      generation INTEGER,
+      category TEXT NOT NULL,
+      statement TEXT NOT NULL,
+      required INTEGER NOT NULL DEFAULT 0,
+      state TEXT NOT NULL DEFAULT 'unverified',
+      created_at INTEGER NOT NULL,
+      checked_at INTEGER,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_claims_job
+      ON job_claims(job_id, category, required, created_at);
+    CREATE TABLE IF NOT EXISTS job_evidence (
+      evidence_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      effect_id TEXT,
+      source TEXT NOT NULL,
+      producer TEXT NOT NULL,
+      captured_at INTEGER NOT NULL,
+      observed_at INTEGER NOT NULL,
+      fresh_until INTEGER,
+      integrity_sha256 TEXT NOT NULL,
+      coverage TEXT NOT NULL,
+      verification_result TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      late INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_evidence_attempt
+      ON job_evidence(job_id, attempt_id, generation, captured_at);
+    CREATE TABLE IF NOT EXISTS claim_evidence (
+      claim_id TEXT NOT NULL,
+      evidence_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (claim_id, evidence_id),
+      FOREIGN KEY (claim_id) REFERENCES job_claims(claim_id) ON DELETE CASCADE,
+      FOREIGN KEY (evidence_id) REFERENCES job_evidence(evidence_id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS job_verdicts (
+      job_id TEXT PRIMARY KEY,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      verdict TEXT NOT NULL,
+      summary_json TEXT NOT NULL,
+      finalized_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS proof_reviews (
+      review_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_id TEXT NOT NULL,
+      evidence_id TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (evidence_id) REFERENCES job_evidence(evidence_id) ON DELETE CASCADE
+    );
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1380,6 +1447,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 26, name: 'exact approval fence binding', apply: applyV26 },
   { version: 27, name: 'durable child Job contracts', apply: applyV27 },
   { version: 28, name: 'durable budgets and capabilities', apply: applyV28 },
+  { version: 29, name: 'durable claims evidence and verdicts', apply: applyV29 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/dispatcher/agentRunner.ts
+++ b/core/v4/daemon/dispatcher/agentRunner.ts
@@ -40,6 +40,7 @@ import type { Message } from '../../../../providers/v4/types';
 import type { TriggerSource } from '../types';
 import type { RunStore } from '../runStore';
 import type { JobEngine } from '../jobEngine';
+import { executeDurableJob, type DurableJobFinalization } from '../jobLifecycle';
 // v4.10 Slice 10.2b — shared event taxonomy.
 import { categorizeEvent } from '../eventCategories';
 
@@ -79,6 +80,8 @@ export interface DaemonAgentInput {
     jobId: string;
     attemptId: string;
     runId: number;
+    generation?: number;
+    fenceToken?: string;
   };
   /**
    * v4.13 Gap 4 — set when this invocation RESUMES a dead run. The
@@ -102,6 +105,8 @@ export interface DaemonAgentResult {
   totalTokens?: number;
   /** Populated when finishReason === 'error'. */
   error?:       string;
+  /** Verification-derived settlement supplied to the durable lifecycle. */
+  finalization?: DurableJobFinalization;
 }
 
 /** The function-shaped agent invocation seam. */
@@ -140,102 +145,59 @@ export function buildInitialHistory(input: DaemonAgentInput): Message[] {
  * "delivery" happened (logs only) so operators can verify the
  * code path via run_events without yet wiring a transport.
  */
-export function deliverOnlyStub(
+export async function deliverOnlyStub(
   input: DaemonAgentInput,
   runStore: RunStore,
   jobEngine?: JobEngine,
-): DaemonAgentResult {
+): Promise<DaemonAgentResult> {
   if (jobEngine) {
-    const admitted = input.admission ?? jobEngine.submitJob({
-      entryPoint: 'daemon',
-      source: input.triggerContext.source,
-      sessionId: input.sessionId,
-      instanceId: input.instanceId,
-      idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
-      idempotencyKey: String(input.triggerEventId),
-      goal: input.initialMessage,
-      title: input.initialMessage,
-      triggerEventId: input.triggerEventId,
-    });
-    const job = jobEngine.getJob(admitted.jobId);
-    const attempt = jobEngine.getAttempt(admitted.attemptId);
-    if (!job || !attempt || attempt.rowId !== admitted.runId || job.activeAttemptId !== admitted.attemptId) {
-      throw new Error('Durable delivery admission does not resolve to the active Attempt');
-    }
-    const lease = jobEngine.claimAttempt({
-      attemptId: admitted.attemptId, ownerId: input.instanceId, ttlMs: 30_000,
-    });
-    if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
-      throw new Error(`Durable delivery lease unavailable: ${lease.conflict ?? 'unknown'}`);
-    }
-    const attemptStarted = jobEngine.transitionAttempt({
-      attemptId: admitted.attemptId,
-      expectedStateVersion: lease.stateVersion,
-      generation: lease.generation,
-      fenceToken: lease.fenceToken,
-      to: 'running',
-      eventIdempotencyKey: `attempt-running:${admitted.attemptId}:${lease.generation}`,
-      producer: 'daemon-delivery',
-    });
-    const jobStarted = jobEngine.transitionJob({
-      jobId: admitted.jobId,
-      attemptId: admitted.attemptId,
-      generation: lease.generation,
-      fenceToken: lease.fenceToken,
-      expectedStateVersion: job.stateVersion,
-      to: 'running',
-      eventIdempotencyKey: `job-running:${admitted.jobId}:${lease.generation}`,
-      producer: 'daemon-delivery',
-    });
-    if (!attemptStarted.applied || attemptStarted.stateVersion === undefined || !jobStarted.applied || jobStarted.stateVersion === undefined) {
-      throw new Error('Durable delivery start was rejected');
-    }
-    const tags = categorizeEvent('delivered');
-    runStore.emitEventRich({
-      runId: admitted.runId,
-      category: tags.category,
-      kind: tags.kind,
-      name: 'delivered',
-      sessionId: input.sessionId,
-      status: 'ok',
-      summary: `delivered ${input.triggerContext.source}/${input.triggerContext.triggerId}`,
-      payload: {
-        source: input.triggerContext.source,
-        triggerId: input.triggerContext.triggerId,
-        eventId: input.triggerEventId,
-        messageBytes: input.initialMessage.length,
-        deliverOnly: true,
+    const execution = await executeDurableJob({
+      engine: jobEngine,
+      ownerId: input.instanceId,
+      leaseTtlMs: 30_000,
+      admission: input.admission
+        ? { existing: { ...input.admission, reused: true }, source: 'daemon-delivery' }
+        : {
+          entryPoint: 'daemon',
+          source: input.triggerContext.source,
+          sessionId: input.sessionId,
+          instanceId: input.instanceId,
+          idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
+          idempotencyKey: String(input.triggerEventId),
+          goal: input.initialMessage,
+          title: input.initialMessage,
+          triggerEventId: input.triggerEventId,
+        },
+      execute: async (handle) => {
+        const tags = categorizeEvent('delivered');
+        runStore.emitEventRich({
+          runId: handle.runId,
+          category: tags.category,
+          kind: tags.kind,
+          name: 'delivered',
+          sessionId: input.sessionId,
+          status: 'ok',
+          summary: `delivered ${input.triggerContext.source}/${input.triggerContext.triggerId}`,
+          payload: {
+            source: input.triggerContext.source,
+            triggerId: input.triggerContext.triggerId,
+            eventId: input.triggerEventId,
+            messageBytes: input.initialMessage.length,
+            deliverOnly: true,
+          },
+          visibility: 'system',
+          source: 'daemon',
+        });
+        return { runId: handle.runId, finishReason: 'delivered' as const };
       },
-      visibility: 'system',
-      source: 'daemon',
+      finalize: () => ({
+        status: 'completed',
+        outcome: 'delivered',
+        finishReason: 'delivered',
+        evidence: { delivered: true, messageBytes: input.initialMessage.length },
+      }),
     });
-    const attemptFinished = jobEngine.transitionAttempt({
-      attemptId: admitted.attemptId,
-      expectedStateVersion: attemptStarted.stateVersion,
-      generation: lease.generation,
-      fenceToken: lease.fenceToken,
-      to: 'succeeded',
-      eventIdempotencyKey: `attempt-succeeded:${admitted.attemptId}:${lease.generation}`,
-      producer: 'daemon-delivery',
-      finishReason: 'delivered',
-    });
-    const jobFinished = jobEngine.finalizeJob({
-      jobId: admitted.jobId,
-      attemptId: admitted.attemptId,
-      generation: lease.generation,
-      fenceToken: lease.fenceToken,
-      expectedStateVersion: jobStarted.stateVersion,
-      status: 'completed',
-      outcome: 'delivered',
-      finishReason: 'delivered',
-      evidence: { delivered: true, messageBytes: input.initialMessage.length },
-      eventIdempotencyKey: `job-finalized:${admitted.jobId}:${lease.generation}`,
-      producer: 'daemon-delivery',
-    });
-    if (!attemptFinished.applied || !jobFinished.applied) {
-      throw new Error('Durable delivery finalization was rejected');
-    }
-    return { runId: admitted.runId, finishReason: 'delivered' };
+    return execution.value;
   }
   const runId = runStore.create({
     sessionId:      input.sessionId,

--- a/core/v4/daemon/dispatcher/dispatcher.ts
+++ b/core/v4/daemon/dispatcher/dispatcher.ts
@@ -49,6 +49,7 @@ import type { RunStore } from '../runStore';
 import type { ClaimedEvent, TriggerSource } from '../types';
 import type { Db } from '../db/connection';
 import type { JobEngine } from '../jobEngine';
+import { admitDurableJob } from '../jobLifecycle';
 import type { TriggerRowSql } from '../db/schema/v1.spec';
 import {
   buildTriggerSessionId,
@@ -345,7 +346,7 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
         && typeof durable.run_id === 'number'
           ? { jobId: durable.job_id, attemptId: durable.attempt_id, runId: durable.run_id }
           : undefined;
-      const admission = existingAdmission ?? opts.jobEngine?.submitJob({
+      const admission = existingAdmission ?? (opts.jobEngine ? admitDurableJob(opts.jobEngine, {
         entryPoint: 'daemon_trigger',
         source: event.source,
         sessionId,
@@ -355,7 +356,7 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
         requestFingerprint: event.idempotencyKey ?? String(event.id),
         goal: message,
         triggerEventId: event.id,
-      });
+      }) : undefined);
       const input: DaemonAgentInput = {
         sessionId,
         instanceId:     opts.instanceId,
@@ -369,7 +370,7 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
 
       let result: DaemonAgentResult;
       if (deliverOnly) {
-        result = deliverOnlyStub(input, opts.runStore, opts.jobEngine);
+        result = await deliverOnlyStub(input, opts.runStore, opts.jobEngine);
         _stats.deliverOnly += 1;
       } else {
         if (!runner) {

--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -80,8 +80,8 @@ import { mapTaskOutcomePresentation, taskOutcomeInputFromFinalization } from '..
 import { emitArtifactVerified, emitCostUpdated, type PillarEventSink } from '../../pillarEvents';
 import type { TaskStore } from '../taskStore';
 import type { JobEngine } from '../jobEngine';
-import { createJobControlAuthority } from '../jobControlAuthority';
-import { runWithJobExecutionContext } from '../jobExecutionContext';
+import { createJobControlAuthority, type JobControlAuthority } from '../jobControlAuthority';
+import { executeDurableJob, type DurableJobHandle } from '../jobLifecycle';
 import {
   resolveDaemonModel,
 } from './resolveModel';
@@ -160,6 +160,10 @@ export interface CreateRealAgentRunnerOptions {
   dailyBudget?:      number | null;
   /** Test-only override clock. */
   now?:              () => number;
+  /** Existing authority used by a canonical lifecycle projection adapter. */
+  jobControlAuthority?: JobControlAuthority;
+  /** Canonical Attempt cancellation signal supplied to the execution adapter. */
+  executionSignal?: AbortSignal;
 }
 
 // ── Implementation ─────────────────────────────────────────────────────────
@@ -181,185 +185,25 @@ export function createRealAgentRunner(
         entryPoint: 'daemon',
       })
     : createDailyBudgetTracker({ db: opts.db, budget: configuredBudget });
-  const jobControls = opts.jobEngine
+  const jobControls = opts.jobControlAuthority ?? (opts.jobEngine
     ? createJobControlAuthority({ db: opts.db, jobEngine: opts.jobEngine })
-    : null;
+    : null);
+
+  if (opts.jobEngine && jobControls) {
+    const durableOptions = { ...opts, jobEngine: opts.jobEngine };
+    return {
+      invoke: (input) => invokeDurableDaemon(input, durableOptions, jobControls),
+    };
+  }
 
   return {
     async invoke(input: DaemonAgentInput): Promise<DaemonAgentResult> {
       const dailyBudget = opts.dailyBudget ?? readDailyBudgetFromEnv();
-      let durableJobId: string | null = null;
-      let durableAttemptId: string | null = null;
-      let durableRunId: number | null = null;
-      let durableGeneration: number | null = null;
-      let durableFenceToken: string | null = null;
-      let durableJobVersion = 0;
-      let durableAttemptVersion = 0;
-      let durableLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
-      let durableControlWatcher: ReturnType<typeof setInterval> | null = null;
-      const durableAbort = new AbortController();
+      let durableJobId: string | null = input.admission?.jobId ?? null;
+      let durableAttemptId: string | null = input.admission?.attemptId ?? null;
+      let durableRunId: number | null = input.admission?.runId ?? null;
+      let durableGeneration: number | null = input.admission?.generation ?? null;
       let pausedAtBoundary = false;
-      const stopDurableHeartbeat = (): void => {
-        if (durableLeaseHeartbeat !== null) {
-          clearInterval(durableLeaseHeartbeat);
-          durableLeaseHeartbeat = null;
-        }
-        if (durableControlWatcher !== null) {
-          clearInterval(durableControlWatcher);
-          durableControlWatcher = null;
-        }
-      };
-      const finishDurable = (input2: {
-        status: 'completed' | 'failed' | 'cancelled';
-        attemptStatus: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | 'unknown';
-        outcome: string;
-        finishReason: string;
-        evidence: unknown;
-        jobCard?: Parameters<JobEngine['finalizeJob']>[0]['jobCard'];
-      }): void => {
-        if (!opts.jobEngine || !durableJobId || !durableAttemptId || durableGeneration === null || !durableFenceToken) return;
-        stopDurableHeartbeat();
-        const attempt = opts.jobEngine.transitionAttempt({
-          attemptId: durableAttemptId,
-          expectedStateVersion: durableAttemptVersion,
-          generation: durableGeneration,
-          fenceToken: durableFenceToken,
-          to: input2.attemptStatus,
-          eventIdempotencyKey: `attempt-${input2.attemptStatus}:${durableAttemptId}:${durableGeneration}`,
-          producer: 'daemon',
-          finishReason: input2.finishReason,
-          now: now(),
-        });
-        if (!attempt.applied) throw new Error(`Durable daemon Attempt finalization rejected: ${attempt.conflict ?? 'unknown'}`);
-        const job = opts.jobEngine.finalizeJob({
-          jobId: durableJobId,
-          attemptId: durableAttemptId,
-          generation: durableGeneration,
-          fenceToken: durableFenceToken,
-          expectedStateVersion: durableJobVersion,
-          status: input2.status,
-          outcome: input2.outcome,
-          finishReason: input2.finishReason,
-          evidence: input2.evidence,
-          jobCard: input2.jobCard,
-          eventIdempotencyKey: `job-finalized:${durableJobId}:${durableGeneration}`,
-          producer: 'daemon',
-        });
-        if (!job.applied) throw new Error(`Durable daemon Job finalization rejected: ${job.conflict ?? 'unknown'}`);
-      };
-
-      if (opts.jobEngine) {
-        let admitted: { jobId: string; attemptId: string; runId: number };
-        if (input.admission) {
-          const admittedJob = opts.jobEngine.getJob(input.admission.jobId);
-          const admittedAttempt = opts.jobEngine.getAttempt(input.admission.attemptId);
-          if (
-            !admittedJob
-            || !admittedAttempt
-            || admittedAttempt.rowId !== input.admission.runId
-            || admittedAttempt.jobId !== input.admission.jobId
-            || admittedJob.activeAttemptId !== input.admission.attemptId
-          ) {
-            throw new Error('Durable daemon admission does not resolve to the active Attempt');
-          }
-          admitted = input.admission;
-        } else if (input.resume?.taskId && opts.jobEngine.getJob(input.resume.taskId)) {
-          const prior = opts.jobEngine.listAttempts(input.resume.taskId)
-            .find((attempt) => attempt.rowId === input.resume!.ofRunId);
-          if (!prior) throw new Error(`Durable recovery Attempt not found for run ${input.resume.ofRunId}`);
-          const recovery = opts.jobEngine.createRecoveryAttempt({
-            jobId: input.resume.taskId,
-            recoveryOfAttemptId: prior.id,
-            instanceId: input.instanceId,
-            triggerReason: 'resume',
-            eventIdempotencyKey: `attempt-resume:${input.triggerEventId}`,
-            producer: 'daemon',
-          });
-          admitted = { jobId: input.resume.taskId, attemptId: recovery.attemptId, runId: recovery.runId };
-        } else {
-          admitted = opts.jobEngine.submitJob({
-            entryPoint: 'daemon',
-            source: input.triggerContext.source,
-            sessionId: input.sessionId,
-            instanceId: input.instanceId,
-            idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
-            idempotencyKey: String(input.triggerEventId),
-            goal: input.initialMessage,
-            title: input.initialMessage,
-            triggerEventId: input.triggerEventId,
-          });
-        }
-        durableJobId = admitted.jobId;
-        durableAttemptId = admitted.attemptId;
-        durableRunId = admitted.runId;
-        durableJobVersion = opts.jobEngine.getJob(admitted.jobId)?.stateVersion ?? 0;
-        const lease = opts.jobEngine.claimAttempt({
-          attemptId: admitted.attemptId, ownerId: input.instanceId, ttlMs: 60_000, now: now(),
-        });
-        if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
-          throw new Error(`Durable daemon Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
-        }
-        durableGeneration = lease.generation;
-        durableFenceToken = lease.fenceToken;
-        durableAttemptVersion = lease.stateVersion;
-        const attemptStarted = opts.jobEngine.transitionAttempt({
-          attemptId: admitted.attemptId,
-          expectedStateVersion: durableAttemptVersion,
-          generation: durableGeneration,
-          fenceToken: durableFenceToken,
-          to: 'running',
-          eventIdempotencyKey: `attempt-running:${admitted.attemptId}:${durableGeneration}`,
-          producer: 'daemon',
-          now: now(),
-        });
-        if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
-          throw new Error(`Durable daemon Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`);
-        }
-        durableAttemptVersion = attemptStarted.stateVersion;
-        const jobStarted = opts.jobEngine.transitionJob({
-          jobId: admitted.jobId,
-          attemptId: admitted.attemptId,
-          generation: durableGeneration,
-          fenceToken: durableFenceToken,
-          expectedStateVersion: durableJobVersion,
-          to: 'running',
-          eventIdempotencyKey: `job-running:${admitted.jobId}:${durableGeneration}`,
-          producer: 'daemon',
-        });
-        if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
-          throw new Error(`Durable daemon Job start rejected: ${jobStarted.conflict ?? 'unknown'}`);
-        }
-        durableJobVersion = jobStarted.stateVersion;
-        durableLeaseHeartbeat = setInterval(() => {
-          if (!opts.jobEngine || !durableAttemptId || durableGeneration === null || !durableFenceToken) return;
-          const renewed = opts.jobEngine.renewAttemptLease({
-            attemptId: durableAttemptId,
-            ownerId: input.instanceId,
-            generation: durableGeneration,
-            fenceToken: durableFenceToken,
-            ttlMs: 60_000,
-            now: now(),
-          });
-          if (!renewed.applied || renewed.stateVersion === undefined) {
-            stopDurableHeartbeat();
-            durableAbort.abort(new Error(`Durable daemon lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
-            return;
-          }
-          durableAttemptVersion = renewed.stateVersion;
-        }, 20_000);
-        durableLeaseHeartbeat.unref?.();
-        // Commands can be written by another process (Workbench/API). Observe
-        // the authoritative Job row and physically abort the active provider or
-        // tool when cancellation wins, rather than merely changing a status.
-        durableControlWatcher = setInterval(() => {
-          if (!opts.jobEngine || !durableJobId || durableAbort.signal.aborted) return;
-          const status = opts.jobEngine.getJob(durableJobId)?.status;
-          if (status === 'cancelled' || status === 'cancelling') {
-            durableAbort.abort(new Error('Durable Job cancellation requested'));
-          }
-        }, 250);
-        durableControlWatcher.unref?.();
-      }
 
       // ── 1: pre-turn budget gate ────────────────────────────────────────
       const verdict = evaluatePreTurn({ tracker, dailyBudget, now: now() });
@@ -385,14 +229,7 @@ export function createRealAgentRunner(
           visibility: 'system',
           source:     'daemon',
         });
-        if (opts.jobEngine) {
-          finishDurable({
-            status: 'failed', attemptStatus: 'failed', outcome: 'failed',
-            finishReason: 'budget_exhausted', evidence: { reason: 'budget_exhausted' },
-          });
-        } else {
-          opts.runStore.setStatus(runId, 'failed', { finishReason: 'budget_exhausted' });
-        }
+        opts.runStore.setStatus(runId, 'failed', { finishReason: 'budget_exhausted' });
         log('warn', `[real-runner] rejected eventId=${input.triggerEventId}: ${verdict.reason}`);
         return {
           runId,
@@ -430,7 +267,7 @@ export function createRealAgentRunner(
       // resume (the card accumulates evidence across attempts). Best-
       // effort — a card failure never blocks dispatch.
       let taskId: string | null = durableJobId;
-      if (!opts.jobEngine && opts.taskStore) {
+      if (opts.taskStore) {
         try {
           if (input.resume?.taskId && opts.taskStore.get(input.resume.taskId)) {
             taskId = input.resume.taskId;
@@ -531,14 +368,7 @@ export function createRealAgentRunner(
           visibility:'system',
           source:    'daemon',
         });
-        if (opts.jobEngine) {
-          finishDurable({
-            status: 'failed', attemptStatus: 'failed', outcome: 'failed',
-            finishReason: 'error', evidence: { errorClass: e instanceof Error ? e.name : 'Error' },
-          });
-        } else {
-          opts.runStore.setStatus(runId, 'failed', { finishReason: 'error' });
-        }
+        opts.runStore.setStatus(runId, 'failed', { finishReason: 'error' });
         return { runId, finishReason: 'error', error: msg };
       }
 
@@ -549,9 +379,11 @@ export function createRealAgentRunner(
       // status) feeds the verify-before-done gate below, same as the REPL.
       let declaredTaskStatus: string | null = null;
       try {
-        const invocationSignal = opts.jobEngine
-          ? AbortSignal.any([perTurnWatcher.signal, durableAbort.signal])
-          : perTurnWatcher.signal;
+        const invocationSignals = [perTurnWatcher.signal];
+        if (opts.executionSignal) invocationSignals.push(opts.executionSignal);
+        const invocationSignal = invocationSignals.length === 1
+          ? invocationSignals[0]!
+          : AbortSignal.any(invocationSignals);
         const invokeAgent = () => runWithProviderUsageContext({
           sessionId: input.sessionId,
           taskId,
@@ -571,10 +403,6 @@ export function createRealAgentRunner(
             const paused = jobControls.commands.applyPendingAtBoundary({ jobId: durableJobId, now: now() });
             if (!paused.applied) return;
             pausedAtBoundary = true;
-            if (durableLeaseHeartbeat !== null) {
-              clearInterval(durableLeaseHeartbeat);
-              durableLeaseHeartbeat = null;
-            }
             throw new Error('Durable Job paused at safe boundary');
           },
           // The agent honours its own abort signal via per-tool aborts;
@@ -615,16 +443,7 @@ export function createRealAgentRunner(
             } catch { /* persistence faults must never break dispatch */ }
           },
         }));
-        result = opts.jobEngine && durableJobId && durableAttemptId && durableGeneration !== null && durableFenceToken
-          ? await runWithJobExecutionContext({
-              engine: opts.jobEngine,
-              jobId: durableJobId,
-              attemptId: durableAttemptId,
-              generation: durableGeneration,
-              fenceToken: durableFenceToken,
-              producer: 'daemon',
-            }, invokeAgent)
-          : await invokeAgent();
+        result = await invokeAgent();
         // Stamp the actual token usage onto the watcher for the
         // post-turn snapshot below.
         const tokens = extractLedgerTokens(runId) ?? extractTokens(result);
@@ -635,7 +454,6 @@ export function createRealAgentRunner(
       }
 
       if (pausedAtBoundary) {
-        stopDurableHeartbeat();
         try {
           opts.runStore.emitEventRich({
             runId,
@@ -651,11 +469,6 @@ export function createRealAgentRunner(
           });
         } catch { /* the authoritative Job event is already durable */ }
         return { runId, finishReason: 'interrupted', error: 'paused' };
-      }
-
-      if (opts.jobEngine && durableJobId && opts.jobEngine.getJob(durableJobId)?.status === 'cancelled') {
-        stopDurableHeartbeat();
-        return { runId, finishReason: 'interrupted', error: 'cancelled' };
       }
 
       if (durableJobId && durableAttemptId && durableGeneration !== null) {
@@ -739,65 +552,59 @@ export function createRealAgentRunner(
         finishReason === 'budget_exhausted'  ? 'failed'    :
         finishReason === 'error'             ? 'failed'    :
         finishReason === 'tool_loop'         ? 'failed'    : 'completed';
-      if (opts.jobEngine) {
-        const fin = computeTaskFinalization(
-          {
-            finishReason: finishReason === 'delivered' ? 'stop' : finishReason,
-            toolCallTrace: result?.toolCallTrace,
-            declaredStatus: declaredTaskStatus,
-          },
-          { approvalMode: approvalPolicy, now: now() },
-        );
-        const jobStatus = finishReason === 'interrupted'
-          ? 'cancelled'
-          : finishReason === 'stop' || finishReason === 'delivered'
-            ? (fin.status === 'completed' || fin.status === 'completed_unverified' ? 'completed' : 'failed')
-            : 'failed';
-        finishDurable({
-          status: jobStatus,
-          attemptStatus: jobStatus === 'completed' ? 'succeeded' : jobStatus === 'cancelled' ? 'cancelled' : 'failed',
-          outcome: fin.status,
-          finishReason,
-          evidence: fin.evidence,
-          jobCard: fin.jobCard,
-        });
-      } else {
-        opts.runStore.setStatus(runId, runStatus, { finishReason });
-      }
+      const durableVerification = computeTaskFinalization(
+        {
+          finishReason: finishReason === 'delivered' ? 'stop' : finishReason,
+          toolCallTrace: result?.toolCallTrace,
+          declaredStatus: declaredTaskStatus,
+        },
+        { approvalMode: approvalPolicy, now: now() },
+      );
+      const durableJobStatus = finishReason === 'interrupted'
+        ? 'cancelled'
+        : finishReason === 'stop' || finishReason === 'delivered'
+          ? (durableVerification.status === 'completed' || durableVerification.status === 'completed_unverified'
+            ? 'completed'
+            : 'failed')
+          : 'failed';
+      const durableFinalization = {
+        status: durableJobStatus,
+        outcome: durableVerification.status,
+        finishReason,
+        evidence: durableVerification.evidence,
+        jobCard: durableVerification.jobCard,
+      } as const;
+      opts.runStore.setStatus(runId, runStatus, { finishReason });
 
       // v4.13 Gap 4 — finalize the job-card through the SAME verify-
       // before-done gate the REPL uses (computeTaskFinalization): a
       // daemon task can no more complete on prose than a REPL one.
       // pending_verification lands first (crash honesty), then the
       // verdict + evidence + card in one UPDATE. Best-effort.
-      if (!opts.jobEngine && opts.taskStore && taskId) {
+      if (opts.taskStore && taskId) {
         try {
-          const fin = computeTaskFinalization(
-            {
-              // 'delivered' is a successful non-agent finish; treat as clean.
-              finishReason:   finishReason === 'delivered' ? 'stop' : finishReason,
-              toolCallTrace:  result?.toolCallTrace,
-              declaredStatus: declaredTaskStatus,
-            },
-            { approvalMode: approvalPolicy, now: now() },
-          );
           const presentation = mapTaskOutcomePresentation(taskOutcomeInputFromFinalization({
-            finalization: fin,
+            finalization: durableVerification,
             trace: result?.toolCallTrace,
             finishReason: finishReason === 'delivered' ? 'stop' : finishReason,
             taskId: taskId ?? undefined,
           }));
           if (result) result.taskOutcome = presentation;
           opts.taskStore.setStatus(taskId, 'pending_verification');
-          opts.taskStore.finalizeVerification(taskId, fin.status, fin.evidence, fin.jobCard);
+          opts.taskStore.finalizeVerification(
+            taskId,
+            durableVerification.status,
+            durableVerification.evidence,
+            durableVerification.jobCard,
+          );
           // v4.14 Pillar 5 Slice C — artifact_verified onto the run's stream.
           try {
             emitArtifactVerified(
               { runStore: opts.runStore as unknown as PillarEventSink['runStore'], runId },
               {
-                verdict:  fin.status,
-                outcome:  fin.outcome,
-                handles:  fin.evidence.handles?.length ?? 0,
+                verdict:  durableVerification.status,
+                outcome:  durableVerification.outcome,
+                handles:  durableVerification.evidence.handles?.length ?? 0,
                 taskId:   taskId ?? undefined,
                 presentation,
               },
@@ -823,12 +630,139 @@ export function createRealAgentRunner(
         finishReason,
         totalTokens: perTurnWatcher.used() > 0 ? perTurnWatcher.used() : undefined,
         error: invocationError ?? (perTurnWatcher.hit() ? perTurnWatcher.reason() ?? undefined : undefined),
+        finalization: durableFinalization,
       };
     },
   };
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+async function invokeDurableDaemon(
+  input: DaemonAgentInput,
+  opts: CreateRealAgentRunnerOptions & { jobEngine: JobEngine },
+  jobControls: JobControlAuthority,
+): Promise<DaemonAgentResult> {
+  let activeHandle: DurableJobHandle | null = null;
+  let projectedResult: DaemonAgentResult | null = null;
+  const admission = input.admission
+    ? { existing: { ...input.admission, reused: true }, source: 'daemon' } as const
+    : input.resume?.taskId && opts.jobEngine.getJob(input.resume.taskId)
+      ? (() => {
+        const prior = opts.jobEngine.listAttempts(input.resume!.taskId)
+          .find((attempt) => attempt.rowId === input.resume!.ofRunId);
+        if (!prior) throw new Error(`Durable recovery Attempt not found for run ${input.resume!.ofRunId}`);
+        return {
+          recovery: {
+            jobId: input.resume!.taskId,
+            recoveryOfAttemptId: prior.id,
+            instanceId: input.instanceId,
+            triggerReason: 'resume',
+            eventIdempotencyKey: `attempt-resume:${input.triggerEventId}`,
+            producer: 'daemon',
+          },
+          source: 'daemon',
+        } as const;
+      })()
+      : {
+        entryPoint: 'daemon',
+        source: input.triggerContext.source,
+        sessionId: input.sessionId,
+        instanceId: input.instanceId,
+        idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
+        idempotencyKey: String(input.triggerEventId),
+        goal: input.initialMessage,
+        title: input.initialMessage,
+        triggerEventId: input.triggerEventId,
+      };
+
+  try {
+    const execution = await executeDurableJob({
+      engine: opts.jobEngine,
+      ownerId: input.instanceId,
+      leaseTtlMs: 60_000,
+      admission,
+      controlAuthority: jobControls,
+      initialInput: {
+        sessionId: input.sessionId,
+        source: input.triggerContext.source,
+        kind: 'message',
+        content: input.initialMessage,
+        idempotencyNamespace: `daemon-input:${input.triggerContext.triggerId}`,
+        idempotencyKey: String(input.triggerEventId),
+      },
+      execute: async (handle) => {
+        activeHandle = handle;
+        const projectedRunStore: RunStore = {
+          ...opts.runStore,
+          create: () => handle.runId,
+          setStatus: () => { /* JobEngine owns the canonical Attempt row. */ },
+        };
+        const projectedRunner = createRealAgentRunner({
+          ...opts,
+          runStore: projectedRunStore,
+          jobEngine: undefined,
+          taskStore: undefined,
+          jobControlAuthority: jobControls,
+          executionSignal: handle.signal,
+          agentBuilder: (builderInput) => opts.agentBuilder({
+            ...builderInput,
+            abortSignal: AbortSignal.any([builderInput.abortSignal, handle.signal]),
+          }),
+        });
+        projectedResult = await projectedRunner.invoke({
+          ...input,
+          admission: {
+            jobId: handle.jobId,
+            attemptId: handle.attemptId,
+            runId: handle.runId,
+            generation: handle.generation,
+            fenceToken: handle.fenceToken,
+          },
+        });
+        if (opts.jobEngine.getJob(handle.jobId)?.status === 'cancelled') {
+          projectedResult = {
+            ...projectedResult,
+            finishReason: 'interrupted',
+            error: 'cancelled',
+            finalization: {
+              status: 'cancelled',
+              outcome: 'cancelled',
+              finishReason: 'interrupted',
+              evidence: { cancelled: true },
+            },
+          };
+        }
+        currentProviderAttemptLedger()?.reconcileJobLinkage({
+          taskId: handle.jobId,
+          runId: handle.runId,
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          attemptGeneration: handle.generation,
+        });
+        return projectedResult;
+      },
+      finalize: (result) => result.finalization ?? {
+        status: result.finishReason === 'interrupted' ? 'cancelled' : 'failed',
+        outcome: result.finishReason === 'interrupted' ? 'cancelled' : 'failed',
+        finishReason: result.finishReason,
+        evidence: { error: result.error ?? null },
+      },
+    });
+    return execution.value;
+  } catch (error) {
+    const identity = activeHandle;
+    const job = identity ? opts.jobEngine.getJob(identity.jobId) : null;
+    if (projectedResult && (job?.status === 'paused' || job?.status === 'cancelled')) {
+      return projectedResult;
+    }
+    return {
+      runId: identity?.runId ?? input.admission?.runId ?? 0,
+      finishReason: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
 
 /** Read the trigger spec row + extract Phase 7 spec fields. */
 function readTriggerSpec(db: Db, triggerId: string): {

--- a/core/v4/daemon/executionGraph.ts
+++ b/core/v4/daemon/executionGraph.ts
@@ -1,0 +1,471 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { Db } from './db/connection';
+
+export type ExecutionNodeKind =
+  | 'planning' | 'tool' | 'verification' | 'approval' | 'wait'
+  | 'child_job' | 'aggregation' | 'reconciliation' | 'finalization';
+export type ExecutionNodeState = 'pending' | 'runnable' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'blocked';
+
+export interface ExecutionNodeDefinition {
+  nodeId: string;
+  kind: ExecutionNodeKind;
+  dependsOn?: readonly string[];
+  label?: string | null;
+  inputRef?: string | null;
+  requiresVerification?: boolean;
+}
+
+export interface ExecutionGraphNode {
+  nodeId: string;
+  kind: ExecutionNodeKind;
+  state: ExecutionNodeState;
+  dependsOn: string[];
+  outputRef: string | null;
+  verificationRef: string | null;
+  stateVersion: number;
+}
+
+export interface ExecutionGraphEvent {
+  sequence: number;
+  type: string;
+  payload: Record<string, unknown>;
+  createdAt: number;
+}
+
+export interface GraphTransitionResult {
+  applied: boolean;
+  duplicate?: boolean;
+  conflict?: 'not_found' | 'state_version' | 'stale_fence' | 'illegal_transition' | 'terminal_job' | 'verification_required';
+}
+
+interface GraphAuthority {
+  create(command: {
+    jobId: string; planDigest: string; nodes: readonly ExecutionNodeDefinition[];
+    producer: string; idempotencyKey: string; now?: number;
+  }): { graphId: string; version: number; duplicate: boolean };
+  edit(command: {
+    jobId: string; expectedVersion: number; nodes?: readonly ExecutionNodeDefinition[];
+    edges?: readonly { from: string; to: string }[]; producer: string; idempotencyKey: string; now?: number;
+  }): { version: number; duplicate: boolean };
+  schedule(command: AuthorityCommand): string[];
+  claim(command: AuthorityCommand & { nodeId: string }): GraphTransitionResult;
+  complete(command: AuthorityCommand & {
+    nodeId: string; state: 'succeeded' | 'failed' | 'cancelled';
+    outputRef?: string | null; verificationRef?: string | null;
+  }): GraphTransitionResult;
+  recover(command: AuthorityCommand): string[];
+  settle(jobId: string, state: 'completed' | 'failed' | 'cancelled', producer: string, idempotencyKey: string, now?: number): GraphTransitionResult;
+  nodes(jobId: string): ExecutionGraphNode[];
+  events(jobId: string): ExecutionGraphEvent[];
+}
+
+interface AuthorityCommand {
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  fenceToken: string;
+  producer: string;
+  idempotencyKey: string;
+  now?: number;
+}
+
+interface GraphRow { graph_id: string; job_id: string; plan_digest: string; state: string; version: number; next_event_sequence: number }
+interface NodeRow {
+  node_id: string; node_key: string; graph_id: string; job_id: string; kind: ExecutionNodeKind;
+  state: ExecutionNodeState; output_ref: string | null; verification_ref: string | null;
+  requires_verification: number; state_version: number; created_at: number;
+  ordinal: number;
+}
+
+const TERMINAL_JOBS = new Set(['cancelled', 'completed', 'failed', 'dead_letter', 'completed_unverified', 'verification_failed', 'abandoned']);
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function validateDefinitions(nodes: readonly ExecutionNodeDefinition[], extraEdges: readonly { from: string; to: string }[] = []): void {
+  const ids = new Set(nodes.map((node) => node.nodeId));
+  if (ids.size !== nodes.length || [...ids].some((id) => !id || id.length > 160)) {
+    throw new Error('Execution graph node identities must be unique and bounded');
+  }
+  const edges = [
+    ...nodes.flatMap((node) => (node.dependsOn ?? []).map((from) => ({ from, to: node.nodeId }))),
+    ...extraEdges,
+  ];
+  for (const edge of edges) {
+    if (!ids.has(edge.from) || !ids.has(edge.to)) throw new Error('Execution graph edge references an unknown node');
+    if (edge.from === edge.to) throw new Error('Execution graph cycle detected');
+  }
+  const incoming = new Map([...ids].map((id) => [id, 0]));
+  const outgoing = new Map([...ids].map((id) => [id, [] as string[]]));
+  for (const edge of edges) {
+    incoming.set(edge.to, (incoming.get(edge.to) ?? 0) + 1);
+    outgoing.get(edge.from)!.push(edge.to);
+  }
+  const queue = [...incoming].filter(([, count]) => count === 0).map(([id]) => id);
+  let visited = 0;
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    visited += 1;
+    for (const target of outgoing.get(id) ?? []) {
+      const next = (incoming.get(target) ?? 0) - 1;
+      incoming.set(target, next);
+      if (next === 0) queue.push(target);
+    }
+  }
+  if (visited !== ids.size) throw new Error('Execution graph cycle detected');
+}
+
+export function createExecutionGraphAuthority(db: Db): GraphAuthority {
+  const graphFor = (jobId: string): GraphRow | undefined => db.prepare(
+    'SELECT graph_id, job_id, plan_digest, state, version, next_event_sequence FROM execution_graphs WHERE job_id = ?',
+  ).get(jobId) as GraphRow | undefined;
+  const physicalNodeId = (graphId: string, nodeKey: string): string => `node_${digest(`${graphId}\0${nodeKey}`)}`;
+  const appendEvent = (graph: GraphRow, type: string, payload: Record<string, unknown>, producer: string, idempotencyKey: string, now: number): boolean => {
+    const duplicate = db.prepare(
+      'SELECT 1 FROM execution_graph_events WHERE graph_id = ? AND idempotency_key = ?',
+    ).get(graph.graph_id, idempotencyKey);
+    if (duplicate) return false;
+    db.prepare(
+      `INSERT INTO execution_graph_events
+         (graph_id, graph_sequence, job_id, type, payload_json, producer, idempotency_key, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(graph.graph_id, graph.next_event_sequence, graph.job_id, type, JSON.stringify(payload), producer, idempotencyKey, now);
+    db.prepare('UPDATE execution_graphs SET next_event_sequence = next_event_sequence + 1, updated_at = ? WHERE graph_id = ?')
+      .run(now, graph.graph_id);
+    graph.next_event_sequence += 1;
+    return true;
+  };
+  const authority = (command: AuthorityCommand): { graph: GraphRow; ok: boolean; terminal: boolean } => {
+    const graph = graphFor(command.jobId);
+    if (!graph) throw new Error('Execution graph not found');
+    const row = db.prepare(
+      `SELECT t.status AS job_status, t.active_attempt_id,
+              r.status AS attempt_status, r.generation, r.fence_token,
+              r.lease_owner, r.lease_expires_at
+         FROM tasks t LEFT JOIN runs r ON r.attempt_id = ?
+        WHERE t.id = ?`,
+    ).get(command.attemptId, command.jobId) as {
+      job_status: string; active_attempt_id: string | null; attempt_status: string | null;
+      generation: number | null; fence_token: string | null; lease_owner: string | null; lease_expires_at: number | null;
+    } | undefined;
+    const terminal = !row || TERMINAL_JOBS.has(row.job_status) || graph.state === 'cancelled' || graph.state === 'completed';
+    const now = command.now ?? Date.now();
+    const ok = !terminal && row.active_attempt_id === command.attemptId
+      && row.generation === command.generation && row.fence_token === command.fenceToken
+      && row.lease_owner !== null && row.lease_expires_at !== null && row.lease_expires_at > now;
+    return { graph, ok, terminal };
+  };
+  const loadDefinitions = (graph: GraphRow, additions: readonly ExecutionNodeDefinition[] = [], edges: readonly { from: string; to: string }[] = []): ExecutionNodeDefinition[] => {
+    const current = db.prepare(
+      `SELECT n.node_key, n.kind, n.label, n.input_ref, n.requires_verification,
+              e.from_node_id
+         FROM execution_graph_nodes n
+         LEFT JOIN execution_graph_edges e ON e.to_node_id = n.node_id
+        WHERE n.graph_id = ? ORDER BY n.ordinal`,
+    ).all(graph.graph_id) as Array<{
+      node_key: string; kind: ExecutionNodeKind; label: string | null; input_ref: string | null;
+      requires_verification: number; from_node_id: string | null;
+    }>;
+    const physicalToKey = new Map((db.prepare(
+      'SELECT node_id, node_key FROM execution_graph_nodes WHERE graph_id = ?',
+    ).all(graph.graph_id) as Array<{ node_id: string; node_key: string }>).map((row) => [row.node_id, row.node_key]));
+    const byId = new Map<string, ExecutionNodeDefinition>();
+    for (const row of current) {
+      const existing = byId.get(row.node_key) ?? {
+        nodeId: row.node_key, kind: row.kind, label: row.label, inputRef: row.input_ref,
+        requiresVerification: row.requires_verification === 1, dependsOn: [],
+      };
+      if (row.from_node_id) (existing.dependsOn as string[]).push(physicalToKey.get(row.from_node_id)!);
+      byId.set(row.node_key, existing);
+    }
+    for (const node of additions) byId.set(node.nodeId, { ...node, dependsOn: [...(node.dependsOn ?? [])] });
+    for (const edge of edges) {
+      const target = byId.get(edge.to);
+      if (!target) continue;
+      target.dependsOn = [...(target.dependsOn ?? []), edge.from];
+    }
+    return [...byId.values()];
+  };
+
+  const createTx = db.transaction((command: Parameters<GraphAuthority['create']>[0]) => {
+    const existing = graphFor(command.jobId);
+    if (existing) {
+      if (existing.plan_digest !== command.planDigest) throw new Error('Execution graph already exists with a different plan digest');
+      return { graphId: existing.graph_id, version: existing.version, duplicate: true };
+    }
+    validateDefinitions(command.nodes);
+    const job = db.prepare('SELECT 1 FROM tasks WHERE id = ?').get(command.jobId);
+    if (!job) throw new Error('Execution graph Job not found');
+    const now = command.now ?? Date.now();
+    const graphId = `graph_${digest(command.jobId)}`;
+    db.prepare(
+      `INSERT INTO execution_graphs
+         (graph_id, job_id, plan_digest, state, version, next_event_sequence, created_at, updated_at)
+       VALUES (?, ?, ?, 'active', 1, 1, ?, ?)`,
+    ).run(graphId, command.jobId, command.planDigest, now, now);
+    const graph = graphFor(command.jobId)!;
+    for (const [ordinal, node] of command.nodes.entries()) {
+      db.prepare(
+        `INSERT INTO execution_graph_nodes
+           (node_id, node_key, graph_id, job_id, kind, state, label, input_ref,
+            requires_verification, ordinal, state_version, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, 0, ?, ?)`,
+      ).run(
+        physicalNodeId(graphId, node.nodeId), node.nodeId, graphId, command.jobId, node.kind,
+        node.label ?? null, node.inputRef ?? null, node.requiresVerification ? 1 : 0, ordinal, now, now,
+      );
+    }
+    for (const node of command.nodes) {
+      for (const dependency of node.dependsOn ?? []) {
+        db.prepare(
+          'INSERT INTO execution_graph_edges (graph_id, from_node_id, to_node_id, created_at) VALUES (?, ?, ?, ?)',
+        ).run(graphId, physicalNodeId(graphId, dependency), physicalNodeId(graphId, node.nodeId), now);
+      }
+    }
+    appendEvent(graph, 'graph.created', { planDigest: command.planDigest, nodeCount: command.nodes.length }, command.producer, command.idempotencyKey, now);
+    return { graphId, version: 1, duplicate: false };
+  }).immediate;
+
+  const editTx = db.transaction((command: Parameters<GraphAuthority['edit']>[0]) => {
+    const graph = graphFor(command.jobId);
+    if (!graph) throw new Error('Execution graph not found');
+    if (graph.state !== 'active') throw new Error('Execution graph is terminal');
+    const duplicate = db.prepare('SELECT 1 FROM execution_graph_events WHERE graph_id = ? AND idempotency_key = ?')
+      .get(graph.graph_id, command.idempotencyKey);
+    if (duplicate) return { version: graph.version, duplicate: true };
+    if (graph.version !== command.expectedVersion) throw new Error('Execution graph version changed concurrently');
+    const definitions = loadDefinitions(graph, command.nodes ?? [], command.edges ?? []);
+    validateDefinitions(definitions);
+    const now = command.now ?? Date.now();
+    const ordinalBase = (db.prepare('SELECT COALESCE(MAX(ordinal), -1) + 1 AS next FROM execution_graph_nodes WHERE graph_id = ?')
+      .get(graph.graph_id) as { next: number }).next;
+    for (const [offset, node] of (command.nodes ?? []).entries()) {
+      if (db.prepare('SELECT 1 FROM execution_graph_nodes WHERE graph_id = ? AND node_key = ?').get(graph.graph_id, node.nodeId)) {
+        throw new Error(`Execution graph node already exists: ${node.nodeId}`);
+      }
+      db.prepare(
+        `INSERT INTO execution_graph_nodes
+           (node_id, node_key, graph_id, job_id, kind, state, label, input_ref,
+            requires_verification, ordinal, state_version, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, 0, ?, ?)`,
+      ).run(
+        physicalNodeId(graph.graph_id, node.nodeId), node.nodeId, graph.graph_id, command.jobId,
+        node.kind, node.label ?? null, node.inputRef ?? null, node.requiresVerification ? 1 : 0, ordinalBase + offset, now, now,
+      );
+    }
+    const allEdges = [
+      ...(command.nodes ?? []).flatMap((node) => (node.dependsOn ?? []).map((from) => ({ from, to: node.nodeId }))),
+      ...(command.edges ?? []),
+    ];
+    for (const edge of allEdges) {
+      db.prepare('INSERT INTO execution_graph_edges (graph_id, from_node_id, to_node_id, created_at) VALUES (?, ?, ?, ?)')
+        .run(graph.graph_id, physicalNodeId(graph.graph_id, edge.from), physicalNodeId(graph.graph_id, edge.to), now);
+    }
+    db.prepare('UPDATE execution_graphs SET version = version + 1, updated_at = ? WHERE graph_id = ? AND version = ?')
+      .run(now, graph.graph_id, graph.version);
+    appendEvent(graph, 'graph.edited', {
+      addedNodes: (command.nodes ?? []).map((node) => node.nodeId), edges: allEdges,
+    }, command.producer, command.idempotencyKey, now);
+    return { version: graph.version + 1, duplicate: false };
+  }).immediate;
+
+  return {
+    create: createTx,
+    edit: editTx,
+    schedule(command) {
+      const result = authority(command);
+      if (result.terminal || !result.ok) return [];
+      const blocked = db.prepare(
+        `SELECT DISTINCT n.node_id, n.node_key
+           FROM execution_graph_nodes n
+           JOIN execution_graph_edges e ON e.to_node_id = n.node_id
+           JOIN execution_graph_nodes dependency ON dependency.node_id = e.from_node_id
+          WHERE n.graph_id = ? AND n.state = 'pending'
+            AND dependency.state IN ('failed','cancelled','blocked')
+          ORDER BY n.ordinal`,
+      ).all(result.graph.graph_id) as Array<{ node_id: string; node_key: string }>;
+      const rows = db.prepare(
+        `SELECT n.node_id, n.node_key
+           FROM execution_graph_nodes n
+          WHERE n.graph_id = ? AND n.state = 'pending'
+            AND NOT EXISTS (
+              SELECT 1 FROM execution_graph_edges e
+              JOIN execution_graph_nodes dependency ON dependency.node_id = e.from_node_id
+              WHERE e.to_node_id = n.node_id AND dependency.state <> 'succeeded'
+            )
+          ORDER BY n.ordinal`,
+      ).all(result.graph.graph_id) as Array<{ node_id: string; node_key: string }>;
+      if (rows.length === 0 && blocked.length === 0) return [];
+      const now = command.now ?? Date.now();
+      const tx = db.transaction(() => {
+        for (const row of blocked) {
+          db.prepare("UPDATE execution_graph_nodes SET state = 'blocked', state_version = state_version + 1, updated_at = ? WHERE node_id = ? AND state = 'pending'")
+            .run(now, row.node_id);
+        }
+        for (const row of rows) {
+          db.prepare("UPDATE execution_graph_nodes SET state = 'runnable', state_version = state_version + 1, updated_at = ? WHERE node_id = ? AND state = 'pending'")
+            .run(now, row.node_id);
+        }
+        appendEvent(result.graph, 'graph.nodes_scheduled', {
+          runnableNodeIds: rows.map((row) => row.node_key),
+          blockedNodeIds: blocked.map((row) => row.node_key),
+        }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return rows.map((row) => row.node_key);
+    },
+    claim(command) {
+      const result = authority(command);
+      if (result.terminal) return { applied: false, conflict: 'terminal_job' };
+      if (!result.ok) return { applied: false, conflict: 'stale_fence' };
+      const node = db.prepare(
+        'SELECT * FROM execution_graph_nodes WHERE graph_id = ? AND node_key = ?',
+      ).get(result.graph.graph_id, command.nodeId) as NodeRow | undefined;
+      if (!node) return { applied: false, conflict: 'not_found' };
+      if (node.state !== 'runnable') return { applied: false, conflict: 'illegal_transition' };
+      const now = command.now ?? Date.now();
+      const executionId = `nodeexec_${digest(`${node.node_id}\0${command.attemptId}\0${command.generation}`)}`;
+      const tx = db.transaction(() => {
+        db.prepare("UPDATE execution_graph_nodes SET state = 'running', state_version = state_version + 1, updated_at = ? WHERE node_id = ? AND state = 'runnable'")
+          .run(now, node.node_id);
+        db.prepare(
+          `INSERT INTO execution_node_attempts
+             (node_execution_id, graph_id, node_id, job_id, attempt_id, generation, state, started_at)
+           VALUES (?, ?, ?, ?, ?, ?, 'running', ?)`,
+        ).run(executionId, result.graph.graph_id, node.node_id, command.jobId, command.attemptId, command.generation, now);
+        appendEvent(result.graph, 'graph.node_started', {
+          nodeId: command.nodeId, nodeExecutionId: executionId, attemptId: command.attemptId, generation: command.generation,
+        }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return { applied: true };
+    },
+    complete(command) {
+      const result = authority(command);
+      if (result.terminal) return { applied: false, conflict: 'terminal_job' };
+      if (!result.ok) return { applied: false, conflict: 'stale_fence' };
+      const node = db.prepare(
+        'SELECT * FROM execution_graph_nodes WHERE graph_id = ? AND node_key = ?',
+      ).get(result.graph.graph_id, command.nodeId) as NodeRow | undefined;
+      if (!node) return { applied: false, conflict: 'not_found' };
+      if (node.state !== 'running') return { applied: false, conflict: 'illegal_transition' };
+      if (command.state === 'succeeded' && node.requires_verification === 1 && !command.verificationRef) {
+        return { applied: false, conflict: 'verification_required' };
+      }
+      const execution = db.prepare(
+        `SELECT node_execution_id FROM execution_node_attempts
+          WHERE node_id = ? AND attempt_id = ? AND generation = ? AND state = 'running'`,
+      ).get(node.node_id, command.attemptId, command.generation) as { node_execution_id: string } | undefined;
+      if (!execution) return { applied: false, conflict: 'stale_fence' };
+      const now = command.now ?? Date.now();
+      const tx = db.transaction(() => {
+        db.prepare(
+          `UPDATE execution_graph_nodes SET state = ?, output_ref = ?, verification_ref = ?,
+                  state_version = state_version + 1, updated_at = ? WHERE node_id = ? AND state = 'running'`,
+        ).run(command.state, command.outputRef ?? null, command.verificationRef ?? null, now, node.node_id);
+        db.prepare(
+          `UPDATE execution_node_attempts SET state = ?, output_ref = ?, verification_ref = ?, completed_at = ?
+            WHERE node_execution_id = ? AND state = 'running'`,
+        ).run(command.state, command.outputRef ?? null, command.verificationRef ?? null, now, execution.node_execution_id);
+        appendEvent(result.graph, `graph.node_${command.state}`, {
+          nodeId: command.nodeId, nodeExecutionId: execution.node_execution_id,
+          outputRef: command.outputRef ?? null, verificationRef: command.verificationRef ?? null,
+          attemptId: command.attemptId, generation: command.generation,
+        }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return { applied: true };
+    },
+    recover(command) {
+      const result = authority(command);
+      if (result.terminal || !result.ok) return [];
+      const rows = db.prepare(
+        `SELECT n.node_id, n.node_key, x.node_execution_id
+           FROM execution_graph_nodes n
+           JOIN execution_node_attempts x ON x.node_id = n.node_id
+          WHERE n.graph_id = ? AND n.state = 'running'
+            AND (x.attempt_id <> ? OR x.generation <> ?) AND x.state = 'running'
+          ORDER BY n.ordinal`,
+      ).all(result.graph.graph_id, command.attemptId, command.generation) as Array<{
+        node_id: string; node_key: string; node_execution_id: string;
+      }>;
+      if (rows.length === 0) return [];
+      const now = command.now ?? Date.now();
+      const tx = db.transaction(() => {
+        for (const row of rows) {
+          db.prepare("UPDATE execution_graph_nodes SET state = 'pending', state_version = state_version + 1, updated_at = ? WHERE node_id = ? AND state = 'running'")
+            .run(now, row.node_id);
+          db.prepare("UPDATE execution_node_attempts SET state = 'crashed', completed_at = ? WHERE node_execution_id = ? AND state = 'running'")
+            .run(now, row.node_execution_id);
+        }
+        appendEvent(result.graph, 'graph.recovered', { resetNodeIds: rows.map((row) => row.node_key) }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return rows.map((row) => row.node_key);
+    },
+    settle(jobId, state, producer, idempotencyKey, now = Date.now()) {
+      const graph = graphFor(jobId);
+      if (!graph) return { applied: false, conflict: 'not_found' };
+      if (graph.state === state) return { applied: false, duplicate: true };
+      if (graph.state !== 'active') return { applied: false, conflict: 'illegal_transition' };
+      if (state === 'completed') {
+        const unfinished = db.prepare(
+          "SELECT 1 FROM execution_graph_nodes WHERE graph_id = ? AND state <> 'succeeded' LIMIT 1",
+        ).get(graph.graph_id);
+        if (unfinished) return { applied: false, conflict: 'illegal_transition' };
+      }
+      const nodeState = state === 'cancelled' ? 'cancelled' : 'blocked';
+      const tx = db.transaction(() => {
+        db.prepare('UPDATE execution_graphs SET state = ?, version = version + 1, updated_at = ? WHERE graph_id = ? AND state = \'active\'')
+          .run(state, now, graph.graph_id);
+        if (state !== 'completed') {
+          db.prepare("UPDATE execution_graph_nodes SET state = ?, state_version = state_version + 1, updated_at = ? WHERE graph_id = ? AND state IN ('pending','runnable','running')")
+            .run(nodeState, now, graph.graph_id);
+          db.prepare("UPDATE execution_node_attempts SET state = ?, completed_at = ? WHERE graph_id = ? AND state = 'running'")
+            .run(nodeState, now, graph.graph_id);
+        }
+        appendEvent(graph, `graph.${state}`, {}, producer, idempotencyKey, now);
+      });
+      tx.immediate();
+      return { applied: true };
+    },
+    nodes(jobId) {
+      const graph = graphFor(jobId);
+      if (!graph) return [];
+      const rows = db.prepare('SELECT * FROM execution_graph_nodes WHERE graph_id = ? ORDER BY ordinal')
+        .all(graph.graph_id) as NodeRow[];
+      const edges = db.prepare(
+        `SELECT source.node_key AS source_key, target.node_key AS target_key
+           FROM execution_graph_edges edge
+           JOIN execution_graph_nodes source ON source.node_id = edge.from_node_id
+           JOIN execution_graph_nodes target ON target.node_id = edge.to_node_id
+          WHERE edge.graph_id = ? ORDER BY source.node_key`,
+      ).all(graph.graph_id) as Array<{ source_key: string; target_key: string }>;
+      return rows.map((row) => ({
+        nodeId: row.node_key, kind: row.kind, state: row.state,
+        dependsOn: edges.filter((edge) => edge.target_key === row.node_key).map((edge) => edge.source_key),
+        outputRef: row.output_ref, verificationRef: row.verification_ref, stateVersion: row.state_version,
+      }));
+    },
+    events(jobId) {
+      const graph = graphFor(jobId);
+      if (!graph) return [];
+      const rows = db.prepare(
+        'SELECT graph_sequence, type, payload_json, created_at FROM execution_graph_events WHERE graph_id = ? ORDER BY graph_sequence',
+      ).all(graph.graph_id) as Array<{ graph_sequence: number; type: string; payload_json: string; created_at: number }>;
+      return rows.map((row) => ({
+        sequence: row.graph_sequence, type: row.type,
+        payload: JSON.parse(row.payload_json) as Record<string, unknown>, createdAt: row.created_at,
+      }));
+    },
+  };
+}
+
+export type ExecutionGraphAuthority = ReturnType<typeof createExecutionGraphAuthority>;

--- a/core/v4/daemon/httpJobIngress.ts
+++ b/core/v4/daemon/httpJobIngress.ts
@@ -9,6 +9,11 @@ import type { NextFunction, Request, RequestHandler, Response } from 'express';
 
 import type { JobEngine } from './jobEngine';
 import { runWithJobExecutionContext } from './jobExecutionContext';
+import {
+  DurableJobDuplicateAdmissionError,
+  executeDurableJob,
+  type DurableJobHandle,
+} from './jobLifecycle';
 
 export interface HttpJobCoordinatorOptions {
   engine: JobEngine;
@@ -23,17 +28,15 @@ export interface HttpJobRouteOptions {
 
 interface ActiveHttpJob {
   token: string;
-  jobId: string;
-  attemptId: string;
-  runId: number;
-  generation: number;
-  fenceToken: string;
-  jobStateVersion: number;
-  attemptStateVersion: number;
+  handle: DurableJobHandle;
   producer: string;
-  heartbeat: ReturnType<typeof setInterval>;
-  settled: boolean;
   loanConsumed: boolean;
+}
+
+interface HttpExecutionOutcome {
+  reason: 'finish' | 'close';
+  statusCode: number;
+  responseFinished: boolean;
 }
 
 const TOKEN_HEADER = 'x-aiden-internal-job-token';
@@ -63,7 +66,7 @@ export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): Ht
   const leaseTtlMs = options.leaseTtlMs ?? 60_000;
   const active = new Map<string, ActiveHttpJob>();
 
-  const installProjection = (res: Response, handle: ActiveHttpJob): void => {
+  const installProjection = (res: Response, handle: DurableJobHandle): void => {
     res.setHeader('X-Aiden-Job-Id', handle.jobId);
     res.setHeader('X-Aiden-Attempt-Id', handle.attemptId);
     res.setHeader('X-Aiden-Run-Id', String(handle.runId));
@@ -77,43 +80,6 @@ export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): Ht
       }
       return originalJson(body);
     }) as Response['json'];
-  };
-
-  const settle = (handle: ActiveHttpJob, res: Response, reason: 'finish' | 'close'): void => {
-    if (handle.settled) return;
-    handle.settled = true;
-    clearInterval(handle.heartbeat);
-    active.delete(handle.token);
-
-    const interrupted = reason === 'close' && !res.writableFinished;
-    const failed = res.statusCode >= 400;
-    const attemptStatus = interrupted ? 'cancelled' : failed ? 'failed' : 'succeeded';
-    const jobStatus = interrupted ? 'cancelled' : failed ? 'failed' : 'completed';
-    const finishReason = interrupted ? 'client_disconnected' : failed ? 'http_error' : 'stop';
-    const attempt = options.engine.transitionAttempt({
-      attemptId: handle.attemptId,
-      expectedStateVersion: handle.attemptStateVersion,
-      generation: handle.generation,
-      fenceToken: handle.fenceToken,
-      to: attemptStatus,
-      eventIdempotencyKey: `http-attempt-final:${handle.attemptId}:${handle.generation}`,
-      producer: handle.producer,
-      finishReason,
-    });
-    if (!attempt.applied) return;
-    options.engine.finalizeJob({
-      jobId: handle.jobId,
-      attemptId: handle.attemptId,
-      generation: handle.generation,
-      fenceToken: handle.fenceToken,
-      expectedStateVersion: handle.jobStateVersion,
-      status: jobStatus,
-      outcome: jobStatus,
-      finishReason,
-      evidence: { httpStatus: res.statusCode, responseFinished: res.writableFinished },
-      eventIdempotencyKey: `http-job-final:${handle.jobId}:${handle.generation}`,
-      producer: handle.producer,
-    });
   };
 
   const middleware = (route: HttpJobRouteOptions): RequestHandler => (
@@ -132,12 +98,12 @@ export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): Ht
         res.status(409).json({ error: 'internal_job_token_consumed' });
         return;
       }
-      const attempt = options.engine.getAttempt(borrowed.attemptId);
+      const attempt = options.engine.getAttempt(borrowed.handle.attemptId);
       if (
         !attempt
-        || attempt.jobId !== borrowed.jobId
-        || attempt.generation !== borrowed.generation
-        || attempt.fenceToken !== borrowed.fenceToken
+        || attempt.jobId !== borrowed.handle.jobId
+        || attempt.generation !== borrowed.handle.generation
+        || attempt.fenceToken !== borrowed.handle.fenceToken
         || attempt.leaseExpiresAt === null
         || attempt.leaseExpiresAt <= Date.now()
       ) {
@@ -145,22 +111,25 @@ export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): Ht
         return;
       }
       borrowed.loanConsumed = true;
-      installProjection(res, borrowed);
+      installProjection(res, borrowed.handle);
       runWithJobExecutionContext({
         engine: options.engine,
-        jobId: borrowed.jobId,
-        attemptId: borrowed.attemptId,
-        generation: borrowed.generation,
-        fenceToken: borrowed.fenceToken,
+        jobId: borrowed.handle.jobId,
+        attemptId: borrowed.handle.attemptId,
+        generation: borrowed.handle.generation,
+        fenceToken: borrowed.handle.fenceToken,
         producer: borrowed.producer,
       }, () => next());
       return;
     }
 
-    try {
-      const fingerprint = digestRequest(req);
-      const suppliedKey = req.header('idempotency-key')?.trim();
-      const admitted = options.engine.submitJob({
+    const fingerprint = digestRequest(req);
+    const suppliedKey = req.header('idempotency-key')?.trim();
+    void executeDurableJob<HttpExecutionOutcome>({
+      engine: options.engine,
+      ownerId: options.instanceId,
+      leaseTtlMs,
+      admission: {
         entryPoint: route.entryPoint,
         source: route.source,
         sessionId: sessionIdFor(req),
@@ -169,101 +138,80 @@ export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): Ht
         idempotencyKey: suppliedKey || undefined,
         requestFingerprint: fingerprint,
         goal: `${route.entryPoint} request ${fingerprint.slice(0, 16)}`,
-      });
-      if (admitted.reused) {
-        const existing = options.engine.getJob(admitted.jobId);
+      },
+      execute: (handle) => new Promise<HttpExecutionOutcome>((resolve, reject) => {
+        const token = randomUUID();
+        const activeHandle: ActiveHttpJob = {
+          token,
+          handle,
+          producer: route.source,
+          loanConsumed: false,
+        };
+        active.set(token, activeHandle);
+        installProjection(res, handle);
+        (res.locals as Record<string, unknown>).durableJobToken = token;
+
+        let settled = false;
+        const settle = (reason: HttpExecutionOutcome['reason']): void => {
+          if (settled) return;
+          settled = true;
+          active.delete(token);
+          resolve({ reason, statusCode: res.statusCode, responseFinished: res.writableFinished });
+        };
+        res.once('finish', () => settle('finish'));
+        res.once('close', () => settle('close'));
+        try {
+          next();
+        } catch (error) {
+          active.delete(token);
+          reject(error);
+        }
+      }),
+      finalize: (outcome) => {
+        const interrupted = outcome.reason === 'close' && !outcome.responseFinished;
+        const failed = outcome.statusCode >= 400;
+        if (interrupted) {
+          return {
+            status: 'cancelled',
+            outcome: 'cancelled',
+            finishReason: 'client_disconnected',
+            evidence: { httpStatus: outcome.statusCode, responseFinished: false },
+          };
+        }
+        if (failed) {
+          return {
+            status: 'failed',
+            outcome: 'failed',
+            finishReason: 'http_error',
+            evidence: { httpStatus: outcome.statusCode, responseFinished: outcome.responseFinished },
+          };
+        }
+        return {
+          status: 'completed',
+          outcome: 'completed_unverified',
+          finishReason: 'http_response_completed',
+          evidence: {
+            httpStatus: outcome.statusCode,
+            responseFinished: outcome.responseFinished,
+            verification: 'compatibility_response_only',
+          },
+        };
+      },
+    }).catch((error: unknown) => {
+      if (error instanceof DurableJobDuplicateAdmissionError) {
+        if (res.headersSent) return;
+        const existing = options.engine.getJob(error.admission.jobId);
         res.status(existing?.terminalAt === null ? 202 : 200).json({
           accepted: true,
           duplicate: true,
-          job_id: admitted.jobId,
-          attempt_id: admitted.attemptId,
-          run_id: admitted.runId,
+          job_id: error.admission.jobId,
+          attempt_id: error.admission.attemptId,
+          run_id: error.admission.runId,
         });
         return;
       }
-      const lease = options.engine.claimAttempt({
-        attemptId: admitted.attemptId,
-        ownerId: options.instanceId,
-        ttlMs: leaseTtlMs,
-      });
-      if (!lease.acquired || lease.generation === undefined || !lease.fenceToken || lease.stateVersion === undefined) {
-        res.status(409).json({ error: 'job_lease_unavailable' });
-        return;
-      }
-      const attemptRunning = options.engine.transitionAttempt({
-        attemptId: admitted.attemptId,
-        expectedStateVersion: lease.stateVersion,
-        generation: lease.generation,
-        fenceToken: lease.fenceToken,
-        to: 'running',
-        eventIdempotencyKey: `http-attempt-running:${admitted.attemptId}:${lease.generation}`,
-        producer: route.source,
-      });
-      if (!attemptRunning.applied || attemptRunning.stateVersion === undefined) {
-        res.status(409).json({ error: 'job_attempt_start_rejected' });
-        return;
-      }
-      const jobRunning = options.engine.transitionJob({
-        jobId: admitted.jobId,
-        attemptId: admitted.attemptId,
-        generation: lease.generation,
-        fenceToken: lease.fenceToken,
-        expectedStateVersion: 0,
-        to: 'running',
-        eventIdempotencyKey: `http-job-running:${admitted.jobId}:${lease.generation}`,
-        producer: route.source,
-      });
-      if (!jobRunning.applied || jobRunning.stateVersion === undefined) {
-        res.status(409).json({ error: 'job_start_rejected' });
-        return;
-      }
-
-      const token = randomUUID();
-      const handle: ActiveHttpJob = {
-        token,
-        jobId: admitted.jobId,
-        attemptId: admitted.attemptId,
-        runId: admitted.runId,
-        generation: lease.generation,
-        fenceToken: lease.fenceToken,
-        jobStateVersion: jobRunning.stateVersion,
-        attemptStateVersion: attemptRunning.stateVersion,
-        producer: route.source,
-        heartbeat: undefined as unknown as ReturnType<typeof setInterval>,
-        settled: false,
-        loanConsumed: false,
-      };
-      handle.heartbeat = setInterval(() => {
-        const renewed = options.engine.renewAttemptLease({
-          attemptId: handle.attemptId,
-          ownerId: options.instanceId,
-          generation: handle.generation,
-          fenceToken: handle.fenceToken,
-          ttlMs: leaseTtlMs,
-        });
-        if (!renewed.applied || renewed.stateVersion === undefined) {
-          clearInterval(handle.heartbeat);
-          return;
-        }
-        handle.attemptStateVersion = renewed.stateVersion;
-      }, Math.max(1_000, Math.floor(leaseTtlMs / 3)));
-      handle.heartbeat.unref?.();
-      active.set(token, handle);
-      installProjection(res, handle);
-      res.once('finish', () => settle(handle, res, 'finish'));
-      res.once('close', () => settle(handle, res, 'close'));
-      (res.locals as Record<string, unknown>).durableJobToken = token;
-      runWithJobExecutionContext({
-        engine: options.engine,
-        jobId: handle.jobId,
-        attemptId: handle.attemptId,
-        generation: handle.generation,
-        fenceToken: handle.fenceToken,
-        producer: handle.producer,
-      }, () => next());
-    } catch (error) {
-      next(error);
-    }
+      if (!res.headersSent) next(error);
+    });
   };
 
   return {

--- a/core/v4/daemon/jobControlAuthority.ts
+++ b/core/v4/daemon/jobControlAuthority.ts
@@ -58,6 +58,13 @@ export interface InputAuthorityStore {
   listPending(jobId: string): DurableInputRecord[];
   listPendingForSession(sessionId: string): DurableInputRecord[];
   cancelPendingForSession(sessionId: string, now?: number): number;
+  retarget(command: {
+    inputId: string;
+    jobId: string;
+    attemptId: string;
+    source: string;
+    now?: number;
+  }): { record: DurableInputRecord; applied: boolean; duplicate?: boolean };
   claimNext(command: {
     jobId: string;
     attemptId: string;
@@ -423,6 +430,62 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
     return claimed;
   }).immediate;
 
+  const retargetTx = db.transaction((command: {
+    inputId: string;
+    jobId: string;
+    attemptId: string;
+    source: string;
+    now?: number;
+  }): { record: DurableInputRecord; applied: boolean; duplicate?: boolean } => {
+    const row = db.prepare('SELECT * FROM durable_inputs WHERE input_id = ?')
+      .get(command.inputId) as InputRow | undefined;
+    if (!row) throw new Error('Durable input not found');
+    if (!['queued', 'claimed'].includes(row.state)) {
+      throw new Error('Only pending durable input can be retargeted');
+    }
+    if (row.job_id === command.jobId && row.target_attempt_id === command.attemptId) {
+      return { record: mapInput(row), applied: false, duplicate: true };
+    }
+    const job = jobEngine.getJob(command.jobId);
+    const attempt = jobEngine.getAttempt(command.attemptId);
+    if (!job || !attempt || attempt.jobId !== job.id || job.activeAttemptId !== attempt.id) {
+      throw new Error('Durable input continuation target is unavailable');
+    }
+    if (['cancelled', 'completed', 'failed', 'dead_letter', 'completed_unverified', 'verification_failed', 'abandoned'].includes(job.status)) {
+      throw new Error('Durable input continuation target is terminal');
+    }
+    const now = command.now ?? Date.now();
+    const allocated = db.prepare(
+      `UPDATE tasks SET next_input_sequence = next_input_sequence + 1, updated_at = ?
+        WHERE id = ? RETURNING next_input_sequence - 1 AS sequence`,
+    ).get(now, command.jobId) as { sequence: number } | undefined;
+    if (!allocated) throw new Error('Durable input continuation target disappeared');
+    const changed = db.prepare(
+      `UPDATE durable_inputs
+          SET job_id = ?, target_attempt_id = ?, target_generation = NULL,
+              sequence = ?, state = 'queued', claimed_by_attempt_id = NULL,
+              claimed_generation = NULL, claimed_at = NULL, updated_at = ?
+        WHERE input_id = ? AND state IN ('queued','claimed')`,
+    ).run(command.jobId, command.attemptId, allocated.sequence, now, command.inputId);
+    if (changed.changes !== 1) throw new Error('Durable input changed during continuation retarget');
+    const record = getInput(command.inputId)!;
+    appendReferenceEvent({
+      jobId: command.jobId,
+      attemptId: command.attemptId,
+      generation: attempt.generation,
+      type: 'input.retargeted',
+      producer: command.source,
+      idempotencyKey: `input:${command.inputId}:retargeted:${command.jobId}`,
+      payload: {
+        inputId: command.inputId,
+        kind: record.kind,
+        sequence: record.sequence,
+        state: record.state,
+      },
+    });
+    return { record, applied: true };
+  }).immediate;
+
   const consumeTx = db.transaction((command: { inputId: string; attemptId: string; generation: number; now?: number }) => {
     const row = db.prepare('SELECT * FROM durable_inputs WHERE input_id = ?').get(command.inputId) as InputRow | undefined;
     if (!row) return { applied: false, conflict: 'not_found' as const };
@@ -468,6 +531,7 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
           WHERE session_id = ? AND state IN ('queued','claimed')`,
       ).run(now, sessionId).changes;
     },
+    retarget: retargetTx,
     claimNext: claimTx,
     consume: consumeTx,
   };

--- a/core/v4/daemon/jobControlAuthority.ts
+++ b/core/v4/daemon/jobControlAuthority.ts
@@ -7,8 +7,12 @@ import { createHash, randomBytes } from 'node:crypto';
 
 import type { Db } from './db/connection';
 import type { JobEngine } from './jobEngine';
+import { createJobWaitAuthority, type JobWaitAuthority } from './jobWaitAuthority';
 
-export type DurableInputKind = 'message' | 'steering' | 'control' | 'approval_decision' | 'credential';
+export type DurableInputKind =
+  | 'message' | 'steering' | 'control' | 'approval_decision' | 'credential'
+  | 'follow_up' | 'steer' | 'redirect' | 'pause' | 'resume' | 'cancel' | 'interrupt'
+  | 'approval_response' | 'clarification_response' | 'external_event';
 export type DurableInputState =
   | 'received' | 'persisted' | 'queued' | 'claimed' | 'consumed'
   | 'superseded' | 'cancelled' | 'expired' | 'rejected_stale';
@@ -115,6 +119,7 @@ export type JobControlKind = 'pause' | 'resume' | 'cancel' | 'interrupt';
 
 export interface JobControlAuthority {
   inputs: InputAuthorityStore;
+  waits: JobWaitAuthority;
   steering: SteeringAuthority;
   commands: {
     request(command: {
@@ -237,6 +242,7 @@ function mapSteering(row: SteeringRow): SteeringRecord {
 
 export function createJobControlAuthority(options: CreateJobControlAuthorityOptions): JobControlAuthority {
   const { db, jobEngine } = options;
+  const waits = createJobWaitAuthority(db, jobEngine);
   const runtimeControllers = new Map<string, { registrationId: string; controller: AbortController }>();
 
   const getInput = (inputId: string): DurableInputRecord | null => {
@@ -274,7 +280,7 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
     }
     const job = jobEngine.getJob(command.jobId);
     if (!job) throw new Error('Input target Job not found');
-    if (['cancelled', 'completed', 'failed', 'dead_letter'].includes(job.status)) {
+    if (['cancelled', 'completed', 'failed', 'dead_letter', 'completed_unverified', 'verification_failed', 'abandoned'].includes(job.status)) {
       throw new Error('Input target Job is terminal; submit a new Job or an explicit continuation');
     }
     if (command.targetAttemptId && command.targetAttemptId !== job.activeAttemptId) {
@@ -347,9 +353,20 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
     kinds?: DurableInputKind[];
     now?: number;
   }) => {
+    const job = jobEngine.getJob(command.jobId);
     const attempt = jobEngine.getAttempt(command.attemptId);
-    if (!attempt || attempt.jobId !== command.jobId || attempt.generation !== command.generation) return null;
+    if (
+      !job || job.activeAttemptId !== command.attemptId
+      || !attempt || attempt.jobId !== command.jobId || attempt.generation !== command.generation
+    ) return null;
     const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE durable_inputs
+          SET state = 'queued', claimed_by_attempt_id = NULL, claimed_generation = NULL,
+              claimed_at = NULL, updated_at = ?
+        WHERE job_id = ? AND state = 'claimed' AND target_attempt_id IS NULL
+          AND (claimed_by_attempt_id <> ? OR claimed_generation <> ?)`,
+    ).run(now, command.jobId, command.attemptId, command.generation);
     const kinds = command.kinds?.length ? command.kinds : null;
     const kindSql = kinds ? ` AND kind IN (${kinds.map(() => '?').join(',')})` : '';
     if (command.inputId) {
@@ -685,6 +702,7 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
 
   return {
     inputs,
+    waits,
     steering,
     commands: {
       request(command) {
@@ -720,6 +738,11 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
           });
           const attemptIds = persisted.attemptId ? [persisted.attemptId] : [];
           if (result.applied) {
+            waits.cancelForJob(command.jobId, command.source, `control:${persisted.controlId}`, command.now);
+            db.prepare(
+              `UPDATE durable_inputs SET state = 'cancelled', updated_at = ?
+                WHERE job_id = ? AND state IN ('queued','claimed')`,
+            ).run(command.now ?? Date.now(), command.jobId);
             const parent = jobEngine.getJob(command.jobId);
             if (parent) {
               const family = jobEngine.listJobs({ rootJobId: parent.rootJobId, limit: 1_000 });
@@ -796,6 +819,10 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
                 SET state = 'applied', attempt_id = ?, generation = ?, applied_at = ?, updated_at = ?
               WHERE control_id = ?`,
           ).run(resumed.attemptId, resumed.generation, now, now, persisted.controlId);
+          waits.adoptPending({
+            jobId: command.jobId, attemptId: resumed.attemptId, generation: resumed.generation,
+            producer: command.source, idempotencyKey: `control:${persisted.controlId}:waits`, now,
+          });
           return { controlId: persisted.controlId, ...resumed, duplicate: false };
         }).immediate();
       },

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -17,6 +17,7 @@ import type {
   EffectReconciliationOutcome,
   EffectRetryRecommendation,
 } from '../effectReconciliation';
+import { createExecutionGraphAuthority, type ExecutionGraphAuthority } from './executionGraph';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -146,6 +147,7 @@ export interface LeaseResult extends TransitionResult {
 }
 
 export interface JobEngine {
+  readonly graph: ExecutionGraphAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -544,6 +546,7 @@ function parseArray(raw: string | null | undefined): unknown[] {
 
 export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   const { db } = opts;
+  const graph = createExecutionGraphAuthority(db);
 
   const getJobRow = (jobId: string): JobSqlRow | undefined => db.prepare(
     `SELECT id, status, state_version, active_attempt_id, root_job_id,
@@ -935,6 +938,12 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
             AND effect_state IN ('unknown','partial','started','committed') LIMIT 1`,
       ).get(command.jobId);
       if (unresolved) return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
+      const unfinishedGraph = db.prepare(
+        `SELECT 1 FROM execution_graphs g
+          JOIN execution_graph_nodes n ON n.graph_id = g.graph_id
+         WHERE g.job_id = ? AND g.state = 'active' AND n.state <> 'succeeded' LIMIT 1`,
+      ).get(command.jobId);
+      if (unfinishedGraph) return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
     }
     if (
       !ATTEMPT_TERMINAL.has(attempt.status)
@@ -2054,6 +2063,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   }).immediate;
 
   return {
+    graph,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);
@@ -2133,8 +2143,18 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     },
     appendJobEvent: appendJobEventTx,
     transitionJob: transitionJobTx,
-    finalizeJob: finalizeJobTx,
-    cancelJob: cancelJobTx,
+    finalizeJob(command) {
+      const result = finalizeJobTx(command);
+      if (result.applied) {
+        graph.settle(command.jobId, command.status, command.producer, `graph-settled:${command.eventIdempotencyKey}`, command.now);
+      }
+      return result;
+    },
+    cancelJob(command) {
+      const result = cancelJobTx(command);
+      if (result.applied) graph.settle(command.jobId, 'cancelled', command.producer, `graph-cancelled:${command.eventIdempotencyKey}`, command.now);
+      return result;
+    },
     pauseJob: pauseJobTx,
     resumeJob: resumeJobTx,
     transitionAttempt: transitionAttemptTx,

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -18,6 +18,8 @@ import type {
   EffectRetryRecommendation,
 } from '../effectReconciliation';
 import { createExecutionGraphAuthority, type ExecutionGraphAuthority } from './executionGraph';
+import { createJobResourceAuthority, type JobResourceAuthority } from './jobResourceAuthority';
+import type { JobBudgetKind, JobCapabilities } from './jobResourceAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -101,6 +103,10 @@ export interface SubmitJobCommand {
     allowedResources: Record<string, unknown>;
     budget: Record<string, unknown>;
   };
+  resourcePolicy?: {
+    budgets?: Partial<Record<JobBudgetKind, number | null>>;
+    capabilities?: JobCapabilities;
+  };
 }
 
 export interface ChildJobContractRecord {
@@ -170,6 +176,7 @@ export interface LeaseResult extends TransitionResult {
 
 export interface JobEngine {
   readonly graph: ExecutionGraphAuthority;
+  readonly resources: JobResourceAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -595,6 +602,7 @@ function parseRecord(raw: string | null | undefined): Record<string, unknown> {
 export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   const { db } = opts;
   const graph = createExecutionGraphAuthority(db);
+  const resources = createJobResourceAuthority(db);
 
   const getJobRow = (jobId: string): JobSqlRow | undefined => db.prepare(
     `SELECT id, status, state_version, active_attempt_id, root_job_id,
@@ -808,6 +816,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         type: 'worker.assigned', producer: command.source,
         idempotencyKey: `worker-assigned:${jobId}`,
         payload: { workerId: command.childContract.workerId, parentJobId: command.parentJobId },
+      });
+    }
+    if (command.resourcePolicy) {
+      resources.configure({
+        jobId,
+        budgets: command.resourcePolicy.budgets,
+        capabilities: command.resourcePolicy.capabilities,
+        now,
       });
     }
     return { jobId, attemptId, runId, reused: false };
@@ -2218,6 +2234,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
 
   return {
     graph,
+    resources,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -10,7 +10,13 @@ import type {
   EffectApprovalRequirement,
   EffectClassification,
   EffectRetrySafety,
+  EffectReconciliationData,
 } from '../effectContract';
+import type {
+  EffectReconciliationConfidence,
+  EffectReconciliationOutcome,
+  EffectRetryRecommendation,
+} from '../effectReconciliation';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -103,6 +109,33 @@ export interface TransitionResult {
   duplicate?: boolean;
   effectId?: string;
   existingToolCallId?: string;
+}
+
+export interface EffectReconciliationRecord {
+  reconciliationId: string;
+  effectId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  outcome: EffectReconciliationOutcome;
+  confidence: EffectReconciliationConfidence;
+  evidence: Record<string, unknown>;
+  retryRecommendation: EffectRetryRecommendation;
+  humanResolutionRequired: boolean;
+  createdAt: number;
+}
+
+export interface EffectForReconciliation {
+  effectId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  kind: string;
+  target: string | null;
+  retrySafety: EffectRetrySafety;
+  idempotencyKey: string | null;
+  reconciliationData: EffectReconciliationData | null;
+  effectState: string;
 }
 
 export interface LeaseResult extends TransitionResult {
@@ -250,6 +283,7 @@ export interface JobEngine {
       sensitiveFields: readonly string[];
       redactionRules: readonly string[];
       trusted: boolean;
+      reconciliationData?: EffectReconciliationData | null;
     };
     modelCallId?: string | null;
     producer: string;
@@ -295,6 +329,20 @@ export interface JobEngine {
     producer: string;
     now?: number;
   }): TransitionResult;
+  recordEffectReconciliation(command: {
+    effectId: string;
+    expectedJobStateVersion: number;
+    outcome: EffectReconciliationOutcome;
+    confidence: EffectReconciliationConfidence;
+    evidence: Record<string, unknown>;
+    retryRecommendation: EffectRetryRecommendation;
+    humanResolutionRequired: boolean;
+    producer: string;
+    idempotencyKey: string;
+    now?: number;
+  }): TransitionResult;
+  listEffectReconciliations(effectId: string): EffectReconciliationRecord[];
+  listEffectsRequiringReconciliation(jobId: string): EffectForReconciliation[];
   recoverExpiredAttempts(command: {
     now?: number;
     instanceId: string;
@@ -417,6 +465,26 @@ function fingerprintOf(command: SubmitJobCommand): string {
       parentJobId: command.parentJobId ?? null,
     }))
     .digest('hex');
+}
+
+const RECONCILIATION_EVIDENCE_KEYS = new Set([
+  'reason', 'effectKind', 'exists', 'size', 'mtimeMs', 'contentSha256',
+  'processId', 'running', 'finalUrl', 'externalId', 'receiptId', 'registry',
+  'packageName', 'version', 'integrity', 'status', 'before', 'after',
+]);
+
+function sanitizeReconciliationEvidence(value: unknown, depth = 0): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value) || depth >= 2) return undefined;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (!RECONCILIATION_EVIDENCE_KEYS.has(key)) continue;
+    const safe = sanitizeReconciliationEvidence(nested, depth + 1);
+    if (safe !== undefined) sanitized[key] = safe;
+  }
+  return sanitized;
 }
 
 function mapJob(row: JobSqlRow): JobRecord {
@@ -859,6 +927,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     }
     if (!isLegal(JOB_TRANSITIONS, job.status, command.status)) {
       return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
+    }
+    if (command.status === 'completed') {
+      const unresolved = db.prepare(
+        `SELECT 1 FROM side_effect_ledger
+          WHERE job_id = ? AND reconciliation_required = 1
+            AND effect_state IN ('unknown','partial','started','committed') LIMIT 1`,
+      ).get(command.jobId);
+      if (unresolved) return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
     }
     if (
       !ATTEMPT_TERMINAL.has(attempt.status)
@@ -1321,25 +1397,43 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     if (command.mutates && !command.effect) {
       return { applied: false, conflict: 'illegal_transition' };
     }
+    let retryEffectId: string | null = null;
     if (command.effect?.idempotencyKey) {
       const prior = db.prepare(
-        `SELECT key, tool_call_id FROM side_effect_ledger
+        `SELECT key, tool_call_id, args_hash, effect_kind, effect_classification,
+                effect_state, retry_safety, idempotency_supported,
+                reconciliation_outcome, reconciliation_required
+           FROM side_effect_ledger
           WHERE job_id = ? AND idempotency_key = ?`,
       ).get(command.jobId, command.effect.idempotencyKey) as {
-        key: string; tool_call_id: string;
+        key: string; tool_call_id: string; args_hash: string; effect_kind: string;
+        effect_classification: string; effect_state: string; retry_safety: string;
+        idempotency_supported: number; reconciliation_outcome: string | null;
+        reconciliation_required: number;
       } | undefined;
       if (prior) {
-        return {
-          applied: false,
-          duplicate: true,
-          effectId: prior.key,
-          existingToolCallId: prior.tool_call_id,
-        };
+        const retryable = prior.args_hash === command.normalizedArgsDigest
+          && prior.effect_kind === command.effect.kind
+          && prior.effect_classification === command.effect.classification
+          && prior.effect_state === 'not_occurred'
+          && prior.reconciliation_outcome === 'did_not_occur'
+          && prior.reconciliation_required === 0
+          && prior.idempotency_supported === 1
+          && ['same_idempotency_key', 'reconcile_before_retry'].includes(prior.retry_safety);
+        if (!retryable) {
+          return {
+            applied: false,
+            duplicate: true,
+            effectId: prior.key,
+            existingToolCallId: prior.tool_call_id,
+          };
+        }
+        retryEffectId = prior.key;
       }
     }
 
     const now = command.now ?? Date.now();
-    const sideEffectId = command.mutates ? `side_effect:${command.toolCallId}` : null;
+    const sideEffectId = command.mutates ? retryEffectId ?? `side_effect:${command.toolCallId}` : null;
     db.prepare(
       `INSERT INTO tool_calls (
          tool_call_id, job_id, attempt_id, generation, model_call_id,
@@ -1362,19 +1456,32 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     );
     if (sideEffectId) {
       const effect = command.effect!;
-      const ordinal = db.prepare(
-        'SELECT COUNT(*) + 1 AS ordinal FROM side_effect_ledger WHERE job_id = ?',
-      ).get(command.jobId) as { ordinal: number };
-      db.prepare(
+      if (retryEffectId) {
+        db.prepare(
+          `UPDATE side_effect_ledger
+              SET attempt_id = ?, generation = ?, tool_call_id = ?, effect_state = 'requested',
+                  status = 'requested', approval_state = ?, approval_id = NULL, action_digest = NULL,
+                  reconciliation_required = 0, reconciliation_data_json = ?, attempted_at = ?, updated_at = ?
+            WHERE key = ? AND effect_state = 'not_occurred' AND reconciliation_outcome = 'did_not_occur'`,
+        ).run(
+          command.attemptId, command.generation, command.toolCallId, effect.approvalState,
+          effect.reconciliationData ? JSON.stringify(effect.reconciliationData) : null,
+          now, now, retryEffectId,
+        );
+      } else {
+        const ordinal = db.prepare(
+          'SELECT COUNT(*) + 1 AS ordinal FROM side_effect_ledger WHERE job_id = ?',
+        ).get(command.jobId) as { ordinal: number };
+        db.prepare(
         `INSERT INTO side_effect_ledger (
            key, task_id, step, tool, args_hash, status, attempted_at,
            job_id, attempt_id, generation, tool_call_id, effect_state,
            effect_classification, effect_kind, target, retry_safety,
            idempotency_key, idempotency_supported, reconciliation_supported,
            verification_supported, approval_requirement, approval_state,
-           sensitive_fields_json, redaction_rules_json, updated_at
+           sensitive_fields_json, redaction_rules_json, reconciliation_data_json, updated_at
          ) VALUES (?, ?, ?, ?, ?, 'requested', ?, ?, ?, ?, ?, 'requested',
-                   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)` ,
+                   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)` ,
       ).run(
         sideEffectId,
         command.jobId,
@@ -1398,8 +1505,10 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         effect.approvalState,
         JSON.stringify(effect.sensitiveFields),
         JSON.stringify(effect.redactionRules),
+        effect.reconciliationData ? JSON.stringify(effect.reconciliationData) : null,
         now,
       );
+      }
     }
     appendEvent({
       jobId: command.jobId,
@@ -1424,7 +1533,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         runId: attempt.id,
         attemptId: command.attemptId,
         generation: command.generation,
-        type: 'effect.requested',
+        type: retryEffectId ? 'effect.retry_scheduled' : 'effect.requested',
         payload: {
           toolCallId: command.toolCallId,
           effectId: sideEffectId,
@@ -1432,7 +1541,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
           effectClassification: command.effect!.classification,
         },
         producer: command.producer,
-        idempotencyKey: `effect-requested:${command.toolCallId}`,
+        idempotencyKey: `${retryEffectId ? 'effect-retry' : 'effect-requested'}:${command.toolCallId}`,
       });
     }
     return { applied: true, effectId: sideEffectId ?? undefined };
@@ -1580,6 +1689,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       db.prepare(
         `UPDATE side_effect_ledger
             SET effect_state = ?, status = ?, result_ref = ?, updated_at = ?,
+                reconciliation_required = CASE WHEN ? = 'unknown' THEN 1 ELSE reconciliation_required END,
                 confirmed_at = CASE WHEN ? = 'committed' THEN ? ELSE confirmed_at END
           WHERE key = ? AND attempt_id = ? AND generation = ? AND effect_state = 'started'`,
       ).run(
@@ -1587,6 +1697,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         sideEffectState === 'committed' ? 'confirmed' : sideEffectState,
         command.resultRef ?? null,
         now,
+        sideEffectState,
         sideEffectState,
         now,
         toolCall.side_effect_id,
@@ -1674,6 +1785,80 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     return { applied: true };
   }).immediate;
 
+  const recordEffectReconciliationTx = db.transaction((
+    command: Parameters<JobEngine['recordEffectReconciliation']>[0],
+  ): TransitionResult => {
+    const effect = db.prepare(
+      `SELECT key, job_id, attempt_id, generation, effect_state
+         FROM side_effect_ledger WHERE key = ?`,
+    ).get(command.effectId) as {
+      key: string; job_id: string; attempt_id: string; generation: number; effect_state: string;
+    } | undefined;
+    if (!effect) return { applied: false, conflict: 'not_found' };
+    const job = getJobRow(effect.job_id);
+    if (!job) return { applied: false, conflict: 'not_found' };
+    const effectAttempt = getAttemptRow(effect.attempt_id);
+    if (!effectAttempt) return { applied: false, conflict: 'not_found' };
+    if (job.state_version !== command.expectedJobStateVersion) {
+      return { applied: false, conflict: 'state_version', stateVersion: job.state_version };
+    }
+    const duplicate = db.prepare(
+      'SELECT 1 FROM effect_reconciliations WHERE effect_id = ? AND idempotency_key = ?',
+    ).get(effect.key, command.idempotencyKey);
+    if (duplicate) return { applied: false, duplicate: true };
+
+    const evidence = sanitizeReconciliationEvidence(command.evidence) as Record<string, unknown>;
+    const now = command.now ?? Date.now();
+    const reconciliationId = `reconciliation_${createHash('sha256')
+      .update(`${effect.key}\0${command.idempotencyKey}`)
+      .digest('hex')}`;
+    db.prepare(
+      `INSERT INTO effect_reconciliations (
+         reconciliation_id, effect_id, job_id, attempt_id, generation,
+         outcome, confidence, evidence_json, retry_recommendation,
+         human_resolution_required, producer, idempotency_key, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      reconciliationId, effect.key, effect.job_id, effect.attempt_id, effect.generation,
+      command.outcome, command.confidence, JSON.stringify(evidence), command.retryRecommendation,
+      command.humanResolutionRequired ? 1 : 0, command.producer, command.idempotencyKey, now,
+    );
+    const effectState = command.outcome === 'occurred' ? 'committed'
+      : command.outcome === 'did_not_occur' ? 'not_occurred'
+        : command.outcome === 'partially_occurred' ? 'partial' : 'unknown';
+    db.prepare(
+      `UPDATE side_effect_ledger
+          SET effect_state = ?, status = ?, reconciliation_outcome = ?,
+              reconciliation_required = ?, last_reconciled_at = ?, updated_at = ?,
+              confirmed_at = CASE WHEN ? = 'committed' THEN ? ELSE confirmed_at END
+        WHERE key = ?`,
+    ).run(
+      effectState,
+      effectState === 'committed' ? 'confirmed' : effectState,
+      command.outcome,
+      command.humanResolutionRequired || command.outcome === 'unknown' || command.outcome === 'partially_occurred' ? 1 : 0,
+      now, now, effectState, now, effect.key,
+    );
+    appendEvent({
+      jobId: effect.job_id,
+      runId: effectAttempt.id,
+      attemptId: effect.attempt_id,
+      generation: effect.generation,
+      type: 'effect.reconciled',
+      payload: {
+        effectId: effect.key,
+        reconciliationId,
+        outcome: command.outcome,
+        confidence: command.confidence,
+        retryRecommendation: command.retryRecommendation,
+        humanResolutionRequired: command.humanResolutionRequired,
+      },
+      producer: command.producer,
+      idempotencyKey: `effect-reconciled:${effect.key}:${command.idempotencyKey}`,
+    });
+    return { applied: true, effectId: effect.key };
+  }).immediate;
+
   const recoverExpiredAttemptTx = db.transaction((command: {
     attemptId: string;
     now: number;
@@ -1733,6 +1918,39 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       command.now,
     );
     if (cleared.changes !== 1) return null;
+    if (ambiguous) {
+      const effects = db.prepare(
+        `SELECT key, tool_call_id, effect_state FROM side_effect_ledger
+          WHERE attempt_id = ? AND generation = ?
+            AND effect_state IN ('started','committed','partial','unknown')`,
+      ).all(attempt.attempt_id, attempt.generation) as Array<{
+        key: string; tool_call_id: string; effect_state: string;
+      }>;
+      db.prepare(
+        `UPDATE side_effect_ledger
+            SET effect_state = CASE WHEN effect_state = 'started' THEN 'unknown' ELSE effect_state END,
+                status = CASE WHEN effect_state = 'started' THEN 'unknown' ELSE status END,
+                reconciliation_required = 1, updated_at = ?
+          WHERE attempt_id = ? AND generation = ?
+            AND effect_state IN ('started','committed','partial','unknown')`,
+      ).run(command.now, attempt.attempt_id, attempt.generation);
+      db.prepare(
+        `UPDATE tool_calls SET state = 'unknown', ended_at = COALESCE(ended_at, ?), updated_at = ?
+          WHERE attempt_id = ? AND generation = ? AND state = 'started'`,
+      ).run(command.now, command.now, attempt.attempt_id, attempt.generation);
+      for (const effect of effects.filter((candidate) => candidate.effect_state === 'started')) {
+        appendEvent({
+          jobId: job.id,
+          runId: attempt.id,
+          attemptId: attempt.attempt_id,
+          generation: attempt.generation,
+          type: 'effect.unknown',
+          payload: { effectId: effect.key, toolCallId: effect.tool_call_id, reason: 'lease_expired_during_execution' },
+          producer: command.producer,
+          idempotencyKey: `effect-crash-unknown:${effect.key}:${attempt.generation}`,
+        });
+      }
+    }
     appendEvent({
       jobId: job.id,
       runId: attempt.id,
@@ -1928,6 +2146,61 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     startToolCall: startToolCallTx,
     completeToolCall: completeToolCallTx,
     attachToolVerification: attachToolVerificationTx,
+    recordEffectReconciliation: recordEffectReconciliationTx,
+    listEffectReconciliations(effectId) {
+      const rows = db.prepare(
+        `SELECT reconciliation_id, effect_id, job_id, attempt_id, generation,
+                outcome, confidence, evidence_json, retry_recommendation,
+                human_resolution_required, created_at
+           FROM effect_reconciliations WHERE effect_id = ?
+          ORDER BY created_at ASC, reconciliation_id ASC`,
+      ).all(effectId) as Array<{
+        reconciliation_id: string; effect_id: string; job_id: string; attempt_id: string;
+        generation: number; outcome: EffectReconciliationOutcome; confidence: EffectReconciliationConfidence;
+        evidence_json: string; retry_recommendation: EffectRetryRecommendation;
+        human_resolution_required: number; created_at: number;
+      }>;
+      return rows.map((row) => ({
+        reconciliationId: row.reconciliation_id,
+        effectId: row.effect_id,
+        jobId: row.job_id,
+        attemptId: row.attempt_id,
+        generation: row.generation,
+        outcome: row.outcome,
+        confidence: row.confidence,
+        evidence: JSON.parse(row.evidence_json) as Record<string, unknown>,
+        retryRecommendation: row.retry_recommendation,
+        humanResolutionRequired: row.human_resolution_required === 1,
+        createdAt: row.created_at,
+      }));
+    },
+    listEffectsRequiringReconciliation(jobId) {
+      const rows = db.prepare(
+        `SELECT key, job_id, attempt_id, generation, effect_kind, target,
+                retry_safety, idempotency_key, reconciliation_data_json, effect_state
+           FROM side_effect_ledger
+          WHERE job_id = ? AND reconciliation_required = 1
+          ORDER BY attempted_at ASC, key ASC`,
+      ).all(jobId) as Array<{
+        key: string; job_id: string; attempt_id: string; generation: number;
+        effect_kind: string; target: string | null; retry_safety: EffectRetrySafety;
+        idempotency_key: string | null; reconciliation_data_json: string | null; effect_state: string;
+      }>;
+      return rows.map((row) => {
+        let reconciliationData: EffectReconciliationData | null = null;
+        try {
+          reconciliationData = row.reconciliation_data_json
+            ? JSON.parse(row.reconciliation_data_json) as EffectReconciliationData
+            : null;
+        } catch { reconciliationData = null; }
+        return {
+          effectId: row.key, jobId: row.job_id, attemptId: row.attempt_id,
+          generation: row.generation, kind: row.effect_kind, target: row.target,
+          retrySafety: row.retry_safety, idempotencyKey: row.idempotency_key,
+          reconciliationData, effectState: row.effect_state,
+        };
+      });
+    },
     recoverExpiredAttempts(command) {
       const now = command.now ?? Date.now();
       const rows = db.prepare(

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -2385,7 +2385,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
                 outcome, confidence, evidence_json, retry_recommendation,
                 human_resolution_required, created_at
            FROM effect_reconciliations WHERE effect_id = ?
-          ORDER BY created_at ASC, reconciliation_id ASC`,
+          ORDER BY created_at ASC, rowid ASC`,
       ).all(effectId) as Array<{
         reconciliation_id: string; effect_id: string; job_id: string; attempt_id: string;
         generation: number; outcome: EffectReconciliationOutcome; confidence: EffectReconciliationConfidence;

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -94,6 +94,28 @@ export interface SubmitJobCommand {
   parentJobId?: string | null;
   rootJobId?: string | null;
   triggerEventId?: number | null;
+  childContract?: {
+    required?: boolean;
+    workerId: string;
+    capabilities: readonly string[];
+    allowedResources: Record<string, unknown>;
+    budget: Record<string, unknown>;
+  };
+}
+
+export interface ChildJobContractRecord {
+  childJobId: string;
+  parentJobId: string;
+  required: boolean;
+  workerId: string;
+  capabilities: string[];
+  allowedResources: Record<string, unknown>;
+  budget: Record<string, unknown>;
+  resultAttemptId: string | null;
+  resultGeneration: number | null;
+  resultStatus: string | null;
+  evidence: unknown;
+  evidenceHandles: unknown[];
 }
 
 export interface AdmissionResult {
@@ -159,6 +181,20 @@ export interface JobEngine {
   getAttempt(attemptId: string): AttemptRecord | null;
   listAttempts(jobId: string): AttemptRecord[];
   listEvents(jobId: string, afterSequence?: number): JobEventRecord[];
+  getChildContract(childJobId: string): ChildJobContractRecord | null;
+  listChildContracts(parentJobId: string): ChildJobContractRecord[];
+  recordChildResult(command: {
+    childJobId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    status: string;
+    evidence: unknown;
+    evidenceHandles: unknown[];
+    producer: string;
+    idempotencyKey: string;
+    now?: number;
+  }): TransitionResult;
   appendJobEvent(command: {
     jobId: string;
     attemptId: string;
@@ -544,6 +580,18 @@ function parseArray(raw: string | null | undefined): unknown[] {
   }
 }
 
+function parseRecord(raw: string | null | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
 export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   const { db } = opts;
   const graph = createExecutionGraphAuthority(db);
@@ -736,7 +784,105 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       idempotencyKey: `attempt-created:${attemptId}`,
       payload: { attemptNumber: 1, triggerReason: 'submission' },
     });
+    if (command.childContract) {
+      if (!command.parentJobId) throw new Error('Child Job contract requires a parent Job');
+      db.prepare(
+        `INSERT INTO child_job_contracts (
+           child_job_id, parent_job_id, required, worker_id,
+           capabilities_json, allowed_resources_json, budget_json,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        jobId,
+        command.parentJobId,
+        command.childContract.required === false ? 0 : 1,
+        command.childContract.workerId,
+        JSON.stringify([...command.childContract.capabilities]),
+        JSON.stringify(command.childContract.allowedResources),
+        JSON.stringify(command.childContract.budget),
+        now,
+        now,
+      );
+      appendEvent({
+        jobId, runId, attemptId, generation: 1,
+        type: 'worker.assigned', producer: command.source,
+        idempotencyKey: `worker-assigned:${jobId}`,
+        payload: { workerId: command.childContract.workerId, parentJobId: command.parentJobId },
+      });
+    }
     return { jobId, attemptId, runId, reused: false };
+  }).immediate;
+
+  type ChildContractRow = {
+    child_job_id: string;
+    parent_job_id: string;
+    required: number;
+    worker_id: string;
+    capabilities_json: string;
+    allowed_resources_json: string;
+    budget_json: string;
+    result_attempt_id: string | null;
+    result_generation: number | null;
+    result_status: string | null;
+    evidence_json: string | null;
+    evidence_handles_json: string | null;
+  };
+  const mapChildContract = (row: ChildContractRow): ChildJobContractRecord => ({
+    childJobId: row.child_job_id,
+    parentJobId: row.parent_job_id,
+    required: row.required === 1,
+    workerId: row.worker_id,
+    capabilities: parseArray(row.capabilities_json).filter((value): value is string => typeof value === 'string'),
+    allowedResources: parseRecord(row.allowed_resources_json),
+    budget: parseRecord(row.budget_json),
+    resultAttemptId: row.result_attempt_id,
+    resultGeneration: row.result_generation,
+    resultStatus: row.result_status,
+    evidence: row.evidence_json === null ? null : JSON.parse(row.evidence_json),
+    evidenceHandles: row.evidence_handles_json === null ? [] : parseArray(row.evidence_handles_json),
+  });
+
+  const recordChildResultTx = db.transaction((command: Parameters<JobEngine['recordChildResult']>[0]): TransitionResult => {
+    if (existingEvent(command.childJobId, command.idempotencyKey)) return { applied: false, duplicate: true };
+    const contract = db.prepare('SELECT * FROM child_job_contracts WHERE child_job_id = ?')
+      .get(command.childJobId) as ChildContractRow | undefined;
+    if (!contract) return { applied: false, conflict: 'not_found' };
+    const parent = getJobRow(contract.parent_job_id);
+    const child = getJobRow(command.childJobId);
+    const attempt = getAttemptRow(command.attemptId);
+    if (!parent || !child || !attempt || attempt.task_id !== child.id) return { applied: false, conflict: 'not_found' };
+    if (JOB_TERMINAL.has(parent.status)) return { applied: false, conflict: 'terminal_state' };
+    if (
+      child.active_attempt_id !== command.attemptId
+      || attempt.generation !== command.generation
+      || attempt.fence_token !== command.fenceToken
+    ) return { applied: false, conflict: 'stale_fence' };
+    const changed = db.prepare(
+      `UPDATE child_job_contracts
+          SET result_attempt_id = ?, result_generation = ?, result_status = ?,
+              evidence_json = ?, evidence_handles_json = ?, updated_at = ?
+        WHERE child_job_id = ? AND result_attempt_id IS NULL`,
+    ).run(
+      command.attemptId,
+      command.generation,
+      command.status,
+      JSON.stringify(command.evidence ?? null),
+      JSON.stringify(command.evidenceHandles),
+      command.now ?? Date.now(),
+      command.childJobId,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_fence' };
+    appendEvent({
+      jobId: command.childJobId,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: 'worker.result_recorded',
+      payload: { status: command.status, handleCount: command.evidenceHandles.length },
+      producer: command.producer,
+      idempotencyKey: command.idempotencyKey,
+    });
+    return { applied: true };
   }).immediate;
 
   const appendJobEventTx = db.transaction((command: {
@@ -932,6 +1078,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
     }
     if (command.status === 'completed') {
+      const unresolvedChild = db.prepare(
+        `SELECT 1 FROM child_job_contracts c
+          JOIN tasks child ON child.id = c.child_job_id
+         WHERE c.parent_job_id = ? AND c.required = 1
+           AND (c.result_attempt_id IS NULL OR child.status NOT IN ('completed','failed','cancelled','unknown','dead_letter'))
+         LIMIT 1`,
+      ).get(command.jobId);
+      if (unresolvedChild) return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
       const unresolved = db.prepare(
         `SELECT 1 FROM side_effect_ledger
           WHERE job_id = ? AND reconciliation_required = 1
@@ -2087,6 +2241,17 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       ).all(...params, limit) as JobSqlRow[];
       return rows.map(mapJob);
     },
+    getChildContract(childJobId) {
+      const row = db.prepare('SELECT * FROM child_job_contracts WHERE child_job_id = ?')
+        .get(childJobId) as ChildContractRow | undefined;
+      return row ? mapChildContract(row) : null;
+    },
+    listChildContracts(parentJobId) {
+      return (db.prepare(
+        'SELECT * FROM child_job_contracts WHERE parent_job_id = ? ORDER BY created_at, child_job_id',
+      ).all(parentJobId) as ChildContractRow[]).map(mapChildContract);
+    },
+    recordChildResult: recordChildResultTx,
     getAttempt(attemptId) {
       const row = getAttemptRow(attemptId);
       return row ? mapAttempt(row) : null;

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -21,6 +21,7 @@ import { createExecutionGraphAuthority, type ExecutionGraphAuthority } from './e
 import { createJobResourceAuthority, type JobResourceAuthority } from './jobResourceAuthority';
 import type { JobBudgetKind, JobCapabilities } from './jobResourceAuthority';
 import { createJobProofAuthority, type JobProofAuthority } from './jobProofAuthority';
+import { createJobEventProjectionAuthority, type JobEventProjectionAuthority } from './jobEventProjection';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -179,6 +180,7 @@ export interface JobEngine {
   readonly graph: ExecutionGraphAuthority;
   readonly resources: JobResourceAuthority;
   readonly proof: JobProofAuthority;
+  readonly projection: JobEventProjectionAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -601,11 +603,28 @@ function parseRecord(raw: string | null | undefined): Record<string, unknown> {
   }
 }
 
+const SENSITIVE_EVENT_KEY = /(?:authorization|api[_-]?key|token|secret|password|credential|cookie)/i;
+function redactEventPayload(value: unknown, key = '', depth = 0): unknown {
+  if (SENSITIVE_EVENT_KEY.test(key)) return '[redacted]';
+  if (depth > 5) return '[truncated]';
+  if (Array.isArray(value)) return value.slice(0, 100).map((item) => redactEventPayload(item, '', depth + 1));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .slice(0, 100)
+      .map(([nestedKey, nested]) => [nestedKey, redactEventPayload(nested, nestedKey, depth + 1)]));
+  }
+  if (typeof value === 'string' && /(?:bearer\s+[a-z0-9._-]{12,}|(?:sk|gsk|ghp)_[a-z0-9_-]{12,})/i.test(value)) {
+    return '[redacted]';
+  }
+  return value;
+}
+
 export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   const { db } = opts;
   const graph = createExecutionGraphAuthority(db);
   const resources = createJobResourceAuthority(db);
   const proof = createJobProofAuthority(db);
+  const projection = createJobEventProjectionAuthority(db);
 
   const getJobRow = (jobId: string): JobSqlRow | undefined => db.prepare(
     `SELECT id, status, state_version, active_attempt_id, root_job_id,
@@ -681,7 +700,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     ).get(event.runId) as { run_sequence: number } | undefined;
     if (!runSequence) throw new Error(`Attempt row not found: ${event.runId}`);
     const now = Date.now();
-    const payload = JSON.stringify(event.payload ?? null);
+    const payload = JSON.stringify(redactEventPayload(event.payload ?? null));
     const inserted = db.prepare(
       `INSERT INTO run_events (
          run_id, session_id, seq, ts, category, kind, name, payload,
@@ -2245,6 +2264,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     graph,
     resources,
     proof,
+    projection,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -6,6 +6,11 @@
 import { createHash, randomBytes } from 'node:crypto';
 
 import type { Db } from './db/connection';
+import type {
+  EffectApprovalRequirement,
+  EffectClassification,
+  EffectRetrySafety,
+} from '../effectContract';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -96,6 +101,8 @@ export interface TransitionResult {
   stateVersion?: number;
   conflict?: TransitionConflict;
   duplicate?: boolean;
+  effectId?: string;
+  existingToolCallId?: string;
 }
 
 export interface LeaseResult extends TransitionResult {
@@ -229,7 +236,33 @@ export interface JobEngine {
     normalizedArgsDigest: string;
     riskTier: string;
     mutates: boolean;
+    effect?: {
+      classification: Exclude<EffectClassification, 'read_only'>;
+      kind: string;
+      target: string | null;
+      retrySafety: EffectRetrySafety;
+      idempotencySupported: boolean;
+      idempotencyKey: string | null;
+      reconciliationSupported: boolean;
+      verificationSupported: boolean;
+      approvalRequirement: EffectApprovalRequirement;
+      approvalState: 'not_required' | 'pending';
+      sensitiveFields: readonly string[];
+      redactionRules: readonly string[];
+      trusted: boolean;
+    };
     modelCallId?: string | null;
+    producer: string;
+    now?: number;
+  }): TransitionResult;
+  resolveToolCallApproval(command: {
+    toolCallId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    state: 'not_required' | 'pending' | 'approved' | 'denied' | 'interrupted' | 'timed_out' | 'blocked';
+    approvalId?: string | null;
+    actionDigest?: string | null;
     producer: string;
     now?: number;
   }): TransitionResult;
@@ -1281,11 +1314,31 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         && existing.tool_name === command.toolName
         && existing.normalized_args_digest === command.normalizedArgsDigest;
       return sameIdentity
-        ? { applied: false, duplicate: true }
+        ? { applied: false, duplicate: true, effectId: existing.side_effect_id ?? undefined, existingToolCallId: existing.tool_call_id }
         : { applied: false, conflict: 'illegal_transition' };
     }
 
-    const now = Date.now();
+    if (command.mutates && !command.effect) {
+      return { applied: false, conflict: 'illegal_transition' };
+    }
+    if (command.effect?.idempotencyKey) {
+      const prior = db.prepare(
+        `SELECT key, tool_call_id FROM side_effect_ledger
+          WHERE job_id = ? AND idempotency_key = ?`,
+      ).get(command.jobId, command.effect.idempotencyKey) as {
+        key: string; tool_call_id: string;
+      } | undefined;
+      if (prior) {
+        return {
+          applied: false,
+          duplicate: true,
+          effectId: prior.key,
+          existingToolCallId: prior.tool_call_id,
+        };
+      }
+    }
+
+    const now = command.now ?? Date.now();
     const sideEffectId = command.mutates ? `side_effect:${command.toolCallId}` : null;
     db.prepare(
       `INSERT INTO tool_calls (
@@ -1308,14 +1361,20 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       now,
     );
     if (sideEffectId) {
+      const effect = command.effect!;
       const ordinal = db.prepare(
         'SELECT COUNT(*) + 1 AS ordinal FROM side_effect_ledger WHERE job_id = ?',
       ).get(command.jobId) as { ordinal: number };
       db.prepare(
         `INSERT INTO side_effect_ledger (
            key, task_id, step, tool, args_hash, status, attempted_at,
-           job_id, attempt_id, generation, tool_call_id, effect_state
-         ) VALUES (?, ?, ?, ?, ?, 'attempting', ?, ?, ?, ?, ?, 'prepared')`,
+           job_id, attempt_id, generation, tool_call_id, effect_state,
+           effect_classification, effect_kind, target, retry_safety,
+           idempotency_key, idempotency_supported, reconciliation_supported,
+           verification_supported, approval_requirement, approval_state,
+           sensitive_fields_json, redaction_rules_json, updated_at
+         ) VALUES (?, ?, ?, ?, ?, 'requested', ?, ?, ?, ?, ?, 'requested',
+                   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)` ,
       ).run(
         sideEffectId,
         command.jobId,
@@ -1327,6 +1386,19 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         command.attemptId,
         command.generation,
         command.toolCallId,
+        effect.classification,
+        effect.kind,
+        effect.target,
+        effect.retrySafety,
+        effect.idempotencyKey,
+        effect.idempotencySupported ? 1 : 0,
+        effect.reconciliationSupported ? 1 : 0,
+        effect.verificationSupported ? 1 : 0,
+        effect.approvalRequirement,
+        effect.approvalState,
+        JSON.stringify(effect.sensitiveFields),
+        JSON.stringify(effect.redactionRules),
+        now,
       );
     }
     appendEvent({
@@ -1335,11 +1407,92 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       attemptId: command.attemptId,
       generation: command.generation,
       type: 'tool_call.prepared',
-      payload: { toolCallId: command.toolCallId, toolName: command.toolName, mutates: command.mutates },
+      payload: {
+        toolCallId: command.toolCallId,
+        effectId: sideEffectId,
+        toolName: command.toolName,
+        mutates: command.mutates,
+        effectKind: command.effect?.kind ?? null,
+        effectClassification: command.effect?.classification ?? 'read_only',
+      },
       producer: command.producer,
       idempotencyKey: `tool-call-prepared:${command.toolCallId}`,
     });
-    return { applied: true };
+    if (sideEffectId) {
+      appendEvent({
+        jobId: command.jobId,
+        runId: attempt.id,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        type: 'effect.requested',
+        payload: {
+          toolCallId: command.toolCallId,
+          effectId: sideEffectId,
+          effectKind: command.effect!.kind,
+          effectClassification: command.effect!.classification,
+        },
+        producer: command.producer,
+        idempotencyKey: `effect-requested:${command.toolCallId}`,
+      });
+    }
+    return { applied: true, effectId: sideEffectId ?? undefined };
+  }).immediate;
+
+  const resolveToolCallApprovalTx = db.transaction((
+    command: Parameters<JobEngine['resolveToolCallApproval']>[0],
+  ): TransitionResult => {
+    const attempt = activeFence(command.attemptId, command.generation, command.fenceToken, command.now);
+    const toolCall = getToolCallRow(command.toolCallId);
+    if (!attempt || !toolCall || toolCall.attempt_id !== command.attemptId || toolCall.generation !== command.generation) {
+      return { applied: false, conflict: 'stale_fence' };
+    }
+    if (!toolCall.side_effect_id) return { applied: false, conflict: 'illegal_transition' };
+    const row = db.prepare(
+      'SELECT approval_state FROM side_effect_ledger WHERE key = ?',
+    ).get(toolCall.side_effect_id) as { approval_state: string } | undefined;
+    if (!row) return { applied: false, conflict: 'not_found' };
+    if (row.approval_state === command.state) return { applied: false, duplicate: true, effectId: toolCall.side_effect_id };
+    if (
+      ['approved', 'denied', 'interrupted', 'timed_out', 'blocked'].includes(row.approval_state)
+      && !(row.approval_state === 'approved' && command.state === 'blocked')
+    ) {
+      return { applied: false, conflict: 'terminal_state' };
+    }
+    const now = command.now ?? Date.now();
+    const changed = db.prepare(
+      `UPDATE side_effect_ledger
+          SET approval_state = ?, approval_id = ?, action_digest = ?,
+              effect_state = CASE WHEN ? = 'approved' THEN 'approved' ELSE effect_state END,
+              updated_at = ?
+        WHERE key = ? AND attempt_id = ? AND generation = ?
+          AND approval_state IN ('not_required','pending')`,
+    ).run(
+      command.state,
+      command.approvalId ?? null,
+      command.actionDigest ?? null,
+      command.state,
+      now,
+      toolCall.side_effect_id,
+      command.attemptId,
+      command.generation,
+    );
+    if (changed.changes !== 1) return { applied: false, conflict: 'illegal_transition' };
+    appendEvent({
+      jobId: toolCall.job_id,
+      runId: attempt.id,
+      attemptId: command.attemptId,
+      generation: command.generation,
+      type: `effect.approval.${command.state}`,
+      payload: {
+        toolCallId: command.toolCallId,
+        effectId: toolCall.side_effect_id,
+        approvalId: command.approvalId ?? null,
+        actionDigest: command.actionDigest ?? null,
+      },
+      producer: command.producer,
+      idempotencyKey: `effect-approval:${command.toolCallId}:${command.state}`,
+    });
+    return { applied: true, effectId: toolCall.side_effect_id };
   }).immediate;
 
   const startToolCallTx = db.transaction((command: Parameters<JobEngine['startToolCall']>[0]): TransitionResult => {
@@ -1350,6 +1503,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     }
     if (toolCall.state === 'started') return { applied: false, duplicate: true };
     if (toolCall.state !== 'prepared') return { applied: false, conflict: 'illegal_transition' };
+    if (toolCall.side_effect_id) {
+      const effect = db.prepare(
+        'SELECT approval_state FROM side_effect_ledger WHERE key = ?',
+      ).get(toolCall.side_effect_id) as { approval_state: string } | undefined;
+      if (!effect || !['approved', 'not_required'].includes(effect.approval_state)) {
+        return { applied: false, conflict: 'illegal_transition' };
+      }
+    }
     const now = Date.now();
     const changed = db.prepare(
       `UPDATE tool_calls SET state = 'started', started_at = ?, updated_at = ?
@@ -1358,9 +1519,9 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     if (changed.changes !== 1) return { applied: false, conflict: 'illegal_transition' };
     if (toolCall.side_effect_id) {
       db.prepare(
-        `UPDATE side_effect_ledger SET effect_state = 'started'
-          WHERE key = ? AND attempt_id = ? AND generation = ? AND effect_state = 'prepared'`,
-      ).run(toolCall.side_effect_id, command.attemptId, command.generation);
+        `UPDATE side_effect_ledger SET effect_state = 'started', status = 'attempting', updated_at = ?
+          WHERE key = ? AND attempt_id = ? AND generation = ? AND effect_state IN ('requested','approved')`,
+      ).run(now, toolCall.side_effect_id, command.attemptId, command.generation);
     }
     appendEvent({
       jobId: toolCall.job_id,
@@ -1372,6 +1533,18 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       producer: command.producer,
       idempotencyKey: `tool-call-started:${command.toolCallId}`,
     });
+    if (toolCall.side_effect_id) {
+      appendEvent({
+        jobId: toolCall.job_id,
+        runId: attempt.id,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        type: 'effect.started',
+        payload: { toolCallId: command.toolCallId, effectId: toolCall.side_effect_id },
+        producer: command.producer,
+        idempotencyKey: `effect-started:${command.toolCallId}`,
+      });
+    }
     return { applied: true };
   }).immediate;
 
@@ -1406,11 +1579,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       const sideEffectState = command.sideEffectState ?? (command.state === 'completed' ? 'committed' : 'unknown');
       db.prepare(
         `UPDATE side_effect_ledger
-            SET effect_state = ?, status = ?, confirmed_at = CASE WHEN ? = 'committed' THEN ? ELSE confirmed_at END
+            SET effect_state = ?, status = ?, result_ref = ?, updated_at = ?,
+                confirmed_at = CASE WHEN ? = 'committed' THEN ? ELSE confirmed_at END
           WHERE key = ? AND attempt_id = ? AND generation = ? AND effect_state = 'started'`,
       ).run(
         sideEffectState,
         sideEffectState === 'committed' ? 'confirmed' : sideEffectState,
+        command.resultRef ?? null,
+        now,
         sideEffectState,
         now,
         toolCall.side_effect_id,
@@ -1428,6 +1604,35 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       producer: command.producer,
       idempotencyKey: `tool-call-${command.state}:${command.toolCallId}`,
     });
+    if (toolCall.side_effect_id) {
+      const effectState = command.sideEffectState ?? (command.state === 'completed' ? 'committed' : 'unknown');
+      appendEvent({
+        jobId: toolCall.job_id,
+        runId: attempt.id,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        type: 'effect.result_received',
+        payload: {
+          toolCallId: command.toolCallId,
+          effectId: toolCall.side_effect_id,
+          effectState,
+          resultRef: command.resultRef ?? null,
+        },
+        producer: command.producer,
+        idempotencyKey: `effect-result:${command.toolCallId}`,
+      });
+      appendEvent({
+        jobId: toolCall.job_id,
+        runId: attempt.id,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        type: effectState === 'unknown' ? 'effect.unknown'
+          : effectState === 'committed' ? 'effect.succeeded' : 'effect.failed',
+        payload: { toolCallId: command.toolCallId, effectId: toolCall.side_effect_id },
+        producer: command.producer,
+        idempotencyKey: `effect-terminal:${command.toolCallId}:${effectState}`,
+      });
+    }
     return { applied: true };
   }).immediate;
 
@@ -1719,6 +1924,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     renewAttemptLease: renewAttemptTx,
     createRecoveryAttempt: recoveryTx,
     prepareToolCall: prepareToolCallTx,
+    resolveToolCallApproval: resolveToolCallApprovalTx,
     startToolCall: startToolCallTx,
     completeToolCall: completeToolCallTx,
     attachToolVerification: attachToolVerificationTx,

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -20,6 +20,7 @@ import type {
 import { createExecutionGraphAuthority, type ExecutionGraphAuthority } from './executionGraph';
 import { createJobResourceAuthority, type JobResourceAuthority } from './jobResourceAuthority';
 import type { JobBudgetKind, JobCapabilities } from './jobResourceAuthority';
+import { createJobProofAuthority, type JobProofAuthority } from './jobProofAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -177,6 +178,7 @@ export interface LeaseResult extends TransitionResult {
 export interface JobEngine {
   readonly graph: ExecutionGraphAuthority;
   readonly resources: JobResourceAuthority;
+  readonly proof: JobProofAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -603,6 +605,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   const { db } = opts;
   const graph = createExecutionGraphAuthority(db);
   const resources = createJobResourceAuthority(db);
+  const proof = createJobProofAuthority(db);
 
   const getJobRow = (jobId: string): JobSqlRow | undefined => db.prepare(
     `SELECT id, status, state_version, active_attempt_id, root_job_id,
@@ -1094,6 +1097,12 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
     }
     if (command.status === 'completed') {
+      if (proof.hasRequiredClaims(command.jobId)) {
+        const verdict = proof.getVerdict(command.jobId);
+        if (!verdict || (command.outcome === 'verified' && verdict.verdict !== 'verified')) {
+          return { applied: false, conflict: 'illegal_transition', stateVersion: job.state_version };
+        }
+      }
       const unresolvedChild = db.prepare(
         `SELECT 1 FROM child_job_contracts c
           JOIN tasks child ON child.id = c.child_job_id
@@ -2235,6 +2244,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
   return {
     graph,
     resources,
+    proof,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);

--- a/core/v4/daemon/jobEventProjection.ts
+++ b/core/v4/daemon/jobEventProjection.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { Db } from './db/connection';
+import type { AttemptRecord, JobEventRecord, JobRecord } from './jobEngine';
+
+export interface JobProjectionSnapshot {
+  job: JobRecord;
+  attempts: AttemptRecord[];
+  children: Array<Record<string, unknown>>;
+  inputs: Array<Record<string, unknown>>;
+  waits: Array<Record<string, unknown>>;
+  approvals: Array<Record<string, unknown>>;
+  effects: Array<Record<string, unknown>>;
+  evidence: Array<Record<string, unknown>>;
+  claims: Array<Record<string, unknown>>;
+  verdict: Record<string, unknown> | null;
+  budgets: Array<Record<string, unknown>>;
+  events: JobEventRecord[];
+}
+
+export interface JobEventProjectionAuthority {
+  cursor(consumerId: string, jobId: string): number;
+  read(consumerId: string, jobId: string, limit?: number): JobEventRecord[];
+  acknowledge(consumerId: string, jobId: string, sequence: number, now?: number): number;
+  rebuild(jobId: string): JobProjectionSnapshot;
+}
+
+type JobRow = {
+  id: string; status: string; state_version: number; active_attempt_id: string | null;
+  root_job_id: string | null; parent_task_id: string | null; session_id: string; goal: string;
+  entry_point: string | null; source: string | null; terminal_at: number | null;
+  terminal_outcome: string | null; finish_reason: string | null; next_event_sequence: number;
+};
+type AttemptRow = {
+  id: number; attempt_id: string; task_id: string | null; status: string; attempt_number: number;
+  generation: number; state_version: number; lease_id: string | null; lease_owner: string | null;
+  lease_expires_at: number | null; lease_heartbeat_at: number | null; fence_token: string | null;
+  recovery_of_attempt_id: string | null;
+};
+type EventRow = {
+  id: number; job_sequence: number; job_id: string; attempt_id: string | null; kind: string;
+  payload: string; producer: string | null; generation: number | null; idempotency_key: string; ts: number;
+};
+
+const mapJob = (row: JobRow): JobRecord => ({
+  id: row.id, status: row.status, stateVersion: row.state_version, activeAttemptId: row.active_attempt_id,
+  rootJobId: row.root_job_id ?? row.id, parentJobId: row.parent_task_id, sessionId: row.session_id,
+  goal: row.goal, entryPoint: row.entry_point, source: row.source, terminalAt: row.terminal_at,
+  terminalOutcome: row.terminal_outcome, finishReason: row.finish_reason,
+  nextEventSequence: row.next_event_sequence,
+});
+const mapAttempt = (row: AttemptRow): AttemptRecord => ({
+  rowId: row.id, id: row.attempt_id, jobId: row.task_id, status: row.status,
+  attemptNumber: row.attempt_number, generation: row.generation, stateVersion: row.state_version,
+  leaseId: row.lease_id, leaseOwner: row.lease_owner, leaseExpiresAt: row.lease_expires_at,
+  leaseHeartbeatAt: row.lease_heartbeat_at, fenceToken: row.fence_token,
+  recoveryOfAttemptId: row.recovery_of_attempt_id,
+});
+const mapEvent = (row: EventRow): JobEventRecord => {
+  let payload: Record<string, unknown> | null = null;
+  try {
+    const parsed: unknown = JSON.parse(row.payload);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) payload = parsed as Record<string, unknown>;
+  } catch { /* legacy malformed payload remains null */ }
+  return {
+    eventId: row.id, jobSequence: row.job_sequence, jobId: row.job_id, attemptId: row.attempt_id,
+    type: row.kind, payload, producer: row.producer, generation: row.generation,
+    idempotencyKey: row.idempotency_key, createdAt: row.ts,
+  };
+};
+
+export function createJobEventProjectionAuthority(db: Db): JobEventProjectionAuthority {
+  const cursor = (consumerId: string, jobId: string): number => {
+    const row = db.prepare(
+      'SELECT last_sequence FROM job_event_cursors WHERE consumer_id = ? AND job_id = ?',
+    ).get(consumerId, jobId) as { last_sequence: number } | undefined;
+    return row?.last_sequence ?? 0;
+  };
+  const eventsAfter = (jobId: string, sequence: number, limit: number): JobEventRecord[] => (
+    db.prepare(
+      `SELECT id, job_sequence, job_id, attempt_id, kind, payload, producer,
+              generation, idempotency_key, ts
+         FROM run_events WHERE job_id = ? AND job_sequence > ?
+        ORDER BY job_sequence LIMIT ?`,
+    ).all(jobId, sequence, limit) as EventRow[]
+  ).map(mapEvent);
+  const rows = (table: string, where: string, order: string, jobId: string): Array<Record<string, unknown>> =>
+    db.prepare(`SELECT * FROM ${table} WHERE ${where} ORDER BY ${order}`).all(jobId) as Array<Record<string, unknown>>;
+  return {
+    cursor,
+    read(consumerId, jobId, limit = 500) {
+      return eventsAfter(jobId, cursor(consumerId, jobId), Math.max(1, Math.min(1_000, limit)));
+    },
+    acknowledge(consumerId, jobId, sequence, now = Date.now()) {
+      const job = db.prepare('SELECT next_event_sequence FROM tasks WHERE id = ?').get(jobId) as
+        { next_event_sequence: number } | undefined;
+      if (!job) throw new Error('Job not found');
+      const bounded = Math.max(0, Math.min(sequence, job.next_event_sequence - 1));
+      db.prepare(
+        `INSERT INTO job_event_cursors (consumer_id, job_id, last_sequence, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(consumer_id, job_id) DO UPDATE SET
+           last_sequence = MAX(last_sequence, excluded.last_sequence), updated_at = excluded.updated_at`,
+      ).run(consumerId, jobId, bounded, now);
+      return cursor(consumerId, jobId);
+    },
+    rebuild(jobId) {
+      const jobRow = db.prepare(
+        `SELECT id, status, state_version, active_attempt_id, root_job_id, parent_task_id,
+                session_id, goal, entry_point, source, terminal_at, terminal_outcome,
+                finish_reason, next_event_sequence FROM tasks WHERE id = ?`,
+      ).get(jobId) as JobRow | undefined;
+      if (!jobRow) throw new Error('Job not found');
+      const attempts = (db.prepare(
+        `SELECT id, attempt_id, task_id, status, attempt_number, generation, state_version,
+                lease_id, lease_owner, lease_expires_at, lease_heartbeat_at, fence_token,
+                recovery_of_attempt_id FROM runs WHERE task_id = ? ORDER BY attempt_number`,
+      ).all(jobId) as AttemptRow[]).map(mapAttempt);
+      return {
+        job: mapJob(jobRow),
+        attempts,
+        children: rows('child_job_contracts', 'parent_job_id = ?', 'created_at, child_job_id', jobId),
+        inputs: rows('durable_inputs', 'job_id = ?', 'sequence', jobId),
+        waits: rows('job_waits', 'job_id = ?', 'sequence', jobId),
+        approvals: rows('approvals', 'job_id = ?', 'rowid', jobId),
+        effects: rows('side_effect_ledger', 'job_id = ?', 'attempted_at, key', jobId),
+        evidence: rows('job_evidence', 'job_id = ?', 'captured_at, evidence_id', jobId),
+        claims: rows('job_claims', 'job_id = ?', 'created_at, claim_id', jobId),
+        verdict: db.prepare('SELECT * FROM job_verdicts WHERE job_id = ?').get(jobId) as Record<string, unknown> | undefined ?? null,
+        budgets: rows('job_budgets', 'job_id = ?', 'kind', jobId),
+        events: eventsAfter(jobId, 0, 1_000),
+      };
+    },
+  };
+}

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -79,6 +79,7 @@ export interface PreparedDurableToolCall {
   toolCallId: string;
   effectId: string | null;
   mutates: boolean;
+  effect?: DurableEffectDescriptor;
 }
 
 function requireApplied(operation: string, result: TransitionResult): void {
@@ -156,7 +157,80 @@ export function prepareDurableToolCall(command: {
     throw new DurableToolCallConflictError('duplicate mutation', result);
   }
   requireApplied('prepare', result);
-  return { toolCallId, effectId: result.effectId ?? null, mutates: command.mutates };
+  return {
+    toolCallId,
+    effectId: result.effectId ?? null,
+    mutates: command.mutates,
+    ...(effect ? { effect } : {}),
+  };
+}
+
+function captureDurableFileProof(
+  context: JobExecutionContext,
+  prepared: PreparedDurableToolCall,
+): void {
+  const effect = prepared.effect;
+  if (!prepared.effectId || effect?.kind !== 'filesystem.write' || !effect.verificationSupported) return;
+  const expected = effect.reconciliationData;
+  const target = expected?.path;
+  const claim = context.engine.proof.createClaim({
+    jobId: context.jobId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    category: 'contract',
+    statement: `file write matches requested content: ${effect.target ?? target ?? 'target'}`,
+    required: true,
+  });
+  let payload: Record<string, unknown> = { path: target ?? effect.target, exists: false, exact: false };
+  let verificationResult: 'verified' | 'failed' | 'unknown' = 'unknown';
+  let coverage: 'full' | 'unknown' = 'unknown';
+  try {
+    if (!target || !existsSync(target)) {
+      payload = { ...payload, exists: false };
+      verificationResult = 'failed';
+      coverage = 'full';
+    } else {
+      const bytes = readFileSync(target);
+      const stat = statSync(target);
+      const contentSha256 = createHash('sha256').update(bytes).digest('hex');
+      const exact = expected?.expectedContentSha256 !== undefined
+        && expected.expectedSize !== undefined
+        && contentSha256 === expected.expectedContentSha256
+        && stat.size === expected.expectedSize;
+      payload = { path: target, exists: true, size: stat.size, contentSha256, exact };
+      verificationResult = exact ? 'verified' : 'failed';
+      coverage = 'full';
+    }
+  } catch (error) {
+    payload = {
+      path: target ?? effect.target,
+      exists: null,
+      exact: null,
+      captureError: error instanceof Error ? error.name : 'Error',
+    };
+  }
+  const observedAt = Date.now();
+  const evidence = context.engine.proof.recordEvidence({
+    jobId: context.jobId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    effectId: prepared.effectId,
+    source: 'filesystem.readback',
+    producer: context.producer,
+    observedAt,
+    freshUntil: observedAt + 60_000,
+    coverage,
+    verificationResult,
+    payload,
+  });
+  context.engine.proof.checkClaim({
+    claimId: claim.claimId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    evidenceIds: [evidence.evidenceId],
+    state: verificationResult,
+  });
 }
 
 export function recordDurableToolApproval(command: {
@@ -218,6 +292,7 @@ export async function executeWithDurableToolCall<T>(command: {
       resultRef: opaqueReference('tool-result', result),
       producer: context.producer,
     }));
+    if (succeeded) captureDurableFileProof(context, prepared);
     return result;
   } catch (error) {
     const completion = context.engine.completeToolCall({

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -7,6 +7,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
 
 import type { JobEngine, TransitionResult } from './jobEngine';
+import type { DurableEffectDescriptor } from '../effectContract';
 
 export interface JobExecutionContext {
   engine: JobEngine;
@@ -71,10 +72,88 @@ export class DurableToolCallConflictError extends Error {
   }
 }
 
+export interface PreparedDurableToolCall {
+  toolCallId: string;
+  effectId: string | null;
+  mutates: boolean;
+}
+
 function requireApplied(operation: string, result: TransitionResult): void {
   if (!result.applied && !result.duplicate) {
     throw new DurableToolCallConflictError(operation, result);
   }
+}
+
+export function prepareDurableToolCall(command: {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  riskTier: string;
+  mutates: boolean;
+  effect?: DurableEffectDescriptor;
+  approvalState?: 'not_required' | 'pending';
+}): PreparedDurableToolCall | null {
+  const context = currentJobExecutionContext();
+  if (!context) return null;
+  const toolCallId = durableToolCallId(context, command.toolCallId);
+  const argsDigest = normalizedArgsDigest(command.args);
+  const effect = command.mutates ? command.effect : undefined;
+  const result = context.engine.prepareToolCall({
+    toolCallId,
+    jobId: context.jobId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    modelCallId: command.toolCallId,
+    toolName: command.toolName,
+    normalizedArgsDigest: argsDigest,
+    riskTier: command.riskTier,
+    mutates: command.mutates,
+    effect: effect && effect.classification !== 'read_only' ? {
+      classification: effect.classification,
+      kind: effect.kind,
+      target: effect.target,
+      retrySafety: effect.retrySafety,
+      idempotencySupported: effect.idempotencySupported,
+      idempotencyKey: effect.idempotencySupported
+        ? createHash('sha256').update(`${command.toolName}\0${argsDigest}`).digest('hex')
+        : null,
+      reconciliationSupported: effect.reconciliationSupported,
+      verificationSupported: effect.verificationSupported,
+      approvalRequirement: effect.approvalRequirement,
+      approvalState: command.approvalState ?? 'not_required',
+      sensitiveFields: effect.sensitiveFields,
+      redactionRules: effect.redactionRules,
+      trusted: effect.trusted,
+    } : undefined,
+    producer: context.producer,
+  });
+  if (result.duplicate && command.mutates) {
+    throw new DurableToolCallConflictError('duplicate mutation', result);
+  }
+  requireApplied('prepare', result);
+  return { toolCallId, effectId: result.effectId ?? null, mutates: command.mutates };
+}
+
+export function recordDurableToolApproval(command: {
+  prepared: PreparedDurableToolCall | null;
+  state: 'not_required' | 'pending' | 'approved' | 'denied' | 'interrupted' | 'timed_out' | 'blocked';
+  approvalId?: string | null;
+  actionDigest?: string | null;
+}): void {
+  if (!command.prepared?.effectId) return;
+  const context = currentJobExecutionContext();
+  if (!context) return;
+  requireApplied('approval', context.engine.resolveToolCallApproval({
+    toolCallId: command.prepared.toolCallId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    state: command.state,
+    approvalId: command.approvalId,
+    actionDigest: command.actionDigest,
+    producer: context.producer,
+  }));
 }
 
 export async function executeWithDurableToolCall<T>(command: {
@@ -83,27 +162,17 @@ export async function executeWithDurableToolCall<T>(command: {
   args: Record<string, unknown>;
   riskTier: string;
   mutates: boolean;
+  effect?: DurableEffectDescriptor;
+  prepared?: PreparedDurableToolCall | null;
   execute: () => Promise<T>;
   isSuccessful?: (result: T) => boolean;
 }): Promise<T> {
   const context = currentJobExecutionContext();
   if (!context) return command.execute();
 
-  const toolCallId = durableToolCallId(context, command.toolCallId);
-
-  requireApplied('prepare', context.engine.prepareToolCall({
-    toolCallId,
-    jobId: context.jobId,
-    attemptId: context.attemptId,
-    generation: context.generation,
-    fenceToken: context.fenceToken,
-    modelCallId: command.toolCallId,
-    toolName: command.toolName,
-    normalizedArgsDigest: normalizedArgsDigest(command.args),
-    riskTier: command.riskTier,
-    mutates: command.mutates,
-    producer: context.producer,
-  }));
+  const prepared = command.prepared ?? prepareDurableToolCall(command);
+  if (!prepared) return command.execute();
+  const toolCallId = prepared.toolCallId;
   requireApplied('start', context.engine.startToolCall({
     toolCallId,
     attemptId: context.attemptId,

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -8,6 +8,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 
 import type { JobEngine, TransitionResult } from './jobEngine';
+import type { JobControlAuthority } from './jobControlAuthority';
 import type { DurableEffectDescriptor } from '../effectContract';
 
 export interface JobExecutionContext {
@@ -17,6 +18,7 @@ export interface JobExecutionContext {
   generation: number;
   fenceToken: string;
   producer: string;
+  controlAuthority?: JobControlAuthority;
 }
 
 const storage = new AsyncLocalStorage<JobExecutionContext>();

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -5,6 +5,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 
 import type { JobEngine, TransitionResult } from './jobEngine';
 import type { DurableEffectDescriptor } from '../effectContract';
@@ -98,6 +99,26 @@ export function prepareDurableToolCall(command: {
   const toolCallId = durableToolCallId(context, command.toolCallId);
   const argsDigest = normalizedArgsDigest(command.args);
   const effect = command.mutates ? command.effect : undefined;
+  const reconciliationData = effect?.reconciliationData ? { ...effect.reconciliationData } : null;
+  if (reconciliationData?.path && effect?.kind.startsWith('filesystem.')) {
+    try {
+      if (!existsSync(reconciliationData.path)) {
+        reconciliationData.before = { exists: false };
+      } else {
+        const stat = statSync(reconciliationData.path);
+        reconciliationData.before = {
+          exists: true,
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+          ...(stat.isFile() ? {
+            contentSha256: createHash('sha256').update(readFileSync(reconciliationData.path)).digest('hex'),
+          } : {}),
+        };
+      }
+    } catch {
+      reconciliationData.before = undefined;
+    }
+  }
   const result = context.engine.prepareToolCall({
     toolCallId,
     jobId: context.jobId,
@@ -125,6 +146,7 @@ export function prepareDurableToolCall(command: {
       sensitiveFields: effect.sensitiveFields,
       redactionRules: effect.redactionRules,
       trusted: effect.trusted,
+      reconciliationData,
     } : undefined,
     producer: context.producer,
   });

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -3,8 +3,19 @@
  * Licensed under AGPL-3.0. See LICENSE for details.
  */
 
-import { runWithJobExecutionContext } from './jobExecutionContext';
-import type { JobEngine, SubmitJobCommand } from './jobEngine';
+import { runWithJobExecutionContext, type JobExecutionContext } from './jobExecutionContext';
+import type {
+  AdmissionResult,
+  AttemptRecord,
+  JobEngine,
+  JobRecord,
+  SubmitJobCommand,
+} from './jobEngine';
+import type {
+  DurableInputRecord,
+  JobControlAuthority,
+  ReceiveInputCommand,
+} from './jobControlAuthority';
 
 export interface DurableJobHandle {
   jobId: string;
@@ -13,10 +24,14 @@ export interface DurableJobHandle {
   generation: number;
   fenceToken: string;
   signal: AbortSignal;
+  initialInput?: DurableInputRecord;
+  pauseAtBoundary(): void;
+  resumeAttempt(admission: AdmissionResult): void;
 }
 
 export interface DurableJobFinalization {
   status: 'completed' | 'failed' | 'cancelled';
+  attemptStatus?: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | 'unknown';
   outcome: string;
   finishReason: string;
   evidence: unknown;
@@ -27,6 +42,47 @@ export interface DurableJobFinalization {
     permissions?: Record<string, unknown> | null;
     constraints?: Record<string, unknown> | null;
   };
+}
+
+export interface DurableJobUncertainDisposition {
+  status: 'unknown' | 'blocked';
+  outcome: string;
+  finishReason: string;
+  evidence: unknown;
+}
+
+export type DurableJobDisposition = DurableJobFinalization | DurableJobUncertainDisposition;
+
+export interface ExistingDurableJobAdmission {
+  existing: AdmissionResult;
+  source: string;
+}
+
+export interface RecoveryDurableJobAdmission {
+  recovery: Parameters<JobEngine['createRecoveryAttempt']>[0];
+  source: string;
+}
+
+export type DurableJobAdmission =
+  | SubmitJobCommand
+  | ExistingDurableJobAdmission
+  | RecoveryDurableJobAdmission;
+
+export type DurableJobLifecyclePhase =
+  | 'admitted'
+  | 'leased'
+  | 'running'
+  | 'executing'
+  | 'verifying'
+  | 'settled'
+  | 'cleanup';
+
+export interface DurableJobLifecyclePhaseEvent {
+  phase: DurableJobLifecyclePhase;
+  jobId: string;
+  attemptId: string;
+  runId: number;
+  generation?: number;
 }
 
 export interface DurableJobExecutionResult<T> extends DurableJobHandle {
@@ -40,16 +96,135 @@ export class DurableJobLifecycleError extends Error {
   }
 }
 
-export async function executeDurableJob<T>(options: {
+export class DurableJobDuplicateAdmissionError extends DurableJobLifecycleError {
+  constructor(readonly admission: AdmissionResult) {
+    super('Durable Job admission already exists', admission);
+    this.name = 'DurableJobDuplicateAdmissionError';
+  }
+}
+
+export class DurableJobAuthorityLostError extends DurableJobLifecycleError {
+  constructor(message: string, handle?: Partial<DurableJobHandle>) {
+    super(message, handle);
+    this.name = 'DurableJobAuthorityLostError';
+  }
+}
+
+export interface ExecuteDurableJobOptions<T> {
   engine: JobEngine;
   ownerId: string;
-  admission: SubmitJobCommand;
+  admission: DurableJobAdmission;
   execute: (handle: DurableJobHandle) => Promise<T>;
-  finalize: (value: T) => DurableJobFinalization;
+  finalize: (value: T, handle: DurableJobHandle) => DurableJobDisposition | Promise<DurableJobDisposition>;
+  classifyError?: (
+    error: unknown,
+    handle: DurableJobHandle,
+  ) => DurableJobDisposition | null | Promise<DurableJobDisposition | null>;
+  controlAuthority?: JobControlAuthority;
+  initialInput?: Omit<ReceiveInputCommand, 'jobId' | 'targetAttemptId' | 'targetGeneration'>;
   leaseTtlMs?: number;
+  controlPollMs?: number;
   onLeaseLost?: (error: DurableJobLifecycleError) => void;
-}): Promise<DurableJobExecutionResult<T>> {
-  const admitted = options.engine.submitJob(options.admission);
+  onPhase?: (event: DurableJobLifecyclePhaseEvent) => void;
+}
+
+function isExistingAdmission(admission: DurableJobAdmission): admission is ExistingDurableJobAdmission {
+  return 'existing' in admission;
+}
+
+function isRecoveryAdmission(admission: DurableJobAdmission): admission is RecoveryDurableJobAdmission {
+  return 'recovery' in admission;
+}
+
+function producerFor(admission: DurableJobAdmission): string {
+  return admission.source;
+}
+
+export function admitDurableJob(engine: JobEngine, admission: DurableJobAdmission): AdmissionResult {
+  if (isRecoveryAdmission(admission)) {
+    return {
+      ...engine.createRecoveryAttempt(admission.recovery),
+      jobId: admission.recovery.jobId,
+      reused: false,
+    };
+  }
+  if (!isExistingAdmission(admission)) return engine.submitJob(admission);
+  const { existing } = admission;
+  const job = engine.getJob(existing.jobId);
+  const attempt = engine.getAttempt(existing.attemptId);
+  if (!job || !attempt || attempt.jobId !== job.id || attempt.rowId !== existing.runId) {
+    throw new DurableJobLifecycleError('Existing durable admission does not identify one Job and Attempt', existing);
+  }
+  if (job.activeAttemptId !== attempt.id) {
+    throw new DurableJobLifecycleError('Existing durable admission is not the active Attempt', existing);
+  }
+  return existing;
+}
+
+function isAttemptTerminal(attempt: AttemptRecord | null): boolean {
+  return attempt !== null && /^(succeeded|completed|failed|cancelled|timed_out|crashed|unknown|interrupted)$/.test(attempt.status);
+}
+
+function isJobTerminal(job: JobRecord | null): boolean {
+  return job !== null && /^(cancelled|completed|failed|dead_letter|completed_unverified|verification_failed|abandoned)$/.test(job.status);
+}
+
+function assertAuthority(engine: JobEngine, handle: DurableJobHandle): { attempt: AttemptRecord; job: JobRecord } {
+  const attempt = engine.getAttempt(handle.attemptId);
+  const job = engine.getJob(handle.jobId);
+  if (
+    !attempt
+    || !job
+    || attempt.jobId !== handle.jobId
+    || attempt.generation !== handle.generation
+    || attempt.fenceToken !== handle.fenceToken
+    || attempt.leaseOwner === null
+    || job.activeAttemptId !== handle.attemptId
+    || isAttemptTerminal(attempt)
+    || isJobTerminal(job)
+  ) {
+    throw new DurableJobAuthorityLostError('Durable lifecycle authority was lost before settlement', handle);
+  }
+  return { attempt, job };
+}
+
+function notifyPhase(
+  callback: ExecuteDurableJobOptions<unknown>['onPhase'],
+  phase: DurableJobLifecyclePhase,
+  identity: Pick<AdmissionResult, 'jobId' | 'attemptId' | 'runId'>,
+  generation?: number,
+): void {
+  if (!callback) return;
+  callback({
+    phase,
+    jobId: identity.jobId,
+    attemptId: identity.attemptId,
+    runId: identity.runId,
+    generation,
+  });
+}
+
+export async function executeDurableJob<T>(
+  options: ExecuteDurableJobOptions<T>,
+): Promise<DurableJobExecutionResult<T>> {
+  const producer = producerFor(options.admission);
+  const admitted = admitDurableJob(options.engine, options.admission);
+  notifyPhase(options.onPhase, 'admitted', admitted);
+  if (!isExistingAdmission(options.admission) && !isRecoveryAdmission(options.admission) && admitted.reused) {
+    throw new DurableJobDuplicateAdmissionError(admitted);
+  }
+
+  const receivedInput = options.initialInput
+    ? options.controlAuthority?.inputs.receive({
+      ...options.initialInput,
+      jobId: admitted.jobId,
+      targetAttemptId: admitted.attemptId,
+    })
+    : null;
+  if (options.initialInput && !options.controlAuthority) {
+    throw new DurableJobLifecycleError('Durable initial input requires JobControlAuthority', admitted);
+  }
+
   const leaseTtlMs = Math.max(3_000, options.leaseTtlMs ?? 45_000);
   const lease = options.engine.claimAttempt({
     attemptId: admitted.attemptId,
@@ -62,156 +237,377 @@ export async function executeDurableJob<T>(options: {
       admitted,
     );
   }
+  notifyPhase(options.onPhase, 'leased', admitted, lease.generation);
+
   const leaseAbort = new AbortController();
-  const handle: DurableJobHandle = {
+  const handle = {
     jobId: admitted.jobId,
     attemptId: admitted.attemptId,
     runId: admitted.runId,
     generation: lease.generation,
     fenceToken: lease.fenceToken,
     signal: leaseAbort.signal,
-  };
-  let attemptStateVersion = lease.stateVersion;
-  let jobStateVersion = options.engine.getJob(handle.jobId)?.stateVersion ?? 0;
-  const attemptStarted = options.engine.transitionAttempt({
-    attemptId: handle.attemptId,
-    expectedStateVersion: attemptStateVersion,
-    generation: handle.generation,
-    fenceToken: handle.fenceToken,
-    to: 'running',
-    eventIdempotencyKey: `attempt-running:${handle.attemptId}:${handle.generation}`,
-    producer: options.admission.source,
-  });
-  if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
-    throw new DurableJobLifecycleError(
-      `Durable Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`,
-      handle,
-    );
-  }
-  attemptStateVersion = attemptStarted.stateVersion;
-  const jobStarted = options.engine.transitionJob({
+  } as DurableJobHandle;
+  const executionContext: JobExecutionContext = {
+    engine: options.engine,
     jobId: handle.jobId,
     attemptId: handle.attemptId,
     generation: handle.generation,
     fenceToken: handle.fenceToken,
-    expectedStateVersion: jobStateVersion,
-    to: 'running',
-    eventIdempotencyKey: `job-running:${handle.jobId}:${handle.generation}`,
-    producer: options.admission.source,
-  });
-  if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
-    throw new DurableJobLifecycleError(
-      `Durable Job start rejected: ${jobStarted.conflict ?? 'unknown'}`,
-      handle,
-    );
-  }
-  jobStateVersion = jobStarted.stateVersion;
-
+    producer,
+  };
+  let attemptStateVersion = lease.stateVersion;
+  let jobStateVersion = options.engine.getJob(handle.jobId)?.stateVersion ?? 0;
+  let detachRuntime = options.controlAuthority?.runtime.attach(handle.attemptId, leaseAbort) ?? null;
   let leaseLost: DurableJobLifecycleError | null = null;
-  const heartbeat = setInterval(() => {
-    const renewed = options.engine.renewAttemptLease({
-      attemptId: handle.attemptId,
-      ownerId: options.ownerId,
-      generation: handle.generation,
-      fenceToken: handle.fenceToken,
-      ttlMs: leaseTtlMs,
-    });
-    if (!renewed.applied || renewed.stateVersion === undefined) {
-      clearInterval(heartbeat);
-      leaseLost = new DurableJobLifecycleError(
-        `Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`,
-        handle,
-      );
-      leaseAbort.abort(leaseLost);
-      options.onLeaseLost?.(leaseLost);
-      return;
-    }
-    attemptStateVersion = renewed.stateVersion;
-  }, Math.max(1_000, Math.floor(leaseTtlMs / 3)));
-  heartbeat.unref?.();
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+  let controlWatcher: ReturnType<typeof setInterval> | null = null;
+
+  const stopHeartbeat = (): void => {
+    if (heartbeat) clearInterval(heartbeat);
+    heartbeat = null;
+  };
+
+  const startHeartbeat = (): void => {
+    stopHeartbeat();
+    heartbeat = setInterval(() => {
+      const renewed = options.engine.renewAttemptLease({
+        attemptId: handle.attemptId,
+        ownerId: options.ownerId,
+        generation: handle.generation,
+        fenceToken: handle.fenceToken,
+        ttlMs: leaseTtlMs,
+      });
+      if (!renewed.applied || renewed.stateVersion === undefined) {
+        stopHeartbeat();
+        leaseLost = new DurableJobAuthorityLostError(
+          `Durable Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`,
+          handle,
+        );
+        leaseAbort.abort(leaseLost);
+        options.onLeaseLost?.(leaseLost);
+        return;
+      }
+      attemptStateVersion = renewed.stateVersion;
+    }, Math.max(1_000, Math.floor(leaseTtlMs / 3)));
+    heartbeat.unref?.();
+  };
+
+  Object.defineProperties(handle, {
+    pauseAtBoundary: {
+      enumerable: false,
+      value: (): void => {
+        const attempt = options.engine.getAttempt(handle.attemptId);
+        const job = options.engine.getJob(handle.jobId);
+        if (
+          !attempt
+          || !job
+          || attempt.jobId !== handle.jobId
+          || attempt.generation !== handle.generation
+          || attempt.status !== 'waiting'
+          || attempt.leaseOwner !== null
+          || attempt.fenceToken !== null
+          || job.status !== 'paused'
+          || job.activeAttemptId !== handle.attemptId
+        ) {
+          throw new DurableJobLifecycleError(
+            'Durable lifecycle pause boundary does not match the active paused Attempt',
+            handle,
+          );
+        }
+        stopHeartbeat();
+        detachRuntime?.();
+        detachRuntime = null;
+        attemptStateVersion = attempt.stateVersion;
+        jobStateVersion = job.stateVersion;
+      },
+    },
+    resumeAttempt: {
+      enumerable: false,
+      value: (nextAdmission: AdmissionResult): void => {
+        if (nextAdmission.jobId !== handle.jobId) {
+          throw new DurableJobLifecycleError('Resumed Attempt belongs to a different Job', nextAdmission);
+        }
+        const queuedAttempt = options.engine.getAttempt(nextAdmission.attemptId);
+        const queuedJob = options.engine.getJob(handle.jobId);
+        if (
+          !queuedAttempt
+          || !queuedJob
+          || queuedAttempt.jobId !== handle.jobId
+          || queuedAttempt.rowId !== nextAdmission.runId
+          || queuedAttempt.status !== 'queued'
+          || queuedJob.status !== 'queued'
+          || queuedJob.activeAttemptId !== nextAdmission.attemptId
+        ) {
+          throw new DurableJobLifecycleError(
+            'Resumed durable admission is not the active queued Attempt',
+            nextAdmission,
+          );
+        }
+
+        const resumedLease = options.engine.claimAttempt({
+          attemptId: nextAdmission.attemptId,
+          ownerId: options.ownerId,
+          ttlMs: leaseTtlMs,
+        });
+        if (
+          !resumedLease.acquired
+          || !resumedLease.fenceToken
+          || resumedLease.generation === undefined
+          || resumedLease.stateVersion === undefined
+        ) {
+          throw new DurableJobLifecycleError(
+            `Resumed durable Attempt lease rejected: ${resumedLease.conflict ?? 'unknown'}`,
+            nextAdmission,
+          );
+        }
+
+        const attemptStarted = options.engine.transitionAttempt({
+          attemptId: nextAdmission.attemptId,
+          expectedStateVersion: resumedLease.stateVersion,
+          generation: resumedLease.generation,
+          fenceToken: resumedLease.fenceToken,
+          to: 'running',
+          eventIdempotencyKey: `attempt-running:${nextAdmission.attemptId}:${resumedLease.generation}`,
+          producer,
+        });
+        if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
+          throw new DurableJobLifecycleError(
+            `Resumed durable Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`,
+            nextAdmission,
+          );
+        }
+        const currentJob = options.engine.getJob(handle.jobId);
+        if (!currentJob || currentJob.activeAttemptId !== nextAdmission.attemptId) {
+          throw new DurableJobLifecycleError('Resumed durable Job authority changed before start', nextAdmission);
+        }
+        const jobStarted = options.engine.transitionJob({
+          jobId: handle.jobId,
+          attemptId: nextAdmission.attemptId,
+          generation: resumedLease.generation,
+          fenceToken: resumedLease.fenceToken,
+          expectedStateVersion: currentJob.stateVersion,
+          to: 'running',
+          eventIdempotencyKey: `job-running:${handle.jobId}:${resumedLease.generation}`,
+          producer,
+        });
+        if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
+          throw new DurableJobLifecycleError(
+            `Resumed durable Job start rejected: ${jobStarted.conflict ?? 'unknown'}`,
+            nextAdmission,
+          );
+        }
+
+        detachRuntime?.();
+        handle.attemptId = nextAdmission.attemptId;
+        handle.runId = nextAdmission.runId;
+        handle.generation = resumedLease.generation;
+        handle.fenceToken = resumedLease.fenceToken;
+        executionContext.attemptId = handle.attemptId;
+        executionContext.generation = handle.generation;
+        executionContext.fenceToken = handle.fenceToken;
+        attemptStateVersion = attemptStarted.stateVersion;
+        jobStateVersion = jobStarted.stateVersion;
+        leaseLost = null;
+        detachRuntime = options.controlAuthority?.runtime.attach(handle.attemptId, leaseAbort) ?? null;
+        startHeartbeat();
+      },
+    },
+  });
 
   try {
-    const value = await runWithJobExecutionContext({
-      engine: options.engine,
-      jobId: handle.jobId,
-      attemptId: handle.attemptId,
-      generation: handle.generation,
-      fenceToken: handle.fenceToken,
-      producer: options.admission.source,
-    }, () => options.execute(handle));
-    if (leaseLost) throw leaseLost;
-
-    const finalization = options.finalize(value);
-    const attemptStatus = finalization.status === 'completed'
-      ? 'succeeded'
-      : finalization.status === 'cancelled' ? 'cancelled' : 'failed';
-    const attemptFinished = options.engine.transitionAttempt({
+    const attemptStarted = options.engine.transitionAttempt({
       attemptId: handle.attemptId,
       expectedStateVersion: attemptStateVersion,
       generation: handle.generation,
       fenceToken: handle.fenceToken,
-      to: attemptStatus,
-      eventIdempotencyKey: `attempt-${attemptStatus}:${handle.attemptId}:${handle.generation}`,
-      producer: options.admission.source,
-      finishReason: finalization.finishReason,
+      to: 'running',
+      eventIdempotencyKey: `attempt-running:${handle.attemptId}:${handle.generation}`,
+      producer,
     });
-    if (!attemptFinished.applied) {
+    if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
       throw new DurableJobLifecycleError(
-        `Durable Attempt finalization rejected: ${attemptFinished.conflict ?? 'unknown'}`,
+        `Durable Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`,
         handle,
       );
     }
-    const jobFinished = options.engine.finalizeJob({
+    attemptStateVersion = attemptStarted.stateVersion;
+    const jobStarted = options.engine.transitionJob({
       jobId: handle.jobId,
       attemptId: handle.attemptId,
       generation: handle.generation,
       fenceToken: handle.fenceToken,
       expectedStateVersion: jobStateVersion,
-      status: finalization.status,
-      outcome: finalization.outcome,
-      finishReason: finalization.finishReason,
-      evidence: finalization.evidence,
-      jobCard: finalization.jobCard,
-      eventIdempotencyKey: `job-finalized:${handle.jobId}:${handle.generation}`,
-      producer: options.admission.source,
+      to: 'running',
+      eventIdempotencyKey: `job-running:${handle.jobId}:${handle.generation}`,
+      producer,
     });
-    if (!jobFinished.applied) {
+    if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
       throw new DurableJobLifecycleError(
-        `Durable Job finalization rejected: ${jobFinished.conflict ?? 'unknown'}`,
+        `Durable Job start rejected: ${jobStarted.conflict ?? 'unknown'}`,
         handle,
       );
     }
-    return { ...handle, value };
-  } catch (error) {
-    if (!options.engine.getAttempt(handle.attemptId)?.status.match(/^(succeeded|failed|cancelled|timed_out|crashed|unknown)$/)) {
-      const attemptFailed = options.engine.transitionAttempt({
+    jobStateVersion = jobStarted.stateVersion;
+
+    if (receivedInput && options.controlAuthority) {
+      const claimed = options.controlAuthority.inputs.claimNext({
+        jobId: handle.jobId,
         attemptId: handle.attemptId,
-        expectedStateVersion: attemptStateVersion,
         generation: handle.generation,
-        fenceToken: handle.fenceToken,
-        to: 'failed',
-        eventIdempotencyKey: `attempt-failed:${handle.attemptId}:${handle.generation}`,
-        producer: options.admission.source,
-        finishReason: 'error',
+        inputId: receivedInput.record.inputId,
       });
-      if (attemptFailed.applied) {
-        options.engine.finalizeJob({
-          jobId: handle.jobId,
-          attemptId: handle.attemptId,
-          generation: handle.generation,
-          fenceToken: handle.fenceToken,
-          expectedStateVersion: jobStateVersion,
-          status: 'failed',
-          outcome: 'failed',
-          finishReason: 'error',
-          evidence: { errorClass: error instanceof Error ? error.name : 'Error' },
-          eventIdempotencyKey: `job-finalized:${handle.jobId}:${handle.generation}`,
-          producer: options.admission.source,
-        });
+      if (!claimed) {
+        throw new DurableJobLifecycleError('Durable initial input could not be claimed by the active Attempt', handle);
       }
+      const consumed = options.controlAuthority.inputs.consume({
+        inputId: claimed.inputId,
+        attemptId: handle.attemptId,
+        generation: handle.generation,
+      });
+      if (!consumed.applied && !consumed.duplicate) {
+        throw new DurableJobLifecycleError(
+          `Durable initial input could not be consumed: ${consumed.conflict ?? 'unknown'}`,
+          handle,
+        );
+      }
+      handle.initialInput = options.controlAuthority.inputs.get(claimed.inputId) ?? claimed;
+    }
+
+    startHeartbeat();
+
+    controlWatcher = setInterval(() => {
+      if (leaseAbort.signal.aborted) return;
+      const status = options.engine.getJob(handle.jobId)?.status;
+      if (status === 'cancelled' || status === 'cancelling') {
+        leaseAbort.abort(new Error('Durable Job cancellation requested'));
+      }
+    }, Math.max(25, options.controlPollMs ?? 250));
+    controlWatcher.unref?.();
+
+    notifyPhase(options.onPhase, 'running', handle, handle.generation);
+    notifyPhase(options.onPhase, 'executing', handle, handle.generation);
+    const value = await runWithJobExecutionContext(executionContext, () => options.execute(handle));
+    if (leaseLost) throw leaseLost;
+    assertAuthority(options.engine, handle);
+
+    notifyPhase(options.onPhase, 'verifying', handle, handle.generation);
+    const finalization = await options.finalize(value, handle);
+    if (leaseLost) throw leaseLost;
+    const authority = assertAuthority(options.engine, handle);
+    attemptStateVersion = authority.attempt.stateVersion;
+    jobStateVersion = authority.job.stateVersion;
+    settle(options.engine, handle, finalization, attemptStateVersion, jobStateVersion, producer);
+    notifyPhase(options.onPhase, 'settled', handle, handle.generation);
+    return Object.assign(handle, { value });
+  } catch (error) {
+    if (leaseLost || error instanceof DurableJobAuthorityLostError) throw error;
+    const attempt = options.engine.getAttempt(handle.attemptId);
+    const job = options.engine.getJob(handle.jobId);
+    if (!isAttemptTerminal(attempt) && !isJobTerminal(job)) {
+      const disposition = await options.classifyError?.(error, handle) ?? {
+        status: 'failed' as const,
+        outcome: 'failed',
+        finishReason: 'error',
+        evidence: { errorClass: error instanceof Error ? error.name : 'Error' },
+      };
+      const authority = assertAuthority(options.engine, handle);
+      settle(
+        options.engine,
+        handle,
+        disposition,
+        authority.attempt.stateVersion,
+        authority.job.stateVersion,
+        producer,
+      );
+      notifyPhase(options.onPhase, 'settled', handle, handle.generation);
     }
     throw error;
   } finally {
-    clearInterval(heartbeat);
+    stopHeartbeat();
+    if (controlWatcher) clearInterval(controlWatcher);
+    controlWatcher = null;
+    detachRuntime?.();
+    detachRuntime = null;
+    notifyPhase(options.onPhase, 'cleanup', handle, handle.generation);
+  }
+}
+
+function settle(
+  engine: JobEngine,
+  handle: DurableJobHandle,
+  finalization: DurableJobDisposition,
+  attemptStateVersion: number,
+  jobStateVersion: number,
+  producer: string,
+): void {
+  const attemptStatus = 'attemptStatus' in finalization && finalization.attemptStatus
+    ? finalization.attemptStatus
+    : finalization.status === 'completed'
+    ? 'succeeded'
+    : finalization.status === 'cancelled'
+      ? 'cancelled'
+      : finalization.status === 'unknown' || finalization.status === 'blocked'
+        ? 'unknown'
+        : 'failed';
+  const attemptFinished = engine.transitionAttempt({
+    attemptId: handle.attemptId,
+    expectedStateVersion: attemptStateVersion,
+    generation: handle.generation,
+    fenceToken: handle.fenceToken,
+    to: attemptStatus,
+    eventIdempotencyKey: `attempt-${attemptStatus}:${handle.attemptId}:${handle.generation}`,
+    producer,
+    finishReason: finalization.finishReason,
+  });
+  if (!attemptFinished.applied) {
+    throw new DurableJobLifecycleError(
+      `Durable Attempt finalization rejected: ${attemptFinished.conflict ?? 'unknown'}`,
+      handle,
+    );
+  }
+
+  if (finalization.status === 'unknown' || finalization.status === 'blocked') {
+    const jobFinished = engine.transitionJob({
+      jobId: handle.jobId,
+      attemptId: handle.attemptId,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      expectedStateVersion: jobStateVersion,
+      to: finalization.status,
+      eventIdempotencyKey: `job-${finalization.status}:${handle.jobId}:${handle.generation}`,
+      producer,
+      finishReason: finalization.finishReason,
+      terminalOutcome: finalization.outcome,
+      payload: { evidence: finalization.evidence },
+    });
+    if (!jobFinished.applied) {
+      throw new DurableJobLifecycleError(
+        `Durable Job uncertainty transition rejected: ${jobFinished.conflict ?? 'unknown'}`,
+        handle,
+      );
+    }
+    return;
+  }
+
+  const jobFinished = engine.finalizeJob({
+    jobId: handle.jobId,
+    attemptId: handle.attemptId,
+    generation: handle.generation,
+    fenceToken: handle.fenceToken,
+    expectedStateVersion: jobStateVersion,
+    status: finalization.status,
+    outcome: finalization.outcome,
+    finishReason: finalization.finishReason,
+    evidence: finalization.evidence,
+    jobCard: 'jobCard' in finalization ? finalization.jobCard : undefined,
+    eventIdempotencyKey: `job-finalized:${handle.jobId}:${handle.generation}`,
+    producer,
+  });
+  if (!jobFinished.applied) {
+    throw new DurableJobLifecycleError(
+      `Durable Job finalization rejected: ${jobFinished.conflict ?? 'unknown'}`,
+      handle,
+    );
   }
 }

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -110,6 +110,13 @@ export class DurableJobAuthorityLostError extends DurableJobLifecycleError {
   }
 }
 
+export class DurableJobBudgetExceededError extends DurableJobLifecycleError {
+  constructor(readonly budgetKind: string, handle?: Partial<DurableJobHandle>) {
+    super(`Durable Job budget exhausted: ${budgetKind}`, handle);
+    this.name = 'DurableJobBudgetExceededError';
+  }
+}
+
 export interface ExecuteDurableJobOptions<T> {
   engine: JobEngine;
   ownerId: string;
@@ -263,6 +270,9 @@ export async function executeDurableJob<T>(
   let leaseLost: DurableJobLifecycleError | null = null;
   let heartbeat: ReturnType<typeof setInterval> | null = null;
   let controlWatcher: ReturnType<typeof setInterval> | null = null;
+  let runtimeBudgetTimer: ReturnType<typeof setTimeout> | null = null;
+  let runtimeBudgetExpired = false;
+  const executionStartedAt = Date.now();
 
   const stopHeartbeat = (): void => {
     if (heartbeat) clearInterval(heartbeat);
@@ -477,6 +487,17 @@ export async function executeDurableJob<T>(
 
     startHeartbeat();
 
+    const runtimeBudget = options.engine.resources.getBudgets(handle.jobId)
+      .find((budget) => budget.kind === 'runtime_ms');
+    if (runtimeBudget?.limit !== null && runtimeBudget !== undefined) {
+      const remaining = Math.max(0, runtimeBudget.limit - runtimeBudget.used);
+      runtimeBudgetTimer = setTimeout(() => {
+        runtimeBudgetExpired = true;
+        leaseAbort.abort(new DurableJobBudgetExceededError('runtime_ms', handle));
+      }, remaining);
+      runtimeBudgetTimer.unref?.();
+    }
+
     controlWatcher = setInterval(() => {
       if (leaseAbort.signal.aborted) return;
       const status = options.engine.getJob(handle.jobId)?.status;
@@ -489,6 +510,7 @@ export async function executeDurableJob<T>(
     notifyPhase(options.onPhase, 'running', handle, handle.generation);
     notifyPhase(options.onPhase, 'executing', handle, handle.generation);
     const value = await runWithJobExecutionContext(executionContext, () => options.execute(handle));
+    if (runtimeBudgetExpired) throw new DurableJobBudgetExceededError('runtime_ms', handle);
     if (leaseLost) throw leaseLost;
     assertAuthority(options.engine, handle);
 
@@ -525,6 +547,23 @@ export async function executeDurableJob<T>(
     }
     throw error;
   } finally {
+    if (runtimeBudgetTimer) clearTimeout(runtimeBudgetTimer);
+    runtimeBudgetTimer = null;
+    if (options.engine.resources.getBudgets(handle.jobId).some((budget) => budget.kind === 'runtime_ms')) {
+      try {
+        options.engine.resources.debit({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          fenceToken: handle.fenceToken,
+          kind: 'runtime_ms',
+          amount: Math.max(0, Date.now() - executionStartedAt),
+          certainty: 'confirmed',
+          idempotencyKey: `runtime:${handle.attemptId}:${handle.generation}`,
+          enforceLimit: false,
+        });
+      } catch { /* stale authority cannot spend after replacement */ }
+    }
     stopHeartbeat();
     if (controlWatcher) clearInterval(controlWatcher);
     controlWatcher = null;

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -129,6 +129,7 @@ export interface ExecuteDurableJobOptions<T> {
   ) => DurableJobDisposition | null | Promise<DurableJobDisposition | null>;
   controlAuthority?: JobControlAuthority;
   initialInput?: Omit<ReceiveInputCommand, 'jobId' | 'targetAttemptId' | 'targetGeneration'>;
+  existingInitialInputId?: string;
   leaseTtlMs?: number;
   controlPollMs?: number;
   onLeaseLost?: (error: DurableJobLifecycleError) => void;
@@ -221,6 +222,13 @@ export async function executeDurableJob<T>(
     throw new DurableJobDuplicateAdmissionError(admitted);
   }
 
+  if (options.initialInput && options.existingInitialInputId) {
+    throw new DurableJobLifecycleError('Durable initial input must be new or existing, not both', admitted);
+  }
+  if ((options.initialInput || options.existingInitialInputId) && !options.controlAuthority) {
+    throw new DurableJobLifecycleError('Durable initial input requires JobControlAuthority', admitted);
+  }
+
   const receivedInput = options.initialInput
     ? options.controlAuthority?.inputs.receive({
       ...options.initialInput,
@@ -228,8 +236,17 @@ export async function executeDurableJob<T>(
       targetAttemptId: admitted.attemptId,
     })
     : null;
-  if (options.initialInput && !options.controlAuthority) {
-    throw new DurableJobLifecycleError('Durable initial input requires JobControlAuthority', admitted);
+  const initialInput = receivedInput?.record
+    ?? (options.existingInitialInputId
+      ? options.controlAuthority?.inputs.get(options.existingInitialInputId) ?? null
+      : null);
+  if (options.existingInitialInputId && (
+    !initialInput
+    || initialInput.jobId !== admitted.jobId
+    || (initialInput.targetAttemptId !== null && initialInput.targetAttemptId !== admitted.attemptId)
+    || !['queued', 'claimed'].includes(initialInput.state)
+  )) {
+    throw new DurableJobLifecycleError('Existing durable initial input does not match the admitted Job', admitted);
   }
 
   const leaseTtlMs = Math.max(3_000, options.leaseTtlMs ?? 45_000);
@@ -461,12 +478,12 @@ export async function executeDurableJob<T>(
     }
     jobStateVersion = jobStarted.stateVersion;
 
-    if (receivedInput && options.controlAuthority) {
+    if (initialInput && options.controlAuthority) {
       const claimed = options.controlAuthority.inputs.claimNext({
         jobId: handle.jobId,
         attemptId: handle.attemptId,
         generation: handle.generation,
-        inputId: receivedInput.record.inputId,
+        inputId: initialInput.inputId,
       });
       if (!claimed) {
         throw new DurableJobLifecycleError('Durable initial input could not be claimed by the active Attempt', handle);

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -255,6 +255,7 @@ export async function executeDurableJob<T>(
     generation: handle.generation,
     fenceToken: handle.fenceToken,
     producer,
+    controlAuthority: options.controlAuthority,
   };
   let attemptStateVersion = lease.stateVersion;
   let jobStateVersion = options.engine.getJob(handle.jobId)?.stateVersion ?? 0;

--- a/core/v4/daemon/jobProofAuthority.ts
+++ b/core/v4/daemon/jobProofAuthority.ts
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { Db } from './db/connection';
+
+export type ClaimCategory = 'contract' | 'observed' | 'courtesy';
+export type ClaimState = 'unverified' | 'verified' | 'failed' | 'unknown';
+export type FinalVerdict = 'verified' | 'partially_verified' | 'failed' | 'unknown' | 'cancelled';
+
+export interface ClaimRecord {
+  claimId: string;
+  jobId: string;
+  attemptId: string | null;
+  generation: number | null;
+  category: ClaimCategory;
+  statement: string;
+  required: boolean;
+  state: ClaimState;
+}
+
+export interface EvidenceRecord {
+  evidenceId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  effectId: string | null;
+  source: string;
+  producer: string;
+  capturedAt: number;
+  observedAt: number;
+  freshUntil: number | null;
+  integritySha256: string;
+  coverage: 'full' | 'partial' | 'unknown';
+  verificationResult: ClaimState;
+  payload: unknown;
+  late: boolean;
+}
+
+export interface JobVerdictRecord {
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  verdict: FinalVerdict;
+  summary: Record<string, unknown>;
+  finalizedAt: number;
+}
+
+export interface JobProofAuthority {
+  createClaim(command: {
+    jobId: string; attemptId?: string | null; generation?: number | null;
+    category: ClaimCategory; statement: string; required?: boolean; now?: number;
+  }): ClaimRecord;
+  recordEvidence(command: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    effectId?: string | null; source: string; producer: string; observedAt: number;
+    freshUntil?: number | null; coverage: 'full' | 'partial' | 'unknown';
+    verificationResult: ClaimState; payload: unknown; now?: number;
+  }): EvidenceRecord;
+  checkClaim(command: {
+    claimId: string; attemptId: string; generation: number; evidenceIds: string[];
+    state: Exclude<ClaimState, 'unverified'>; now?: number;
+  }): ClaimRecord;
+  listClaims(jobId: string): ClaimRecord[];
+  listEvidence(jobId: string): EvidenceRecord[];
+  hasRequiredClaims(jobId: string): boolean;
+  finalize(command: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    cancelled?: boolean; now?: number;
+  }): JobVerdictRecord;
+  getVerdict(jobId: string): JobVerdictRecord | null;
+  exportJson(jobId: string): Record<string, unknown>;
+  exportMarkdown(jobId: string): string;
+}
+
+type ClaimRow = {
+  claim_id: string; job_id: string; attempt_id: string | null; generation: number | null;
+  category: ClaimCategory; statement: string; required: number; state: ClaimState;
+};
+type EvidenceRow = {
+  evidence_id: string; job_id: string; attempt_id: string; generation: number; effect_id: string | null;
+  source: string; producer: string; captured_at: number; observed_at: number; fresh_until: number | null;
+  integrity_sha256: string; coverage: EvidenceRecord['coverage']; verification_result: ClaimState;
+  payload_json: string; late: number;
+};
+
+const id = (prefix: string): string => `${prefix}_${randomBytes(12).toString('hex')}`;
+const digest = (value: unknown): string => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+const mapClaim = (row: ClaimRow): ClaimRecord => ({
+  claimId: row.claim_id, jobId: row.job_id, attemptId: row.attempt_id, generation: row.generation,
+  category: row.category, statement: row.statement, required: row.required === 1, state: row.state,
+});
+const mapEvidence = (row: EvidenceRow): EvidenceRecord => ({
+  evidenceId: row.evidence_id, jobId: row.job_id, attemptId: row.attempt_id,
+  generation: row.generation, effectId: row.effect_id, source: row.source, producer: row.producer,
+  capturedAt: row.captured_at, observedAt: row.observed_at, freshUntil: row.fresh_until,
+  integritySha256: row.integrity_sha256, coverage: row.coverage,
+  verificationResult: row.verification_result, payload: JSON.parse(row.payload_json), late: row.late === 1,
+});
+
+export function createJobProofAuthority(db: Db): JobProofAuthority {
+  const assertAttempt = (jobId: string, attemptId: string, generation: number, fenceToken?: string): void => {
+    const row = db.prepare(
+      `SELECT r.generation, r.fence_token FROM runs r WHERE r.task_id = ? AND r.attempt_id = ?`,
+    ).get(jobId, attemptId) as { generation: number; fence_token: string | null } | undefined;
+    if (!row || row.generation !== generation || (fenceToken !== undefined && row.fence_token !== fenceToken)) {
+      throw new Error('Evidence authority does not match the producing Attempt');
+    }
+  };
+  const getVerdict = (jobId: string): JobVerdictRecord | null => {
+    const row = db.prepare('SELECT * FROM job_verdicts WHERE job_id = ?').get(jobId) as {
+      job_id: string; attempt_id: string; generation: number; verdict: FinalVerdict;
+      summary_json: string; finalized_at: number;
+    } | undefined;
+    return row ? {
+      jobId: row.job_id, attemptId: row.attempt_id, generation: row.generation,
+      verdict: row.verdict, summary: JSON.parse(row.summary_json) as Record<string, unknown>, finalizedAt: row.finalized_at,
+    } : null;
+  };
+  const listClaims = (jobId: string): ClaimRecord[] => (
+    db.prepare('SELECT * FROM job_claims WHERE job_id = ? ORDER BY created_at, claim_id').all(jobId) as ClaimRow[]
+  ).map(mapClaim);
+  const listEvidence = (jobId: string): EvidenceRecord[] => (
+    db.prepare('SELECT * FROM job_evidence WHERE job_id = ? ORDER BY captured_at, evidence_id').all(jobId) as EvidenceRow[]
+  ).map(mapEvidence);
+
+  const authority: JobProofAuthority = {
+    createClaim(command) {
+      if (!db.prepare('SELECT 1 FROM tasks WHERE id = ?').get(command.jobId)) throw new Error('Job not found');
+      if (command.attemptId && command.generation !== null && command.generation !== undefined) {
+        assertAttempt(command.jobId, command.attemptId, command.generation);
+      }
+      const claimId = id('claim');
+      db.prepare(
+        `INSERT INTO job_claims
+           (claim_id, job_id, attempt_id, generation, category, statement, required, state, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'unverified', ?)`,
+      ).run(
+        claimId, command.jobId, command.attemptId ?? null, command.generation ?? null,
+        command.category, command.statement, command.required === true ? 1 : 0, command.now ?? Date.now(),
+      );
+      return authority.listClaims(command.jobId).find((claim) => claim.claimId === claimId)!;
+    },
+    recordEvidence(command) {
+      assertAttempt(command.jobId, command.attemptId, command.generation, command.fenceToken);
+      const now = command.now ?? Date.now();
+      const payloadJson = JSON.stringify(command.payload ?? null);
+      const evidenceId = id('evidence');
+      const late = getVerdict(command.jobId) !== null;
+      db.transaction(() => {
+        db.prepare(
+          `INSERT INTO job_evidence (
+             evidence_id, job_id, attempt_id, generation, effect_id, source, producer,
+             captured_at, observed_at, fresh_until, integrity_sha256, coverage,
+             verification_result, payload_json, late
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          evidenceId, command.jobId, command.attemptId, command.generation, command.effectId ?? null,
+          command.source, command.producer, now, command.observedAt, command.freshUntil ?? null,
+          digest(command.payload ?? null), command.coverage, command.verificationResult, payloadJson, late ? 1 : 0,
+        );
+        if (late) db.prepare(
+          `INSERT INTO proof_reviews (job_id, evidence_id, reason, created_at) VALUES (?, ?, 'late evidence', ?)`,
+        ).run(command.jobId, evidenceId, now);
+      }).immediate();
+      return authority.listEvidence(command.jobId).find((evidence) => evidence.evidenceId === evidenceId)!;
+    },
+    checkClaim(command) {
+      const claim = db.prepare('SELECT * FROM job_claims WHERE claim_id = ?').get(command.claimId) as ClaimRow | undefined;
+      if (!claim) throw new Error('Claim not found');
+      if (getVerdict(claim.job_id)) throw new Error('Final verdict is immutable');
+      assertAttempt(claim.job_id, command.attemptId, command.generation);
+      const now = command.now ?? Date.now();
+      db.transaction(() => {
+        for (const evidenceId of command.evidenceIds) {
+          const evidence = db.prepare('SELECT * FROM job_evidence WHERE evidence_id = ?').get(evidenceId) as EvidenceRow | undefined;
+          if (!evidence || evidence.job_id !== claim.job_id || evidence.attempt_id !== command.attemptId || evidence.generation !== command.generation) {
+            throw new Error('Stale or unrelated evidence cannot prove this claim');
+          }
+          if (evidence.fresh_until !== null && evidence.fresh_until < now) throw new Error('Stale evidence cannot prove a claim');
+          db.prepare('INSERT OR IGNORE INTO claim_evidence (claim_id, evidence_id, created_at) VALUES (?, ?, ?)')
+            .run(command.claimId, evidenceId, now);
+        }
+        db.prepare('UPDATE job_claims SET state = ?, attempt_id = ?, generation = ?, checked_at = ? WHERE claim_id = ?')
+          .run(command.state, command.attemptId, command.generation, now, command.claimId);
+      }).immediate();
+      return authority.listClaims(claim.job_id).find((item) => item.claimId === command.claimId)!;
+    },
+    listClaims,
+    listEvidence,
+    hasRequiredClaims(jobId) {
+      return db.prepare("SELECT 1 FROM job_claims WHERE job_id = ? AND category = 'contract' AND required = 1 LIMIT 1")
+        .get(jobId) !== undefined;
+    },
+    finalize(command) {
+      const existing = getVerdict(command.jobId);
+      if (existing) return existing;
+      assertAttempt(command.jobId, command.attemptId, command.generation, command.fenceToken);
+      const claims = listClaims(command.jobId).filter((claim) => claim.category === 'contract' && claim.required);
+      const evidence = listEvidence(command.jobId).filter(
+        (item) => item.attemptId === command.attemptId && item.generation === command.generation && !item.late,
+      );
+      const unresolvedEffect = db.prepare(
+        `SELECT 1 FROM side_effect_ledger WHERE job_id = ?
+          AND effect_state IN ('unknown','partial','started') LIMIT 1`,
+      ).get(command.jobId) !== undefined;
+      const verifiedCount = claims.filter((claim) => claim.state === 'verified').length;
+      const failedCount = claims.filter((claim) => claim.state === 'failed').length;
+      const unknownCount = claims.filter((claim) => claim.state === 'unknown' || claim.state === 'unverified').length;
+      const incompleteCoverage = evidence.some((item) => item.coverage !== 'full' || item.verificationResult === 'unknown');
+      let verdict: FinalVerdict;
+      if (command.cancelled) verdict = 'cancelled';
+      else if (unresolvedEffect || unknownCount > 0 || incompleteCoverage) verdict = verifiedCount > 0 ? 'partially_verified' : 'unknown';
+      else if (failedCount > 0) verdict = verifiedCount > 0 ? 'partially_verified' : 'failed';
+      else if (claims.length > 0 && verifiedCount === claims.length) verdict = 'verified';
+      else verdict = 'unknown';
+      const now = command.now ?? Date.now();
+      const summary = { requiredClaims: claims.length, verifiedClaims: verifiedCount, failedClaims: failedCount, unknownClaims: unknownCount };
+      db.prepare(
+        `INSERT INTO job_verdicts (job_id, attempt_id, generation, verdict, summary_json, finalized_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(command.jobId, command.attemptId, command.generation, verdict, JSON.stringify(summary), now);
+      return getVerdict(command.jobId)!;
+    },
+    getVerdict,
+    exportJson(jobId) {
+      const job = db.prepare('SELECT id, goal, status, terminal_outcome, finish_reason FROM tasks WHERE id = ?').get(jobId);
+      if (!job) throw new Error('Job not found');
+      const rows = (table: string, order: string): unknown[] => db.prepare(`SELECT * FROM ${table} WHERE job_id = ? ORDER BY ${order}`).all(jobId);
+      return {
+        job,
+        graph: db.prepare('SELECT * FROM execution_graphs WHERE job_id = ?').get(jobId) ?? null,
+        attempts: db.prepare('SELECT attempt_id, attempt_number, generation, status, finish_reason FROM runs WHERE task_id = ? ORDER BY attempt_number').all(jobId),
+        approvals: rows('approvals', 'rowid'),
+        effects: rows('side_effect_ledger', 'attempted_at'),
+        claims: listClaims(jobId),
+        evidence: listEvidence(jobId),
+        verdict: getVerdict(jobId),
+      };
+    },
+    exportMarkdown(jobId) {
+      const proof = authority.exportJson(jobId) as {
+        job: { goal: string }; claims: ClaimRecord[]; evidence: EvidenceRecord[]; verdict: JobVerdictRecord | null;
+      };
+      const lines = [
+        '# Aiden Proof', '', `Goal: ${proof.job.goal}`, '',
+        `Verdict: ${proof.verdict?.verdict ?? 'not finalized'}`, '',
+        '## Claims',
+        ...proof.claims.map((claim) => `- [${claim.state}] ${claim.statement}`),
+        '', '## Evidence',
+        ...proof.evidence.map((evidence) => `- ${evidence.evidenceId}: ${evidence.source} (${evidence.verificationResult}, ${evidence.coverage})`),
+      ];
+      return `${lines.join('\n')}\n`;
+    },
+  };
+  return authority;
+}

--- a/core/v4/daemon/jobProofAuthority.ts
+++ b/core/v4/daemon/jobProofAuthority.ts
@@ -147,6 +147,23 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
     recordEvidence(command) {
       assertAttempt(command.jobId, command.attemptId, command.generation, command.fenceToken);
       const now = command.now ?? Date.now();
+      if (command.effectId) {
+        const effect = db.prepare(
+          `SELECT job_id, attempt_id, generation, attempted_at
+             FROM side_effect_ledger WHERE key = ?`,
+        ).get(command.effectId) as {
+          job_id: string; attempt_id: string; generation: number; attempted_at: number;
+        } | undefined;
+        if (!effect
+          || effect.job_id !== command.jobId
+          || effect.attempt_id !== command.attemptId
+          || effect.generation !== command.generation) {
+          throw new Error('Evidence does not match the linked Effect authority');
+        }
+        if (command.observedAt < effect.attempted_at) {
+          throw new Error('Evidence must be observed after the linked Effect began');
+        }
+      }
       const payloadJson = JSON.stringify(command.payload ?? null);
       const evidenceId = id('evidence');
       const late = getVerdict(command.jobId) !== null;
@@ -175,14 +192,22 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       assertAttempt(claim.job_id, command.attemptId, command.generation);
       const now = command.now ?? Date.now();
       db.transaction(() => {
+        const linkedEvidence: EvidenceRow[] = [];
         for (const evidenceId of command.evidenceIds) {
           const evidence = db.prepare('SELECT * FROM job_evidence WHERE evidence_id = ?').get(evidenceId) as EvidenceRow | undefined;
           if (!evidence || evidence.job_id !== claim.job_id || evidence.attempt_id !== command.attemptId || evidence.generation !== command.generation) {
             throw new Error('Stale or unrelated evidence cannot prove this claim');
           }
           if (evidence.fresh_until !== null && evidence.fresh_until < now) throw new Error('Stale evidence cannot prove a claim');
+          linkedEvidence.push(evidence);
           db.prepare('INSERT OR IGNORE INTO claim_evidence (claim_id, evidence_id, created_at) VALUES (?, ?, ?)')
             .run(command.claimId, evidenceId, now);
+        }
+        if (command.state === 'verified' && (
+          linkedEvidence.length === 0
+          || linkedEvidence.some((item) => item.verification_result !== 'verified' || item.coverage !== 'full')
+        )) {
+          throw new Error('Verified claims require complete verified evidence');
         }
         db.prepare('UPDATE job_claims SET state = ?, attempt_id = ?, generation = ?, checked_at = ? WHERE claim_id = ?')
           .run(command.state, command.attemptId, command.generation, now, command.claimId);
@@ -238,6 +263,12 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
         effects: rows('side_effect_ledger', 'attempted_at'),
         claims: listClaims(jobId),
         evidence: listEvidence(jobId),
+        claimEvidence: db.prepare(
+          `SELECT ce.claim_id AS claimId, ce.evidence_id AS evidenceId, ce.created_at AS createdAt
+             FROM claim_evidence ce
+             JOIN job_claims c ON c.claim_id = ce.claim_id
+            WHERE c.job_id = ? ORDER BY ce.created_at, ce.claim_id, ce.evidence_id`,
+        ).all(jobId),
         verdict: getVerdict(jobId),
       };
     },

--- a/core/v4/daemon/jobRecoverySweep.ts
+++ b/core/v4/daemon/jobRecoverySweep.ts
@@ -5,6 +5,7 @@
 
 import type { JobEngine } from './jobEngine';
 import type { TriggerBus } from './triggerBus';
+import { reconcileFilesystemEffectSync } from '../effectReconciliation';
 
 export interface DurableRecoverySweepResult {
   expired: number;
@@ -12,6 +13,7 @@ export interface DurableRecoverySweepResult {
   needsUser: number;
   deadLettered: number;
   enqueued: number;
+  reconciled: number;
 }
 
 /**
@@ -40,7 +42,38 @@ export function sweepDurableJobRecovery(input: {
     needsUser: decisions.filter((item) => item.decision === 'ask_user').length,
     deadLettered: decisions.filter((item) => item.decision === 'dead_letter').length,
     enqueued: 0,
+    reconciled: 0,
   };
+
+  for (const decision of decisions.filter((item) => item.decision === 'ask_user')) {
+    const job = input.jobEngine.getJob(decision.jobId);
+    if (!job) continue;
+    const effects = input.jobEngine.listEffectsRequiringReconciliation(job.id);
+    for (const effect of effects) {
+      const reconciliation = reconcileFilesystemEffectSync(effect);
+      const recorded = input.jobEngine.recordEffectReconciliation({
+        effectId: effect.effectId,
+        expectedJobStateVersion: input.jobEngine.getJob(job.id)?.stateVersion ?? job.stateVersion,
+        ...reconciliation,
+        producer: input.producer,
+        idempotencyKey: `recovery:${effect.effectId}:${effect.generation}`,
+        now: input.now,
+      });
+      if (recorded.applied) result.reconciled += 1;
+    }
+    if (input.jobEngine.listEffectsRequiringReconciliation(job.id).length === 0) {
+      input.jobEngine.createRecoveryAttempt({
+        jobId: job.id,
+        recoveryOfAttemptId: decision.expiredAttemptId,
+        instanceId: input.instanceId,
+        triggerReason: 'effect_reconciled',
+        producer: input.producer,
+        eventIdempotencyKey: `effect-reconciled-resume:${job.id}:${job.stateVersion}`,
+      });
+      result.needsUser = Math.max(0, result.needsUser - 1);
+      result.retried += 1;
+    }
+  }
 
   for (const job of input.jobEngine.listJobs({ status: 'recovering' })) {
     const attempt = job.activeAttemptId

--- a/core/v4/daemon/jobResourceAuthority.ts
+++ b/core/v4/daemon/jobResourceAuthority.ts
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { resolve, sep } from 'node:path';
+
+import type { Db } from './db/connection';
+
+export type JobBudgetKind =
+  | 'runtime_ms' | 'model_calls' | 'input_tokens' | 'output_tokens'
+  | 'reasoning_tokens' | 'tool_calls' | 'retries' | 'workers'
+  | 'external_cost' | 'effects' | 'concurrent_nodes' | 'storage_bytes'
+  | 'output_bytes';
+
+export type BudgetCertainty = 'estimated' | 'confirmed' | 'unknown';
+
+export interface JobCapabilities {
+  tools?: readonly string[];
+  paths?: readonly string[];
+  hosts?: readonly string[];
+  applications?: readonly string[];
+  connections?: readonly string[];
+  accounts?: readonly string[];
+  workers?: readonly string[];
+  effectKinds?: readonly string[];
+}
+
+export interface JobBudgetRecord {
+  jobId: string;
+  kind: JobBudgetKind;
+  limit: number | null;
+  used: number;
+  hasUnknownUsage: boolean;
+  stateVersion: number;
+}
+
+export interface JobResourceAuthority {
+  configure(command: {
+    jobId: string;
+    budgets?: Partial<Record<JobBudgetKind, number | null>>;
+    capabilities?: JobCapabilities;
+    now?: number;
+  }): void;
+  getBudgets(jobId: string): JobBudgetRecord[];
+  debit(command: {
+    jobId: string;
+    attemptId: string;
+    generation: number;
+    fenceToken: string;
+    kind: JobBudgetKind;
+    amount: number | null;
+    certainty: BudgetCertainty;
+    idempotencyKey: string;
+    enforceLimit?: boolean;
+    now?: number;
+  }): { applied: boolean; duplicate?: boolean; exhausted?: boolean; remaining: number | null };
+  authorize(command: {
+    jobId: string;
+    kind: 'tool' | 'path' | 'host' | 'application' | 'connection' | 'account' | 'worker' | 'effect';
+    value: string;
+  }): boolean;
+}
+
+const CAPABILITY_COLUMN = {
+  tool: 'allowed_tools_json',
+  path: 'allowed_paths_json',
+  host: 'allowed_hosts_json',
+  application: 'allowed_applications_json',
+  connection: 'allowed_connections_json',
+  account: 'allowed_accounts_json',
+  worker: 'allowed_workers_json',
+  effect: 'allowed_effect_kinds_json',
+} as const;
+
+function parseList(raw: string): string[] {
+  try {
+    const value: unknown = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeCapabilities(value: JobCapabilities = {}): Required<JobCapabilities> {
+  return {
+    tools: value.tools === undefined ? ['*'] : [...value.tools],
+    paths: value.paths === undefined ? ['*'] : [...value.paths].map((path) => resolve(path)),
+    hosts: value.hosts === undefined ? ['*'] : [...value.hosts].map((host) => host.toLowerCase()),
+    applications: value.applications === undefined ? ['*'] : [...value.applications],
+    connections: value.connections === undefined ? ['*'] : [...value.connections],
+    accounts: value.accounts === undefined ? ['*'] : [...value.accounts],
+    workers: value.workers === undefined ? ['*'] : [...value.workers],
+    effectKinds: value.effectKinds === undefined ? ['*'] : [...value.effectKinds],
+  };
+}
+
+export function createJobResourceAuthority(db: Db): JobResourceAuthority {
+  return {
+    configure(command) {
+      const now = command.now ?? Date.now();
+      db.transaction(() => {
+        const job = db.prepare('SELECT parent_task_id FROM tasks WHERE id = ?').get(command.jobId) as
+          { parent_task_id: string | null } | undefined;
+        if (!job) throw new Error(`Job not found: ${command.jobId}`);
+        for (const [kind, requested] of Object.entries(command.budgets ?? {}) as Array<[JobBudgetKind, number | null]>) {
+          if (requested !== null && (!Number.isFinite(requested) || requested < 0)) {
+            throw new Error(`Invalid ${kind} budget`);
+          }
+          if (job.parent_task_id) {
+            const parent = db.prepare('SELECT limit_value, used_value FROM job_budgets WHERE job_id = ? AND kind = ?')
+              .get(job.parent_task_id, kind) as { limit_value: number | null; used_value: number } | undefined;
+            const parentRemaining = parent?.limit_value === null || parent === undefined
+              ? null
+              : Math.max(0, parent.limit_value - parent.used_value);
+            if (parentRemaining !== null && (requested === null || requested > parentRemaining)) {
+              throw new Error(`Child ${kind} budget exceeds parent remaining budget`);
+            }
+          }
+          db.prepare(
+            `INSERT INTO job_budgets (job_id, kind, limit_value, used_value, has_unknown_usage, state_version, updated_at)
+             VALUES (?, ?, ?, 0, 0, 0, ?)`,
+          ).run(command.jobId, kind, requested, now);
+        }
+        const capabilities = normalizeCapabilities(command.capabilities);
+        if (job.parent_task_id) {
+          const parent = db.prepare('SELECT * FROM job_capability_sets WHERE job_id = ?').get(job.parent_task_id) as
+            Record<string, string> | undefined;
+          if (parent) {
+            for (const [kind, column] of Object.entries(CAPABILITY_COLUMN)) {
+              const parentValues = parseList(parent[column]!);
+              const childValues = capabilities[`${kind === 'effect' ? 'effectKinds' : `${kind}s`}` as keyof JobCapabilities] ?? [];
+              const exceedsParent = !parentValues.includes('*') && (kind === 'path'
+                ? childValues.some((item) => item === '*' || !parentValues.some((root) => item === root || item.startsWith(`${root}${sep}`)))
+                : childValues.some((item) => item === '*' || !parentValues.includes(item)));
+              if (exceedsParent) {
+                throw new Error(`Child ${kind} capability exceeds parent boundary`);
+              }
+            }
+          }
+        }
+        db.prepare(
+          `INSERT INTO job_capability_sets (
+             job_id, allowed_tools_json, allowed_paths_json, allowed_hosts_json,
+             allowed_applications_json, allowed_connections_json, allowed_accounts_json,
+             allowed_workers_json, allowed_effect_kinds_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          command.jobId, JSON.stringify(capabilities.tools), JSON.stringify(capabilities.paths),
+          JSON.stringify(capabilities.hosts), JSON.stringify(capabilities.applications),
+          JSON.stringify(capabilities.connections), JSON.stringify(capabilities.accounts),
+          JSON.stringify(capabilities.workers), JSON.stringify(capabilities.effectKinds), now, now,
+        );
+      }).immediate();
+    },
+    getBudgets(jobId) {
+      const rows = db.prepare(
+        'SELECT job_id, kind, limit_value, used_value, has_unknown_usage, state_version FROM job_budgets WHERE job_id = ? ORDER BY kind',
+      ).all(jobId) as Array<{
+        job_id: string; kind: JobBudgetKind; limit_value: number | null; used_value: number;
+        has_unknown_usage: number; state_version: number;
+      }>;
+      return rows.map((row) => ({
+        jobId: row.job_id, kind: row.kind, limit: row.limit_value, used: row.used_value,
+        hasUnknownUsage: row.has_unknown_usage === 1, stateVersion: row.state_version,
+      }));
+    },
+    debit(command) {
+      return db.transaction(() => {
+        const prior = db.prepare('SELECT 1 FROM job_budget_debits WHERE job_id = ? AND idempotency_key = ?')
+          .get(command.jobId, command.idempotencyKey);
+        const budget = db.prepare('SELECT * FROM job_budgets WHERE job_id = ? AND kind = ?')
+          .get(command.jobId, command.kind) as {
+            limit_value: number | null; used_value: number; state_version: number; has_unknown_usage: number;
+          } | undefined;
+        if (!budget) throw new Error(`Budget not configured: ${command.kind}`);
+        const remaining = budget.limit_value === null ? null : Math.max(0, budget.limit_value - budget.used_value);
+        if (prior) return { applied: false, duplicate: true, remaining };
+        const attempt = db.prepare(
+          `SELECT r.task_id, r.generation, r.fence_token, r.status AS attempt_status,
+                  t.active_attempt_id, t.status AS job_status
+             FROM runs r JOIN tasks t ON t.id = r.task_id WHERE r.attempt_id = ?`,
+        ).get(command.attemptId) as {
+          task_id: string; generation: number; fence_token: string | null; attempt_status: string;
+          active_attempt_id: string | null; job_status: string;
+        } | undefined;
+        const terminalAccounting = attempt?.active_attempt_id === null
+          && /^(succeeded|failed|cancelled|timed_out|crashed|unknown)$/.test(attempt.attempt_status)
+          && /^(completed|failed|cancelled|dead_letter)$/.test(attempt.job_status);
+        if (
+          !attempt || attempt.task_id !== command.jobId
+          || (attempt.active_attempt_id !== command.attemptId && !terminalAccounting)
+          || attempt.generation !== command.generation || attempt.fence_token !== command.fenceToken
+        ) throw new Error('Stale worker cannot debit Job budget');
+        const amount = command.certainty === 'unknown' ? null : command.amount;
+        if (amount !== null && (!Number.isFinite(amount) || amount < 0)) throw new Error('Budget debit must be non-negative');
+        const exceedsLimit = amount !== null && budget.limit_value !== null && budget.used_value + amount > budget.limit_value;
+        if (exceedsLimit && command.enforceLimit !== false) {
+          return { applied: false, exhausted: true, remaining };
+        }
+        db.prepare(
+          `INSERT INTO job_budget_debits
+             (debit_id, job_id, attempt_id, generation, kind, amount, certainty, idempotency_key, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          `debit_${randomBytes(12).toString('hex')}`, command.jobId, command.attemptId,
+          command.generation, command.kind, amount, command.certainty,
+          command.idempotencyKey, command.now ?? Date.now(),
+        );
+        const nextUsed = budget.used_value + (amount ?? 0);
+        db.prepare(
+          `UPDATE job_budgets SET used_value = ?, has_unknown_usage = ?,
+             state_version = state_version + 1, updated_at = ? WHERE job_id = ? AND kind = ? AND state_version = ?`,
+        ).run(
+          nextUsed, amount === null ? 1 : budget.has_unknown_usage, command.now ?? Date.now(),
+          command.jobId, command.kind, budget.state_version,
+        );
+        return {
+          applied: true,
+          ...(exceedsLimit ? { exhausted: true } : {}),
+          remaining: budget.limit_value === null ? null : Math.max(0, budget.limit_value - nextUsed),
+        };
+      }).immediate();
+    },
+    authorize(command) {
+      const column = CAPABILITY_COLUMN[command.kind];
+      const row = db.prepare(`SELECT ${column} AS allowed FROM job_capability_sets WHERE job_id = ?`)
+        .get(command.jobId) as { allowed: string } | undefined;
+      if (!row) return true;
+      const allowed = parseList(row.allowed);
+      if (allowed.includes('*')) return true;
+      if (allowed.length === 0) return false;
+      if (command.kind === 'path') {
+        const candidate = resolve(command.value);
+        return allowed.some((root) => candidate === root || candidate.startsWith(`${root}${sep}`));
+      }
+      if (command.kind === 'host') return allowed.includes(command.value.toLowerCase());
+      return allowed.includes(command.value);
+    },
+  };
+}

--- a/core/v4/daemon/jobResourceAuthority.ts
+++ b/core/v4/daemon/jobResourceAuthority.ts
@@ -4,8 +4,8 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { resolve, sep } from 'node:path';
 
+import { isPortablePathWithin, resolvePortablePath } from '../portablePath';
 import type { Db } from './db/connection';
 
 export type JobBudgetKind =
@@ -86,7 +86,9 @@ function parseList(raw: string): string[] {
 function normalizeCapabilities(value: JobCapabilities = {}): Required<JobCapabilities> {
   return {
     tools: value.tools === undefined ? ['*'] : [...value.tools],
-    paths: value.paths === undefined ? ['*'] : [...value.paths].map((path) => resolve(path)),
+    paths: value.paths === undefined
+      ? ['*']
+      : [...value.paths].map((path) => path === '*' ? path : resolvePortablePath(process.cwd(), path)),
     hosts: value.hosts === undefined ? ['*'] : [...value.hosts].map((host) => host.toLowerCase()),
     applications: value.applications === undefined ? ['*'] : [...value.applications],
     connections: value.connections === undefined ? ['*'] : [...value.connections],
@@ -132,7 +134,7 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
               const parentValues = parseList(parent[column]!);
               const childValues = capabilities[`${kind === 'effect' ? 'effectKinds' : `${kind}s`}` as keyof JobCapabilities] ?? [];
               const exceedsParent = !parentValues.includes('*') && (kind === 'path'
-                ? childValues.some((item) => item === '*' || !parentValues.some((root) => item === root || item.startsWith(`${root}${sep}`)))
+                ? childValues.some((item) => item === '*' || !parentValues.some((root) => isPortablePathWithin(item, root)))
                 : childValues.some((item) => item === '*' || !parentValues.includes(item)));
               if (exceedsParent) {
                 throw new Error(`Child ${kind} capability exceeds parent boundary`);
@@ -232,8 +234,8 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
       if (allowed.includes('*')) return true;
       if (allowed.length === 0) return false;
       if (command.kind === 'path') {
-        const candidate = resolve(command.value);
-        return allowed.some((root) => candidate === root || candidate.startsWith(`${root}${sep}`));
+        const candidate = resolvePortablePath(process.cwd(), command.value);
+        return allowed.some((root) => isPortablePathWithin(candidate, root));
       }
       if (command.kind === 'host') return allowed.includes(command.value.toLowerCase());
       return allowed.includes(command.value);

--- a/core/v4/daemon/jobWaitAuthority.ts
+++ b/core/v4/daemon/jobWaitAuthority.ts
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { Db } from './db/connection';
+import type { JobEngine } from './jobEngine';
+
+export type DurableWaitKind =
+  | 'approval' | 'clarification' | 'scheduled_time' | 'rate_limit_reset'
+  | 'external_event' | 'child_job' | 'reconciliation' | 'resource_availability';
+export type DurableWaitState = 'pending' | 'satisfied' | 'timed_out' | 'cancelled';
+
+export interface DurableWaitRecord {
+  waitId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  sequence: number;
+  graphNodeKey: string | null;
+  kind: DurableWaitKind;
+  state: DurableWaitState;
+  deadlineAt: number | null;
+  externalKey: string | null;
+  payloadRef: string | null;
+  resolvedByInputId: string | null;
+  resolutionRef: string | null;
+  createdAt: number;
+  resolvedAt: number | null;
+}
+
+export interface JobWaitAuthority {
+  create(command: {
+    jobId: string; attemptId: string; generation: number; kind: DurableWaitKind;
+    graphNodeKey?: string | null; deadlineAt?: number | null; externalKey?: string | null;
+    payloadRef?: string | null; producer: string; idempotencyNamespace: string;
+    idempotencyKey: string; now?: number;
+  }): { record: DurableWaitRecord; duplicate: boolean };
+  get(waitId: string): DurableWaitRecord | null;
+  listPending(jobId: string): DurableWaitRecord[];
+  resolve(command: {
+    waitId: string; attemptId: string; generation: number; producer: string;
+    idempotencyKey: string; inputId?: string | null; resolutionRef?: string | null; now?: number;
+  }): { applied: boolean; duplicate?: boolean; conflict?: 'not_found' | 'stale_generation' | 'terminal_state' };
+  resolveExternal(command: {
+    jobId: string; externalKey: string; attemptId: string; generation: number;
+    producer: string; idempotencyKey: string; resolutionRef?: string | null; now?: number;
+  }): { applied: boolean; duplicate?: boolean; conflict?: 'not_found' | 'stale_generation' | 'terminal_state' };
+  cancel(command: {
+    waitId: string; attemptId: string; generation: number; producer: string;
+    idempotencyKey: string; now?: number;
+  }): { applied: boolean; duplicate?: boolean; conflict?: 'not_found' | 'stale_generation' | 'terminal_state' };
+  expireDue(now?: number, producer?: string): string[];
+  cancelForJob(jobId: string, producer: string, idempotencyKey: string, now?: number): number;
+  adoptPending(command: {
+    jobId: string; attemptId: string; generation: number; producer: string;
+    idempotencyKey: string; now?: number;
+  }): number;
+}
+
+interface WaitRow {
+  wait_id: string; job_id: string; attempt_id: string; generation: number;
+  sequence: number;
+  graph_node_key: string | null; kind: DurableWaitKind; state: DurableWaitState;
+  deadline_at: number | null; external_key: string | null; payload_ref: string | null;
+  resolved_by_input_id: string | null; resolution_ref: string | null;
+  created_at: number; resolved_at: number | null;
+}
+
+const TERMINAL_JOBS = new Set(['cancelled', 'completed', 'failed', 'dead_letter', 'completed_unverified', 'verification_failed', 'abandoned']);
+
+function map(row: WaitRow): DurableWaitRecord {
+  return {
+    waitId: row.wait_id, jobId: row.job_id, attemptId: row.attempt_id, generation: row.generation,
+    sequence: row.sequence,
+    graphNodeKey: row.graph_node_key, kind: row.kind, state: row.state,
+    deadlineAt: row.deadline_at, externalKey: row.external_key, payloadRef: row.payload_ref,
+    resolvedByInputId: row.resolved_by_input_id, resolutionRef: row.resolution_ref,
+    createdAt: row.created_at, resolvedAt: row.resolved_at,
+  };
+}
+
+function waitId(jobId: string, namespace: string, key: string): string {
+  return `wait_${createHash('sha256').update(`${jobId}\0${namespace}\0${key}`).digest('hex')}`;
+}
+
+export function createJobWaitAuthority(db: Db, jobs: JobEngine): JobWaitAuthority {
+  const get = (id: string): DurableWaitRecord | null => {
+    const row = db.prepare('SELECT * FROM job_waits WHERE wait_id = ?').get(id) as WaitRow | undefined;
+    return row ? map(row) : null;
+  };
+  const event = (record: DurableWaitRecord, type: string, producer: string, idempotencyKey: string, payload: Record<string, unknown>, now: number): void => {
+    db.prepare(
+      `INSERT OR IGNORE INTO job_wait_events
+         (wait_id, job_id, type, payload_json, producer, idempotency_key, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(record.waitId, record.jobId, type, JSON.stringify(payload), producer, idempotencyKey, now);
+    jobs.appendJobEvent({
+      jobId: record.jobId, attemptId: record.attemptId, generation: record.generation,
+      type, payload: { waitId: record.waitId, kind: record.kind, state: record.state },
+      producer, idempotencyKey: `wait-event:${record.waitId}:${idempotencyKey}`,
+    });
+  };
+  const resolveTx = db.transaction((command: Parameters<JobWaitAuthority['resolve']>[0]) => {
+    const row = db.prepare('SELECT * FROM job_waits WHERE wait_id = ?').get(command.waitId) as WaitRow | undefined;
+    if (!row) return { applied: false, conflict: 'not_found' as const };
+    const priorEvent = db.prepare('SELECT 1 FROM job_wait_events WHERE wait_id = ? AND idempotency_key = ?')
+      .get(command.waitId, command.idempotencyKey);
+    if (priorEvent) return { applied: false, duplicate: true };
+    if (row.state !== 'pending') return { applied: false, conflict: 'terminal_state' as const };
+    const job = jobs.getJob(row.job_id);
+    const attempt = jobs.getAttempt(command.attemptId);
+    if (
+      !job || TERMINAL_JOBS.has(job.status) || job.activeAttemptId !== command.attemptId
+      || !attempt || attempt.jobId !== row.job_id || attempt.generation !== command.generation
+      || row.attempt_id !== command.attemptId || row.generation !== command.generation
+    ) return { applied: false, conflict: 'stale_generation' as const };
+    const now = command.now ?? Date.now();
+    const changed = db.prepare(
+      `UPDATE job_waits SET state = 'satisfied', resolved_by_input_id = ?, resolution_ref = ?,
+              resolved_at = ?, updated_at = ?
+        WHERE wait_id = ? AND state = 'pending' AND attempt_id = ? AND generation = ?`,
+    ).run(command.inputId ?? null, command.resolutionRef ?? null, now, now, row.wait_id, command.attemptId, command.generation);
+    if (changed.changes !== 1) return { applied: false, conflict: 'stale_generation' as const };
+    const record = get(row.wait_id)!;
+    event(record, 'wait.satisfied', command.producer, command.idempotencyKey, {
+      inputId: command.inputId ?? null, resolutionRef: command.resolutionRef ?? null,
+    }, now);
+    return { applied: true };
+  }).immediate;
+
+  return {
+    create(command) {
+      return db.transaction(() => {
+        const existing = db.prepare(
+          'SELECT * FROM job_waits WHERE idempotency_namespace = ? AND idempotency_key = ?',
+        ).get(command.idempotencyNamespace, command.idempotencyKey) as WaitRow | undefined;
+        if (existing) {
+          if (existing.job_id !== command.jobId || existing.kind !== command.kind) throw new Error('Wait idempotency conflict');
+          return { record: map(existing), duplicate: true };
+        }
+        const job = jobs.getJob(command.jobId);
+        const attempt = jobs.getAttempt(command.attemptId);
+        if (!job || TERMINAL_JOBS.has(job.status)) throw new Error('Wait target Job is terminal or missing');
+        if (
+          job.activeAttemptId !== command.attemptId || !attempt || attempt.jobId !== command.jobId
+          || attempt.generation !== command.generation
+        ) throw new Error('Wait target has a stale Attempt or generation');
+        const now = command.now ?? Date.now();
+        const id = waitId(command.jobId, command.idempotencyNamespace, command.idempotencyKey);
+        const allocated = db.prepare(
+          `UPDATE tasks SET next_wait_sequence = next_wait_sequence + 1, updated_at = ?
+            WHERE id = ? RETURNING next_wait_sequence - 1 AS sequence`,
+        ).get(now, command.jobId) as { sequence: number } | undefined;
+        if (!allocated) throw new Error('Wait target Job disappeared');
+        db.prepare(
+          `INSERT INTO job_waits
+             (wait_id, job_id, attempt_id, generation, sequence, graph_node_key, kind, state,
+              deadline_at, external_key, payload_ref, idempotency_namespace,
+              idempotency_key, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          id, command.jobId, command.attemptId, command.generation, allocated.sequence, command.graphNodeKey ?? null,
+          command.kind, command.deadlineAt ?? null, command.externalKey ?? null, command.payloadRef ?? null,
+          command.idempotencyNamespace, command.idempotencyKey, now, now,
+        );
+        const record = get(id)!;
+        event(record, 'wait.created', command.producer, 'created', {
+          deadlineAt: record.deadlineAt, externalKey: record.externalKey, graphNodeKey: record.graphNodeKey,
+        }, now);
+        return { record, duplicate: false };
+      }).immediate();
+    },
+    get,
+    listPending(jobId) {
+      return (db.prepare("SELECT * FROM job_waits WHERE job_id = ? AND state = 'pending' ORDER BY sequence")
+        .all(jobId) as WaitRow[]).map(map);
+    },
+    resolve: resolveTx,
+    resolveExternal(command) {
+      const row = db.prepare(
+        `SELECT wait_id FROM job_waits
+          WHERE job_id = ? AND external_key = ? AND kind = 'external_event'
+          ORDER BY CASE state WHEN 'pending' THEN 0 ELSE 1 END, sequence LIMIT 1`,
+      ).get(command.jobId, command.externalKey) as { wait_id: string } | undefined;
+      if (!row) return { applied: false, conflict: 'not_found' };
+      return resolveTx({ ...command, waitId: row.wait_id });
+    },
+    cancel(command) {
+      return db.transaction(() => {
+        const row = db.prepare('SELECT * FROM job_waits WHERE wait_id = ?').get(command.waitId) as WaitRow | undefined;
+        if (!row) return { applied: false, conflict: 'not_found' as const };
+        const prior = db.prepare('SELECT 1 FROM job_wait_events WHERE wait_id = ? AND idempotency_key = ?')
+          .get(row.wait_id, command.idempotencyKey);
+        if (prior) return { applied: false, duplicate: true };
+        if (row.state !== 'pending') return { applied: false, conflict: 'terminal_state' as const };
+        if (row.attempt_id !== command.attemptId || row.generation !== command.generation) {
+          return { applied: false, conflict: 'stale_generation' as const };
+        }
+        const now = command.now ?? Date.now();
+        db.prepare("UPDATE job_waits SET state = 'cancelled', resolved_at = ?, updated_at = ? WHERE wait_id = ? AND state = 'pending'")
+          .run(now, now, row.wait_id);
+        event(get(row.wait_id)!, 'wait.cancelled', command.producer, command.idempotencyKey, {}, now);
+        return { applied: true };
+      }).immediate();
+    },
+    expireDue(now = Date.now(), producer = 'wait-scheduler') {
+      return db.transaction(() => {
+        const rows = db.prepare(
+          "SELECT * FROM job_waits WHERE state = 'pending' AND deadline_at IS NOT NULL AND deadline_at <= ? ORDER BY deadline_at, job_id, sequence",
+        ).all(now) as WaitRow[];
+        for (const row of rows) {
+          db.prepare("UPDATE job_waits SET state = 'timed_out', resolved_at = ?, updated_at = ? WHERE wait_id = ? AND state = 'pending'")
+            .run(now, now, row.wait_id);
+          event(get(row.wait_id)!, 'wait.timed_out', producer, `timeout:${row.deadline_at}`, {}, now);
+        }
+        return rows.map((row) => row.wait_id);
+      }).immediate();
+    },
+    cancelForJob(jobId, producer, idempotencyKey, now = Date.now()) {
+      return db.transaction(() => {
+        const rows = db.prepare("SELECT * FROM job_waits WHERE job_id = ? AND state = 'pending' ORDER BY sequence")
+          .all(jobId) as WaitRow[];
+        for (const row of rows) {
+          db.prepare("UPDATE job_waits SET state = 'cancelled', resolved_at = ?, updated_at = ? WHERE wait_id = ? AND state = 'pending'")
+            .run(now, now, row.wait_id);
+          event(get(row.wait_id)!, 'wait.cancelled', producer, `${idempotencyKey}:${row.wait_id}`, {}, now);
+        }
+        return rows.length;
+      }).immediate();
+    },
+    adoptPending(command) {
+      const job = jobs.getJob(command.jobId);
+      const attempt = jobs.getAttempt(command.attemptId);
+      if (!job || job.activeAttemptId !== command.attemptId || !attempt || attempt.generation !== command.generation) {
+        throw new Error('Wait adoption target is not the active generation');
+      }
+      return db.transaction(() => {
+        const rows = db.prepare(
+          "SELECT * FROM job_waits WHERE job_id = ? AND state = 'pending' AND (attempt_id <> ? OR generation <> ?) ORDER BY sequence",
+        ).all(command.jobId, command.attemptId, command.generation) as WaitRow[];
+        const now = command.now ?? Date.now();
+        for (const row of rows) {
+          db.prepare('UPDATE job_waits SET attempt_id = ?, generation = ?, updated_at = ? WHERE wait_id = ? AND state = \'pending\'')
+            .run(command.attemptId, command.generation, now, row.wait_id);
+          event(get(row.wait_id)!, 'wait.adopted', command.producer, `${command.idempotencyKey}:${row.wait_id}`, {
+            previousAttemptId: row.attempt_id, previousGeneration: row.generation,
+          }, now);
+        }
+        return rows.length;
+      }).immediate();
+    },
+  };
+}

--- a/core/v4/effectContract.ts
+++ b/core/v4/effectContract.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+export type EffectClassification =
+  | 'read_only'
+  | 'idempotent_mutation'
+  | 'reconcilable_mutation'
+  | 'unsafe_mutation'
+  | 'unknown_mutation';
+
+export type EffectRetrySafety =
+  | 'same_idempotency_key'
+  | 'reconcile_before_retry'
+  | 'never_automatic';
+
+export type EffectApprovalRequirement = 'none' | 'policy' | 'always';
+
+export interface ToolEffectContract {
+  classification: Exclude<EffectClassification, 'read_only'>;
+  kind: string;
+  retrySafety: EffectRetrySafety;
+  idempotencySupported: boolean;
+  reconciliationSupported: boolean;
+  verificationSupported: boolean;
+  approvalRequirement: EffectApprovalRequirement;
+  sensitiveFields: readonly string[];
+  redactionRules: readonly string[];
+  target(args: Readonly<Record<string, unknown>>): string | null;
+}
+
+export interface DurableEffectDescriptor {
+  classification: EffectClassification;
+  kind: string;
+  target: string | null;
+  retrySafety: EffectRetrySafety;
+  idempotencySupported: boolean;
+  reconciliationSupported: boolean;
+  verificationSupported: boolean;
+  approvalRequirement: EffectApprovalRequirement;
+  sensitiveFields: readonly string[];
+  redactionRules: readonly string[];
+  trusted: boolean;
+}
+
+export const UNKNOWN_MUTATION_EFFECT_CONTRACT = Object.freeze({
+  classification: 'unknown_mutation' as const,
+  kind: 'unknown',
+  retrySafety: 'never_automatic' as const,
+  idempotencySupported: false,
+  reconciliationSupported: false,
+  verificationSupported: false,
+  approvalRequirement: 'always' as const,
+  sensitiveFields: Object.freeze([] as string[]),
+  redactionRules: Object.freeze(['digest_arguments', 'omit_values']),
+});
+
+interface EffectBearingHandler {
+  mutates?: boolean;
+  effectContract?: ToolEffectContract;
+}
+
+function safeTarget(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 512 || /[\r\n\0]/.test(trimmed)) return null;
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      url.username = '';
+      url.password = '';
+      url.search = '';
+      url.hash = '';
+      return url.toString();
+    } catch { return null; }
+  }
+  if (/(?:api[_-]?key|token|secret|password|authorization|credential)\s*=/i.test(trimmed)) return null;
+  return trimmed;
+}
+
+export function describeToolEffect(
+  handler: EffectBearingHandler,
+  args: Readonly<Record<string, unknown>>,
+): DurableEffectDescriptor {
+  if (handler.mutates === false) {
+    return {
+      classification: 'read_only',
+      kind: 'none',
+      target: null,
+      retrySafety: 'never_automatic',
+      idempotencySupported: false,
+      reconciliationSupported: false,
+      verificationSupported: false,
+      approvalRequirement: 'policy',
+      sensitiveFields: [],
+      redactionRules: [],
+      trusted: true,
+    };
+  }
+  const contract = handler.effectContract;
+  if (!contract) {
+    return {
+      ...UNKNOWN_MUTATION_EFFECT_CONTRACT,
+      target: null,
+      trusted: false,
+    };
+  }
+  let target: string | null = null;
+  try { target = safeTarget(contract.target(args)); } catch { target = null; }
+  return {
+    classification: contract.classification,
+    kind: contract.kind,
+    target,
+    retrySafety: contract.retrySafety,
+    idempotencySupported: contract.idempotencySupported,
+    reconciliationSupported: contract.reconciliationSupported,
+    verificationSupported: contract.verificationSupported,
+    approvalRequirement: contract.approvalRequirement,
+    sensitiveFields: [...contract.sensitiveFields],
+    redactionRules: [...contract.redactionRules],
+    trusted: true,
+  };
+}

--- a/core/v4/effectContract.ts
+++ b/core/v4/effectContract.ts
@@ -17,6 +17,22 @@ export type EffectRetrySafety =
 
 export type EffectApprovalRequirement = 'none' | 'policy' | 'always';
 
+export interface EffectReconciliationData {
+  path?: string;
+  sourcePath?: string;
+  destinationPath?: string;
+  expectedContentSha256?: string;
+  expectedSize?: number;
+  before?: {
+    exists: boolean;
+    size?: number;
+    mtimeMs?: number;
+    contentSha256?: string;
+  };
+  sourceBefore?: { exists: boolean; size?: number; mtimeMs?: number; contentSha256?: string };
+  destinationBefore?: { exists: boolean; size?: number; mtimeMs?: number; contentSha256?: string };
+}
+
 export interface ToolEffectContract {
   classification: Exclude<EffectClassification, 'read_only'>;
   kind: string;
@@ -28,6 +44,7 @@ export interface ToolEffectContract {
   sensitiveFields: readonly string[];
   redactionRules: readonly string[];
   target(args: Readonly<Record<string, unknown>>): string | null;
+  reconciliationData?(args: Readonly<Record<string, unknown>>, cwd: string): EffectReconciliationData | null;
 }
 
 export interface DurableEffectDescriptor {
@@ -42,6 +59,7 @@ export interface DurableEffectDescriptor {
   sensitiveFields: readonly string[];
   redactionRules: readonly string[];
   trusted: boolean;
+  reconciliationData: EffectReconciliationData | null;
 }
 
 export const UNKNOWN_MUTATION_EFFECT_CONTRACT = Object.freeze({
@@ -82,6 +100,7 @@ function safeTarget(value: unknown): string | null {
 export function describeToolEffect(
   handler: EffectBearingHandler,
   args: Readonly<Record<string, unknown>>,
+  cwd = process.cwd(),
 ): DurableEffectDescriptor {
   if (handler.mutates === false) {
     return {
@@ -96,6 +115,7 @@ export function describeToolEffect(
       sensitiveFields: [],
       redactionRules: [],
       trusted: true,
+      reconciliationData: null,
     };
   }
   const contract = handler.effectContract;
@@ -104,10 +124,13 @@ export function describeToolEffect(
       ...UNKNOWN_MUTATION_EFFECT_CONTRACT,
       target: null,
       trusted: false,
+      reconciliationData: null,
     };
   }
   let target: string | null = null;
   try { target = safeTarget(contract.target(args)); } catch { target = null; }
+  let reconciliationData: EffectReconciliationData | null = null;
+  try { reconciliationData = contract.reconciliationData?.(args, cwd) ?? null; } catch { reconciliationData = null; }
   return {
     classification: contract.classification,
     kind: contract.kind,
@@ -120,5 +143,6 @@ export function describeToolEffect(
     sensitiveFields: [...contract.sensitiveFields],
     redactionRules: [...contract.redactionRules],
     trusted: true,
+    reconciliationData,
   };
 }

--- a/core/v4/effectReconciliation.ts
+++ b/core/v4/effectReconciliation.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+import { promises as fs, readFileSync, statSync } from 'node:fs';
+
+import type { EffectReconciliationData, EffectRetrySafety } from './effectContract';
+
+export type EffectReconciliationOutcome = 'occurred' | 'did_not_occur' | 'partially_occurred' | 'unknown';
+export type EffectReconciliationConfidence = 'high' | 'medium' | 'low';
+export type EffectRetryRecommendation = 'retry_same_identity' | 'do_not_retry' | 'human_review';
+
+export interface EffectReconciliationInput {
+  effectId: string;
+  kind: string;
+  target: string | null;
+  retrySafety: EffectRetrySafety;
+  idempotencyKey: string | null;
+  reconciliationData: EffectReconciliationData | null;
+}
+
+export interface EffectReconciliationResult {
+  outcome: EffectReconciliationOutcome;
+  confidence: EffectReconciliationConfidence;
+  evidence: Record<string, unknown>;
+  retryRecommendation: EffectRetryRecommendation;
+  humanResolutionRequired: boolean;
+}
+
+export interface FileObservation {
+  exists: boolean;
+  size?: number;
+  mtimeMs?: number;
+  contentSha256?: string;
+}
+
+export async function observeFile(path: string): Promise<FileObservation> {
+  try {
+    const stat = await fs.stat(path);
+    if (!stat.isFile()) return { exists: true, size: stat.size, mtimeMs: stat.mtimeMs };
+    const bytes = await fs.readFile(path);
+    return {
+      exists: true,
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      contentSha256: createHash('sha256').update(bytes).digest('hex'),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { exists: false };
+    throw error;
+  }
+}
+
+export function observeFileSync(path: string): FileObservation {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return { exists: true, size: stat.size, mtimeMs: stat.mtimeMs };
+    const bytes = readFileSync(path);
+    return {
+      exists: true, size: stat.size, mtimeMs: stat.mtimeMs,
+      contentSha256: createHash('sha256').update(bytes).digest('hex'),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { exists: false };
+    throw error;
+  }
+}
+
+function unknown(evidence: Record<string, unknown>): EffectReconciliationResult {
+  return {
+    outcome: 'unknown', confidence: 'low', evidence,
+    retryRecommendation: 'human_review', humanResolutionRequired: true,
+  };
+}
+
+/** Conservative readback for filesystem effects. Other effect kinds remain unknown. */
+export async function reconcileFilesystemEffect(
+  effect: EffectReconciliationInput,
+): Promise<EffectReconciliationResult> {
+  const path = effect.reconciliationData?.path ?? effect.target;
+  return reconcileFilesystemObservation(effect, path ? await observeFile(path) : null);
+}
+
+export function reconcileFilesystemEffectSync(effect: EffectReconciliationInput): EffectReconciliationResult {
+  const path = effect.reconciliationData?.path ?? effect.target;
+  return reconcileFilesystemObservation(effect, path ? observeFileSync(path) : null);
+}
+
+function reconcileFilesystemObservation(
+  effect: EffectReconciliationInput,
+  current: FileObservation | null,
+): EffectReconciliationResult {
+  const data = effect.reconciliationData;
+  if (!effect.kind.startsWith('filesystem.') || !data) {
+    return unknown({ reason: 'no_supported_reconciler', effectKind: effect.kind });
+  }
+  const path = data.path ?? effect.target;
+  if (!path) return unknown({ reason: 'missing_safe_target', effectKind: effect.kind });
+  if (!current) return unknown({ reason: 'missing_safe_target', effectKind: effect.kind });
+  const evidence: Record<string, unknown> = {
+    exists: current.exists,
+    ...(current.size !== undefined ? { size: current.size } : {}),
+    ...(current.mtimeMs !== undefined ? { mtimeMs: current.mtimeMs } : {}),
+    ...(current.contentSha256 ? { contentSha256: current.contentSha256 } : {}),
+    ...(data.before ? { before: data.before } : {}),
+    after: current,
+  };
+
+  if (effect.kind === 'filesystem.write') {
+    if (
+      current.exists
+      && data.expectedContentSha256
+      && current.contentSha256 === data.expectedContentSha256
+      && (data.expectedSize === undefined || current.size === data.expectedSize)
+    ) {
+      return {
+        outcome: 'occurred', confidence: 'high', evidence,
+        retryRecommendation: 'do_not_retry', humanResolutionRequired: false,
+      };
+    }
+    if (!current.exists && data.before?.exists === false) {
+      return {
+        outcome: 'did_not_occur', confidence: 'high', evidence,
+        retryRecommendation: effect.idempotencyKey ? 'retry_same_identity' : 'human_review',
+        humanResolutionRequired: !effect.idempotencyKey,
+      };
+    }
+  }
+
+  return unknown(evidence);
+}

--- a/core/v4/portablePath.ts
+++ b/core/v4/portablePath.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import path from 'node:path';
+
+type PathDialect = 'windows' | 'posix' | 'native';
+
+function dialect(value: string): PathDialect {
+  if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) return 'windows';
+  if (path.posix.isAbsolute(value)) return 'posix';
+  return 'native';
+}
+
+function normalize(value: string, kind: PathDialect): string {
+  if (kind === 'windows') return path.win32.resolve(value);
+  if (kind === 'posix') return path.posix.resolve(value);
+  return path.resolve(value);
+}
+
+/** Resolve a path using the syntax carried by the value or its durable base. */
+export function resolvePortablePath(base: string, value: string): string {
+  const valueDialect = dialect(value);
+  if (valueDialect !== 'native') return normalize(value, valueDialect);
+  const baseDialect = dialect(base);
+  if (baseDialect === 'windows') return path.win32.resolve(base, value);
+  if (baseDialect === 'posix') return path.posix.resolve(base, value);
+  return path.resolve(base, value);
+}
+
+/** Compare a candidate with a durable path root without adopting the current host's syntax. */
+export function isPortablePathWithin(candidate: string, root: string): boolean {
+  const rootDialect = dialect(root);
+  const candidateDialect = dialect(candidate);
+  if (rootDialect !== 'native' && candidateDialect !== rootDialect) return false;
+  const comparisonDialect = rootDialect === 'native' ? candidateDialect : rootDialect;
+  const normalizedRoot = normalize(root, comparisonDialect);
+  const normalizedCandidate = normalize(candidate, comparisonDialect);
+  const separator = comparisonDialect === 'windows'
+    ? path.win32.sep
+    : comparisonDialect === 'posix' ? path.posix.sep : path.sep;
+  const comparableRoot = comparisonDialect === 'windows' ? normalizedRoot.toLowerCase() : normalizedRoot;
+  const comparableCandidate = comparisonDialect === 'windows' ? normalizedCandidate.toLowerCase() : normalizedCandidate;
+  return comparableCandidate === comparableRoot
+    || comparableCandidate.startsWith(`${comparableRoot}${separator}`);
+}

--- a/core/v4/promptBuilder.ts
+++ b/core/v4/promptBuilder.ts
@@ -89,6 +89,8 @@ export interface PromptBuilderOptions {
   initialBudget?:       { used: number; max: number };
   platform?:            'windows' | 'linux' | 'macos';
   cwd?:                 string;
+  /** Authoritative local temporary directory. Injectable for deterministic tests. */
+  tempDir?:             string;
   /** When true the SOUL.md disk read is skipped entirely (used by tests). */
   skipFilesystem?:      boolean;
   /**
@@ -494,12 +496,14 @@ function formatBudgetSection(used: number, max: number): string {
   return [HEADER_BUDGET, '', renderBudgetLine(used, max)].join('\n');
 }
 
-function formatEnvironmentSection(platform: string, cwd: string): string {
+function formatEnvironmentSection(platform: string, cwd: string, tempDir: string): string {
   return [
     HEADER_ENVIRONMENT,
     '',
     `Platform: ${platform}`,
     `Working directory: ${cwd}`,
+    `Temporary directory: ${tempDir}`,
+    'Use this path directly; do not run a shell command to discover it.',
     `Date: ${dateStamp()}`,
   ].join('\n');
 }
@@ -684,7 +688,7 @@ export class PromptBuilder {
     const cwd      = opts.cwd      ?? process.cwd();
     slots.push({
       name:     'environment',
-      content:  formatEnvironmentSection(platform, cwd),
+      content:  formatEnvironmentSection(platform, cwd, opts.tempDir ?? os.tmpdir()),
       optional: false,
     });
 

--- a/core/v4/subagent/spawnSubAgent.ts
+++ b/core/v4/subagent/spawnSubAgent.ts
@@ -43,8 +43,12 @@ import type { Logger } from '../logger/logger';
 import { noopLogger } from '../logger/factory';
 import type { ProviderAttemptBudget } from '../../../providers/v4/types';
 import type { JobEngine } from '../daemon/jobEngine';
-import { currentJobExecutionContext, runWithJobExecutionContext } from '../daemon/jobExecutionContext';
-import { runWithProviderUsageContext } from '../../../providers/v4/providerAttemptAccounting';
+import { currentJobExecutionContext } from '../daemon/jobExecutionContext';
+import { executeDurableJob } from '../daemon/jobLifecycle';
+import {
+  currentProviderAttemptLedger,
+  runWithProviderUsageContext,
+} from '../../../providers/v4/providerAttemptAccounting';
 
 // ── Public types (per design doc §3) ─────────────────────────────────────
 
@@ -163,6 +167,8 @@ export interface SpawnSubAgentDeps extends ChildBuilderDeps {
 
 /** Per-call context — parent identity + signal. */
 export interface SpawnSubAgentCtx {
+  /** Existing child identity when a durable lifecycle adapter delegates execution. */
+  childSessionId?: string;
   /** Parent's AbortSignal (read via parentAgent.getCurrentSignal() at the
    *  tool wrapper) — when aborted, cascades to the child immediately. */
   signal?: AbortSignal;
@@ -221,109 +227,98 @@ export async function spawnSubAgent(
   );
 
   // ── 2. Fresh sessionId + run row ────────────────────────────────────────
-  const childSessionId = randomUUID();
+  const childSessionId = ctx.childSessionId ?? randomUUID();
   const parentJobContext = currentJobExecutionContext();
-  let childJobId: string | null = null;
-  let childAttemptId: string | null = null;
-  let childGeneration: number | null = null;
-  let childFenceToken: string | null = null;
-  let childAttemptVersion = 0;
-  let childJobVersion = 0;
-  let childLeaseHeartbeat: ReturnType<typeof setInterval> | null = null;
-  const childCtrl = new AbortController();
-  const stopChildHeartbeat = (): void => {
-    if (childLeaseHeartbeat !== null) {
-      clearInterval(childLeaseHeartbeat);
-      childLeaseHeartbeat = null;
+  if (deps.jobEngine && parentJobContext) {
+    const parentJob = deps.jobEngine.getJob(parentJobContext.jobId);
+    if (!parentJob) {
+      return failureEnvelope({
+        childRunId: '0',
+        childSessionId,
+        error: `Failed to create child run row: Parent Job not found: ${parentJobContext.jobId}`,
+        durationMs: Date.now() - startedAt,
+      });
     }
-  };
+    try {
+      const execution = await executeDurableJob({
+        engine: deps.jobEngine,
+        ownerId: deps.instanceId,
+        leaseTtlMs: 45_000,
+        admission: {
+          entryPoint: 'subagent',
+          source: 'subagent',
+          sessionId: childSessionId,
+          instanceId: deps.instanceId,
+          idempotencyNamespace: `child:${parentJobContext.jobId}`,
+          idempotencyKey: childSessionId,
+          goal: spec.goal,
+          title: spec.goal,
+          parentJobId: parentJobContext.jobId,
+          rootJobId: parentJob.rootJobId,
+        },
+        execute: async (handle) => {
+          const projectedRunStore: RunStore = {
+            ...deps.runStore,
+            create: () => handle.runId,
+            setStatus: () => { /* JobEngine owns the canonical Attempt row. */ },
+          };
+          const signal = ctx.signal
+            ? AbortSignal.any([ctx.signal, handle.signal])
+            : handle.signal;
+          const result = await spawnSubAgent(
+            spec,
+            { ...deps, runStore: projectedRunStore, jobEngine: undefined },
+            { ...ctx, childSessionId, signal },
+          );
+          currentProviderAttemptLedger()?.reconcileJobLinkage({
+            taskId: handle.jobId,
+            runId: handle.runId,
+            jobId: handle.jobId,
+            attemptId: handle.attemptId,
+            attemptGeneration: handle.generation,
+          });
+          return result;
+        },
+        finalize: (result) => {
+          const completed = result.status === 'completed' && result.verdict !== 'verification_failed';
+          const cancelled = result.status === 'interrupted';
+          return {
+            status: completed ? 'completed' : cancelled ? 'cancelled' : 'failed',
+            attemptStatus: completed
+              ? 'succeeded'
+              : cancelled
+                ? 'cancelled'
+                : result.status === 'timeout' ? 'timed_out' : 'failed',
+            outcome: result.verdict ?? result.status,
+            finishReason: result.exitReason,
+            evidence: result.evidence ?? { status: result.status, exitReason: result.exitReason },
+          };
+        },
+      });
+      return execution.value;
+    } catch (error) {
+      return failureEnvelope({
+        childRunId: '0',
+        childSessionId,
+        error: `Failed to execute durable child Job: ${errorMessage(error)}`,
+        durationMs: Date.now() - startedAt,
+      });
+    }
+  }
+  const childCtrl = new AbortController();
 
   // Pre-create the child run row in 'running' state so the envelope
   // always carries a valid childRunId — even if buildChildAgent throws.
   let childRunId: number;
   try {
-    if (deps.jobEngine && parentJobContext) {
-      const parentJob = deps.jobEngine.getJob(parentJobContext.jobId);
-      if (!parentJob) throw new Error(`Parent Job not found: ${parentJobContext.jobId}`);
-      const admitted = deps.jobEngine.submitJob({
-        entryPoint: 'subagent',
-        source: 'subagent',
-        sessionId: childSessionId,
-        instanceId: deps.instanceId,
-        idempotencyNamespace: `child:${parentJobContext.jobId}`,
-        idempotencyKey: childSessionId,
-        goal: spec.goal,
-        title: spec.goal,
-        parentJobId: parentJobContext.jobId,
-        rootJobId: parentJob.rootJobId,
-      });
-      childJobId = admitted.jobId;
-      childAttemptId = admitted.attemptId;
-      childRunId = admitted.runId;
-      childJobVersion = deps.jobEngine.getJob(childJobId)?.stateVersion ?? 0;
-      const lease = deps.jobEngine.claimAttempt({
-        attemptId: childAttemptId, ownerId: deps.instanceId, ttlMs: 45_000,
-      });
-      if (!lease.acquired || !lease.fenceToken || lease.generation === undefined || lease.stateVersion === undefined) {
-        throw new Error(`Child Attempt lease unavailable: ${lease.conflict ?? 'unknown'}`);
-      }
-      childGeneration = lease.generation;
-      childFenceToken = lease.fenceToken;
-      childAttemptVersion = lease.stateVersion;
-      const attemptStarted = deps.jobEngine.transitionAttempt({
-        attemptId: childAttemptId,
-        expectedStateVersion: childAttemptVersion,
-        generation: childGeneration,
-        fenceToken: childFenceToken,
-        to: 'running',
-        eventIdempotencyKey: `attempt-running:${childAttemptId}:${childGeneration}`,
-        producer: 'subagent',
-      });
-      if (!attemptStarted.applied || attemptStarted.stateVersion === undefined) {
-        throw new Error(`Child Attempt start rejected: ${attemptStarted.conflict ?? 'unknown'}`);
-      }
-      childAttemptVersion = attemptStarted.stateVersion;
-      const jobStarted = deps.jobEngine.transitionJob({
-        jobId: childJobId,
-        attemptId: childAttemptId,
-        generation: childGeneration,
-        fenceToken: childFenceToken,
-        expectedStateVersion: childJobVersion,
-        to: 'running',
-        eventIdempotencyKey: `job-running:${childJobId}:${childGeneration}`,
-        producer: 'subagent',
-      });
-      if (!jobStarted.applied || jobStarted.stateVersion === undefined) {
-        throw new Error(`Child Job start rejected: ${jobStarted.conflict ?? 'unknown'}`);
-      }
-      childJobVersion = jobStarted.stateVersion;
-      childLeaseHeartbeat = setInterval(() => {
-        if (!deps.jobEngine || !childAttemptId || childGeneration === null || !childFenceToken) return;
-        const renewed = deps.jobEngine.renewAttemptLease({
-          attemptId: childAttemptId,
-          ownerId: deps.instanceId,
-          generation: childGeneration,
-          fenceToken: childFenceToken,
-          ttlMs: 45_000,
-        });
-        if (!renewed.applied || renewed.stateVersion === undefined) {
-          stopChildHeartbeat();
-          childCtrl.abort(new Error(`Child Attempt lease renewal failed: ${renewed.conflict ?? 'unknown'}`));
-          return;
-        }
-        childAttemptVersion = renewed.stateVersion;
-      }, 15_000);
-      childLeaseHeartbeat.unref?.();
-    } else {
-      childRunId = deps.runStore.create({
-        sessionId: childSessionId,
-        instanceId: deps.instanceId,
-        status: 'running',
-        startedAt,
-        spawnedFromRunId: ctx.parentRunId,
-        spawnedFromSessionId: ctx.parentSessionId,
-      });
-    }
+    childRunId = deps.runStore.create({
+      sessionId: childSessionId,
+      instanceId: deps.instanceId,
+      status: 'running',
+      startedAt,
+      spawnedFromRunId: ctx.parentRunId,
+      spawnedFromSessionId: ctx.parentSessionId,
+    });
   } catch (err) {
     // Persistence failed before we even started — surface as failed
     // envelope with a synthetic id of '0' so the contract holds.
@@ -336,42 +331,6 @@ export async function spawnSubAgent(
   }
 
   // ── 3. Build child agent ────────────────────────────────────────────────
-  const finalizeChildDurable = (input: {
-    jobStatus: 'completed' | 'failed' | 'cancelled';
-    attemptStatus: 'succeeded' | 'failed' | 'cancelled' | 'timed_out';
-    outcome: string;
-    finishReason: string;
-    evidence: unknown;
-  }): void => {
-    if (!deps.jobEngine || !childJobId || !childAttemptId || childGeneration === null || !childFenceToken) return;
-    stopChildHeartbeat();
-    const attempt = deps.jobEngine.transitionAttempt({
-      attemptId: childAttemptId,
-      expectedStateVersion: childAttemptVersion,
-      generation: childGeneration,
-      fenceToken: childFenceToken,
-      to: input.attemptStatus,
-      eventIdempotencyKey: `attempt-${input.attemptStatus}:${childAttemptId}:${childGeneration}`,
-      producer: 'subagent',
-      finishReason: input.finishReason,
-    });
-    if (!attempt.applied) throw new Error(`Child Attempt finalization rejected: ${attempt.conflict ?? 'unknown'}`);
-    const job = deps.jobEngine.finalizeJob({
-      jobId: childJobId,
-      attemptId: childAttemptId,
-      generation: childGeneration,
-      fenceToken: childFenceToken,
-      expectedStateVersion: childJobVersion,
-      status: input.jobStatus,
-      outcome: input.outcome,
-      finishReason: input.finishReason,
-      evidence: input.evidence,
-      eventIdempotencyKey: `job-finalized:${childJobId}:${childGeneration}`,
-      producer: 'subagent',
-    });
-    if (!job.applied) throw new Error(`Child Job finalization rejected: ${job.conflict ?? 'unknown'}`);
-  };
-
   const logger = deps.logger ?? noopLogger();
   // v4.12.1 Pillar 2 — collect escalations the child raised to the parent
   // (destructive / external / out-of-scope ops it refused to run itself).
@@ -420,14 +379,7 @@ export async function spawnSubAgent(
     // failures (constructor throws, registry issues, etc.) collapse
     // to the generic 'error' exitReason.
     if (err instanceof ProviderNotFoundError) {
-      if (deps.jobEngine && childJobId) {
-        finalizeChildDurable({
-          jobStatus: 'failed', attemptStatus: 'failed', outcome: 'failed',
-          finishReason: 'provider_not_found', evidence: { errorClass: err.name },
-        });
-      } else {
-        deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'provider_not_found' });
-      }
+      deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'provider_not_found' });
       return {
         ok:             false,
         status:         'failed',
@@ -446,14 +398,7 @@ export async function spawnSubAgent(
         escalations:    [],
       };
     }
-    if (deps.jobEngine && childJobId) {
-      finalizeChildDurable({
-        jobStatus: 'failed', attemptStatus: 'failed', outcome: 'failed',
-        finishReason: 'error', evidence: { errorClass: err instanceof Error ? err.name : 'Error' },
-      });
-    } else {
-      deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'error' });
-    }
+    deps.runStore.setStatus(childRunId, 'failed', { finishReason: 'error' });
     return failureEnvelope({
       childRunId:     String(childRunId),
       childSessionId,
@@ -546,27 +491,19 @@ export async function spawnSubAgent(
       },
     );
   const runChild = async (): Promise<Awaited<ReturnType<typeof agentBundle.agent.runConversation>>> =>
-    runWithProviderUsageContext({
+    runWithProviderUsageContext((() => {
+      const durable = currentJobExecutionContext();
+      return {
       sessionId: childSessionId,
-      taskId: childJobId,
+      taskId: durable?.jobId ?? null,
       runId: childRunId,
-      jobId: childJobId,
-      attemptId: childAttemptId,
-      attemptGeneration: childGeneration,
+      jobId: durable?.jobId ?? null,
+      attemptId: durable?.attemptId ?? null,
+      attemptGeneration: durable?.generation ?? null,
       entryPoint: 'subagent',
       purpose: 'subagent',
-    }, () => (
-      deps.jobEngine && childJobId && childAttemptId && childGeneration !== null && childFenceToken
-        ? runWithJobExecutionContext({
-            engine: deps.jobEngine,
-            jobId: childJobId,
-            attemptId: childAttemptId,
-            generation: childGeneration,
-            fenceToken: childFenceToken,
-            producer: 'subagent',
-          }, invokeChild)
-        : invokeChild()
-    ));
+      };
+    })(), invokeChild);
 
   try {
     const result = await (parentCtx
@@ -635,9 +572,7 @@ export async function spawnSubAgent(
     status === 'completed'   ? 'completed'
     : status === 'interrupted' ? 'interrupted'
     : 'failed';
-  if (!deps.jobEngine || !childJobId) {
-    deps.runStore.setStatus(childRunId, dbStatus, { finishReason: exitReason });
-  }
+  deps.runStore.setStatus(childRunId, dbStatus, { finishReason: exitReason });
 
   const durationMs = Date.now() - startedAt;
 
@@ -662,25 +597,6 @@ export async function spawnSubAgent(
     reasoningOnly     = ev.reasoningOnly;
     unconfirmedRemote = ev.unconfirmedRemote;
     handles           = ev.handles;
-  }
-
-  if (deps.jobEngine && childJobId) {
-    const jobStatus = status === 'completed' && verdict !== 'verification_failed'
-      ? 'completed'
-      : status === 'interrupted' ? 'cancelled' : 'failed';
-    const attemptStatus = status === 'completed'
-      ? 'succeeded'
-      : status === 'interrupted' ? 'cancelled'
-      : status === 'timeout' ? 'timed_out' : 'failed';
-    finalizeChildDurable({
-      jobStatus,
-      attemptStatus,
-      outcome: verdict ?? status,
-      finishReason: exitReason,
-      evidence: evidence ?? { status, exitReason },
-    });
-  } else {
-    stopChildHeartbeat();
   }
 
   // Pillar 3: `ok` now means VERIFIED completion, not a clean loop exit.

--- a/core/v4/subagent/spawnSubAgent.ts
+++ b/core/v4/subagent/spawnSubAgent.ts
@@ -26,7 +26,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { buildChildAgent, ProviderNotFoundError } from './childBuilder';
+import { buildChildAgent, ProviderNotFoundError, SUBAGENT_BLOCKED_TOOL_NAMES } from './childBuilder';
 import type { ChildBuilderDeps } from './childBuilder';
 // v4.12.1 Pillar 3 — evidence-required subagent reports. The child's own
 // tool trace is run through the SAME verify-before-done gate the REPL/daemon
@@ -239,6 +239,16 @@ export async function spawnSubAgent(
         durationMs: Date.now() - startedAt,
       });
     }
+    const parentToolsets = deps.parentProfileToolsets ? [...deps.parentProfileToolsets] : undefined;
+    const requestedToolsets = spec.toolsets?.length ? spec.toolsets : undefined;
+    const selectedToolsets = parentToolsets && requestedToolsets
+      ? parentToolsets.filter((toolset) => requestedToolsets.includes(toolset))
+      : requestedToolsets ?? parentToolsets;
+    const effectiveToolsets = selectedToolsets?.length === 0 ? parentToolsets : selectedToolsets;
+    const allowedTools = deps.toolRegistry
+      .getSchemas(effectiveToolsets, 'repl', deps.parentExcludeToolsets ? [...deps.parentExcludeToolsets] : undefined)
+      .map((schema) => schema.name)
+      .filter((name) => !SUBAGENT_BLOCKED_TOOL_NAMES.has(name));
     try {
       const execution = await executeDurableJob({
         engine: deps.jobEngine,
@@ -264,6 +274,20 @@ export async function spawnSubAgent(
               maxIterations,
               timeoutMs,
               providerAttempts: spec.providerAttemptBudgets ?? null,
+            },
+          },
+          resourcePolicy: {
+            budgets: {
+              runtime_ms: timeoutMs,
+              model_calls: maxIterations,
+              tool_calls: maxIterations,
+              effects: maxIterations,
+              output_bytes: null,
+            },
+            capabilities: {
+              tools: allowedTools,
+              paths: [deps.parentToolContext.cwd],
+              workers: [`${deps.instanceId}:${childSessionId}`],
             },
           },
         },

--- a/core/v4/subagent/spawnSubAgent.ts
+++ b/core/v4/subagent/spawnSubAgent.ts
@@ -255,6 +255,17 @@ export async function spawnSubAgent(
           title: spec.goal,
           parentJobId: parentJobContext.jobId,
           rootJobId: parentJob.rootJobId,
+          childContract: {
+            required: true,
+            workerId: `${deps.instanceId}:${childSessionId}`,
+            capabilities: spec.toolsets ?? deps.parentProfileToolsets ?? ['inherited'],
+            allowedResources: { cwd: deps.parentToolContext.cwd },
+            budget: {
+              maxIterations,
+              timeoutMs,
+              providerAttempts: spec.providerAttemptBudgets ?? null,
+            },
+          },
         },
         execute: async (handle) => {
           const projectedRunStore: RunStore = {
@@ -279,7 +290,21 @@ export async function spawnSubAgent(
           });
           return result;
         },
-        finalize: (result) => {
+        finalize: (result, handle) => {
+          const recorded = deps.jobEngine!.recordChildResult({
+            childJobId: handle.jobId,
+            attemptId: handle.attemptId,
+            generation: handle.generation,
+            fenceToken: handle.fenceToken,
+            status: result.status,
+            evidence: result.evidence ?? { status: result.status, exitReason: result.exitReason },
+            evidenceHandles: result.handles,
+            producer: 'subagent',
+            idempotencyKey: `worker-result:${handle.attemptId}:${handle.generation}`,
+          });
+          if (!recorded.applied && !recorded.duplicate) {
+            throw new Error(`Child result attribution rejected: ${recorded.conflict ?? 'unknown'}`);
+          }
           const completed = result.status === 'completed' && result.verdict !== 'verification_failed';
           const cancelled = result.status === 'interrupted';
           return {

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -464,6 +464,7 @@ export class ToolRegistry {
         toolCallId: string;
         actionDigest: string;
         policySnapshotId: string;
+        effectId: string | null;
         riskTier: string;
       } | undefined;
       let preparedToolCall: PreparedDurableToolCall | null | undefined;
@@ -719,6 +720,7 @@ export class ToolRegistry {
               jobId: jobContext.jobId,
               attemptId: jobContext.attemptId,
               generation: jobContext.generation,
+              fenceToken: jobContext.fenceToken,
               toolCallId: persistedToolCallId,
               effectId: preparedToolCall?.effectId ?? null,
               toolName: call.name,
@@ -742,6 +744,7 @@ export class ToolRegistry {
             actionDigest: normalized.actionDigest,
             policySnapshotId: normalized.policySnapshot.policySnapshotId,
             riskTier: effectiveTier ?? 'caution',
+            effectId: preparedToolCall?.effectId ?? null,
           };
         }
         if (!context.approvalEngine) {
@@ -861,6 +864,7 @@ export class ToolRegistry {
               : approvalDecision?.state === 'interrupted' ? 'cancelled' : 'denied',
             decidedBy: 'user',
             decisionChannel: 'interactive',
+            decisionScope: approvalDecision?.scope ?? 'once',
           });
         }
         if (!allowed) {
@@ -1093,6 +1097,7 @@ export class ToolRegistry {
           generation: jobContext.generation,
           fenceToken: jobContext.fenceToken,
           toolCallId: durableApproval.toolCallId,
+          effectId: durableApproval.effectId,
           actionDigest: current.actionDigest,
           policySnapshotId: current.policySnapshot.policySnapshotId,
         });

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -468,6 +468,7 @@ export class ToolRegistry {
       } | undefined;
       let preparedToolCall: PreparedDurableToolCall | null | undefined;
       let effectDescriptor: DurableEffectDescriptor | undefined;
+      let approvalWaitId: string | null = null;
       const emit = (phase: ToolActivityUpdate['phase'], attempt?: number): void => {
         try { onActivity?.({ phase, at: Date.now(), attempt, timing }); } catch { /* observational */ }
       };
@@ -759,6 +760,25 @@ export class ToolRegistry {
             error: `Approval required: ${durableApproval?.approvalId ?? 'interactive approval channel unavailable'}`,
           }, 'blocked');
         }
+        if (jobContext?.controlAuthority) {
+          try {
+            approvalWaitId = jobContext.controlAuthority.waits.create({
+              jobId: jobContext.jobId,
+              attemptId: jobContext.attemptId,
+              generation: jobContext.generation,
+              kind: 'approval',
+              payloadRef: durableApproval?.approvalId ?? null,
+              producer: jobContext.producer,
+              idempotencyNamespace: `approval-wait:${jobContext.jobId}`,
+              idempotencyKey: durableApproval?.approvalId ?? call.id,
+            }).record.waitId;
+          } catch (error) {
+            return finish({
+              id: call.id, name: call.name, result: null,
+              error: `Approval wait could not be persisted: ${error instanceof Error ? error.message : String(error)}`,
+            }, 'blocked');
+          }
+        }
         timing.approvalStartedAt = Date.now();
         emit('awaiting_approval');
         let allowed: boolean;
@@ -798,6 +818,12 @@ export class ToolRegistry {
           const terminal = signal?.aborted
             ? 'cancelled'
             : /timed?\s*out|timeout/i.test(message) ? 'timed_out' : 'failed';
+          if (approvalWaitId && jobContext?.controlAuthority) {
+            jobContext.controlAuthority.waits.cancel({
+              waitId: approvalWaitId, attemptId: jobContext.attemptId, generation: jobContext.generation,
+              producer: jobContext.producer, idempotencyKey: `approval-prompt-ended:${call.id}`,
+            });
+          }
           try {
             recordDurableToolApproval({
               prepared: preparedToolCall ?? null,
@@ -809,6 +835,19 @@ export class ToolRegistry {
           return finish({ id: call.id, name: call.name, result: null, error: message }, terminal);
         }
         timing.approvalEndedAt = Date.now();
+        if (approvalWaitId && jobContext?.controlAuthority) {
+          const waitResult = jobContext.controlAuthority.waits.resolve({
+            waitId: approvalWaitId, attemptId: jobContext.attemptId, generation: jobContext.generation,
+            producer: jobContext.producer, idempotencyKey: `approval-decision:${call.id}`,
+            resolutionRef: `approval:${approvalDecision?.state ?? (allowed ? 'approved' : 'denied')}`,
+          });
+          if (allowed && !waitResult.applied && !waitResult.duplicate) {
+            return finish({
+              id: call.id, name: call.name, result: null,
+              error: `Approval wait settlement rejected: ${waitResult.conflict ?? 'unknown'}`,
+            }, 'blocked');
+          }
+        }
         if (durableApproval && context.actionAuthority && jobContext) {
           context.actionAuthority.decide({
             approvalId: durableApproval.approvalId,
@@ -959,7 +998,48 @@ export class ToolRegistry {
           mutates: effectiveMutates,
           effect: effectDescriptor,
           prepared: preparedToolCall,
-          execute: () => handler.execute(a, signal ? { ...context, signal } : context),
+          execute: async () => {
+            const jobContext = currentJobExecutionContext();
+            const interactive = isExclusiveToolInteraction(handler.interaction);
+            let waitId: string | null = null;
+            if (interactive && jobContext?.controlAuthority) {
+              waitId = jobContext.controlAuthority.waits.create({
+                jobId: jobContext.jobId, attemptId: jobContext.attemptId, generation: jobContext.generation,
+                kind: handler.interaction?.decision === 'batch_approval' ? 'approval' : 'clarification',
+                producer: jobContext.producer,
+                idempotencyNamespace: `interaction-wait:${jobContext.jobId}`,
+                idempotencyKey: `${jobContext.attemptId}:${call.id}`,
+              }).record.waitId;
+            }
+            try {
+              const value = await handler.execute(a, signal ? { ...context, signal } : context);
+              if (waitId && jobContext?.controlAuthority) {
+                const status = value && typeof value === 'object'
+                  ? String((value as Record<string, unknown>).status ?? '') : '';
+                if (status === 'cancelled' || status === 'interrupted') {
+                  jobContext.controlAuthority.waits.cancel({
+                    waitId, attemptId: jobContext.attemptId, generation: jobContext.generation,
+                    producer: jobContext.producer, idempotencyKey: `interaction-cancelled:${call.id}`,
+                  });
+                } else {
+                  jobContext.controlAuthority.waits.resolve({
+                    waitId, attemptId: jobContext.attemptId, generation: jobContext.generation,
+                    producer: jobContext.producer, idempotencyKey: `interaction-resolved:${call.id}`,
+                    resolutionRef: `interaction:${status || 'completed'}`,
+                  });
+                }
+              }
+              return value;
+            } catch (error) {
+              if (waitId && jobContext?.controlAuthority) {
+                jobContext.controlAuthority.waits.cancel({
+                  waitId, attemptId: jobContext.attemptId, generation: jobContext.generation,
+                  producer: jobContext.producer, idempotencyKey: `interaction-failed:${call.id}`,
+                });
+              }
+              throw error;
+            }
+          },
         });
 
       // ── P1B-2B — FAIL-SAFE pre-state snapshot (shadow, non-authoritative) ──

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -28,6 +28,8 @@
  * Status: PHASE 8.
  */
 
+import { resolve as resolvePath } from 'node:path';
+
 import type {
   ToolSchema,
   ToolCallRequest,
@@ -586,6 +588,46 @@ export class ToolRegistry {
         args,
         context.cwd ?? process.cwd(),
       );
+      const resourceAuthority = durableJobContext?.engine.resources;
+      if (durableJobContext && resourceAuthority) {
+        if (!resourceAuthority.authorize({ jobId: durableJobContext.jobId, kind: 'tool', value: call.name })) {
+          return finish({ id: call.id, name: call.name, result: null, error: 'Tool is outside this Job capability boundary' }, 'blocked');
+        }
+        for (const key of ['path', 'from', 'to', 'source', 'destination']) {
+          const value = args[key];
+          if (
+            typeof value === 'string' && value.length > 0
+            && !resourceAuthority.authorize({
+              jobId: durableJobContext.jobId,
+              kind: 'path',
+              value: resolvePath(context.cwd ?? process.cwd(), value),
+            })
+          ) {
+            return finish({ id: call.id, name: call.name, result: null, error: 'Path is outside this Job capability boundary' }, 'blocked');
+          }
+        }
+        if (
+          effectiveMutates
+          && !resourceAuthority.authorize({ jobId: durableJobContext.jobId, kind: 'effect', value: preliminaryEffect.kind })
+        ) {
+          return finish({ id: call.id, name: call.name, result: null, error: 'Effect is outside this Job capability boundary' }, 'blocked');
+        }
+        if (resourceAuthority.getBudgets(durableJobContext.jobId).some((budget) => budget.kind === 'tool_calls')) {
+          const debit = resourceAuthority.debit({
+            jobId: durableJobContext.jobId,
+            attemptId: durableJobContext.attemptId,
+            generation: durableJobContext.generation,
+            fenceToken: durableJobContext.fenceToken,
+            kind: 'tool_calls',
+            amount: 1,
+            certainty: 'confirmed',
+            idempotencyKey: `tool-call:${call.id}`,
+          });
+          if (debit.exhausted) {
+            return finish({ id: call.id, name: call.name, result: null, error: 'Tool-call budget exhausted' }, 'blocked');
+          }
+        }
+      }
       const approvalGated = effectiveMutates && preliminaryEffect.approvalRequirement !== 'none' && (
         context.approvalEngine !== undefined || (context.actionAuthority !== undefined && durableJobContext !== undefined)
       );
@@ -1004,6 +1046,22 @@ export class ToolRegistry {
           prepared: preparedToolCall,
           execute: async () => {
             const jobContext = currentJobExecutionContext();
+            if (
+              effectiveMutates && jobContext
+              && jobContext.engine.resources.getBudgets(jobContext.jobId).some((budget) => budget.kind === 'effects')
+            ) {
+              const debit = jobContext.engine.resources.debit({
+                jobId: jobContext.jobId,
+                attemptId: jobContext.attemptId,
+                generation: jobContext.generation,
+                fenceToken: jobContext.fenceToken,
+                kind: 'effects',
+                amount: 1,
+                certainty: 'confirmed',
+                idempotencyKey: `effect:${call.id}`,
+              });
+              if (debit.exhausted) throw new Error('Effect budget exhausted');
+            }
             const interactive = isExclusiveToolInteraction(handler.interaction);
             let waitId: string | null = null;
             if (interactive && jobContext?.controlAuthority) {

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -66,7 +66,11 @@ import {
   currentDurableToolCallId,
   currentJobExecutionContext,
   executeWithDurableToolCall,
+  prepareDurableToolCall,
+  recordDurableToolApproval,
+  type PreparedDurableToolCall,
 } from './daemon/jobExecutionContext';
+import { describeToolEffect, type DurableEffectDescriptor } from './effectContract';
 import {
   normalizeExecutionPlan,
   type ActionAuthority,
@@ -248,6 +252,8 @@ export interface ToolHandler {
    * the `checkApproval` call site below.
    */
   effects?: import('../../moat/approvalEngine').ToolEffects;
+  /** Durable mutation semantics used by the canonical ToolCall/Effect authority. */
+  effectContract?: import('./effectContract').ToolEffectContract;
   /**
    * v4.6 Phase 1 — the execution contexts in which this tool is
    * visible to the LLM. Default behaviour (when the field is
@@ -460,6 +466,8 @@ export class ToolRegistry {
         policySnapshotId: string;
         riskTier: string;
       } | undefined;
+      let preparedToolCall: PreparedDurableToolCall | null | undefined;
+      let effectDescriptor: DurableEffectDescriptor | undefined;
       const emit = (phase: ToolActivityUpdate['phase'], attempt?: number): void => {
         try { onActivity?.({ phase, at: Date.now(), attempt, timing }); } catch { /* observational */ }
       };
@@ -570,9 +578,48 @@ export class ToolRegistry {
       // a forgotten declaration must not become a silent bypass.
       const assumeMutates = handler.mutates ?? true;
       const durableJobContext = currentJobExecutionContext();
+      const effectiveMutates = assumeMutates && !readOnlyShell;
+      const preliminaryEffect = describeToolEffect(
+        effectiveMutates ? handler : { ...handler, mutates: false },
+        args,
+      );
+      const approvalGated = effectiveMutates && preliminaryEffect.approvalRequirement !== 'none' && (
+        context.approvalEngine !== undefined || (context.actionAuthority !== undefined && durableJobContext !== undefined)
+      );
+      effectDescriptor = preliminaryEffect;
+      if (effectiveMutates && durableJobContext) {
+        try {
+          preparedToolCall = prepareDurableToolCall({
+            toolCallId: call.id,
+            toolName: call.name,
+            args,
+            riskTier: handler.riskTier ?? 'caution',
+            mutates: true,
+            effect: effectDescriptor,
+            approvalState: approvalGated ? 'pending' : 'not_required',
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return finish({ id: call.id, name: call.name, result: null, error: message }, 'blocked');
+        }
+      }
       if (
-        assumeMutates && !readOnlyShell &&
-        (context.approvalEngine || (context.actionAuthority && durableJobContext))
+        effectiveMutates && durableJobContext &&
+        (!effectDescriptor.trusted || effectDescriptor.approvalRequirement === 'always') &&
+        !context.approvalEngine && !context.actionAuthority
+      ) {
+        try { recordDurableToolApproval({ prepared: preparedToolCall ?? null, state: 'blocked' }); } catch { /* durable conflict is reported below */ }
+        return finish({
+          id: call.id,
+          name: call.name,
+          result: null,
+          error: effectDescriptor.trusted
+            ? 'Interactive approval is required for this mutation'
+            : 'Mutating tool has no trusted effect contract and cannot run unattended',
+        }, 'blocked');
+      }
+      if (
+        approvalGated
       ) {
         // Pre-classify shell_exec commands so smart-mode has a tier.
         let riskTier: 'safe' | 'caution' | 'dangerous' | undefined;
@@ -664,16 +711,28 @@ export class ToolRegistry {
             },
           });
           const persistedToolCallId = currentDurableToolCallId(call.id) ?? call.id;
-          const record = context.actionAuthority.request({
-            jobId: jobContext.jobId,
-            attemptId: jobContext.attemptId,
-            generation: jobContext.generation,
-            toolCallId: persistedToolCallId,
-            toolName: call.name,
-            riskTier: effectiveTier ?? 'caution',
-            riskReasons: reason ? [reason] : [],
-            normalized,
-          });
+          let record: ReturnType<ActionAuthority['request']>;
+          try {
+            record = context.actionAuthority.request({
+              jobId: jobContext.jobId,
+              attemptId: jobContext.attemptId,
+              generation: jobContext.generation,
+              toolCallId: persistedToolCallId,
+              effectId: preparedToolCall?.effectId ?? null,
+              toolName: call.name,
+              riskTier: effectiveTier ?? 'caution',
+              riskReasons: reason ? [reason] : [],
+              normalized,
+            });
+          } catch (error) {
+            try { recordDurableToolApproval({ prepared: preparedToolCall ?? null, state: 'blocked' }); } catch { /* binding failure remains authoritative */ }
+            return finish({
+              id: call.id,
+              name: call.name,
+              result: null,
+              error: error instanceof Error ? error.message : String(error),
+            }, 'blocked');
+          }
           if (context.approvalEngine) context.actionAuthority.markDisplayed(record.approvalId);
           durableApproval = {
             approvalId: record.approvalId,
@@ -684,6 +743,14 @@ export class ToolRegistry {
           };
         }
         if (!context.approvalEngine) {
+          try {
+            recordDurableToolApproval({
+              prepared: preparedToolCall ?? null,
+              state: 'blocked',
+              approvalId: durableApproval?.approvalId,
+              actionDigest: durableApproval?.actionDigest,
+            });
+          } catch { /* the approval error remains authoritative */ }
           return finish({
             id: call.id,
             name: call.name,
@@ -730,6 +797,14 @@ export class ToolRegistry {
           const terminal = signal?.aborted
             ? 'cancelled'
             : /timed?\s*out|timeout/i.test(message) ? 'timed_out' : 'failed';
+          try {
+            recordDurableToolApproval({
+              prepared: preparedToolCall ?? null,
+              state: signal?.aborted ? 'interrupted' : terminal === 'timed_out' ? 'timed_out' : 'blocked',
+              approvalId: durableApproval?.approvalId,
+              actionDigest: durableApproval?.actionDigest,
+            });
+          } catch { /* the prompt failure remains authoritative */ }
           return finish({ id: call.id, name: call.name, result: null, error: message }, terminal);
         }
         timing.approvalEndedAt = Date.now();
@@ -749,6 +824,16 @@ export class ToolRegistry {
           });
         }
         if (!allowed) {
+          try {
+            recordDurableToolApproval({
+              prepared: preparedToolCall ?? null,
+              state: approvalDecision?.state === 'interrupted'
+                ? 'interrupted'
+                : approvalDecision?.state === 'blocked' ? 'blocked' : 'denied',
+              approvalId: durableApproval?.approvalId,
+              actionDigest: durableApproval?.actionDigest,
+            });
+          } catch { /* the approval decision remains authoritative */ }
           if (approvalDecision?.state === 'interrupted') {
             return finish({
               id: call.id,
@@ -776,6 +861,21 @@ export class ToolRegistry {
             result: null,
             error: `Tool execution denied by approval engine — ${why}`,
           }, signal?.aborted ? 'cancelled' : 'denied');
+        }
+        try {
+          recordDurableToolApproval({
+            prepared: preparedToolCall ?? null,
+            state: 'approved',
+            approvalId: durableApproval?.approvalId,
+            actionDigest: durableApproval?.actionDigest,
+          });
+        } catch (error) {
+          return finish({
+            id: call.id,
+            name: call.name,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          }, 'blocked');
         }
       }
 
@@ -855,7 +955,9 @@ export class ToolRegistry {
           toolName: call.name,
           args: a,
           riskTier: handler.riskTier ?? (handler.mutates === false ? 'safe' : 'caution'),
-          mutates: handler.mutates ?? true,
+          mutates: effectiveMutates,
+          effect: effectDescriptor,
+          prepared: preparedToolCall,
           execute: () => handler.execute(a, signal ? { ...context, signal } : context),
         });
 
@@ -914,6 +1016,14 @@ export class ToolRegistry {
           policySnapshotId: current.policySnapshot.policySnapshotId,
         });
         if (!authorization.authorized) {
+          try {
+            recordDurableToolApproval({
+              prepared: preparedToolCall ?? null,
+              state: 'blocked',
+              approvalId: durableApproval.approvalId,
+              actionDigest: durableApproval.actionDigest,
+            });
+          } catch { /* authorization failure remains authoritative */ }
           return finish({
             id: call.id,
             name: call.name,

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -1283,6 +1283,7 @@ export class ToolRegistry {
         const message = err instanceof Error ? err.message : String(err);
         const terminal = signal?.aborted
           ? 'cancelled'
+          : preparedToolCall?.mutates ? 'unknown'
           : /timed?\s*out|timeout/i.test(message) ? 'timed_out' : 'failed';
         executionAttempt.terminalResult = terminal;
         return finish({ id: call.id, name: call.name, result: null, error: message }, terminal);

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -582,6 +582,7 @@ export class ToolRegistry {
       const preliminaryEffect = describeToolEffect(
         effectiveMutates ? handler : { ...handler, mutates: false },
         args,
+        context.cwd ?? process.cwd(),
       );
       const approvalGated = effectiveMutates && preliminaryEffect.approvalRequirement !== 'none' && (
         context.approvalEngine !== undefined || (context.actionAuthority !== undefined && durableJobContext !== undefined)

--- a/core/v4/workbench/jobCommands.ts
+++ b/core/v4/workbench/jobCommands.ts
@@ -8,6 +8,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import type { Db } from '../daemon/db/connection';
 import { createActionAuthority, type ActionAuthority } from '../actionAuthority';
 import type { JobEngine } from '../daemon/jobEngine';
+import { admitDurableJob } from '../daemon/jobLifecycle';
 import { createJobControlAuthority, type JobControlAuthority } from '../daemon/jobControlAuthority';
 import type { RunStore } from '../daemon/runStore';
 import type { TriggerBus } from '../daemon/triggerBus';
@@ -32,7 +33,7 @@ export function createWorkbenchJobCommands(options: {
       source: 'manual', sourceKey: 'workbench-web', idempotencyKey,
       payload: { body: { prompt: task.message, source: 'workbench-web' }, sessionId: task.sessionId },
     });
-    const admission = options.jobEngine.submitJob({
+    const admission = admitDurableJob(options.jobEngine, {
       entryPoint: 'workbench', source: 'workbench',
       sessionId: task.sessionId ?? `workbench:${idempotencyKey}`,
       instanceId: options.instanceId,

--- a/docs/DURABLE_AUTONOMY_KERNEL.md
+++ b/docs/DURABLE_AUTONOMY_KERNEL.md
@@ -1,0 +1,215 @@
+# Durable Autonomy Kernel
+
+Aiden's durable autonomy kernel gives every autonomous operation one persistent
+identity, one current execution authority, and one replayable history. Terminal
+and background entry points use the same contracts; presentation surfaces read
+those contracts rather than defining lifecycle truth.
+
+## Authority map
+
+```mermaid
+flowchart TD
+  E["Entry-point adapter"] --> L["Durable lifecycle"]
+  L --> J["JobEngine"]
+  J --> A["Job and Attempt records"]
+  J --> G["Execution graph"]
+  J --> F["Effect ledger"]
+  J --> R["Resource authority"]
+  J --> P["Proof authority"]
+  J --> V["Ordered events and projections"]
+  L --> C["Job control authority"]
+  C --> I["Durable input and steering"]
+  C --> W["Waits and continuations"]
+  L --> X["Action authority"]
+  X --> O["Exact-action approvals"]
+```
+
+The primary owners are:
+
+| Concern | Authority | Durable records |
+| --- | --- | --- |
+| Job and Attempt state | `JobEngine` | `tasks`, `runs` |
+| Lifecycle coordination | `executeDurableJob()` | transitions through `JobEngine` |
+| Dependency execution | `ExecutionGraphAuthority` | `execution_graphs`, nodes, edges, events |
+| Mutating work | `JobEngine` ToolCall methods | `tool_calls`, `side_effect_ledger` |
+| Input and control | `JobControlAuthority` | inputs, steering, control commands, waits |
+| Approval | `ActionAuthority` | approvals and policy snapshots |
+| Children | `JobEngine` child contracts | `child_job_contracts` |
+| Budgets and capabilities | `JobResourceAuthority` | budgets, debits, capability sets |
+| Claims and evidence | `JobProofAuthority` | claims, evidence, links, verdicts, reviews |
+| Projection | `JobEventProjectionAuthority` | ordered events and consumer cursors |
+
+## Job and Attempt authority
+
+A Job is the durable unit of intent. An Attempt is one physical execution of
+that intent. Admission creates both records transactionally, assigns stable
+identities, and appends the first ordered events before returning.
+
+An Attempt can execute only while it owns the current Job generation, lease,
+and fence token. State transitions use compare-and-set versions. A replaced or
+expired owner cannot renew, write a result, attach evidence, settle a graph
+node, report a child result, debit a budget, or finalize the Job.
+
+Terminal Job and Attempt states are immutable. Cancellation is persisted before
+the runtime abort signal is delivered, so a late successful callback cannot
+replace cancellation.
+
+## Canonical lifecycle
+
+`executeDurableJob()` coordinates the production lifecycle:
+
+1. admit or validate a supplied Job and Attempt;
+2. persist and bind initial input when applicable;
+3. claim the Attempt and establish its lease and fence;
+4. transition the Attempt and Job to running;
+5. install the exact execution context;
+6. attach cancellation and heartbeat ownership;
+7. invoke the entry-point execution callback;
+8. apply verification-aware finalization;
+9. transition the Attempt and Job once;
+10. release runtime registrations without finalizing after authority loss.
+
+Interactive CLI, one-shot CLI, daemon dispatch, HTTP ingress, MCP, child work,
+Workbench admission, schedule dispatch, and messaging execution adapt their
+inputs and outputs around this lifecycle. Terminal rendering, HTTP response
+formatting, channel replies, and session history remain adapter concerns.
+
+## Durable execution graph
+
+Each Job may own one dependency graph. Nodes have stable keys, explicit kinds,
+dependencies, state versions, outputs, and optional verification requirements.
+Independent runnable nodes may execute concurrently. Failed prerequisites block
+dependants. Graph events are ordered and idempotent.
+
+Recovery preserves completed nodes and returns only abandoned running nodes to
+a schedulable state under the new Attempt. A cancelled or terminal Job cannot
+schedule or complete graph work.
+
+## Effects and unknown outcomes
+
+Every mutating ToolCall is normalized and classified before execution. Its
+Effect record includes:
+
+- exact Job, Attempt, generation, and ToolCall identity;
+- effect kind and target;
+- retry-safety and idempotency policy;
+- approval requirement and state;
+- reconciliation and verification support;
+- redaction rules and secret-free argument digests.
+
+The Effect is durable before the handler starts. If ownership is lost while a
+mutation may have reached the outside world, the Effect becomes `unknown` or
+`partial`; it is not converted into ordinary failure and is not automatically
+replayed.
+
+Reconciliation is append-only. A reconciler records whether an Effect occurred,
+did not occur, partially occurred, or remains unknown, together with confidence,
+evidence, and retry guidance. Trusted idempotent work can be retried only after
+the durable contract permits it. Unresolved unsafe work requires human action.
+
+## Exact-action approvals
+
+An approval binds to the Job, Attempt, generation, fence digest, ToolCall,
+Effect, normalized action digest, and immutable policy snapshot. Arguments,
+working directory, environment, network target, or policy changes invalidate
+the authorization.
+
+Approval requests and decisions survive restart. Execution authorization is
+claimed once immediately before the handler starts. Missing interactive
+approval channels fail closed for mutating work. A stale or terminal Attempt
+cannot use a prior approval.
+
+## Durable input, waits, and continuation
+
+User messages, follow-ups, steering, and control commands receive durable IDs
+and ordered per-Job sequence numbers. Persistence precedes acknowledgement.
+Claim and consume operations bind to an exact Attempt generation and are
+idempotent.
+
+Untargeted claimed input can be adopted once by an authoritative recovery
+Attempt. Input targeted at a stale Attempt is rejected rather than silently
+delivered elsewhere. Steering applies only at declared safe boundaries.
+
+Waits represent approval, clarification, timer, external-event, and child-work
+pauses. Wait identity and resolution history survive restart. Resume creates a
+new Attempt generation instead of reviving an old writer.
+
+## Child Jobs and worker supervision
+
+Delegated work is represented by a normal durable child Job plus a child
+contract. The contract records whether the child is required, its worker
+identity, capability and resource bounds, budget snapshot, and attributed
+result.
+
+A child result must match the child's exact Attempt, generation, and fence.
+Required child results gate parent completion. Parent cancellation propagates
+through the control authority, and late child results cannot make a cancelled
+parent successful.
+
+## Budgets and capabilities
+
+Resource policy is admitted with the Job and persists across restart. Supported
+budget dimensions cover runtime, model and token usage, tools, retries, workers,
+cost, Effects, concurrency, storage, and output size. Debits are atomic,
+idempotent, and fenced to the producing Attempt.
+
+Capability sets constrain tools, paths, hosts, applications, connections,
+accounts, workers, and Effect kinds. Child policy must be equal to or narrower
+than parent policy. An explicitly empty capability set denies access; omission
+retains the compatibility wildcard.
+
+## Claims, evidence, verdicts, and Proof
+
+Claims are categorized as required contract claims, observed claims, or
+courtesy statements. Evidence records its producer, producing Attempt and
+generation, observation and capture times, freshness, integrity digest,
+coverage, verification result, optional Effect, and redacted payload.
+
+Only fresh, attributable evidence can verify a claim. Required claims and
+unresolved Effects determine the final verdict: verified, partially verified,
+failed, unknown, or cancelled. A verdict is immutable. Evidence arriving after
+the verdict is retained for review but cannot rewrite terminal truth.
+
+Proof export provides JSON and Markdown views over the Job, graph, Attempts,
+approvals, Effects, claims, evidence, and verdict.
+
+## Events and projections
+
+Job events have a per-Job sequence and idempotency key. Sensitive payload fields
+are redacted before persistence. Consumer cursors are durable and monotonic, so
+missed events can replay without accepting a stale acknowledgement.
+
+Projection rebuilds read canonical tables plus ordered events. The TUI and
+Workbench are projections of that state; neither owns Job completion, elapsed
+runtime, approval truth, or Effect truth.
+
+## Recovery guarantees
+
+Recovery sweeps classify expired leases transactionally:
+
+- read-only or safely unstarted work becomes a new recovery Attempt;
+- the old Attempt becomes crashed or interrupted;
+- in-flight mutations become unknown and require reconciliation;
+- unsafe unknown Effects remain blocked;
+- stale writers remain fenced;
+- queued input, waits, child attribution, verdicts, and event order persist;
+- replay reconstructs UI state after process-memory loss.
+
+Database migrations are ordered and transactional. Existing databases are
+backed up before a schema upgrade. IDs, terminal truth, evidence, input, and
+approval history are preserved; approval records lacking a historical fence
+digest remain visible but fail closed.
+
+## Known limitations
+
+- Workers remain local and in-process; distributed worker transport is not part
+  of this kernel.
+- The graph scheduler is local and durable, not a distributed scheduler.
+- Reconciliation depends on an effect-specific observer. The recovery sweep
+  currently performs automatic filesystem reconciliation; other unsafe
+  unknown Effects remain blocked until an appropriate observer resolves them.
+- Projection rebuild returns a bounded event window while canonical tables
+  retain the complete current state. Consumers use cursors for additional
+  pages.
+- Physical database table names retain compatibility with earlier Task and Run
+  storage even though the authoritative API uses Job and Attempt terminology.

--- a/moat/approvalEngine.ts
+++ b/moat/approvalEngine.ts
@@ -312,6 +312,7 @@ export class ApprovalEngine {
    * so it never reflects a previous request.
    */
   private lastPromptDecision: ApprovalDecision | null = null;
+  private lastApprovalScope: 'once' | 'session' | 'permanent' = 'once';
   /**
    * v4.12.1 Pillar 2 — the installed autonomy policy. When set, the
    * mutating-path decision routes through `decideAutonomy`. Opt-in: when
@@ -588,6 +589,7 @@ export class ApprovalEngine {
     // never reaches a prompt (hard-block / autonomy / no-prompter), it stays
     // null and explainDenial reports from the deterministic gates instead.
     this.lastPromptDecision = null;
+    this.lastApprovalScope = 'once';
 
     // ★ v4.12.1 Pillar 2 — HARD-BLOCK FLOOR. Catastrophic, no-recovery ops
     // (wipe root/home, mkfs, dd-to-device, fork bomb, shutdown, kill-all,
@@ -626,6 +628,7 @@ export class ApprovalEngine {
     const sig = argSignature(req.toolName, req.args);
     const key = `${req.toolName}::${sig}`;
     if (this.sessionAllow.has(key)) {
+      this.lastApprovalScope = this.permanentAllow.has(key) ? 'permanent' : 'session';
       // v4.10 Slice 10.6 — refresh the audit timestamp for any
       // PERMANENT-tier match (session-only matches stay in memory
       // and are gone on /quit, so no disk refresh is meaningful).
@@ -754,11 +757,17 @@ export class ApprovalEngine {
     // (callbacks.decisionChoicesFor) already withholds these options for
     // floor-gated calls; this is the engine-level backstop.
     if (decision === 'allow_session') {
-      if (!isNeverBlanketAllow(req)) this.allowForSession(req.toolName, sig);
+      if (!isNeverBlanketAllow(req)) {
+        this.allowForSession(req.toolName, sig);
+        this.lastApprovalScope = 'session';
+      }
       return true;
     }
     if (decision === 'allow_always') {
-      if (!isNeverBlanketAllow(req)) this.allowAlways(req.toolName, sig);
+      if (!isNeverBlanketAllow(req)) {
+        this.allowAlways(req.toolName, sig);
+        this.lastApprovalScope = 'permanent';
+      }
       return true;
     }
     return false;
@@ -767,7 +776,7 @@ export class ApprovalEngine {
   /** Detailed companion to the stable boolean approval seam. */
   async checkApprovalDetailed(req: ApprovalRequest): Promise<ApprovalCheckResult> {
     const approved = await this.checkApproval(req);
-    if (approved) return { state: 'approved', approved: true };
+    if (approved) return { state: 'approved', approved: true, scope: this.lastApprovalScope };
 
     const promptDecision = this.lastPromptDecision;
     if (promptDecision === 'interrupted') {

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -222,7 +222,8 @@ export type ToolTerminalClassification =
   | 'blocked'
   | 'denied'
   | 'cancelled'
-  | 'timed_out';
+  | 'timed_out'
+  | 'unknown';
 
 export interface ToolExecutionAttemptTiming {
   attempt: number;

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -204,6 +204,7 @@ export interface ToolApprovalDecision {
   state: ToolApprovalDecisionState;
   approved: boolean;
   reason?: string;
+  scope?: 'once' | 'session' | 'permanent';
 }
 
 export type ToolActivityPhase =

--- a/tests/v4/aidenAgent.test.ts
+++ b/tests/v4/aidenAgent.test.ts
@@ -45,6 +45,7 @@ describe('AidenAgent.runConversation', () => {
     expect(result.finishReason).toBe('stop');
     expect(result.messages).toHaveLength(2); // user, assistant
     expect(result.messages[1]).toEqual({ role: 'assistant', content: 'hello world' });
+    expect(provider.capturedInputs).toHaveLength(1);
   });
 
   it('2. one tool call, then response — message history shape is correct', async () => {
@@ -82,6 +83,7 @@ describe('AidenAgent.runConversation', () => {
 
     expect(result.toolCallCount).toBe(2);
     expect(result.turnCount).toBe(3);
+    expect(provider.capturedInputs).toHaveLength(3);
     expect(provider.capturedInputs[1].messages.filter((m) => m.role === 'tool')).toHaveLength(1);
     expect(provider.capturedInputs[2].messages.filter((m) => m.role === 'tool')).toHaveLength(2);
     expect(result.finalContent).toBe('finished');

--- a/tests/v4/auxiliaryClient.test.ts
+++ b/tests/v4/auxiliaryClient.test.ts
@@ -71,6 +71,26 @@ describe('AuxiliaryClient', () => {
     expect(u.risk_assess.calls).toBe(2);
   });
 
+  it('attributes shutdown distillation to the provider-attempt usage ledger', async () => {
+    const adapter = new StubAdapter();
+    const c = new AuxiliaryClient({
+      defaultProvider: 'p',
+      defaultModel: 'm',
+      adapter,
+      warn: () => {},
+    });
+
+    await c.call({ purpose: 'session_summary', prompt: 'summarize the session' });
+
+    expect(adapter.calls).toHaveLength(1);
+    expect(adapter.calls[0]?.usageContext).toMatchObject({
+      entryPoint: 'auxiliary',
+      purpose: 'distillation',
+      providerConfigured: 'p',
+      modelConfigured: 'm',
+    });
+  });
+
   it('3. default maxTokens is 200', async () => {
     const adapter = new StubAdapter();
     const c = new AuxiliaryClient({

--- a/tests/v4/cli/callbacks.test.ts
+++ b/tests/v4/cli/callbacks.test.ts
@@ -612,10 +612,10 @@ describe('CliCallbacks Phase 23.5 onToolCall', () => {
     // v4.1.5 Issue N: clean-success now writes a completed row so the
     // log scrollback captures the action timeline. The exact ms suffix
     // is non-deterministic in tests (depends on fake-clock advance);
-    // assert the row chrome + verb appear.
+    // assert the row chrome + terminal state appear.
     const out = output();
     expect(out).toContain('┊');
-    expect(out).toContain('fetching');
+    expect(out).toContain('completed');
   });
 
   it('uses "blocked" suffix when result.error mentions URL provenance gate', () => {

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -726,6 +726,54 @@ describe('ChatSession — v4.6 Phase 2Q-B REPL parent-run row', () => {
 });
 
 describe('ChatSession durable Job admission', () => {
+  it('uses a fresh durable input identity after restarting the same session', async () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    for (const instanceId of ['instance_first', 'instance_restart']) {
+      db.prepare(
+        `INSERT INTO daemon_instances
+           (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES (?, 1, 'localhost', ?, ?, '4.16.1')`,
+      ).run(instanceId, now, now);
+    }
+    const jobEngine = createJobEngine({ db });
+    const controls = createJobControlAuthority({ db, jobEngine });
+
+    try {
+      for (const [instanceId, input] of [
+        ['instance_first', 'first turn'],
+        ['instance_restart', 'restart turn'],
+      ] as const) {
+        const { agent } = mkAgent({ finalContent: 'ok' });
+        const session = new ChatSession(buildOpts({
+          agent: agent as never,
+          promptApi: mkPromptApi({ inputs: [input, '/quit'] }),
+          replInstanceId: instanceId,
+          jobEngine: jobEngine as never,
+          jobControlAuthority: controls,
+        }));
+        await session.run();
+        expect(agent.runConversation).toHaveBeenCalledTimes(1);
+      }
+
+      const inputs = db.prepare(
+        `SELECT content, idempotency_key
+           FROM durable_inputs
+          ORDER BY created_at, input_id`,
+      ).all() as Array<{ content: string; idempotency_key: string }>;
+      expect(inputs).toHaveLength(2);
+      expect(inputs.map((record) => record.content).sort()).toEqual(['first turn', 'restart turn']);
+      expect(new Set(inputs.map((record) => record.idempotency_key)).size).toBe(2);
+      expect(inputs.map((record) => record.idempotency_key)).toEqual(expect.arrayContaining([
+        'initial:instance_first:0',
+        'initial:instance_restart:0',
+      ]));
+    } finally {
+      db.close();
+    }
+  });
+
   it('cancels staged continuation Jobs when the durable queue is cleared', () => {
     const db = new Database(':memory:');
     runMigrations(db);

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -19,6 +19,7 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
+import { currentJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
 
 function mkDisplay() {
   const chunks: string[] = [];
@@ -774,6 +775,44 @@ describe('ChatSession durable Job admission', () => {
     }
   });
 
+  it('finishes shutdown work before printing Goodbye', async () => {
+    const { display, out } = mkDisplay();
+    const reg = new CommandRegistry();
+    reg.register({ name: 'quit', description: 'quit', category: 'system', handler: async () => ({ exit: true }) });
+    const session = new ChatSession(buildOpts({
+      display,
+      commandRegistry: reg,
+      promptApi: mkPromptApi({ inputs: ['/quit'] }),
+    }));
+    await session.run();
+    const text = out.join('');
+    expect(text.indexOf('Finalizing session')).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf('Goodbye.')).toBeGreaterThan(text.indexOf('Finalizing session'));
+  });
+
+  it('honors the configured shutdown-distillation opt-out', async () => {
+    const { display, out } = mkDisplay();
+    const { agent } = mkAgent();
+    const reg = new CommandRegistry();
+    reg.register({ name: 'quit', description: 'quit', category: 'system', handler: async () => ({ exit: true }) });
+    const session = new ChatSession(buildOpts({
+      agent: agent as never,
+      display,
+      commandRegistry: reg,
+      config: { getValue: vi.fn(() => false) } as never,
+      promptApi: mkPromptApi({ inputs: ['one', 'two', 'three', '/quit'] }),
+    }));
+
+    await session.run();
+
+    const text = out.join('');
+    expect(agent.runConversation).toHaveBeenCalledTimes(3);
+    expect(text).toContain('Skipping session summary');
+    expect(text).toContain('disabled by configuration');
+    expect(text).not.toContain('Generating session distillation');
+    expect(text.indexOf('Goodbye.')).toBeGreaterThan(text.indexOf('disabled by configuration'));
+  });
+
   it('cancels staged continuation Jobs when the durable queue is cleared', () => {
     const db = new Database(':memory:');
     runMigrations(db);
@@ -904,6 +943,65 @@ describe('ChatSession durable Job admission', () => {
       'job.running', 'attempt.succeeded', 'job.finalized',
     ]);
     expect(ref.runId).toBeNull();
+  });
+
+  it('uses required proof instead of a recovered optional helper failure for final truth', async () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance_proof_turn', 1, 'localhost', ?, ?, '4.16.1')`,
+    ).run(now, now);
+    const jobEngine = createJobEngine({ db });
+    const { agent } = mkAgent();
+    agent.runConversation.mockImplementation(async (history: Message[]) => {
+      const context = currentJobExecutionContext();
+      if (!context) throw new Error('missing durable execution context');
+      const claim = jobEngine.proof.createClaim({
+        jobId: context.jobId, attemptId: context.attemptId, generation: context.generation,
+        category: 'contract', statement: 'required artifact verified', required: true,
+      });
+      const evidence = jobEngine.proof.recordEvidence({
+        jobId: context.jobId, attemptId: context.attemptId, generation: context.generation,
+        fenceToken: context.fenceToken, source: 'filesystem.readback', producer: 'test',
+        observedAt: Date.now(), coverage: 'full', verificationResult: 'verified',
+        payload: { exists: true, exact: true },
+      });
+      jobEngine.proof.checkClaim({
+        claimId: claim.claimId, attemptId: context.attemptId, generation: context.generation,
+        evidenceIds: [evidence.evidenceId], state: 'verified',
+      });
+      return {
+        finalContent: 'done', messages: [...history, { role: 'assistant', content: 'done' }],
+        turnCount: 1, toolCallCount: 2, fallbackActivated: false, finishReason: 'stop',
+        totalUsage: { inputTokens: 10, outputTokens: 2 }, compressionEvents: 0, auxiliaryUsage: {},
+        toolCallTrace: [{
+          name: 'shell_exec', result: null, error: 'optional lookup failed', handlerMutates: true,
+          verification: { ok: false, confidence: 1, code: 'failed', reason: 'optional lookup failed' },
+        }],
+      } as never;
+    });
+    const session = new ChatSession(buildOpts({
+      agent: agent as never,
+      promptApi: mkPromptApi({ inputs: ['create verified artifact', '/quit'] }),
+      replInstanceId: 'instance_proof_turn',
+      jobEngine: jobEngine as never,
+    }));
+    try {
+      await session.run();
+      const [job] = jobEngine.listJobs({ sessionId: 'sess-abc-123' });
+      expect(job?.status).toBe('completed');
+      expect(job?.terminalOutcome).toBe('verified');
+      expect(agent.runConversation).toHaveBeenCalledTimes(1);
+      expect(jobEngine.proof.getVerdict(job!.id)?.verdict).toBe('verified');
+      expect(jobEngine.proof.exportJson(job!.id)).toMatchObject({
+        evidence: [expect.objectContaining({ verificationResult: 'verified' })],
+      });
+    } finally {
+      db.close();
+    }
   });
 
   it('does not call the provider when durable admission fails', async () => {

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -15,6 +15,9 @@ import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import type { Message } from '../../../providers/v4/types';
 import { DuringTurnInput } from '../../../cli/v4/duringTurnInput';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 
 function mkDisplay() {
   const chunks: string[] = [];
@@ -734,32 +737,40 @@ describe('ChatSession durable Job admission', () => {
         compressionEvents: [], auxiliaryUsage: [],
       } as never;
     });
-    const jobEngine = {
-      submitJob: vi.fn(() => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance_job', 1, 'localhost', ?, ?, '4.16.1')`,
+    ).run(now, now);
+    const jobEngine = createJobEngine({ db });
+    const submitJob = jobEngine.submitJob.bind(jobEngine);
+    const claimAttempt = jobEngine.claimAttempt.bind(jobEngine);
+    const transitionAttempt = jobEngine.transitionAttempt.bind(jobEngine);
+    const transitionJob = jobEngine.transitionJob.bind(jobEngine);
+    const finalizeJob = jobEngine.finalizeJob.bind(jobEngine);
+    vi.spyOn(jobEngine, 'submitJob').mockImplementation((command) => {
         order.push('submit');
-        return { jobId: 'task_job', attemptId: 'attempt_job', runId: 41, reused: false };
-      }),
-      claimAttempt: vi.fn(() => {
+        return submitJob(command);
+      });
+    vi.spyOn(jobEngine, 'claimAttempt').mockImplementation((command) => {
         order.push('claim');
-        return {
-          acquired: true, applied: true, leaseId: 'lease_job',
-          fenceToken: 'fence_job', generation: 1, stateVersion: 1,
-        };
-      }),
-      transitionAttempt: vi.fn((command: { to: string }) => {
+        return claimAttempt(command);
+      });
+    vi.spyOn(jobEngine, 'transitionAttempt').mockImplementation((command) => {
         order.push(`attempt:${command.to}`);
-        return { applied: true, stateVersion: command.to === 'running' ? 2 : 3 };
-      }),
-      transitionJob: vi.fn((command: { to: string }) => {
+        return transitionAttempt(command);
+      });
+    vi.spyOn(jobEngine, 'transitionJob').mockImplementation((command) => {
         order.push(`job:${command.to}`);
-        return { applied: true, stateVersion: 1 };
-      }),
-      finalizeJob: vi.fn(() => {
+        return transitionJob(command);
+      });
+    vi.spyOn(jobEngine, 'finalizeJob').mockImplementation((command) => {
         order.push('job:finalized');
-        return { applied: true, stateVersion: 2 };
-      }),
-      renewAttemptLease: vi.fn(() => ({ applied: true, stateVersion: 3 })),
-    };
+        return finalizeJob(command);
+      });
     const ref: { runId: number | null; sessionId: string | null } = { runId: null, sessionId: null };
     const session = new ChatSession(buildOpts({
       agent: agent as never,
@@ -769,7 +780,14 @@ describe('ChatSession durable Job admission', () => {
       jobEngine: jobEngine as never,
     }));
 
-    await session.run();
+    let eventTypes: string[] = [];
+    try {
+      await session.run();
+      const [job] = jobEngine.listJobs({ sessionId: 'sess-abc-123' });
+      if (job) eventTypes = jobEngine.listEvents(job.id).map((event) => event.type);
+    } finally {
+      db.close();
+    }
 
     expect(order.slice(0, 5)).toEqual([
       'submit', 'claim', 'attempt:running', 'job:running', 'provider',
@@ -781,9 +799,13 @@ describe('ChatSession durable Job admission', () => {
       goal: 'hello',
     }));
     expect(jobEngine.transitionAttempt).toHaveBeenCalledWith(expect.objectContaining({
-      attemptId: 'attempt_job', generation: 1, fenceToken: 'fence_job',
+      generation: 1,
     }));
     expect(jobEngine.finalizeJob).toHaveBeenCalledTimes(1);
+    expect(eventTypes).toEqual([
+      'job.submitted', 'attempt.created', 'attempt.leased', 'attempt.running',
+      'job.running', 'attempt.succeeded', 'job.finalized',
+    ]);
     expect(ref.runId).toBeNull();
   });
 

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -18,6 +18,7 @@ import { DuringTurnInput } from '../../../cli/v4/duringTurnInput';
 import Database from 'better-sqlite3';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
 
 function mkDisplay() {
   const chunks: string[] = [];
@@ -725,6 +726,54 @@ describe('ChatSession — v4.6 Phase 2Q-B REPL parent-run row', () => {
 });
 
 describe('ChatSession durable Job admission', () => {
+  it('cancels staged continuation Jobs when the durable queue is cleared', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance_job', 1, 'localhost', ?, ?, '4.16.1')`,
+    ).run(now, now);
+    const jobEngine = createJobEngine({ db });
+    const controls = createJobControlAuthority({ db, jobEngine });
+    const staged = jobEngine.submitJob({
+      entryPoint: 'interactive', source: 'repl', sessionId: 'session_queue_clear',
+      instanceId: 'instance_job', idempotencyNamespace: 'queue-clear',
+      idempotencyKey: 'staged-job', goal: 'queued message',
+    });
+    const input = controls.inputs.receive({
+      jobId: staged.jobId,
+      targetAttemptId: staged.attemptId,
+      sessionId: 'session_queue_clear',
+      source: 'tui',
+      kind: 'message',
+      content: 'queued message',
+      idempotencyNamespace: 'queue-clear-input',
+      idempotencyKey: 'staged-input',
+    });
+    const session = new ChatSession(buildOpts({
+      jobEngine: jobEngine as never,
+      jobControlAuthority: controls,
+    }));
+    const internals = session as unknown as {
+      sessionId: string;
+      duringTurnInput: DuringTurnInput;
+      durableQueueInputIds: string[];
+    };
+    internals.sessionId = 'session_queue_clear';
+    internals.duringTurnInput.enqueue('queued message');
+    internals.durableQueueInputIds.push(input.record.inputId);
+
+    try {
+      expect(session.clearQueue()).toBe(1);
+      expect(jobEngine.getJob(staged.jobId)?.status).toBe('cancelled');
+      expect(controls.inputs.get(input.record.inputId)?.state).toBe('cancelled');
+    } finally {
+      db.close();
+    }
+  });
+
   it('creates and leases the Job Attempt before the first provider call', async () => {
     const order: string[] = [];
     const { agent } = mkAgent({ finalContent: 'ok' });

--- a/tests/v4/cli/commands/queue.test.ts
+++ b/tests/v4/cli/commands/queue.test.ts
@@ -31,4 +31,29 @@ describe('/queue', () => {
     expect(writes[0].length).toBeLessThanOrEqual(106);
     expect(listQueue()).toEqual([stored]);
   });
+
+  it('shows each durable input identity without changing FIFO content', async () => {
+    const writes: string[] = [];
+    const entries = [
+      { inputId: 'input_first-identity', message: 'QUEUE ONE' },
+      { inputId: 'input_second-identity', message: 'QUEUE TWO' },
+    ];
+    await queue.handler({
+      args: [],
+      display: {
+        info: vi.fn(), dim: vi.fn(), success: vi.fn(), warn: vi.fn(),
+        write: vi.fn((text: string) => { writes.push(text); }),
+      },
+      session: {
+        listQueue: vi.fn(() => entries.map((entry) => entry.message)),
+        listQueueEntries: vi.fn(() => entries),
+        clearQueue: vi.fn(() => 0),
+      },
+    } as never);
+
+    expect(writes).toEqual([
+      '  1. [input_first-identity] QUEUE ONE\n',
+      '  2. [input_second-identity] QUEUE TWO\n',
+    ]);
+  });
 });

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -321,7 +321,7 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     // A completed row IS now written on non-TTY so log scrollback
     // records the action + duration.
     expect(out.length).toBeGreaterThan(0);
-    expect(stripAnsi(out)).toContain('fetching');
+    expect(stripAnsi(out)).toContain('completed');
     expect(stripAnsi(out)).toContain('220ms');
   });
 
@@ -336,7 +336,7 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     const second = chunks.join('');
     // Erase ANSI (running row removed) AND a new completed row written.
     expect(second).toMatch(/\x1b\[1A\x1b\[2K\r/);
-    expect(stripAnsi(second)).toContain('fetching');
+    expect(stripAnsi(second)).toContain('completed');
     expect(stripAnsi(second)).toContain('180ms');
   });
 
@@ -550,7 +550,29 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     const row = d.toolRow('shell_exec', { command: 'echo ok' }, () => snapshot);
     chunks.length = 0;
     row.finish?.(snapshot);
-    expect(stripAnsi(chunks.join(''))).toContain(expected);
+    const rendered = stripAnsi(chunks.join(''));
+    expect(rendered).toContain(expected);
+    expect(rendered).not.toMatch(/\b(?:running|writing|calling|waiting)\b/u);
+  });
+
+  it.each([
+    ['failed', 'failed'],
+    ['blocked', 'blocked'],
+    ['degraded', 'partial'],
+    ['unknown', 'unknown'],
+  ] as const)('replaces the active tool verb for %s terminal rows', (terminalClassification, expected) => {
+    const { d, chunks } = captureDisplay({ tty: true });
+    const snapshot: ActivitySnapshot = {
+      phase: 'terminal', phaseElapsedMs: 0, lifecycleElapsedMs: 2_000,
+      approvalWaitMs: 0, executionDurationMs: 1_500, verificationDurationMs: 0,
+      retryBackoffMs: 0, attemptCount: 1, terminalClassification,
+    };
+    const row = d.toolRow('file_write', { path: 'result.txt' }, () => snapshot);
+    chunks.length = 0;
+    row.finish?.(snapshot);
+    const rendered = stripAnsi(chunks.join(''));
+    expect(rendered).toContain(expected);
+    expect(rendered).not.toMatch(/\b(?:running|writing|calling|waiting)\b/u);
   });
 
   it('keeps the primary outcome and execution duration at narrow width', () => {
@@ -815,7 +837,7 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     d.toolRow('open_url', { url: 'https://example.com/x' }).fail(1500);
     const flat = stripAnsi(chunks.join(''));
     expect(flat).toMatch(/┊/);
-    expect(flat).toMatch(/fetching/);
+    expect(flat).toMatch(/failed/);
     expect(flat).toMatch(/fail 1\.5s/);
   });
 
@@ -883,8 +905,8 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     const flat = stripAnsi(chunks.join(''));
     // Must NOT contain the literal "{}" — the v4.1.4-media fix.
     expect(flat).not.toMatch(/\{\}/);
-    // Must still contain the verb (it's the trail's identity anchor).
-    expect(flat).toMatch(/media\s/);
+    // Must still contain the terminal state (the settled trail's identity anchor).
+    expect(flat).toMatch(/failed\s/);
   });
 
   it('media_transport row previews target arg (not raw JSON)', () => {
@@ -922,8 +944,8 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     // 'foo' → fallback verb 'calling' (7 chars), padded to 12
     d.toolRow('foo', { query: 'q' }).fail(10);
     const flat = stripAnsi(chunks.join(''));
-    // "calling" padded to 12 => 5 trailing spaces before the detail
-    expect(flat).toMatch(/calling {5}/);
+    // "failed" padded to 12 => 6 trailing spaces before the detail.
+    expect(flat).toMatch(/failed {6,}/);
   });
 });
 

--- a/tests/v4/cli/render/promptBoundary.test.ts
+++ b/tests/v4/cli/render/promptBoundary.test.ts
@@ -30,7 +30,7 @@ describe('prompt-zone rule boundaries', () => {
   it('chatSession.ts emits BOTTOM rule immediately before runAgentTurn', () => {
     const src = readFileSync(path.join(__dirname, '../../../../cli/v4/chatSession.ts'), 'utf8');
     const lines = src.split('\n');
-    const idx = lines.findIndex((l) => /await this\.runAgentTurn\(input(?:,\s*inputAlreadyPersisted)?\)/.test(l));
+    const idx = lines.findIndex((l) => /await this\.runAgentTurn\(input,\s*inputAlreadyPersisted,\s*queuedDurableInputId\)/.test(l));
     expect(idx).toBeGreaterThan(0);
     const preceding = lines.slice(Math.max(0, idx - 8), idx).join('\n');
     expect(preceding).toMatch(/display\.write\(\s*`\s+\$\{this\.opts\.display\.rule\(\)\}\\n`\s*\)/);

--- a/tests/v4/cli/render/promptBoundary.test.ts
+++ b/tests/v4/cli/render/promptBoundary.test.ts
@@ -5,9 +5,9 @@
  * Aiden — local-first agent.
  */
 /**
- * v4.9.0 pre-ship UI — prompt-zone rule boundaries.
- * TOP rule = `printTurnSeparator()` (already shipping).
- * BOTTOM rule = NEW seam in chatSession right before `runAgentTurn`.
+ * Turn-transition separator ownership.
+ * Completed output or a completed local command owns one separator;
+ * composer acquisition owns none.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -27,12 +27,11 @@ describe('prompt-zone rule boundaries', () => {
     expect(/─{10,}/.test(stripAnsi(chunks.join('')))).toBe(true);
   });
 
-  it('chatSession.ts emits BOTTOM rule immediately before runAgentTurn', () => {
+  it('chatSession does not add separator rules while acquiring the next composer', () => {
     const src = readFileSync(path.join(__dirname, '../../../../cli/v4/chatSession.ts'), 'utf8');
-    const lines = src.split('\n');
-    const idx = lines.findIndex((l) => /await this\.runAgentTurn\(input,\s*inputAlreadyPersisted,\s*queuedDurableInputId\)/.test(l));
-    expect(idx).toBeGreaterThan(0);
-    const preceding = lines.slice(Math.max(0, idx - 8), idx).join('\n');
-    expect(preceding).toMatch(/display\.write\(\s*`\s+\$\{this\.opts\.display\.rule\(\)\}\\n`\s*\)/);
+    expect(src).not.toMatch(/if \(iter > 1\) this\.opts\.display\.printTurnSeparator\(\)/);
+    const dispatch = src.indexOf('await this.runAgentTurn(input, inputAlreadyPersisted, queuedDurableInputId)');
+    expect(dispatch).toBeGreaterThan(0);
+    expect(src.slice(Math.max(0, dispatch - 500), dispatch)).not.toMatch(/display\.rule\(\)/);
   });
 });

--- a/tests/v4/cli/replyRenderer.test.ts
+++ b/tests/v4/cli/replyRenderer.test.ts
@@ -344,4 +344,22 @@ describe('replyRenderer — Bug 2 (inline-code colon token decode)', () => {
     expect(out).toContain('C:\\x');
     expect(out).not.toContain('*#COLON|*');
   });
+
+  it('does not inject spaces around inline Windows paths or punctuation', () => {
+    const out = stripAnsi(getReplyRenderer().render(
+      'Created `C:\\Users\\sample\\AppData\\Local\\Temp\\aiden.txt` containing `approval-once`.',
+    ));
+    expect(out).toContain(
+      'Created C:\\Users\\sample\\AppData\\Local\\Temp\\aiden.txt containing approval-once.',
+    );
+    expect(out).not.toContain('Created  C:');
+    expect(out).not.toContain('approval-once .');
+  });
+
+  it('preserves intentional prose and code-block whitespace', () => {
+    const prose = stripAnsi(getReplyRenderer().render('Keep  intentional spacing outside `code`.'));
+    expect(prose).toContain('Keep  intentional spacing outside code.');
+    const block = stripAnsi(getReplyRenderer().render('```text\n  indented  value\n```'));
+    expect(block).toContain('  indented  value');
+  });
 });

--- a/tests/v4/cli/sessionSummaryGate.test.ts
+++ b/tests/v4/cli/sessionSummaryGate.test.ts
@@ -20,6 +20,14 @@ import {
  *     (covers same-length replace-section writes that bump mtime only)
  */
 describe('shouldAutoSummarize', () => {
+  it('honors an explicit distillation opt-out before other gates', () => {
+    expect(shouldAutoSummarize({
+      userTurns: 8,
+      unconfigured: false,
+      memoryPath: '/tmp/m.md',
+      disabled: true,
+    })).toEqual({ fire: false, reason: 'disabled' });
+  });
   it('exposes the threshold constant as 3', () => {
     expect(SESSION_SUMMARY_MIN_TURNS).toBe(3);
   });

--- a/tests/v4/cli/startupNotices.test.ts
+++ b/tests/v4/cli/startupNotices.test.ts
@@ -5,6 +5,7 @@ import {
   buildAuthenticationNotice,
   buildLocalRuntimeNotice,
   buildNoProviderNotice,
+  buildPluginGrantNotice,
   buildProviderFallbackNotice,
   buildProviderResolutionNotice,
   buildSavedModelNotice,
@@ -157,6 +158,24 @@ describe('startup notices', () => {
       notice({ id: 'block', severity: 'blocking', blocking: true, source: 'provider', command: '/model', dedupeKey: 'block' }),
     ], registry());
     expect(prepared.map((n) => n.id)).toEqual(['block', 'auth', 'model', 'mcp', 'plugin', 'info']);
+  });
+
+  it('suppresses a stale plugin notice when the active provider route already works', () => {
+    expect(buildPluginGrantNotice('hosted-route-plugin', {
+      activeProvider: 'hosted-route',
+      providedProviders: ['hosted-route'],
+    })).toBeNull();
+  });
+
+  it('describes an ungranted plugin as an optional capability, not a provider outage', () => {
+    const n = buildPluginGrantNotice('browser-plugin', {
+      activeProvider: 'hosted-route',
+      providedProviders: [],
+      capabilities: ['browser_read'],
+    });
+    expect(n?.title).toContain('capability');
+    expect(n?.detail).toContain('browser_read');
+    expect(`${n?.title} ${n?.detail}`).not.toMatch(/provider.*unavailable|provider.*required/i);
   });
 
   it('bounds wide, medium, narrow, and minimal rendering', () => {

--- a/tests/v4/core/actionAuthority.test.ts
+++ b/tests/v4/core/actionAuthority.test.ts
@@ -137,17 +137,30 @@ describe('final action and durable Approval authority', () => {
       riskTier: 'caution',
       policy,
     });
+    const prepared = jobs.prepareToolCall({
+      toolCallId: 'tool-call-1', jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, fenceToken, toolName: 'file_write', normalizedArgsDigest: 'fixture-digest',
+      riskTier: 'caution', mutates: true, producer: 'test',
+      effect: {
+        classification: 'reconcilable_mutation', kind: 'filesystem.write', target: 'result.txt',
+        retrySafety: 'reconcile_before_retry', idempotencySupported: false, idempotencyKey: null,
+        reconciliationSupported: true, verificationSupported: true, approvalRequirement: 'policy',
+        approvalState: 'pending', sensitiveFields: ['content'], redactionRules: ['digest_arguments'], trusted: true,
+      },
+    });
     const approval = actions.request({
       jobId: admission.jobId,
       attemptId: admission.attemptId,
       generation: 1,
       toolCallId: 'tool-call-1',
+      effectId: prepared.effectId,
       toolName: 'file_write',
       riskTier: 'caution',
       riskReasons: ['filesystem write'],
       normalized,
       expiresAt: Date.now() + 60_000,
     });
+    expect(approval.effectId).toBe('side_effect:tool-call-1');
     expect(actions.listPending(admission.jobId)).toHaveLength(1);
     expect(actions.decide({
       approvalId: approval.approvalId,

--- a/tests/v4/core/actionAuthority.test.ts
+++ b/tests/v4/core/actionAuthority.test.ts
@@ -152,6 +152,7 @@ describe('final action and durable Approval authority', () => {
       jobId: admission.jobId,
       attemptId: admission.attemptId,
       generation: 1,
+      fenceToken,
       toolCallId: 'tool-call-1',
       effectId: prepared.effectId,
       toolName: 'file_write',
@@ -180,6 +181,7 @@ describe('final action and durable Approval authority', () => {
       generation: 1,
       fenceToken,
       toolCallId: 'tool-call-1',
+      effectId: approval.effectId,
       actionDigest: normalized.actionDigest,
       policySnapshotId: approval.policySnapshotId,
     }).authorized).toBe(true);
@@ -190,6 +192,7 @@ describe('final action and durable Approval authority', () => {
       generation: 1,
       fenceToken,
       toolCallId: 'tool-call-1',
+      effectId: approval.effectId,
       actionDigest: normalized.actionDigest,
       policySnapshotId: approval.policySnapshotId,
     })).toMatchObject({ authorized: false, duplicate: true });
@@ -208,6 +211,7 @@ describe('final action and durable Approval authority', () => {
       jobId: admission.jobId,
       attemptId: admission.attemptId,
       generation: 1,
+      fenceToken,
       toolCallId: 'tool-call-events',
       toolName: 'file_write',
       riskTier: 'caution',
@@ -233,6 +237,7 @@ describe('final action and durable Approval authority', () => {
       generation: 1,
       fenceToken,
       toolCallId: 'tool-call-events',
+      effectId: approval.effectId,
       actionDigest: normalized.actionDigest,
       policySnapshotId: approval.policySnapshotId,
     });
@@ -265,6 +270,7 @@ describe('final action and durable Approval authority', () => {
       jobId: admission.jobId,
       attemptId: admission.attemptId,
       generation: 1,
+      fenceToken,
       toolCallId: 'tool-call-change',
       toolName: 'shell_exec',
       riskTier: 'dangerous',
@@ -297,6 +303,7 @@ describe('final action and durable Approval authority', () => {
       generation: 1,
       fenceToken,
       toolCallId: 'tool-call-change',
+      effectId: approval.effectId,
       actionDigest: changed.actionDigest,
       policySnapshotId: changed.policySnapshot.policySnapshotId,
     })).toMatchObject({ authorized: false, reason: expect.stringMatching(/changed|mismatch|invalid/i) });
@@ -315,6 +322,7 @@ describe('final action and durable Approval authority', () => {
       jobId: admission.jobId,
       attemptId: admission.attemptId,
       generation: 1,
+      fenceToken,
       toolCallId: 'tool-call-2',
       toolName: 'file_write',
       riskTier: 'caution',
@@ -342,7 +350,7 @@ describe('final action and durable Approval authority', () => {
       mutates: true, riskTier: 'caution', policy,
     });
     const approval = actions.request({
-      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
       toolCallId: 'tool-call-stale-fence', toolName: 'file_write', riskTier: 'caution',
       riskReasons: [], normalized,
     });
@@ -356,10 +364,59 @@ describe('final action and durable Approval authority', () => {
     expect(actions.authorizeExecution({
       approvalId: approval.approvalId, jobId: admission.jobId,
       attemptId: admission.attemptId, generation: 1, fenceToken: 'stale-fence',
-      toolCallId: 'tool-call-stale-fence', actionDigest: normalized.actionDigest,
+      toolCallId: 'tool-call-stale-fence', effectId: approval.effectId, actionDigest: normalized.actionDigest,
       policySnapshotId: approval.policySnapshotId,
     })).toMatchObject({ authorized: false, reason: expect.stringMatching(/fence/i) });
     expect(actions.get(approval.approvalId)?.state).toBe('invalidated');
+  });
+
+  it('rejects changed Effect identity and a replacement fence after approval', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'bound.txt' }, cwd: 'C:/workspace',
+      mutates: true, riskTier: 'caution', policy,
+    });
+    const approve = (toolCallId: string) => {
+      const prepared = jobs.prepareToolCall({
+        toolCallId, jobId: admission.jobId, attemptId: admission.attemptId,
+        generation: 1, fenceToken, toolName: 'file_write', normalizedArgsDigest: normalized.actionDigest,
+        riskTier: 'caution', mutates: true, producer: 'test',
+        effect: {
+          classification: 'reconcilable_mutation', kind: 'filesystem.write', target: 'bound.txt',
+          retrySafety: 'reconcile_before_retry', idempotencySupported: false, idempotencyKey: null,
+          reconciliationSupported: true, verificationSupported: true, approvalRequirement: 'policy',
+          approvalState: 'pending', sensitiveFields: [], redactionRules: [], trusted: true,
+        },
+      });
+      const record = actions.request({
+        jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
+        toolCallId, effectId: prepared.effectId, toolName: 'file_write', riskTier: 'caution',
+        riskReasons: [], normalized,
+      });
+      actions.decide({
+        approvalId: record.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+        generation: 1, actionDigest: normalized.actionDigest, policySnapshotId: record.policySnapshotId,
+        decision: 'approved', decidedBy: 'user', decisionChannel: 'tui',
+      });
+      return record;
+    };
+
+    const changedEffect = approve('tool-effect-binding');
+    expect(actions.authorizeExecution({
+      approvalId: changedEffect.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, fenceToken, toolCallId: changedEffect.toolCallId, effectId: null,
+      actionDigest: normalized.actionDigest, policySnapshotId: changedEffect.policySnapshotId,
+    })).toMatchObject({ authorized: false, reason: expect.stringMatching(/binding|changed/i) });
+
+    const changedFence = approve('tool-fence-binding');
+    const replacementFence = 'replacement-fence';
+    db.prepare('UPDATE runs SET fence_token = ?, lease_expires_at = ? WHERE attempt_id = ?')
+      .run(replacementFence, Date.now() + 60_000, admission.attemptId);
+    expect(actions.authorizeExecution({
+      approvalId: changedFence.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, fenceToken: replacementFence, toolCallId: changedFence.toolCallId,
+      effectId: changedFence.effectId, actionDigest: normalized.actionDigest,
+      policySnapshotId: changedFence.policySnapshotId,
+    })).toMatchObject({ authorized: false, reason: expect.stringMatching(/binding|changed/i) });
   });
 
   it('restores pending approvals by exact ID after authority restart', () => {
@@ -368,7 +425,7 @@ describe('final action and durable Approval authority', () => {
       mutates: true, riskTier: 'caution', policy,
     });
     const created = actions.request({
-      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
       toolCallId: 'tool-restart', toolName: 'file_write', riskTier: 'caution',
       riskReasons: ['filesystem write'], normalized, expiresAt: 10_000, now: 1_000,
     });
@@ -385,13 +442,49 @@ describe('final action and durable Approval authority', () => {
     ]);
   });
 
+  it('preserves denial and exact approved identity across authority restart', () => {
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'restart-decision.txt' }, cwd: 'C:/workspace',
+      mutates: true, riskTier: 'caution', policy,
+    });
+    const request = (toolCallId: string) => actions.request({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
+      toolCallId, toolName: 'file_write', riskTier: 'caution', riskReasons: [], normalized,
+    });
+    const denied = request('tool-restart-denied');
+    actions.decide({
+      approvalId: denied.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, actionDigest: normalized.actionDigest, policySnapshotId: denied.policySnapshotId,
+      decision: 'denied', decidedBy: 'user', decisionChannel: 'tui',
+    });
+    const approved = request('tool-restart-approved');
+    actions.decide({
+      approvalId: approved.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, actionDigest: normalized.actionDigest, policySnapshotId: approved.policySnapshotId,
+      decision: 'approved', decidedBy: 'user', decisionChannel: 'tui',
+    });
+
+    const restarted = createActionAuthority({ db, jobEngine: createJobEngine({ db }) });
+    expect(restarted.get(denied.approvalId)?.state).toBe('denied');
+    expect(restarted.authorizeExecution({
+      approvalId: denied.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, fenceToken, toolCallId: denied.toolCallId, effectId: denied.effectId,
+      actionDigest: normalized.actionDigest, policySnapshotId: denied.policySnapshotId,
+    })).toMatchObject({ authorized: false, reason: 'approval is denied' });
+    expect(restarted.authorizeExecution({
+      approvalId: approved.approvalId, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: 1, fenceToken, toolCallId: approved.toolCallId, effectId: approved.effectId,
+      actionDigest: normalized.actionDigest, policySnapshotId: approved.policySnapshotId,
+    }).authorized).toBe(true);
+  });
+
   it('makes duplicate decisions idempotent but rejects a conflicting decision', () => {
     const normalized = normalizeExecutionPlan({
       toolName: 'file_write', args: { path: 'once.txt' }, cwd: 'C:/workspace',
       mutates: true, riskTier: 'caution', policy,
     });
     const approval = actions.request({
-      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
       toolCallId: 'tool-decision', toolName: 'file_write', riskTier: 'caution',
       riskReasons: [], normalized,
     });
@@ -403,10 +496,12 @@ describe('final action and durable Approval authority', () => {
       actionDigest: normalized.actionDigest,
       policySnapshotId: approval.policySnapshotId,
       decision: 'approved' as const,
+      decisionScope: 'session' as const,
       decidedBy: 'user',
       decisionChannel: 'tui',
     };
     expect(actions.decide(decision).state).toBe('approved');
+    expect(actions.get(approval.approvalId)?.decisionScope).toBe('session');
     expect(actions.decide(decision).state).toBe('approved');
     expect(() => actions.decide({ ...decision, decision: 'denied' })).toThrow(/conflicting decision/i);
   });
@@ -417,7 +512,7 @@ describe('final action and durable Approval authority', () => {
       mutates: true, riskTier: 'caution', policy,
     });
     const expired = actions.request({
-      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
       toolCallId: 'tool-expired', toolName: 'file_write', riskTier: 'caution',
       riskReasons: [], normalized, expiresAt: 2, now: 1,
     });
@@ -430,7 +525,7 @@ describe('final action and durable Approval authority', () => {
     expect(actions.get(expired.approvalId)?.state).toBe('expired');
 
     const pending = actions.request({
-      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1, fenceToken,
       toolCallId: 'tool-terminal', toolName: 'file_write', riskTier: 'caution',
       riskReasons: [], normalized,
     });
@@ -448,6 +543,7 @@ describe('final action and durable Approval authority', () => {
       jobId: admission.jobId,
       attemptId: admission.attemptId,
       generation: 1,
+      fenceToken,
       toolCallId,
       toolName: 'file_write',
       riskTier: 'caution',

--- a/tests/v4/core/effectContract.test.ts
+++ b/tests/v4/core/effectContract.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { createHash } from 'node:crypto';
-import { join } from 'node:path';
+import { win32 } from 'node:path';
 
 import {
   UNKNOWN_MUTATION_EFFECT_CONTRACT,
@@ -80,7 +80,7 @@ describe('durable tool effect contracts', () => {
     );
 
     expect(descriptor.reconciliationData).toEqual({
-      path: join('C:\\workspace', 'result.txt'),
+      path: win32.join('C:\\workspace', 'result.txt'),
       expectedContentSha256: createHash('sha256').update(content).digest('hex'),
       expectedSize: Buffer.byteLength(content),
     });

--- a/tests/v4/core/effectContract.test.ts
+++ b/tests/v4/core/effectContract.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  UNKNOWN_MUTATION_EFFECT_CONTRACT,
+  describeToolEffect,
+} from '../../../core/v4/effectContract';
+import { ToolRegistry } from '../../../core/v4/toolRegistry';
+import { registerAllTools } from '../../../tools/v4';
+
+describe('durable tool effect contracts', () => {
+  it('classifies every registered tool and gives every built-in mutation a trusted contract', () => {
+    const registry = new ToolRegistry();
+    registerAllTools(registry);
+
+    for (const name of registry.list()) {
+      const handler = registry.get(name)!;
+      const descriptor = describeToolEffect(handler, {});
+      if (handler.mutates === false) {
+        expect(descriptor.classification, name).toBe('read_only');
+      } else {
+        expect(handler.effectContract, name).toBeDefined();
+        expect(descriptor.classification, name).not.toBe('read_only');
+        expect(descriptor.trusted, name).toBe(true);
+      }
+    }
+  });
+
+  it('uses a fail-closed unknown contract without retaining secret values', () => {
+    const descriptor = describeToolEffect({
+      schema: { name: 'plugin_write', description: 'writes externally', inputSchema: { type: 'object' } },
+      category: 'write', riskTier: 'dangerous', mutates: true, toolset: 'plugin',
+      async execute() { return { ok: true }; },
+    }, {
+      endpoint: 'https://example.test/resource',
+      apiKey: 'must-not-survive',
+      password: 'also-secret',
+    });
+
+    expect(descriptor).toMatchObject({
+      ...UNKNOWN_MUTATION_EFFECT_CONTRACT,
+      trusted: false,
+      target: null,
+      retrySafety: 'never_automatic',
+      approvalRequirement: 'always',
+    });
+    expect(JSON.stringify(descriptor)).not.toContain('must-not-survive');
+    expect(JSON.stringify(descriptor)).not.toContain('also-secret');
+  });
+
+  it('removes URL credentials, query values, and fragments from durable targets', () => {
+    const descriptor = describeToolEffect({
+      mutates: true,
+      effectContract: {
+        classification: 'unsafe_mutation', kind: 'network.request', retrySafety: 'never_automatic',
+        idempotencySupported: false, reconciliationSupported: false, verificationSupported: false,
+        approvalRequirement: 'always', sensitiveFields: ['url'], redactionRules: ['strip_url_secrets'],
+        target: (args) => String(args.url),
+      },
+    }, { url: 'https://user:password@example.test/path?token=private#secret' });
+
+    expect(descriptor.target).toBe('https://example.test/path');
+    expect(JSON.stringify(descriptor)).not.toMatch(/password|private|#secret/);
+  });
+});

--- a/tests/v4/core/effectContract.test.ts
+++ b/tests/v4/core/effectContract.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
 
 import {
   UNKNOWN_MUTATION_EFFECT_CONTRACT,
@@ -65,5 +67,23 @@ describe('durable tool effect contracts', () => {
 
     expect(descriptor.target).toBe('https://example.test/path');
     expect(JSON.stringify(descriptor)).not.toMatch(/password|private|#secret/);
+  });
+
+  it('persists only a digest and resolved target for file-write reconciliation', () => {
+    const registry = new ToolRegistry();
+    registerAllTools(registry);
+    const content = 'private file body';
+    const descriptor = describeToolEffect(
+      registry.get('file_write')!,
+      { path: 'result.txt', content },
+      'C:\\workspace',
+    );
+
+    expect(descriptor.reconciliationData).toEqual({
+      path: join('C:\\workspace', 'result.txt'),
+      expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+      expectedSize: Buffer.byteLength(content),
+    });
+    expect(JSON.stringify(descriptor.reconciliationData)).not.toContain(content);
   });
 });

--- a/tests/v4/core/effectReconciliation.test.ts
+++ b/tests/v4/core/effectReconciliation.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  reconcileFilesystemEffect,
+  type EffectReconciliationInput,
+} from '../../../core/v4/effectReconciliation';
+
+const dirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'aiden-effect-reconcile-'));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function input(overrides: Partial<EffectReconciliationInput> = {}): EffectReconciliationInput {
+  return {
+    effectId: 'effect_1',
+    kind: 'filesystem.write',
+    target: null,
+    retrySafety: 'reconcile_before_retry',
+    idempotencyKey: 'idem_1',
+    reconciliationData: null,
+    ...overrides,
+  };
+}
+
+describe('Effect reconciliation', () => {
+  it('proves an expected file write occurred from exact content evidence', async () => {
+    const dir = tempDir();
+    const path = join(dir, 'result.txt');
+    const content = 'durable result';
+    writeFileSync(path, content);
+
+    const result = await reconcileFilesystemEffect(input({
+      target: path,
+      reconciliationData: {
+        expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+        expectedSize: Buffer.byteLength(content),
+      },
+    }));
+
+    expect(result).toMatchObject({
+      outcome: 'occurred', confidence: 'high', retryRecommendation: 'do_not_retry',
+      humanResolutionRequired: false,
+    });
+    expect(result.evidence).toMatchObject({ exists: true, size: Buffer.byteLength(content) });
+  });
+
+  it('proves a new-file write did not occur only when prior absence is known', async () => {
+    const dir = tempDir();
+    const path = join(dir, 'missing.txt');
+
+    const result = await reconcileFilesystemEffect(input({
+      target: path,
+      reconciliationData: { before: { exists: false }, expectedContentSha256: 'abc' },
+    }));
+
+    expect(result).toMatchObject({
+      outcome: 'did_not_occur', confidence: 'high', retryRecommendation: 'retry_same_identity',
+      humanResolutionRequired: false,
+    });
+  });
+
+  it('keeps mismatched or insufficient file state unknown', async () => {
+    const dir = tempDir();
+    const path = join(dir, 'existing.txt');
+    writeFileSync(path, 'different');
+
+    const result = await reconcileFilesystemEffect(input({
+      target: path,
+      reconciliationData: { before: { exists: true, contentSha256: 'old' }, expectedContentSha256: 'expected' },
+    }));
+
+    expect(result).toMatchObject({
+      outcome: 'unknown', retryRecommendation: 'human_review', humanResolutionRequired: true,
+    });
+    expect(JSON.stringify(result)).not.toContain('different');
+  });
+
+  it('never infers arbitrary process effects from an exit status', async () => {
+    const result = await reconcileFilesystemEffect(input({
+      kind: 'process.command', target: 'local-runtime', reconciliationData: { exitCode: 0 },
+    }));
+    expect(result).toMatchObject({
+      outcome: 'unknown', confidence: 'low', retryRecommendation: 'human_review',
+      humanResolutionRequired: true,
+    });
+  });
+});

--- a/tests/v4/core/portablePath.test.ts
+++ b/tests/v4/core/portablePath.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isPortablePathWithin, resolvePortablePath } from '../../../core/v4/portablePath';
+
+describe('portable durable paths', () => {
+  it('resolves Windows and POSIX paths independently of the current host', () => {
+    expect(resolvePortablePath('C:\\workspace', 'result.txt')).toBe('C:\\workspace\\result.txt');
+    expect(resolvePortablePath('/workspace', 'result.txt')).toBe('/workspace/result.txt');
+  });
+
+  it('enforces component boundaries using the persisted path dialect', () => {
+    expect(isPortablePathWithin('c:\\WORKSPACE\\safe\\nested.txt', 'C:\\workspace\\safe')).toBe(true);
+    expect(isPortablePathWithin('C:\\workspace\\safe\\..\\escape.txt', 'C:\\workspace\\safe')).toBe(false);
+    expect(isPortablePathWithin('C:\\workspace\\safe-other', 'C:\\workspace\\safe')).toBe(false);
+    expect(isPortablePathWithin('/workspace/safe/nested.txt', '/workspace/safe')).toBe(true);
+    expect(isPortablePathWithin('/workspace/escape.txt', '/workspace/safe')).toBe(false);
+    expect(isPortablePathWithin('/workspace/safe', 'C:\\workspace\\safe')).toBe(false);
+  });
+});

--- a/tests/v4/core/runtimeAuthority.test.ts
+++ b/tests/v4/core/runtimeAuthority.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(__dirname, '../../..');
+
+const executionAdapters = [
+  'cli/v4/aidenCLI.ts',
+  'cli/v4/chatSession.ts',
+  'core/v4/daemon/dispatcher/agentRunner.ts',
+  'core/v4/daemon/dispatcher/realAgentRunner.ts',
+  'core/v4/daemon/httpJobIngress.ts',
+  'core/v4/mcp/server/toolBridge.ts',
+  'core/v4/subagent/spawnSubAgent.ts',
+];
+
+const admissionAdapters = [
+  'core/v4/daemon/api/runs.ts',
+  'core/v4/daemon/dispatcher/dispatcher.ts',
+  'core/v4/workbench/jobCommands.ts',
+];
+
+const forbiddenLifecycleWrites = [
+  /\.submitJob\s*\(/,
+  /\.claimAttempt\s*\(/,
+  /\.renewAttemptLease\s*\(/,
+  /\.transitionAttempt\s*\(/,
+  /\.transitionJob\s*\(/,
+  /\.finalizeJob\s*\(/,
+];
+
+function source(relativePath: string): string {
+  return readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+describe('production runtime authority contract', () => {
+  it.each(executionAdapters)('%s delegates execution lifecycle to the canonical service', (relativePath) => {
+    const text = source(relativePath);
+    expect(text).toContain('executeDurableJob');
+    for (const pattern of forbiddenLifecycleWrites) expect(text).not.toMatch(pattern);
+  });
+
+  it.each(admissionAdapters)('%s uses canonical admission without owning execution transitions', (relativePath) => {
+    const text = source(relativePath);
+    expect(text).toContain('admitDurableJob');
+    for (const pattern of forbiddenLifecycleWrites) expect(text).not.toMatch(pattern);
+  });
+});

--- a/tests/v4/core/toolRegistry.jobIdentity.test.ts
+++ b/tests/v4/core/toolRegistry.jobIdentity.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import Database from 'better-sqlite3';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -12,16 +13,100 @@ import {
   runWithJobExecutionContext,
 } from '../../../core/v4/daemon/jobExecutionContext';
 import type { JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { resolveAidenPaths } from '../../../core/v4/paths';
 import { ToolRegistry } from '../../../core/v4/toolRegistry';
-import type { ActionAuthority, NormalizedAction, PolicySnapshotInput } from '../../../core/v4/actionAuthority';
+import { createActionAuthority, type ActionAuthority, type NormalizedAction, type PolicySnapshotInput } from '../../../core/v4/actionAuthority';
 import { ApprovalEngine } from '../../../moat/approvalEngine';
 
+const TEST_EFFECT_CONTRACT = {
+  classification: 'reconcilable_mutation' as const,
+  kind: 'fixture.write',
+  retrySafety: 'reconcile_before_retry' as const,
+  idempotencySupported: false,
+  reconciliationSupported: true,
+  verificationSupported: true,
+  approvalRequirement: 'policy' as const,
+  sensitiveFields: [] as string[],
+  redactionRules: ['digest_arguments'],
+  target: () => 'fixture-target',
+};
+
 describe('ToolRegistry durable execution identity', () => {
+  it('links a requested Effect to the exact approval before dispatch', async () => {
+    const db = new Database(':memory:');
+    try {
+      db.pragma('foreign_keys = ON');
+      runMigrations(db);
+      db.prepare(
+        `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES ('instance-effect', 1, 'test', 1, 1, 'test')`,
+      ).run();
+      const engine = createJobEngine({ db });
+      const admission = engine.submitJob({
+        entryPoint: 'test', source: 'test', sessionId: 'session-effect', instanceId: 'instance-effect',
+        idempotencyNamespace: 'test', idempotencyKey: 'effect-approval', goal: 'effect approval',
+      });
+      const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'test', ttlMs: 60_000 });
+      engine.transitionAttempt({
+        attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!, generation: lease.generation!,
+        fenceToken: lease.fenceToken!, to: 'running', eventIdempotencyKey: 'attempt-running', producer: 'test',
+      });
+      engine.transitionJob({
+        jobId: admission.jobId, attemptId: admission.attemptId, generation: lease.generation!,
+        fenceToken: lease.fenceToken!, expectedStateVersion: 0, to: 'running',
+        eventIdempotencyKey: 'job-running', producer: 'test',
+      });
+      const registry = new ToolRegistry();
+      const handler = vi.fn(async () => ({ ok: true }));
+      registry.register({
+        schema: { name: 'approved_write', description: 'writes', inputSchema: { type: 'object' } },
+        category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc', execute: handler,
+        effectContract: { ...TEST_EFFECT_CONTRACT, sensitiveFields: ['apiKey'] },
+      });
+      const execute = registry.buildExecutor({
+        cwd: process.cwd(), paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+        actionAuthority: createActionAuthority({ db, jobEngine: engine }),
+        approvalEngine: new ApprovalEngine('manual', { promptUser: async () => 'allow' }),
+        policySnapshot: {
+          trustLevel: 'Assistant', autonomyPolicy: 'ask_for_mutations', approvalMode: 'manual',
+          toolMetadataVersion: 'test', sandboxPolicy: {}, networkPolicy: {}, pluginGrants: [],
+          mcpGrants: [], workspaceOverrides: {}, jobOverrides: {},
+        },
+      });
+
+      const result = await runWithJobExecutionContext({
+        engine, jobId: admission.jobId, attemptId: admission.attemptId,
+        generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+      }, () => execute({
+        id: 'provider-effect-call', name: 'approved_write',
+        arguments: { path: 'result.txt', apiKey: 'private-fixture-value' },
+      }));
+
+      expect(result.error).toBeUndefined();
+      expect(handler).toHaveBeenCalledOnce();
+      const binding = db.prepare(
+        `SELECT a.effect_id, a.action_digest, se.action_digest AS effect_action_digest,
+                se.approval_id, se.approval_state, se.effect_state
+           FROM approvals a JOIN side_effect_ledger se ON se.key = a.effect_id`,
+      ).get() as Record<string, unknown>;
+      expect(binding).toMatchObject({
+        approval_state: 'approved', effect_state: 'committed',
+        action_digest: binding.effect_action_digest,
+        approval_id: expect.any(String), effect_id: expect.any(String),
+      });
+      expect(JSON.stringify(db.prepare('SELECT * FROM side_effect_ledger').all()))
+        .not.toContain('private-fixture-value');
+    } finally {
+      db.close();
+    }
+  });
+
   it('persists and starts a mutating ToolCall before the handler executes', async () => {
     const order: string[] = [];
     const engine = {
-      prepareToolCall: vi.fn(() => { order.push('prepared'); return { applied: true }; }),
+      prepareToolCall: vi.fn(() => { order.push('prepared'); return { applied: true, effectId: 'effect_1' }; }),
       startToolCall: vi.fn(() => { order.push('started'); return { applied: true }; }),
       completeToolCall: vi.fn(() => { order.push('completed'); return { applied: true }; }),
     } as unknown as JobEngine;
@@ -35,6 +120,7 @@ describe('ToolRegistry durable execution identity', () => {
       category: 'write',
       riskTier: 'caution',
       mutates: true,
+      effectContract: TEST_EFFECT_CONTRACT,
       toolset: 'misc',
       async execute() {
         order.push('handler');
@@ -73,6 +159,11 @@ describe('ToolRegistry durable execution identity', () => {
       toolName: 'durable_write',
       mutates: true,
       normalizedArgsDigest: createHash('sha256').update('{"value":"exact"}').digest('hex'),
+      effect: expect.objectContaining({
+        classification: 'reconcilable_mutation',
+        kind: 'fixture.write',
+        approvalState: 'not_required',
+      }),
     }));
     expect(engine.completeToolCall).toHaveBeenCalledWith(expect.objectContaining({
       toolCallId: persistedToolCallId,
@@ -140,6 +231,7 @@ describe('ToolRegistry durable execution identity', () => {
     registry.register({
       schema: { name: 'guarded_write', description: 'guarded', inputSchema: { type: 'object' } },
       category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc', execute: handler,
+      effectContract: TEST_EFFECT_CONTRACT,
     });
     const execute = registry.buildExecutor({
       cwd: process.cwd(),
@@ -158,16 +250,18 @@ describe('ToolRegistry durable execution identity', () => {
   });
 
   it('persists approval_required and denies safely when no interactive channel exists', async () => {
+    const order: string[] = [];
     const handler = vi.fn(async () => ({ ok: true }));
     const engine = {
-      prepareToolCall: vi.fn(() => ({ applied: true })),
+      prepareToolCall: vi.fn(() => { order.push('effect'); return { applied: true, effectId: 'effect_exact' }; }),
+      resolveToolCallApproval: vi.fn(() => { order.push('effect-blocked'); return { applied: true }; }),
       startToolCall: vi.fn(),
       completeToolCall: vi.fn(() => ({ applied: true })),
     } as unknown as JobEngine;
     const actionAuthority = {
-      request: vi.fn(() => ({
+      request: vi.fn(() => { order.push('approval'); return ({
         approvalId: 'approval_exact', policySnapshotId: 'policy_exact',
-      })),
+      }); }),
       markDisplayed: vi.fn(),
     } as unknown as ActionAuthority;
     const registry = new ToolRegistry();
@@ -192,15 +286,77 @@ describe('ToolRegistry durable execution identity', () => {
     }, () => execute({ id: 'tool_unattended', name: 'unattended_write', arguments: {} }));
 
     expect(actionAuthority.request).toHaveBeenCalledOnce();
+    expect(actionAuthority.request).toHaveBeenCalledWith(expect.objectContaining({ effectId: 'effect_exact' }));
+    expect(order).toEqual(['effect', 'approval', 'effect-blocked']);
     expect(actionAuthority.markDisplayed).not.toHaveBeenCalled();
     expect(handler).not.toHaveBeenCalled();
     expect(result.error).toContain('approval_exact');
+  });
+
+  it('records verified read-only shell execution without a mutation Effect', async () => {
+    const handler = vi.fn(async () => ({ ok: true }));
+    const engine = {
+      prepareToolCall: vi.fn(() => ({ applied: true })),
+      startToolCall: vi.fn(() => ({ applied: true })),
+      completeToolCall: vi.fn(() => ({ applied: true })),
+    } as unknown as JobEngine;
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'shell_exec', description: 'shell', inputSchema: { type: 'object' } },
+      category: 'execute', riskTier: 'caution', mutates: true, toolset: 'terminal', execute: handler,
+      effectContract: TEST_EFFECT_CONTRACT,
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(),
+      paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+    });
+
+    const result = await runWithJobExecutionContext({
+      engine, jobId: 'job_1', attemptId: 'attempt_1', generation: 1,
+      fenceToken: 'fence_1', producer: 'test',
+    }, () => execute({ id: 'tool_read_shell', name: 'shell_exec', arguments: { command: 'rg --files' } }));
+
+    expect(result.error).toBeUndefined();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(engine.prepareToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      mutates: false,
+      effect: undefined,
+    }));
+  });
+
+  it('retains an unknown Effect when a mutating handler throws', async () => {
+    const engine = {
+      prepareToolCall: vi.fn(() => ({ applied: true, effectId: 'effect_failure' })),
+      startToolCall: vi.fn(() => ({ applied: true })),
+      completeToolCall: vi.fn(() => ({ applied: true })),
+    } as unknown as JobEngine;
+    const registry = new ToolRegistry();
+    registry.register({
+      schema: { name: 'failing_write', description: 'fails', inputSchema: { type: 'object' } },
+      category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc',
+      effectContract: TEST_EFFECT_CONTRACT,
+      async execute() { throw new Error('fixture failure'); },
+    });
+    const execute = registry.buildExecutor({
+      cwd: process.cwd(), paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-identity' }),
+    });
+
+    const result = await runWithJobExecutionContext({
+      engine, jobId: 'job_1', attemptId: 'attempt_1', generation: 1,
+      fenceToken: 'fence_1', producer: 'test',
+    }, () => execute({ id: 'tool_failure', name: 'failing_write', arguments: {} }));
+
+    expect(result.error).toBe('fixture failure');
+    expect(engine.completeToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      state: 'failed', sideEffectState: 'unknown',
+    }));
   });
 
   it('recomputes policy and action identity immediately before execution', async () => {
     const handler = vi.fn(async () => ({ ok: true }));
     const engine = {
       prepareToolCall: vi.fn(() => ({ applied: true })),
+      resolveToolCallApproval: vi.fn(() => ({ applied: true })),
       startToolCall: vi.fn(),
       completeToolCall: vi.fn(() => ({ applied: true })),
     } as unknown as JobEngine;
@@ -236,6 +392,7 @@ describe('ToolRegistry durable execution identity', () => {
     registry.register({
       schema: { name: 'policy_bound_write', description: 'writes', inputSchema: { type: 'object' } },
       category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc', execute: handler,
+      effectContract: TEST_EFFECT_CONTRACT,
     });
     const execute = registry.buildExecutor({
       cwd: process.cwd(),

--- a/tests/v4/core/toolRegistry.jobIdentity.test.ts
+++ b/tests/v4/core/toolRegistry.jobIdentity.test.ts
@@ -15,6 +15,7 @@ import {
 import type { JobEngine } from '../../../core/v4/daemon/jobEngine';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
 import { resolveAidenPaths } from '../../../core/v4/paths';
 import { ToolRegistry } from '../../../core/v4/toolRegistry';
 import { createActionAuthority, type ActionAuthority, type NormalizedAction, type PolicySnapshotInput } from '../../../core/v4/actionAuthority';
@@ -34,6 +35,81 @@ const TEST_EFFECT_CONTRACT = {
 };
 
 describe('ToolRegistry durable execution identity', () => {
+  it('persists and settles waits around approval and exclusive interaction', async () => {
+    const db = new Database(':memory:');
+    try {
+      db.pragma('foreign_keys = ON');
+      runMigrations(db);
+      db.prepare(
+        `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES ('instance-waits', 1, 'test', 1, 1, 'test')`,
+      ).run();
+      const engine = createJobEngine({ db });
+      const admission = engine.submitJob({
+        entryPoint: 'test', source: 'test', sessionId: 'session-waits', instanceId: 'instance-waits',
+        idempotencyNamespace: 'test', idempotencyKey: 'interaction-waits', goal: 'wait durably',
+      });
+      const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'test', ttlMs: 60_000 });
+      engine.transitionAttempt({
+        attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!, generation: lease.generation!,
+        fenceToken: lease.fenceToken!, to: 'running', eventIdempotencyKey: 'attempt-running', producer: 'test',
+      });
+      engine.transitionJob({
+        jobId: admission.jobId, attemptId: admission.attemptId, generation: lease.generation!,
+        fenceToken: lease.fenceToken!, expectedStateVersion: 0, to: 'running',
+        eventIdempotencyKey: 'job-running', producer: 'test',
+      });
+      const controls = createJobControlAuthority({ db, jobEngine: engine });
+      const observed: string[] = [];
+      const registry = new ToolRegistry();
+      registry.register({
+        schema: { name: 'approval_write', description: 'writes', inputSchema: { type: 'object' } },
+        category: 'write', riskTier: 'caution', mutates: true, toolset: 'misc',
+        effectContract: TEST_EFFECT_CONTRACT,
+        async execute() { return { ok: true }; },
+      });
+      registry.register({
+        schema: { name: 'interactive_read', description: 'asks', inputSchema: { type: 'object' } },
+        category: 'read', riskTier: 'safe', mutates: false, toolset: 'misc',
+        interaction: { mode: 'exclusive_modal', decision: 'clarification', cancellation: 'cancelled' },
+        async execute() {
+          observed.push(...controls.waits.listPending(admission.jobId).map((wait) => wait.kind));
+          return { ok: true, status: 'completed' };
+        },
+      });
+      const execute = registry.buildExecutor({
+        cwd: process.cwd(), paths: resolveAidenPaths({ rootOverride: 'C:/tmp/aiden-job-waits' }),
+        approvalEngine: new ApprovalEngine('manual', {
+          promptUser: async () => {
+            observed.push(...controls.waits.listPending(admission.jobId).map((wait) => wait.kind));
+            return 'allow';
+          },
+        }),
+      });
+      const context = {
+        engine, jobId: admission.jobId, attemptId: admission.attemptId,
+        generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+        controlAuthority: controls,
+      };
+
+      expect((await runWithJobExecutionContext(context, () => execute({
+        id: 'approval-call', name: 'approval_write', arguments: {},
+      }))).error).toBeUndefined();
+      expect((await runWithJobExecutionContext(context, () => execute({
+        id: 'interaction-call', name: 'interactive_read', arguments: {},
+      }))).error).toBeUndefined();
+
+      expect(observed).toEqual(['approval', 'clarification']);
+      expect(controls.waits.listPending(admission.jobId)).toEqual([]);
+      expect(db.prepare('SELECT kind, state FROM job_waits ORDER BY sequence').all()).toEqual([
+        { kind: 'approval', state: 'satisfied' },
+        { kind: 'clarification', state: 'satisfied' },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
   it('links a requested Effect to the exact approval before dispatch', async () => {
     const db = new Database(':memory:');
     try {

--- a/tests/v4/core/toolRegistry.jobIdentity.test.ts
+++ b/tests/v4/core/toolRegistry.jobIdentity.test.ts
@@ -4,11 +4,15 @@
  */
 
 import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import Database from 'better-sqlite3';
 
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  executeWithDurableToolCall,
   recordDurableToolVerification,
   runWithJobExecutionContext,
 } from '../../../core/v4/daemon/jobExecutionContext';
@@ -45,6 +49,118 @@ function resourceAuthorityMock() {
 }
 
 describe('ToolRegistry durable execution identity', () => {
+  it('captures fresh exact file readback and links proof to the current Effect', async () => {
+    const db = new Database(':memory:');
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-proof-readback-'));
+    try {
+      db.pragma('foreign_keys = ON');
+      runMigrations(db);
+      db.prepare(
+        `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES ('instance-proof', 1, 'test', 1, 1, 'test')`,
+      ).run();
+      const engine = createJobEngine({ db });
+      const admission = engine.submitJob({
+        entryPoint: 'test', source: 'test', sessionId: 'session-proof', instanceId: 'instance-proof',
+        idempotencyNamespace: 'test', idempotencyKey: 'file-proof', goal: 'write exact artifact',
+      });
+      const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'test', ttlMs: 60_000 });
+      const target = path.join(dir, 'approval-once.txt');
+      const content = 'approval-once';
+
+      await runWithJobExecutionContext({
+        engine, jobId: admission.jobId, attemptId: admission.attemptId,
+        generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+      }, () => executeWithDurableToolCall({
+        toolCallId: 'write-exact', toolName: 'file_write', args: { path: target, content },
+        riskTier: 'caution', mutates: true,
+        effect: {
+          classification: 'reconcilable_mutation', kind: 'filesystem.write', target,
+          retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+          reconciliationSupported: true, verificationSupported: true,
+          approvalRequirement: 'policy', sensitiveFields: ['content'],
+          redactionRules: ['omit_sensitive_values'], trusted: true,
+          reconciliationData: {
+            path: target,
+            expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+            expectedSize: Buffer.byteLength(content),
+          },
+        },
+        execute: async () => {
+          await fs.writeFile(target, content);
+          return { success: true, path: target, bytes: Buffer.byteLength(content) };
+        },
+        isSuccessful: (result) => result.success,
+      }));
+
+      const claims = engine.proof.listClaims(admission.jobId);
+      const evidence = engine.proof.listEvidence(admission.jobId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0]).toMatchObject({ required: true, state: 'verified' });
+      expect(evidence).toHaveLength(1);
+      expect(evidence[0]).toMatchObject({
+        attemptId: admission.attemptId, generation: lease.generation,
+        effectId: expect.any(String), source: 'filesystem.readback',
+        coverage: 'full', verificationResult: 'verified', late: false,
+        payload: expect.objectContaining({ path: target, exists: true, exact: true }),
+      });
+      const exported = engine.proof.exportJson(admission.jobId) as {
+        effects: Array<{ key: string }>; evidence: Array<{ effectId: string }>;
+      };
+      expect(exported.evidence[0].effectId).toBe(exported.effects[0].key);
+
+      const exerciseMismatch = async (
+        key: string,
+        proofTarget: string,
+        actual: string | null,
+      ) => {
+        const next = engine.submitJob({
+          entryPoint: 'test', source: 'test', sessionId: `session-${key}`, instanceId: 'instance-proof',
+          idempotencyNamespace: 'test', idempotencyKey: key, goal: key,
+        });
+        const nextLease = engine.claimAttempt({ attemptId: next.attemptId, ownerId: 'test', ttlMs: 60_000 });
+        await runWithJobExecutionContext({
+          engine, jobId: next.jobId, attemptId: next.attemptId,
+          generation: nextLease.generation!, fenceToken: nextLease.fenceToken!, producer: 'test',
+        }, () => executeWithDurableToolCall({
+          toolCallId: key, toolName: 'file_write', args: { path: proofTarget, content },
+          riskTier: 'caution', mutates: true,
+          effect: {
+            classification: 'reconcilable_mutation', kind: 'filesystem.write', target: proofTarget,
+            retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+            reconciliationSupported: true, verificationSupported: true,
+            approvalRequirement: 'policy', sensitiveFields: ['content'], redactionRules: [], trusted: true,
+            reconciliationData: {
+              path: proofTarget,
+              expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+              expectedSize: Buffer.byteLength(content),
+            },
+          },
+          execute: async () => {
+            if (actual !== null) await fs.writeFile(proofTarget, actual);
+            return { success: true };
+          },
+          isSuccessful: (result) => result.success,
+        }));
+        return { next, claims: engine.proof.listClaims(next.jobId), evidence: engine.proof.listEvidence(next.jobId) };
+      };
+
+      const wrong = await exerciseMismatch('wrong-file-content', path.join(dir, 'wrong.txt'), 'different');
+      expect(wrong.claims[0]?.state).toBe('failed');
+      expect(wrong.evidence[0]).toMatchObject({ coverage: 'full', verificationResult: 'failed' });
+
+      const unreadable = path.join(dir, 'capture-directory');
+      await fs.mkdir(unreadable);
+      const captureFailure = await exerciseMismatch('readback-capture-failure', unreadable, null);
+      expect(captureFailure.claims[0]?.state).toBe('unknown');
+      expect(captureFailure.evidence[0]).toMatchObject({ coverage: 'unknown', verificationResult: 'unknown' });
+      expect(captureFailure.evidence[0]?.payload).toMatchObject({ exists: null, exact: null });
+    } finally {
+      db.close();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('persists and settles waits around approval and exclusive interaction', async () => {
     const db = new Database(':memory:');
     try {
@@ -416,6 +532,7 @@ describe('ToolRegistry durable execution identity', () => {
   });
 
   it('retains an unknown Effect when a mutating handler throws', async () => {
+    const updates: Array<{ phase: string; timing?: { terminalClassification?: string } }> = [];
     const engine = {
       ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => ({ applied: true, effectId: 'effect_failure' })),
@@ -436,12 +553,19 @@ describe('ToolRegistry durable execution identity', () => {
     const result = await runWithJobExecutionContext({
       engine, jobId: 'job_1', attemptId: 'attempt_1', generation: 1,
       fenceToken: 'fence_1', producer: 'test',
-    }, () => execute({ id: 'tool_failure', name: 'failing_write', arguments: {} }));
+    }, () => execute(
+      { id: 'tool_failure', name: 'failing_write', arguments: {} },
+      undefined,
+      (update) => updates.push(update),
+    ));
 
     expect(result.error).toBe('fixture failure');
     expect(engine.completeToolCall).toHaveBeenCalledWith(expect.objectContaining({
       state: 'failed', sideEffectState: 'unknown',
     }));
+    expect(updates.at(-1)).toMatchObject({
+      phase: 'terminal', timing: { terminalClassification: 'unknown' },
+    });
   });
 
   it('recomputes policy and action identity immediately before execution', async () => {

--- a/tests/v4/core/toolRegistry.jobIdentity.test.ts
+++ b/tests/v4/core/toolRegistry.jobIdentity.test.ts
@@ -34,6 +34,16 @@ const TEST_EFFECT_CONTRACT = {
   target: () => 'fixture-target',
 };
 
+function resourceAuthorityMock() {
+  return {
+    resources: {
+      authorize: vi.fn(() => true),
+      getBudgets: vi.fn(() => []),
+      debit: vi.fn(() => ({ applied: true })),
+    },
+  };
+}
+
 describe('ToolRegistry durable execution identity', () => {
   it('persists and settles waits around approval and exclusive interaction', async () => {
     const db = new Database(':memory:');
@@ -182,6 +192,7 @@ describe('ToolRegistry durable execution identity', () => {
   it('persists and starts a mutating ToolCall before the handler executes', async () => {
     const order: string[] = [];
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => { order.push('prepared'); return { applied: true, effectId: 'effect_1' }; }),
       startToolCall: vi.fn(() => { order.push('started'); return { applied: true }; }),
       completeToolCall: vi.fn(() => { order.push('completed'); return { applied: true }; }),
@@ -252,6 +263,7 @@ describe('ToolRegistry durable execution identity', () => {
   it('scopes a repeated provider ToolCall id to each durable Attempt', async () => {
     const persisted = new Map<string, { attemptId: string; verification?: string }>();
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn((command: { toolCallId: string; attemptId: string }) => {
         if (persisted.has(command.toolCallId)) return { applied: false, conflict: 'illegal_transition' };
         persisted.set(command.toolCallId, { attemptId: command.attemptId });
@@ -299,6 +311,7 @@ describe('ToolRegistry durable execution identity', () => {
   it('does not execute when durable preparation rejects a stale fence', async () => {
     const handler = vi.fn(async () => ({ ok: true }));
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => ({ applied: false, conflict: 'stale_fence' })),
       startToolCall: vi.fn(),
       completeToolCall: vi.fn(),
@@ -329,6 +342,7 @@ describe('ToolRegistry durable execution identity', () => {
     const order: string[] = [];
     const handler = vi.fn(async () => ({ ok: true }));
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => { order.push('effect'); return { applied: true, effectId: 'effect_exact' }; }),
       resolveToolCallApproval: vi.fn(() => { order.push('effect-blocked'); return { applied: true }; }),
       startToolCall: vi.fn(),
@@ -372,6 +386,7 @@ describe('ToolRegistry durable execution identity', () => {
   it('records verified read-only shell execution without a mutation Effect', async () => {
     const handler = vi.fn(async () => ({ ok: true }));
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => ({ applied: true })),
       startToolCall: vi.fn(() => ({ applied: true })),
       completeToolCall: vi.fn(() => ({ applied: true })),
@@ -402,6 +417,7 @@ describe('ToolRegistry durable execution identity', () => {
 
   it('retains an unknown Effect when a mutating handler throws', async () => {
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => ({ applied: true, effectId: 'effect_failure' })),
       startToolCall: vi.fn(() => ({ applied: true })),
       completeToolCall: vi.fn(() => ({ applied: true })),
@@ -431,6 +447,7 @@ describe('ToolRegistry durable execution identity', () => {
   it('recomputes policy and action identity immediately before execution', async () => {
     const handler = vi.fn(async () => ({ ok: true }));
     const engine = {
+      ...resourceAuthorityMock(),
       prepareToolCall: vi.fn(() => ({ applied: true })),
       resolveToolCallApproval: vi.fn(() => ({ applied: true })),
       startToolCall: vi.fn(),

--- a/tests/v4/daemon/db/effectContractMigration.test.ts
+++ b/tests/v4/daemon/db/effectContractMigration.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  LATEST_SCHEMA_VERSION,
+  MIGRATIONS_FOR_TESTS,
+  runMigrations,
+} from '../../../../core/v4/daemon/db/migrations';
+
+let db: Database.Database;
+
+function applyThrough(version: number): void {
+  for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= version)) {
+    db.transaction(() => {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare('INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)')
+        .run(migration.version, Date.now());
+    })();
+  }
+}
+
+describe('durable effect contract migration', () => {
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+  });
+  afterEach(() => db.close());
+
+  it('upgrades the v21 ledger additively and preserves legacy effects', () => {
+    applyThrough(21);
+    db.prepare(
+      `INSERT INTO side_effect_ledger
+         (key, task_id, step, tool, args_hash, status, attempted_at, effect_state)
+       VALUES ('legacy-effect', 'legacy-job', 1, 'send', 'digest', 'confirmed', 1, 'committed')`,
+    ).run();
+
+    expect(runMigrations(db)).toEqual({ from: 21, to: LATEST_SCHEMA_VERSION });
+    expect(db.prepare(
+      'SELECT key, effect_state, effect_classification, updated_at FROM side_effect_ledger WHERE key = ?',
+    ).get('legacy-effect')).toMatchObject({
+      key: 'legacy-effect', effect_state: 'committed', effect_classification: 'unsafe_mutation', updated_at: 1,
+    });
+  });
+
+  it('rolls back the additive migration when version persistence fails', () => {
+    applyThrough(21);
+    db.exec(`
+      CREATE TRIGGER reject_effect_contract_version
+      BEFORE INSERT ON schema_version
+      WHEN NEW.version = 22
+      BEGIN
+        SELECT RAISE(ABORT, 'effect fixture interruption');
+      END;
+    `);
+
+    expect(() => runMigrations(db)).toThrow(/Migration 22 .*effect fixture interruption/i);
+    const names = (db.prepare('PRAGMA table_info(side_effect_ledger)').all() as Array<{ name: string }>).map((row) => row.name);
+    expect(names).not.toContain('effect_classification');
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 21 });
+  });
+});

--- a/tests/v4/daemon/db/effectContractMigration.test.ts
+++ b/tests/v4/daemon/db/effectContractMigration.test.ts
@@ -64,4 +64,22 @@ describe('durable effect contract migration', () => {
     expect(names).not.toContain('effect_classification');
     expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 21 });
   });
+
+  it('adds reconciliation history without replacing existing Effect rows', () => {
+    applyThrough(22);
+    db.prepare(
+      `INSERT INTO side_effect_ledger
+         (key, task_id, step, tool, args_hash, status, attempted_at, effect_state,
+          effect_classification, effect_kind, retry_safety, updated_at)
+       VALUES ('effect-before-v23', 'job-before-v23', 1, 'file_write', 'digest',
+               'unknown', 1, 'unknown', 'reconcilable_mutation', 'filesystem.write',
+               'reconcile_before_retry', 1)`,
+    ).run();
+
+    expect(runMigrations(db)).toEqual({ from: 22, to: LATEST_SCHEMA_VERSION });
+    expect(db.prepare('SELECT key, effect_state FROM side_effect_ledger WHERE key = ?')
+      .get('effect-before-v23')).toEqual({ key: 'effect-before-v23', effect_state: 'unknown' });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='effect_reconciliations'").get())
+      .toEqual({ name: 'effect_reconciliations' });
+  });
 });

--- a/tests/v4/daemon/db/jobControlMigration.test.ts
+++ b/tests/v4/daemon/db/jobControlMigration.test.ts
@@ -53,7 +53,7 @@ describe('durable input and approval migration', () => {
       'approvals',
     ]));
     expect(tableNames()).not.toContain('jobs');
-    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 21 });
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: LATEST_SCHEMA_VERSION });
   });
 
   it('is idempotent when the additive migration is applied repeatedly', () => {

--- a/tests/v4/daemon/db/jobEngineMigration.test.ts
+++ b/tests/v4/daemon/db/jobEngineMigration.test.ts
@@ -114,7 +114,12 @@ describe('durable Job and Attempt migration', () => {
     ]));
     expect([...columns('side_effect_ledger')]).toEqual(expect.arrayContaining([
       'job_id', 'attempt_id', 'generation', 'tool_call_id', 'effect_state',
+      'effect_classification', 'effect_kind', 'retry_safety', 'idempotency_key',
+      'idempotency_supported', 'reconciliation_supported', 'verification_supported',
+      'approval_requirement', 'approval_state', 'approval_id', 'action_digest',
+      'sensitive_fields_json', 'redaction_rules_json', 'result_ref', 'updated_at',
     ]));
+    expect([...columns('approvals')]).toContain('effect_id');
   });
 
   it('backfills stable Attempt identities and deterministic per-Job event order', () => {

--- a/tests/v4/daemon/db/jobEngineMigration.test.ts
+++ b/tests/v4/daemon/db/jobEngineMigration.test.ts
@@ -144,6 +144,7 @@ describe('durable Job and Attempt migration', () => {
     expect([...columns('job_wait_events')]).toEqual(expect.arrayContaining([
       'wait_event_id', 'wait_id', 'job_id', 'type', 'payload_json', 'idempotency_key',
     ]));
+    expect([...columns('approvals')]).toContain('fence_token_digest');
   });
 
   it('backfills stable Attempt identities and deterministic per-Job event order', () => {

--- a/tests/v4/daemon/db/jobEngineMigration.test.ts
+++ b/tests/v4/daemon/db/jobEngineMigration.test.ts
@@ -127,6 +127,16 @@ describe('durable Job and Attempt migration', () => {
       'outcome', 'confidence', 'evidence_json', 'retry_recommendation',
       'human_resolution_required', 'idempotency_key', 'created_at',
     ]));
+    expect([...columns('execution_graphs')]).toEqual(expect.arrayContaining([
+      'graph_id', 'job_id', 'plan_digest', 'state', 'version', 'next_event_sequence',
+    ]));
+    expect([...columns('execution_graph_nodes')]).toEqual(expect.arrayContaining([
+      'node_id', 'node_key', 'graph_id', 'job_id', 'kind', 'state', 'ordinal',
+      'output_ref', 'verification_ref', 'requires_verification', 'state_version',
+    ]));
+    expect([...columns('execution_node_attempts')]).toEqual(expect.arrayContaining([
+      'node_execution_id', 'node_id', 'attempt_id', 'generation', 'state', 'output_ref',
+    ]));
   });
 
   it('backfills stable Attempt identities and deterministic per-Job event order', () => {

--- a/tests/v4/daemon/db/jobEngineMigration.test.ts
+++ b/tests/v4/daemon/db/jobEngineMigration.test.ts
@@ -118,8 +118,15 @@ describe('durable Job and Attempt migration', () => {
       'idempotency_supported', 'reconciliation_supported', 'verification_supported',
       'approval_requirement', 'approval_state', 'approval_id', 'action_digest',
       'sensitive_fields_json', 'redaction_rules_json', 'result_ref', 'updated_at',
+      'reconciliation_data_json', 'reconciliation_outcome',
+      'reconciliation_required', 'last_reconciled_at',
     ]));
     expect([...columns('approvals')]).toContain('effect_id');
+    expect([...columns('effect_reconciliations')]).toEqual(expect.arrayContaining([
+      'reconciliation_id', 'effect_id', 'job_id', 'attempt_id', 'generation',
+      'outcome', 'confidence', 'evidence_json', 'retry_recommendation',
+      'human_resolution_required', 'idempotency_key', 'created_at',
+    ]));
   });
 
   it('backfills stable Attempt identities and deterministic per-Job event order', () => {

--- a/tests/v4/daemon/db/jobEngineMigration.test.ts
+++ b/tests/v4/daemon/db/jobEngineMigration.test.ts
@@ -137,6 +137,13 @@ describe('durable Job and Attempt migration', () => {
     expect([...columns('execution_node_attempts')]).toEqual(expect.arrayContaining([
       'node_execution_id', 'node_id', 'attempt_id', 'generation', 'state', 'output_ref',
     ]));
+    expect([...columns('job_waits')]).toEqual(expect.arrayContaining([
+      'wait_id', 'job_id', 'attempt_id', 'generation', 'sequence', 'graph_node_key', 'kind',
+      'state', 'deadline_at', 'external_key', 'resolved_by_input_id', 'resolution_ref',
+    ]));
+    expect([...columns('job_wait_events')]).toEqual(expect.arrayContaining([
+      'wait_event_id', 'wait_id', 'job_id', 'type', 'payload_json', 'idempotency_key',
+    ]));
   });
 
   it('backfills stable Attempt identities and deterministic per-Job event order', () => {

--- a/tests/v4/daemon/db/kernelMigration.test.ts
+++ b/tests/v4/daemon/db/kernelMigration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeDaemonDb, openDaemonDb } from '../../../../core/v4/daemon/db/connection';
+import {
+  LATEST_SCHEMA_VERSION,
+  MIGRATIONS_FOR_TESTS,
+  runMigrations,
+} from '../../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../../core/v4/daemon/jobEngine';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function applyThrough(db: Database.Database, version: number): void {
+  for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= version)) {
+    db.transaction(() => {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare('INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)')
+        .run(migration.version, Date.now());
+    }).immediate();
+  }
+}
+
+function tempDb(): { root: string; path: string } {
+  const root = mkdtempSync(join(tmpdir(), 'aiden-kernel-migration-'));
+  roots.push(root);
+  return { root, path: join(root, 'daemon.db') };
+}
+
+describe('kernel migration compatibility', () => {
+  it('opens a populated v4.16-era database without changing terminal truth or queued input', () => {
+    const location = tempDb();
+    const legacy = new Database(location.path);
+    legacy.pragma('foreign_keys = ON');
+    applyThrough(legacy, 21);
+    const now = Date.now();
+    legacy.prepare(
+      `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('legacy-instance', 1, 'localhost', ?, ?, '4.16.1')`,
+    ).run(now, now);
+    const engine = createJobEngine({ db: legacy });
+    const admitted = engine.submitJob({
+      entryPoint: 'legacy', source: 'legacy', sessionId: 'legacy-session', instanceId: 'legacy-instance',
+      idempotencyNamespace: 'legacy', idempotencyKey: 'job', requestFingerprint: 'job', goal: 'legacy goal',
+    });
+    legacy.prepare(
+      `UPDATE tasks SET status = 'completed', terminal_at = ?, terminal_outcome = 'verified',
+         finish_reason = 'legacy_done', evidence = ?, active_attempt_id = NULL WHERE id = ?`,
+    ).run(now, JSON.stringify({ preserved: true }), admitted.jobId);
+    legacy.prepare(
+      `UPDATE runs SET status = 'succeeded', completed_at = ?, ended_at = ? WHERE attempt_id = ?`,
+    ).run(now, now, admitted.attemptId);
+    legacy.prepare(
+      `INSERT INTO durable_inputs (
+         input_id, job_id, target_attempt_id, target_generation, session_id, source, sequence,
+         kind, content, content_hash, state, idempotency_namespace, idempotency_key, created_at, updated_at
+       ) VALUES ('input_legacy', ?, NULL, NULL, 'legacy-session', 'repl', 1,
+                 'follow_up', 'preserve me', 'hash', 'queued', 'legacy', 'input', ?, ?)`,
+    ).run(admitted.jobId, now, now);
+    legacy.prepare(
+      `INSERT INTO policy_snapshots (
+         policy_snapshot_id, schema_version, digest, trust_level, autonomy_policy, approval_mode,
+         tool_metadata_version, sandbox_policy_json, network_policy_json, plugin_grants_json,
+         mcp_grants_json, workspace_overrides_json, job_overrides_json, created_at
+       ) VALUES ('policy_legacy', 1, 'digest', 'Assistant', 'ask', 'smart', 'legacy', '{}', '{}', '[]', '[]', '{}', '{}', ?)`,
+    ).run(now);
+    legacy.prepare(
+      `INSERT INTO approvals (
+         approval_id, job_id, attempt_id, generation, tool_call_id, request_sequence, tool_name,
+         risk_tier, risk_reasons_json, normalized_execution_plan, action_digest, policy_snapshot_id,
+         state, requested_at
+       ) VALUES ('approval_legacy', ?, ?, 1, 'tool_legacy', 1, 'file_write',
+                 'caution', '[]', '{}', 'action', 'policy_legacy', 'approved', ?)`,
+    ).run(admitted.jobId, admitted.attemptId, now);
+    legacy.close();
+
+    const upgraded = openDaemonDb(location.path);
+    expect(upgraded.prepare('SELECT version FROM schema_version WHERE id = 1').get())
+      .toEqual({ version: LATEST_SCHEMA_VERSION });
+    expect(upgraded.prepare('SELECT status, terminal_outcome, finish_reason, evidence FROM tasks WHERE id = ?').get(admitted.jobId))
+      .toEqual({ status: 'completed', terminal_outcome: 'verified', finish_reason: 'legacy_done', evidence: '{"preserved":true}' });
+    expect(upgraded.prepare('SELECT content, state FROM durable_inputs WHERE input_id = ?').get('input_legacy'))
+      .toEqual({ content: 'preserve me', state: 'queued' });
+    expect(upgraded.prepare('SELECT state, fence_token_digest FROM approvals WHERE approval_id = ?').get('approval_legacy'))
+      .toEqual({ state: 'approved', fence_token_digest: null });
+    const backupPath = `${location.path}.pre-schema-v21.bak`;
+    expect(existsSync(backupPath)).toBe(true);
+    closeDaemonDb(location.path);
+    const backup = new Database(backupPath, { readonly: true });
+    expect(backup.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 21 });
+    expect(backup.prepare('SELECT content FROM durable_inputs WHERE input_id = ?').get('input_legacy'))
+      .toEqual({ content: 'preserve me' });
+    backup.close();
+  });
+
+  it('rolls back an interrupted kernel migration and reruns cleanly', () => {
+    const db = new Database(':memory:');
+    applyThrough(db, 29);
+    db.exec(`
+      CREATE TRIGGER reject_cursor_version BEFORE INSERT ON schema_version
+      WHEN NEW.version = 30 BEGIN SELECT RAISE(ABORT, 'cursor migration interrupted'); END;
+    `);
+    expect(() => runMigrations(db)).toThrow(/Migration 30 .*cursor migration interrupted/);
+    expect(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'job_event_cursors'").get()).toBeUndefined();
+    expect(db.prepare('SELECT version FROM schema_version WHERE id = 1').get()).toEqual({ version: 29 });
+    db.exec('DROP TRIGGER reject_cursor_version');
+    expect(runMigrations(db)).toEqual({ from: 29, to: LATEST_SCHEMA_VERSION });
+    expect(runMigrations(db)).toEqual({ from: LATEST_SCHEMA_VERSION, to: LATEST_SCHEMA_VERSION });
+    db.close();
+  });
+
+  it('repairs a missing optional cursor projection but rejects missing canonical tables', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    db.exec('DROP TABLE job_event_cursors');
+    expect(runMigrations(db)).toEqual({ from: LATEST_SCHEMA_VERSION, to: LATEST_SCHEMA_VERSION });
+    expect(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'job_event_cursors'").get()).toBeDefined();
+    db.exec('DROP TABLE durable_inputs');
+    expect(() => runMigrations(db)).toThrow(/schema is incomplete.*durable_inputs/i);
+    db.close();
+  });
+});

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -54,6 +54,7 @@ describe('runMigrations', () => {
     expect(names).toContain('job_evidence');
     expect(names).toContain('job_verdicts');
     expect(names).toContain('proof_reviews');
+    expect(names).toContain('job_event_cursors');
   });
 
   it('enforces trigger_events UNIQUE(source, idempotency_key) when key present', () => {

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -50,6 +50,10 @@ describe('runMigrations', () => {
     expect(names).toContain('job_budgets');
     expect(names).toContain('job_budget_debits');
     expect(names).toContain('job_capability_sets');
+    expect(names).toContain('job_claims');
+    expect(names).toContain('job_evidence');
+    expect(names).toContain('job_verdicts');
+    expect(names).toContain('proof_reviews');
   });
 
   it('enforces trigger_events UNIQUE(source, idempotency_key) when key present', () => {

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -46,6 +46,7 @@ describe('runMigrations', () => {
     expect(names).toContain('crash_reports');
     expect(names).toContain('restart_failure_counts');
     expect(names).toContain('triggers');
+    expect(names).toContain('child_job_contracts');
   });
 
   it('enforces trigger_events UNIQUE(source, idempotency_key) when key present', () => {

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -47,6 +47,9 @@ describe('runMigrations', () => {
     expect(names).toContain('restart_failure_counts');
     expect(names).toContain('triggers');
     expect(names).toContain('child_job_contracts');
+    expect(names).toContain('job_budgets');
+    expect(names).toContain('job_budget_debits');
+    expect(names).toContain('job_capability_sets');
   });
 
   it('enforces trigger_events UNIQUE(source, idempotency_key) when key present', () => {

--- a/tests/v4/daemon/effectReconciliationRecovery.test.ts
+++ b/tests/v4/daemon/effectReconciliationRecovery.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { reconcileFilesystemEffectSync } from '../../../core/v4/effectReconciliation';
+import { openDaemonDb, type Db } from '../../../core/v4/daemon/db/connection';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+
+describe('Effect reconciliation across process restart', () => {
+  let db: Db | null = null;
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    db?.close();
+    db = null;
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('retains the unknown Effect and resolves external file state after reopening SQLite', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aiden-effect-restart-'));
+    dirs.push(dir);
+    const dbPath = join(dir, 'runtime.db');
+    const target = join(dir, 'result.txt');
+    const content = 'persisted before crash';
+    db = openDaemonDb(dbPath);
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('old', 1, 'localhost', 1, 1, '4.16.1'),
+              ('new', 2, 'localhost', 2, 2, '4.16.1')`,
+    ).run();
+    let engine = createJobEngine({ db });
+    const admitted = engine.submitJob({
+      entryPoint: 'daemon', source: 'daemon', sessionId: 'session-restart', instanceId: 'old',
+      idempotencyNamespace: 'restart', idempotencyKey: 'job', goal: 'write result',
+    });
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'worker', ttlMs: 10, now: 100 });
+    engine.prepareToolCall({
+      toolCallId: 'tool_restart', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, toolName: 'file_write',
+      normalizedArgsDigest: 'digest', riskTier: 'caution', mutates: true,
+      effect: {
+        classification: 'reconcilable_mutation', kind: 'filesystem.write', target,
+        retrySafety: 'reconcile_before_retry', idempotencySupported: true, idempotencyKey: 'idem-restart',
+        reconciliationSupported: true, verificationSupported: true,
+        approvalRequirement: 'policy', approvalState: 'not_required', sensitiveFields: ['content'],
+        redactionRules: ['digest_arguments'], trusted: true,
+        reconciliationData: {
+          path: target, before: { exists: false }, expectedSize: Buffer.byteLength(content),
+          expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+        },
+      },
+      producer: 'test', now: 101,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_restart', attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test', now: 102,
+    });
+    writeFileSync(target, content);
+    db.close();
+    db = openDaemonDb(dbPath);
+    engine = createJobEngine({ db });
+
+    expect(engine.recoverExpiredAttempts({
+      now: 111, instanceId: 'new', producer: 'restart-recovery', maxCrashes: 3,
+    })).toMatchObject([{ decision: 'ask_user' }]);
+    const effect = engine.listEffectsRequiringReconciliation(admitted.jobId)[0]!;
+    const result = reconcileFilesystemEffectSync(effect);
+    expect(result.outcome).toBe('occurred');
+    expect(engine.recordEffectReconciliation({
+      effectId: effect.effectId,
+      expectedJobStateVersion: engine.getJob(admitted.jobId)!.stateVersion,
+      ...result,
+      producer: 'restart-recovery', idempotencyKey: 'restart-readback', now: 112,
+    }).applied).toBe(true);
+    expect(engine.listEffectsRequiringReconciliation(admitted.jobId)).toEqual([]);
+    expect(JSON.stringify(engine.listEffectReconciliations(effect.effectId))).not.toContain(content);
+  });
+});

--- a/tests/v4/daemon/executionGraph.test.ts
+++ b/tests/v4/daemon/executionGraph.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+describe('durable execution graph', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let admitted: ReturnType<JobEngine['submitJob']>;
+  let authority: { attemptId: string; generation: number; fenceToken: string };
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance', 1, 'localhost', 1, 1, '4.16.1')`,
+    ).run();
+    engine = createJobEngine({ db });
+    admitted = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'session', instanceId: 'instance',
+      idempotencyNamespace: 'graph', idempotencyKey: 'job', goal: 'execute graph',
+    });
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner', ttlMs: 30_000 });
+    authority = { attemptId: admitted.attemptId, generation: lease.generation!, fenceToken: lease.fenceToken! };
+  });
+
+  afterEach(() => db.close());
+
+  const create = () => engine.graph.create({
+    jobId: admitted.jobId, planDigest: 'plan-digest', producer: 'test', idempotencyKey: 'graph-create',
+    nodes: [
+      { nodeId: 'plan', kind: 'planning' as const },
+      { nodeId: 'read-a', kind: 'tool' as const, dependsOn: ['plan'] },
+      { nodeId: 'read-b', kind: 'tool' as const, dependsOn: ['plan'] },
+      { nodeId: 'verify', kind: 'verification' as const, dependsOn: ['read-a', 'read-b'], requiresVerification: true },
+      { nodeId: 'finish', kind: 'finalization' as const, dependsOn: ['verify'] },
+    ],
+  });
+
+  it('persists dependency order and schedules independent nodes in parallel', () => {
+    create();
+    expect(engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-1' }))
+      .toEqual(['plan']);
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'plan', ...authority, producer: 'test', idempotencyKey: 'claim-plan' });
+    engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'plan', ...authority, state: 'succeeded',
+      outputRef: 'plan:sha256:1', producer: 'test', idempotencyKey: 'complete-plan',
+    });
+    expect(engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-2' }))
+      .toEqual(['read-a', 'read-b']);
+  });
+
+  it('rejects cycles on initial and dynamic graph edits', () => {
+    expect(() => engine.graph.create({
+      jobId: admitted.jobId, planDigest: 'cycle', producer: 'test', idempotencyKey: 'cycle',
+      nodes: [
+        { nodeId: 'a', kind: 'tool', dependsOn: ['b'] },
+        { nodeId: 'b', kind: 'tool', dependsOn: ['a'] },
+      ],
+    })).toThrow(/cycle/i);
+    create();
+    expect(() => engine.graph.edit({
+      jobId: admitted.jobId, expectedVersion: 1, producer: 'test', idempotencyKey: 'edit-cycle',
+      nodes: [{ nodeId: 'later', kind: 'aggregation', dependsOn: ['finish'] }],
+      edges: [{ from: 'later', to: 'plan' }],
+    })).toThrow(/cycle/i);
+  });
+
+  it('audits dynamic graph edits and prevents duplicate scheduling', () => {
+    create();
+    const edited = engine.graph.edit({
+      jobId: admitted.jobId, expectedVersion: 1, producer: 'test', idempotencyKey: 'edit-1',
+      nodes: [{ nodeId: 'wait', kind: 'wait', dependsOn: ['plan'] }],
+    });
+    expect(edited.version).toBe(2);
+    expect(engine.graph.events(admitted.jobId).map((event) => event.type)).toEqual(['graph.created', 'graph.edited']);
+    expect(engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-a' }))
+      .toEqual(['plan']);
+    expect(engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-b' }))
+      .toEqual([]);
+  });
+
+  it('replays completed state after restart and resets only a stale running node', () => {
+    create();
+    engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule' });
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'plan', ...authority, producer: 'test', idempotencyKey: 'claim' });
+    engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'plan', ...authority, state: 'succeeded',
+      outputRef: 'plan:sha256:1', producer: 'test', idempotencyKey: 'complete',
+    });
+    engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-tools' });
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'read-a', ...authority, producer: 'test', idempotencyKey: 'claim-a' });
+
+    db.prepare("UPDATE runs SET lease_expires_at = 1 WHERE attempt_id = ?").run(admitted.attemptId);
+    engine.recoverExpiredAttempts({ now: 2, instanceId: 'instance', producer: 'test', maxCrashes: 3 });
+    engine = createJobEngine({ db });
+    const recovery = engine.listAttempts(admitted.jobId)[1]!;
+    const next = engine.claimAttempt({ attemptId: recovery.id, ownerId: 'next', ttlMs: 30_000, now: 3 });
+    const reset = engine.graph.recover({
+      jobId: admitted.jobId, attemptId: recovery.id, generation: next.generation!,
+      fenceToken: next.fenceToken!, producer: 'test', idempotencyKey: 'recover-graph', now: 3,
+    });
+    expect(reset).toEqual(['read-a']);
+    expect(engine.graph.nodes(admitted.jobId)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ nodeId: 'plan', state: 'succeeded' }),
+      expect.objectContaining({ nodeId: 'read-a', state: 'pending' }),
+      expect.objectContaining({ nodeId: 'read-b', state: 'runnable' }),
+    ]));
+  });
+
+  it('rejects stale completion and requires verification proof', () => {
+    create();
+    engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule' });
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'plan', ...authority, producer: 'test', idempotencyKey: 'claim' });
+    expect(engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'plan', attemptId: authority.attemptId,
+      generation: authority.generation + 1, fenceToken: authority.fenceToken,
+      state: 'succeeded', producer: 'test', idempotencyKey: 'stale',
+    })).toMatchObject({ applied: false, conflict: 'stale_fence' });
+
+    db.prepare("UPDATE execution_graph_nodes SET state = 'runnable' WHERE node_key = 'verify'").run();
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'verify', ...authority, producer: 'test', idempotencyKey: 'claim-verify' });
+    expect(engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'verify', ...authority, state: 'succeeded',
+      producer: 'test', idempotencyKey: 'verify-without-proof',
+    })).toMatchObject({ applied: false, conflict: 'verification_required' });
+  });
+
+  it('prevents a cancelled parent graph from scheduling or completing', () => {
+    create();
+    engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule' });
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'plan', ...authority, producer: 'test', idempotencyKey: 'claim' });
+    engine.cancelJob({ jobId: admitted.jobId, reason: 'user', producer: 'test', eventIdempotencyKey: 'cancel' });
+    expect(db.prepare('SELECT state FROM execution_graphs WHERE job_id = ?').get(admitted.jobId)).toEqual({ state: 'cancelled' });
+    expect(engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'plan', ...authority, state: 'succeeded',
+      producer: 'test', idempotencyKey: 'late-complete',
+    })).toMatchObject({ applied: false, conflict: 'terminal_job' });
+    expect(engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'late-schedule' }))
+      .toEqual([]);
+  });
+
+  it('supports wait, child Job, reconciliation, and verification as first-class node kinds', () => {
+    engine.graph.create({
+      jobId: admitted.jobId, planDigest: 'kinds', producer: 'test', idempotencyKey: 'kinds',
+      nodes: [
+        { nodeId: 'wait', kind: 'wait' },
+        { nodeId: 'child', kind: 'child_job', dependsOn: ['wait'] },
+        { nodeId: 'reconcile', kind: 'reconciliation', dependsOn: ['child'] },
+        { nodeId: 'verify', kind: 'verification', dependsOn: ['reconcile'], requiresVerification: true },
+      ],
+    });
+    expect(engine.graph.nodes(admitted.jobId).map((node) => node.kind))
+      .toEqual(['wait', 'child_job', 'reconciliation', 'verification']);
+  });
+
+  it('blocks dependents when a required predecessor fails', () => {
+    create();
+    engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-plan' });
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'plan', ...authority, producer: 'test', idempotencyKey: 'claim-plan' });
+    engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'plan', ...authority, state: 'failed',
+      producer: 'test', idempotencyKey: 'fail-plan',
+    });
+    expect(engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule-blocked' }))
+      .toEqual([]);
+    expect(engine.graph.nodes(admitted.jobId)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ nodeId: 'read-a', state: 'blocked' }),
+      expect.objectContaining({ nodeId: 'read-b', state: 'blocked' }),
+    ]));
+  });
+
+  it('allows authoritative Job completion only after every graph node succeeds', () => {
+    engine.graph.create({
+      jobId: admitted.jobId, planDigest: 'single', producer: 'test', idempotencyKey: 'single',
+      nodes: [{ nodeId: 'execute', kind: 'tool' }],
+    });
+    engine.transitionJob({
+      jobId: admitted.jobId, ...authority, expectedStateVersion: 0, to: 'running',
+      producer: 'test', eventIdempotencyKey: 'job-running',
+    });
+    expect(engine.finalizeJob({
+      jobId: admitted.jobId, ...authority, expectedStateVersion: 1, status: 'completed',
+      outcome: 'verified', finishReason: 'done', evidence: {}, producer: 'test',
+      eventIdempotencyKey: 'too-early',
+    })).toMatchObject({ applied: false, conflict: 'illegal_transition' });
+    engine.graph.schedule({ jobId: admitted.jobId, ...authority, producer: 'test', idempotencyKey: 'schedule' });
+    engine.graph.claim({ jobId: admitted.jobId, nodeId: 'execute', ...authority, producer: 'test', idempotencyKey: 'claim' });
+    engine.graph.complete({
+      jobId: admitted.jobId, nodeId: 'execute', ...authority, state: 'succeeded',
+      outputRef: 'result:sha256:1', producer: 'test', idempotencyKey: 'complete',
+    });
+    expect(engine.finalizeJob({
+      jobId: admitted.jobId, ...authority, expectedStateVersion: 1, status: 'completed',
+      outcome: 'verified', finishReason: 'done', evidence: {}, producer: 'test',
+      eventIdempotencyKey: 'complete-job',
+    }).applied).toBe(true);
+    expect(db.prepare('SELECT state FROM execution_graphs WHERE job_id = ?').get(admitted.jobId)).toEqual({ state: 'completed' });
+  });
+});

--- a/tests/v4/daemon/jobControlAuthority.test.ts
+++ b/tests/v4/daemon/jobControlAuthority.test.ts
@@ -280,6 +280,30 @@ describe('durable Job input and control authority', () => {
     }).applied).toBe(true);
   });
 
+  it('requeues an untargeted claimed input for the new recovery generation exactly once', () => {
+    const received = controls.inputs.receive({
+      jobId: admission.jobId, sessionId: 'session-1', source: 'tui', kind: 'follow_up',
+      content: 'continue after crash', idempotencyNamespace: 'tui:recovery', idempotencyKey: 'follow-up',
+    });
+    expect(controls.inputs.claimNext({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: 1,
+    })?.inputId).toBe(received.record.inputId);
+    db.prepare('UPDATE runs SET lease_expires_at = 1 WHERE attempt_id = ?').run(admission.attemptId);
+    jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'expired', ttlMs: 1, now: 0 });
+    const recovery = jobs.recoverExpiredAttempts({ now: 2, instanceId: 'instance-2', producer: 'test', maxCrashes: 3 })[0]!;
+    const attempt = jobs.getAttempt(recovery.recoveryAttemptId!)!;
+    const restored = createJobControlAuthority({ db, jobEngine: createJobEngine({ db }) });
+    expect(restored.inputs.claimNext({
+      jobId: admission.jobId, attemptId: attempt.id, generation: attempt.generation,
+    })?.inputId).toBe(received.record.inputId);
+    expect(restored.inputs.consume({
+      inputId: received.record.inputId, attemptId: attempt.id, generation: attempt.generation,
+    }).applied).toBe(true);
+    expect(restored.inputs.consume({
+      inputId: received.record.inputId, attemptId: attempt.id, generation: attempt.generation,
+    })).toMatchObject({ applied: false, duplicate: true });
+  });
+
   it('projects input lifecycle by reference without copying content into Job events', () => {
     const secretLikeContent = 'ordinary input with private material';
     const received = controls.inputs.receive({

--- a/tests/v4/daemon/jobControlAuthority.test.ts
+++ b/tests/v4/daemon/jobControlAuthority.test.ts
@@ -280,6 +280,72 @@ describe('durable Job input and control authority', () => {
     }).applied).toBe(true);
   });
 
+  it('retargets a pending input to a continuation Job and rejects the stale Attempt', () => {
+    const received = controls.inputs.receive({
+      jobId: admission.jobId,
+      targetAttemptId: admission.attemptId,
+      sessionId: 'session-1',
+      source: 'tui',
+      kind: 'message',
+      content: 'continue as a new Job',
+      idempotencyNamespace: 'tui:continuation',
+      idempotencyKey: 'continuation-input',
+    });
+    expect(controls.inputs.claimNext({
+      jobId: admission.jobId,
+      attemptId: admission.attemptId,
+      generation: 1,
+      inputId: received.record.inputId,
+    })?.state).toBe('claimed');
+    const continuation = jobs.submitJob({
+      entryPoint: 'interactive', source: 'repl', sessionId: 'session-1',
+      instanceId: 'instance-1', idempotencyNamespace: 'continuation',
+      idempotencyKey: 'continuation-job', goal: 'continue as a new Job',
+    });
+
+    const moved = controls.inputs.retarget({
+      inputId: received.record.inputId,
+      jobId: continuation.jobId,
+      attemptId: continuation.attemptId,
+      source: 'repl',
+    });
+    expect(moved).toMatchObject({
+      applied: true,
+      record: {
+        inputId: received.record.inputId,
+        jobId: continuation.jobId,
+        targetAttemptId: continuation.attemptId,
+        targetGeneration: null,
+        state: 'queued',
+        claimedByAttemptId: null,
+      },
+    });
+    expect(controls.inputs.consume({
+      inputId: received.record.inputId,
+      attemptId: admission.attemptId,
+      generation: 1,
+    })).toMatchObject({ applied: false, conflict: 'stale_generation' });
+
+    const lease = jobs.claimAttempt({
+      attemptId: continuation.attemptId,
+      ownerId: 'instance-1',
+      ttlMs: 30_000,
+    });
+    expect(lease).toMatchObject({ acquired: true, generation: 1 });
+    expect(controls.inputs.claimNext({
+      jobId: continuation.jobId,
+      attemptId: continuation.attemptId,
+      generation: 1,
+      inputId: received.record.inputId,
+    })?.inputId).toBe(received.record.inputId);
+    expect(controls.inputs.consume({
+      inputId: received.record.inputId,
+      attemptId: continuation.attemptId,
+      generation: 1,
+    }).applied).toBe(true);
+    expect(jobs.listEvents(continuation.jobId).map((event) => event.type)).toContain('input.retargeted');
+  });
+
   it('requeues an untargeted claimed input for the new recovery generation exactly once', () => {
     const received = controls.inputs.receive({
       jobId: admission.jobId, sessionId: 'session-1', source: 'tui', kind: 'follow_up',

--- a/tests/v4/daemon/jobEngine.test.ts
+++ b/tests/v4/daemon/jobEngine.test.ts
@@ -686,6 +686,128 @@ describe('ToolCall and SideEffect identity', () => {
       now: base + 11,
     })).toMatchObject({ applied: false, conflict: 'lease_expired' });
   });
+
+  it('records append-only Effect reconciliation and rejects a stale Job version', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    engine.prepareToolCall({
+      toolCallId: 'tool_reconcile', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, toolName: 'file_write',
+      normalizedArgsDigest: 'digest_reconcile', riskTier: 'caution', mutates: true,
+      effect: { ...effect, idempotencyKey: 'effect-reconcile', approvalState: 'not_required' }, producer: 'test',
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_reconcile', attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+    });
+    engine.completeToolCall({
+      toolCallId: 'tool_reconcile', attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, state: 'unknown',
+      sideEffectState: 'unknown', producer: 'test',
+    });
+
+    const jobVersion = engine.getJob(admitted.jobId)!.stateVersion;
+    expect(engine.recordEffectReconciliation({
+      effectId: 'side_effect:tool_reconcile', expectedJobStateVersion: jobVersion + 1,
+      outcome: 'occurred', confidence: 'high', evidence: { exists: true, contentSha256: 'digest' },
+      retryRecommendation: 'do_not_retry', humanResolutionRequired: false,
+      producer: 'test', idempotencyKey: 'reconcile-stale',
+    })).toMatchObject({ applied: false, conflict: 'state_version' });
+
+    expect(engine.recordEffectReconciliation({
+      effectId: 'side_effect:tool_reconcile', expectedJobStateVersion: jobVersion,
+      outcome: 'unknown', confidence: 'low', evidence: { exists: true },
+      retryRecommendation: 'human_review', humanResolutionRequired: true,
+      producer: 'test', idempotencyKey: 'reconcile-1',
+    }).applied).toBe(true);
+    expect(engine.recordEffectReconciliation({
+      effectId: 'side_effect:tool_reconcile', expectedJobStateVersion: jobVersion,
+      outcome: 'occurred', confidence: 'high', evidence: { contentSha256: 'digest' },
+      retryRecommendation: 'do_not_retry', humanResolutionRequired: false,
+      producer: 'test', idempotencyKey: 'reconcile-2',
+    }).applied).toBe(true);
+
+    expect(engine.listEffectReconciliations('side_effect:tool_reconcile')).toMatchObject([
+      { outcome: 'unknown', humanResolutionRequired: true },
+      { outcome: 'occurred', humanResolutionRequired: false },
+    ]);
+    expect(db.prepare('SELECT effect_state, reconciliation_outcome FROM side_effect_ledger WHERE key = ?')
+      .get('side_effect:tool_reconcile')).toEqual({ effect_state: 'committed', reconciliation_outcome: 'occurred' });
+  });
+
+  it('reuses the trusted idempotency identity only after did-not-occur reconciliation', () => {
+    const admitted = submit();
+    const first = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 10, now: 100 });
+    const sharedEffect = { ...effect, idempotencyKey: 'effect-retry-same', approvalState: 'not_required' as const };
+    engine.prepareToolCall({
+      toolCallId: 'tool_retry_first', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: first.generation!, fenceToken: first.fenceToken!, toolName: 'file_write',
+      normalizedArgsDigest: 'same-digest', riskTier: 'caution', mutates: true,
+      effect: sharedEffect, producer: 'test', now: 101,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_retry_first', attemptId: admitted.attemptId,
+      generation: first.generation!, fenceToken: first.fenceToken!, producer: 'test', now: 102,
+    });
+    recoverExpired(111);
+    const version = engine.getJob(admitted.jobId)!.stateVersion;
+    engine.recordEffectReconciliation({
+      effectId: 'side_effect:tool_retry_first', expectedJobStateVersion: version,
+      outcome: 'did_not_occur', confidence: 'high', evidence: { exists: false },
+      retryRecommendation: 'retry_same_identity', humanResolutionRequired: false,
+      producer: 'test', idempotencyKey: 'did-not-occur', now: 112,
+    });
+    const recovered = engine.createRecoveryAttempt({
+      jobId: admitted.jobId, recoveryOfAttemptId: admitted.attemptId,
+      instanceId: 'instance_test', triggerReason: 'effect_reconciled',
+      producer: 'test', eventIdempotencyKey: 'resume-after-reconcile',
+    });
+    const second = engine.claimAttempt({ attemptId: recovered.attemptId, ownerId: 'owner_b', ttlMs: 30_000, now: 114 });
+
+    expect(engine.prepareToolCall({
+      toolCallId: 'tool_retry_second', jobId: admitted.jobId, attemptId: recovered.attemptId,
+      generation: second.generation!, fenceToken: second.fenceToken!, toolName: 'file_write',
+      normalizedArgsDigest: 'same-digest', riskTier: 'caution', mutates: true,
+      effect: sharedEffect, producer: 'test', now: 115,
+    })).toMatchObject({ applied: true, effectId: 'side_effect:tool_retry_first' });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM side_effect_ledger WHERE job_id = ?')
+      .get(admitted.jobId)).toEqual({ count: 1 });
+  });
+
+  it('does not finalize a Job as completed while an Effect requires reconciliation', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    engine.transitionJob({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'job-running-reconcile-cap', producer: 'test',
+    });
+    engine.prepareToolCall({
+      toolCallId: 'tool_unresolved_cap', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, toolName: 'file_write',
+      normalizedArgsDigest: 'digest-cap', riskTier: 'caution', mutates: true,
+      effect: { ...effect, idempotencyKey: 'effect-cap', approvalState: 'not_required' }, producer: 'test',
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_unresolved_cap', attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+    });
+    engine.completeToolCall({
+      toolCallId: 'tool_unresolved_cap', attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, state: 'unknown',
+      sideEffectState: 'unknown', producer: 'test',
+    });
+    db.prepare('UPDATE side_effect_ledger SET reconciliation_required = 1 WHERE tool_call_id = ?')
+      .run('tool_unresolved_cap');
+
+    expect(engine.finalizeJob({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, expectedStateVersion: 1, status: 'completed',
+      outcome: 'verified', finishReason: 'done', evidence: {},
+      eventIdempotencyKey: 'invalid-completion', producer: 'test',
+    })).toMatchObject({ applied: false, conflict: 'illegal_transition' });
+    expect(engine.getJob(admitted.jobId)?.status).toBe('running');
+  });
 });
 
 describe('Job queries', () => {

--- a/tests/v4/daemon/jobEngine.test.ts
+++ b/tests/v4/daemon/jobEngine.test.ts
@@ -467,6 +467,99 @@ describe('Attempt leases and fencing', () => {
 });
 
 describe('ToolCall and SideEffect identity', () => {
+  const effect = {
+    classification: 'reconcilable_mutation' as const,
+    kind: 'filesystem.write',
+    target: 'C:/workspace/result.txt',
+    retrySafety: 'reconcile_before_retry' as const,
+    idempotencySupported: true,
+    idempotencyKey: 'effect-idem-1',
+    reconciliationSupported: true,
+    verificationSupported: true,
+    approvalRequirement: 'policy' as const,
+    approvalState: 'pending' as const,
+    sensitiveFields: ['content', 'apiKey'],
+    redactionRules: ['digest_arguments', 'omit_sensitive_values'],
+    trusted: true,
+  };
+
+  it('persists a secret-free requested Effect and approval state before execution starts', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    const prepared = engine.prepareToolCall({
+      toolCallId: 'tool_call_requested',
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      toolName: 'file_write',
+      normalizedArgsDigest: 'digest-secret-not-present',
+      riskTier: 'caution',
+      mutates: true,
+      effect,
+      producer: 'test',
+    });
+
+    expect(prepared).toMatchObject({ applied: true, effectId: 'side_effect:tool_call_requested' });
+    const row = db.prepare('SELECT * FROM side_effect_ledger WHERE tool_call_id = ?')
+      .get('tool_call_requested') as Record<string, unknown>;
+    expect(row).toMatchObject({
+      effect_state: 'requested',
+      approval_state: 'pending',
+      effect_classification: 'reconcilable_mutation',
+      effect_kind: 'filesystem.write',
+      retry_safety: 'reconcile_before_retry',
+      target: 'C:/workspace/result.txt',
+      idempotency_key: 'effect-idem-1',
+      reconciliation_supported: 1,
+      verification_supported: 1,
+    });
+    expect(JSON.stringify(row)).not.toContain('apiKey-value');
+
+    expect(engine.resolveToolCallApproval({
+      toolCallId: 'tool_call_requested',
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      state: 'approved',
+      approvalId: 'approval_exact',
+      actionDigest: 'action_exact',
+      producer: 'test',
+    }).applied).toBe(true);
+    expect(db.prepare(
+      'SELECT approval_state, approval_id, action_digest FROM side_effect_ledger WHERE tool_call_id = ?',
+    ).get('tool_call_requested')).toEqual({
+      approval_state: 'approved', approval_id: 'approval_exact', action_digest: 'action_exact',
+    });
+  });
+
+  it('does not create or execute a second Effect for one Job idempotency key', () => {
+    const admitted = submit();
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
+    const base = {
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+      toolName: 'file_write',
+      normalizedArgsDigest: 'same-digest',
+      riskTier: 'caution',
+      mutates: true,
+      effect,
+      producer: 'test',
+    };
+
+    expect(engine.prepareToolCall({ ...base, toolCallId: 'tool_call_idem_1' })).toMatchObject({ applied: true });
+    expect(engine.prepareToolCall({ ...base, toolCallId: 'tool_call_idem_2' })).toMatchObject({
+      applied: false,
+      duplicate: true,
+      existingToolCallId: 'tool_call_idem_1',
+    });
+    expect(db.prepare(
+      'SELECT COUNT(*) AS count FROM side_effect_ledger WHERE job_id = ? AND idempotency_key = ?',
+    ).get(admitted.jobId, effect.idempotencyKey)).toEqual({ count: 1 });
+  });
+
   it('persists prepared, started, and committed mutating execution under the active fence', () => {
     const admitted = submit();
     const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'owner_a', ttlMs: 30_000 });
@@ -490,6 +583,7 @@ describe('ToolCall and SideEffect identity', () => {
       normalizedArgsDigest: 'digest_1',
       riskTier: 'caution',
       mutates: true,
+      effect: { ...effect, approvalState: 'not_required' },
       producer: 'test',
     }).applied).toBe(true);
     expect(engine.startToolCall({
@@ -530,6 +624,15 @@ describe('ToolCall and SideEffect identity', () => {
     expect(db.prepare('SELECT effect_state FROM side_effect_ledger WHERE tool_call_id = ?').get('tool_call_1')).toEqual({
       effect_state: 'committed',
     });
+    expect(engine.listEvents(admitted.jobId).map((event) => event.type)).toEqual(expect.arrayContaining([
+      'tool_call.prepared',
+      'effect.requested',
+      'tool_call.started',
+      'effect.started',
+      'tool_call.completed',
+      'effect.result_received',
+      'effect.succeeded',
+    ]));
   });
 
   it('rejects a stale ToolCall result after the Attempt is reclaimed', () => {
@@ -548,6 +651,7 @@ describe('ToolCall and SideEffect identity', () => {
       normalizedArgsDigest: 'digest_stale',
       riskTier: 'caution',
       mutates: true,
+      effect: { ...effect, idempotencyKey: 'effect-stale', approvalState: 'not_required' },
       producer: 'test',
     });
     recoverExpired(base + 11);

--- a/tests/v4/daemon/jobEngine.test.ts
+++ b/tests/v4/daemon/jobEngine.test.ts
@@ -820,3 +820,99 @@ describe('Job queries', () => {
     ]);
   });
 });
+
+describe('Durable child Job contracts', () => {
+  it('blocks parent completion until two required child results are durably attributed', () => {
+    const parent = submit();
+    const parentLease = claimJob(parent);
+    engine.transitionAttempt({
+      attemptId: parent.attemptId, expectedStateVersion: 1, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, to: 'running', eventIdempotencyKey: 'parent-running-attempt', producer: 'test',
+    });
+    engine.transitionJob({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'parent-running-job', producer: 'test',
+    });
+    const children = ['one', 'two'].map((key) => submit({
+      idempotencyKey: `child-${key}`,
+      requestFingerprint: `child-${key}`,
+      sessionId: `child-session-${key}`,
+      parentJobId: parent.jobId,
+      rootJobId: parent.jobId,
+      goal: `child ${key}`,
+      childContract: {
+        workerId: `worker-${key}`,
+        capabilities: ['files'],
+        allowedResources: { cwd: 'workspace' },
+        budget: { maxIterations: 2 },
+      },
+    }));
+
+    expect(engine.listChildContracts(parent.jobId)).toHaveLength(2);
+    expect(engine.finalizeJob({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, expectedStateVersion: 1, status: 'completed',
+      outcome: 'verified', finishReason: 'done', evidence: {},
+      eventIdempotencyKey: 'parent-too-early', producer: 'test',
+    })).toMatchObject({ applied: false, conflict: 'illegal_transition' });
+
+    for (const child of children) {
+      const lease = claimJob(child, `owner-${child.jobId}`);
+      engine.transitionAttempt({
+        attemptId: child.attemptId, expectedStateVersion: 1, generation: lease.generation,
+        fenceToken: lease.fenceToken, to: 'running', eventIdempotencyKey: `child-attempt-running-${child.jobId}`, producer: 'test',
+      });
+      engine.transitionJob({
+        jobId: child.jobId, attemptId: child.attemptId, generation: lease.generation,
+        fenceToken: lease.fenceToken, expectedStateVersion: 0, to: 'running',
+        eventIdempotencyKey: `child-job-running-${child.jobId}`, producer: 'test',
+      });
+      expect(engine.recordChildResult({
+        childJobId: child.jobId, attemptId: child.attemptId, generation: lease.generation,
+        fenceToken: lease.fenceToken, status: 'completed', evidence: { observed: true },
+        evidenceHandles: [{ kind: 'path', value: child.jobId }], producer: 'test',
+        idempotencyKey: `child-result-${child.jobId}`,
+      }).applied).toBe(true);
+      engine.transitionAttempt({
+        attemptId: child.attemptId, expectedStateVersion: 2, generation: lease.generation,
+        fenceToken: lease.fenceToken, to: 'succeeded', eventIdempotencyKey: `child-attempt-done-${child.jobId}`, producer: 'test',
+      });
+      expect(engine.finalizeJob({
+        jobId: child.jobId, attemptId: child.attemptId, generation: lease.generation,
+        fenceToken: lease.fenceToken, expectedStateVersion: 1, status: 'completed',
+        outcome: 'verified', finishReason: 'done', evidence: {},
+        eventIdempotencyKey: `child-job-done-${child.jobId}`, producer: 'test',
+      }).applied).toBe(true);
+    }
+
+    const recorded = engine.listChildContracts(parent.jobId);
+    expect(recorded.map((child) => child.resultStatus)).toEqual(['completed', 'completed']);
+    expect(recorded.every((child) => child.evidenceHandles.length === 1)).toBe(true);
+    expect(engine.finalizeJob({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, expectedStateVersion: 1, status: 'completed',
+      outcome: 'verified', finishReason: 'done', evidence: { children: recorded.map((child) => child.childJobId) },
+      eventIdempotencyKey: 'parent-after-children', producer: 'test',
+    }).applied).toBe(true);
+  });
+
+  it('rejects a late child result after the parent is cancelled', () => {
+    const parent = submit();
+    const child = submit({
+      idempotencyKey: 'late-child', requestFingerprint: 'late-child', parentJobId: parent.jobId,
+      rootJobId: parent.jobId, childContract: {
+        workerId: 'worker-late', capabilities: [], allowedResources: {}, budget: {},
+      },
+    });
+    const lease = claimJob(child, 'child-owner');
+    expect(engine.cancelJob({
+      jobId: parent.jobId, reason: 'cancelled', producer: 'test', eventIdempotencyKey: 'cancel-parent',
+    }).applied).toBe(true);
+    expect(engine.recordChildResult({
+      childJobId: child.jobId, attemptId: child.attemptId, generation: lease.generation,
+      fenceToken: lease.fenceToken, status: 'completed', evidence: {}, evidenceHandles: [],
+      producer: 'test', idempotencyKey: 'late-result',
+    })).toMatchObject({ applied: false, conflict: 'terminal_state' });
+  });
+});

--- a/tests/v4/daemon/jobEngine.test.ts
+++ b/tests/v4/daemon/jobEngine.test.ts
@@ -718,13 +718,13 @@ describe('ToolCall and SideEffect identity', () => {
       effectId: 'side_effect:tool_reconcile', expectedJobStateVersion: jobVersion,
       outcome: 'unknown', confidence: 'low', evidence: { exists: true },
       retryRecommendation: 'human_review', humanResolutionRequired: true,
-      producer: 'test', idempotencyKey: 'reconcile-1',
+      producer: 'test', idempotencyKey: 'reconcile-1', now: 1_000,
     }).applied).toBe(true);
     expect(engine.recordEffectReconciliation({
       effectId: 'side_effect:tool_reconcile', expectedJobStateVersion: jobVersion,
       outcome: 'occurred', confidence: 'high', evidence: { contentSha256: 'digest' },
       retryRecommendation: 'do_not_retry', humanResolutionRequired: false,
-      producer: 'test', idempotencyKey: 'reconcile-2',
+      producer: 'test', idempotencyKey: 'reconcile-2', now: 1_000,
     }).applied).toBe(true);
 
     expect(engine.listEffectReconciliations('side_effect:tool_reconcile')).toMatchObject([

--- a/tests/v4/daemon/jobEventProjection.test.ts
+++ b/tests/v4/daemon/jobEventProjection.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+let db: Database.Database;
+let jobs: JobEngine;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  runMigrations(db);
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES ('projection-test', 1, 'localhost', ?, ?, '4.16.1')`,
+  ).run(now, now);
+  jobs = createJobEngine({ db });
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* already closed */ }
+});
+
+function admission() {
+  return jobs.submitJob({
+    entryPoint: 'test', source: 'test', sessionId: 'projection-session', instanceId: 'projection-test',
+    idempotencyNamespace: 'projection', idempotencyKey: 'one', requestFingerprint: 'one', goal: 'project truth',
+  });
+}
+
+describe('JobEventProjectionAuthority', () => {
+  it('replays from a durable cursor and duplicate acknowledgement is harmless', () => {
+    const admitted = admission();
+    expect(jobs.projection.read('tui', admitted.jobId).map((event) => event.type)).toEqual([
+      'job.submitted', 'attempt.created',
+    ]);
+    expect(jobs.projection.acknowledge('tui', admitted.jobId, 1)).toBe(1);
+    expect(jobs.projection.acknowledge('tui', admitted.jobId, 1)).toBe(1);
+    expect(jobs.projection.read('tui', admitted.jobId).map((event) => event.type)).toEqual(['attempt.created']);
+    expect(jobs.projection.acknowledge('tui', admitted.jobId, 2)).toBe(2);
+    expect(jobs.projection.read('tui', admitted.jobId)).toEqual([]);
+
+    const restarted = createJobEngine({ db });
+    expect(restarted.projection.cursor('tui', admitted.jobId)).toBe(2);
+  });
+
+  it('redacts event payloads before persistence', () => {
+    const admitted = admission();
+    expect(jobs.appendJobEvent({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1,
+      type: 'provider.observed', producer: 'test', idempotencyKey: 'secret-event',
+      payload: { apiKey: 'secret-value', nested: { authorization: 'Bearer sensitivevalue12345' }, safe: 'visible' },
+    }).applied).toBe(true);
+    const event = jobs.listEvents(admitted.jobId).at(-1)!;
+    expect(event.payload).toEqual({
+      apiKey: '[redacted]', nested: { authorization: '[redacted]' }, safe: 'visible',
+    });
+    const raw = db.prepare("SELECT payload FROM run_events WHERE idempotency_key = 'secret-event'").get() as { payload: string };
+    expect(raw.payload).not.toContain('secret-value');
+    expect(raw.payload).not.toContain('sensitivevalue');
+  });
+
+  it('rebuilds the same terminal truth without live projection memory', () => {
+    const admitted = admission();
+    const lease = jobs.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'projection-owner', ttlMs: 30_000 });
+    jobs.transitionAttempt({
+      attemptId: admitted.attemptId, expectedStateVersion: lease.stateVersion!, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, to: 'running', eventIdempotencyKey: 'attempt-running', producer: 'test',
+    });
+    jobs.transitionJob({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, expectedStateVersion: 0, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, to: 'running', eventIdempotencyKey: 'job-running', producer: 'test',
+    });
+    jobs.transitionAttempt({
+      attemptId: admitted.attemptId, expectedStateVersion: 2, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, to: 'succeeded', eventIdempotencyKey: 'attempt-succeeded', producer: 'test',
+    });
+    jobs.finalizeJob({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, expectedStateVersion: 1, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, status: 'completed', outcome: 'completed', finishReason: 'done', evidence: {},
+      eventIdempotencyKey: 'job-finalized', producer: 'test',
+    });
+
+    const tui = jobs.projection.rebuild(admitted.jobId);
+    const workbench = createJobEngine({ db }).projection.rebuild(admitted.jobId);
+    expect(tui).toEqual(workbench);
+    expect(tui.job).toMatchObject({ status: 'completed', terminalOutcome: 'completed' });
+    expect(tui.attempts).toMatchObject([{ status: 'succeeded' }]);
+    expect(tui.events.at(-1)?.type).toBe('job.finalized');
+  });
+
+  it('bounds high-volume replay pages without losing cursor order', () => {
+    const admitted = admission();
+    for (let index = 0; index < 1_050; index += 1) {
+      jobs.appendJobEvent({
+        jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1,
+        type: 'worker.heartbeat', producer: 'test', idempotencyKey: `heartbeat-${index}`, payload: { index },
+      });
+    }
+    const first = jobs.projection.read('workbench', admitted.jobId, 5_000);
+    expect(first).toHaveLength(1_000);
+    expect(first[0]!.jobSequence).toBe(1);
+    expect(first.at(-1)!.jobSequence).toBe(1_000);
+    jobs.projection.acknowledge('workbench', admitted.jobId, 1_000);
+    expect(jobs.projection.read('workbench', admitted.jobId, 1_000)).toHaveLength(52);
+  });
+});

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -10,6 +10,7 @@ import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
 import { executeDurableJob } from '../../../core/v4/daemon/jobLifecycle';
 import { currentJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
+import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
 
 describe('executeDurableJob', () => {
   let db: Database.Database;
@@ -82,8 +83,12 @@ describe('executeDurableJob', () => {
 
   it('aborts active work when lease renewal loses authority', async () => {
     let sawAbort = false;
+    const authorityLosingEngine: JobEngine = {
+      ...engine,
+      renewAttemptLease: () => ({ applied: false, conflict: 'stale_fence' }),
+    };
     const execution = executeDurableJob({
-      engine,
+      engine: authorityLosingEngine,
       ownerId: 'instance_lifecycle',
       leaseTtlMs: 3_000,
       admission: {
@@ -101,17 +106,224 @@ describe('executeDurableJob', () => {
         status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
       }),
     });
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    const job = engine.listJobs({ sessionId: 'session_lease_loss' })[0]!;
-    engine.cancelJob({
-      jobId: job.id,
-      reason: 'test cancellation',
-      producer: 'test',
-      eventIdempotencyKey: 'cancel-lease-loss',
-    });
-
     await expect(execution).rejects.toThrow(/lease renewal failed/i);
     expect(sawAbort).toBe(true);
-    expect(engine.getJob(job.id)?.status).toBe('cancelled');
+    const job = engine.listJobs({ sessionId: 'session_lease_loss' })[0]!;
+    expect(engine.getJob(job.id)?.status).toBe('running');
+    expect(engine.getAttempt(job.activeAttemptId!)?.status).toBe('running');
+  });
+
+  it('adopts an already admitted Job without creating a parallel lifecycle', async () => {
+    const admitted = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'session_adopted',
+      instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+      idempotencyKey: 'request_adopted', requestFingerprint: 'fingerprint_adopted', goal: 'adopt work',
+    });
+
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      admission: { existing: admitted, source: 'test' },
+      execute: async () => 'done',
+      finalize: async () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: { verified: true },
+      }),
+    });
+
+    expect(execution).toMatchObject({
+      jobId: admitted.jobId,
+      attemptId: admitted.attemptId,
+      runId: admitted.runId,
+    });
+    expect(engine.listJobs({ sessionId: 'session_adopted' })).toHaveLength(1);
+    expect(engine.listAttempts(admitted.jobId)).toHaveLength(1);
+    expect(engine.listEvents(admitted.jobId).map((event) => event.type)).toEqual([
+      'job.submitted', 'attempt.created', 'attempt.leased', 'attempt.running',
+      'job.running', 'attempt.succeeded', 'job.finalized',
+    ]);
+  });
+
+  it('persists and consumes initial input under the exact claimed Attempt', async () => {
+    const controlAuthority = createJobControlAuthority({ db, jobEngine: engine });
+    let inputObservedDuringExecution: string | null = null;
+
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      controlAuthority,
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_input',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_input', requestFingerprint: 'fingerprint_input', goal: 'consume input',
+      },
+      initialInput: {
+        sessionId: 'session_input', source: 'test', kind: 'message', content: 'durable request',
+        idempotencyNamespace: 'lifecycle-input', idempotencyKey: 'request_input',
+      },
+      execute: async (handle) => {
+        inputObservedDuringExecution = handle.initialInput?.content ?? null;
+        expect(handle.initialInput).toMatchObject({
+          jobId: handle.jobId,
+          claimedByAttemptId: handle.attemptId,
+          claimedGeneration: handle.generation,
+          state: 'consumed',
+        });
+        return 'done';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: { verified: true },
+      }),
+    });
+
+    expect(inputObservedDuringExecution).toBe('durable request');
+    expect(controlAuthority.inputs.listPending(execution.jobId)).toEqual([]);
+    expect(engine.listEvents(execution.jobId).map((event) => event.type)).toContain('input.consumed');
+  });
+
+  it('attaches cancellation to the active Attempt and detaches exactly once on cleanup', async () => {
+    const controlAuthority = createJobControlAuthority({ db, jobEngine: engine });
+    let handleDuringExecution: { jobId: string; attemptId: string; generation: number } | null = null;
+    let sawAbort = false;
+
+    const running = executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      controlAuthority,
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_cancel',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_cancel', requestFingerprint: 'fingerprint_cancel', goal: 'cancel work',
+      },
+      execute: async (handle) => {
+        handleDuringExecution = handle;
+        expect(controlAuthority.runtime.isAttached(handle.attemptId)).toBe(true);
+        await new Promise<void>((_resolve, reject) => {
+          handle.signal.addEventListener('abort', () => {
+            sawAbort = true;
+            reject(handle.signal.reason);
+          }, { once: true });
+        });
+        return 'unreachable';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    });
+
+    while (!handleDuringExecution) await new Promise((resolve) => setTimeout(resolve, 0));
+    const active = handleDuringExecution as { jobId: string; attemptId: string; generation: number };
+    const cancelled = controlAuthority.commands.request({
+      jobId: active.jobId,
+      attemptId: active.attemptId,
+      generation: active.generation,
+      kind: 'cancel',
+      source: 'test',
+      reason: 'test cancellation',
+      idempotencyNamespace: 'lifecycle-control',
+      idempotencyKey: 'cancel_active',
+    });
+
+    expect(cancelled).toMatchObject({ persisted: true, applied: true });
+    await expect(running).rejects.toBeTruthy();
+    expect(sawAbort).toBe(true);
+    expect(engine.getJob(active.jobId)?.status).toBe('cancelled');
+    expect(controlAuthority.runtime.isAttached(active.attemptId)).toBe(false);
+  });
+
+  it('emits one ordered phase trace and finalizes once', async () => {
+    const phases: string[] = [];
+    let finalizations = 0;
+    const instrumentedEngine: JobEngine = {
+      ...engine,
+      finalizeJob(command) {
+        finalizations += 1;
+        return engine.finalizeJob(command);
+      },
+    };
+
+    await executeDurableJob({
+      engine: instrumentedEngine,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_phases',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_phases', requestFingerprint: 'fingerprint_phases', goal: 'trace work',
+      },
+      onPhase: (event) => phases.push(event.phase),
+      execute: async () => 'done',
+      finalize: async () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: { verified: true },
+      }),
+    });
+
+    expect(phases).toEqual([
+      'admitted', 'leased', 'running', 'executing', 'verifying', 'settled', 'cleanup',
+    ]);
+    expect(finalizations).toBe(1);
+  });
+
+  it('rebinds one active execution to a resumed Attempt with a new generation and fence', async () => {
+    const controlAuthority = createJobControlAuthority({ db, jobEngine: engine });
+    let firstAttemptId = '';
+    let resumedAttemptId = '';
+
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      controlAuthority,
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_resume',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_resume', requestFingerprint: 'fingerprint_resume', goal: 'resume work',
+      },
+      execute: async (handle) => {
+        firstAttemptId = handle.attemptId;
+        controlAuthority.commands.request({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          kind: 'pause',
+          source: 'test',
+          idempotencyNamespace: 'lifecycle-control',
+          idempotencyKey: 'pause-active',
+        });
+        expect(controlAuthority.commands.applyPendingAtBoundary({ jobId: handle.jobId })).toMatchObject({
+          applied: true,
+          kind: 'pause',
+        });
+        handle.pauseAtBoundary();
+
+        const resumed = controlAuthority.commands.resume({
+          jobId: handle.jobId,
+          source: 'test',
+          instanceId: 'instance_lifecycle',
+          idempotencyNamespace: 'lifecycle-control',
+          idempotencyKey: 'resume-active',
+        });
+        handle.resumeAttempt({
+          jobId: handle.jobId,
+          attemptId: resumed.attemptId,
+          runId: resumed.runId,
+          reused: resumed.duplicate,
+        });
+        resumedAttemptId = handle.attemptId;
+        expect(handle.generation).toBe(2);
+        expect(currentJobExecutionContext()).toMatchObject({
+          attemptId: resumed.attemptId,
+          generation: 2,
+          fenceToken: handle.fenceToken,
+        });
+        return 'done';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: { verified: true },
+      }),
+    });
+
+    expect(execution.attemptId).toBe(resumedAttemptId);
+    expect(firstAttemptId).not.toBe(resumedAttemptId);
+    expect(engine.getAttempt(firstAttemptId)?.status).toBe('cancelled');
+    expect(engine.getAttempt(resumedAttemptId)?.status).toBe('succeeded');
+    expect(engine.getJob(execution.jobId)?.status).toBe('completed');
   });
 });

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -205,6 +205,58 @@ describe('executeDurableJob', () => {
     expect(engine.listEvents(execution.jobId).map((event) => event.type)).toContain('input.consumed');
   });
 
+  it('adopts a previously queued Job and consumes its existing input exactly once', async () => {
+    const controlAuthority = createJobControlAuthority({ db, jobEngine: engine });
+    const admitted = engine.submitJob({
+      entryPoint: 'interactive', source: 'repl', sessionId: 'session_queued',
+      instanceId: 'instance_lifecycle', idempotencyNamespace: 'queued-turn',
+      idempotencyKey: 'queued-job', requestFingerprint: 'queued-fingerprint', goal: 'queued work',
+    });
+    const received = controlAuthority.inputs.receive({
+      jobId: admitted.jobId,
+      targetAttemptId: admitted.attemptId,
+      sessionId: 'session_queued',
+      source: 'tui',
+      kind: 'message',
+      content: 'queued durable request',
+      idempotencyNamespace: 'queued-input',
+      idempotencyKey: 'queued-message',
+    });
+    const restoredControls = createJobControlAuthority({ db, jobEngine: createJobEngine({ db }) });
+
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      controlAuthority: restoredControls,
+      admission: { existing: admitted, source: 'repl' },
+      existingInitialInputId: received.record.inputId,
+      execute: async (handle) => {
+        expect(handle.initialInput).toMatchObject({
+          inputId: received.record.inputId,
+          jobId: admitted.jobId,
+          claimedByAttemptId: admitted.attemptId,
+          claimedGeneration: 1,
+          state: 'consumed',
+          content: 'queued durable request',
+        });
+        return 'done';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: { verified: true },
+      }),
+    });
+
+    expect(execution.initialInput?.inputId).toBe(received.record.inputId);
+    expect(restoredControls.inputs.listPending(admitted.jobId)).toEqual([]);
+    expect(engine.listJobs({ sessionId: 'session_queued' })).toHaveLength(1);
+    expect(engine.listEvents(admitted.jobId).filter((event) => event.type === 'input.consumed')).toHaveLength(1);
+    expect(restoredControls.inputs.consume({
+      inputId: received.record.inputId,
+      attemptId: admitted.attemptId,
+      generation: 1,
+    })).toMatchObject({ applied: false, duplicate: true });
+  });
+
   it('attaches cancellation to the active Attempt and detaches exactly once on cleanup', async () => {
     const controlAuthority = createJobControlAuthority({ db, jobEngine: engine });
     let handleDuringExecution: { jobId: string; attemptId: string; generation: number } | null = null;

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -113,6 +113,31 @@ describe('executeDurableJob', () => {
     expect(engine.getAttempt(job.activeAttemptId!)?.status).toBe('running');
   });
 
+  it('expires a durable runtime budget while execution is waiting and records actual elapsed use', async () => {
+    const execution = executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_runtime_budget',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_runtime_budget', requestFingerprint: 'fingerprint_runtime_budget',
+        goal: 'wait beyond budget', resourcePolicy: { budgets: { runtime_ms: 5 } },
+      },
+      execute: async (handle) => new Promise<string>((resolve) => {
+        handle.signal.addEventListener('abort', () => resolve('aborted'), { once: true });
+      }),
+      finalize: () => ({ status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {} }),
+    });
+
+    await expect(execution).rejects.toThrow(/runtime_ms/);
+    const job = engine.listJobs({ sessionId: 'session_runtime_budget' })[0]!;
+    expect(job.status).toBe('failed');
+    expect(engine.resources.getBudgets(job.id)).toMatchObject([
+      { kind: 'runtime_ms', limit: 5, hasUnknownUsage: false },
+    ]);
+    expect(engine.resources.getBudgets(job.id)[0]!.used).toBeGreaterThanOrEqual(5);
+  });
+
   it('adopts an already admitted Job without creating a parallel lifecycle', async () => {
     const admitted = engine.submitJob({
       entryPoint: 'test', source: 'test', sessionId: 'session_adopted',

--- a/tests/v4/daemon/jobProofAuthority.test.ts
+++ b/tests/v4/daemon/jobProofAuthority.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+let db: Database.Database;
+let jobs: JobEngine;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES ('proof-test', 1, 'localhost', ?, ?, '4.16.1')`,
+  ).run(now, now);
+  jobs = createJobEngine({ db });
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* already closed */ }
+});
+
+function activeJob(key: string) {
+  const admission = jobs.submitJob({
+    entryPoint: 'test', source: 'test', sessionId: `session-${key}`, instanceId: 'proof-test',
+    idempotencyNamespace: 'proof-test', idempotencyKey: key, requestFingerprint: key, goal: `goal ${key}`,
+  });
+  const lease = jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'proof-owner', ttlMs: 30_000 });
+  if (!lease.fenceToken || lease.generation === undefined) throw new Error('lease unavailable');
+  return { ...admission, generation: lease.generation, fenceToken: lease.fenceToken };
+}
+
+describe('JobProofAuthority', () => {
+  it('turns a clean execution with wrong observed result into a failed verdict', () => {
+    const job = activeJob('wrong-result');
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'result equals expected value', required: true,
+    });
+    const evidence = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'tool', producer: 'test', observedAt: 100, coverage: 'full',
+      verificationResult: 'failed', payload: { exitCode: 0, actual: 'wrong' }, now: 101,
+    });
+    jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [evidence.evidenceId], state: 'failed', now: 102,
+    });
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken, now: 103,
+    }).verdict).toBe('failed');
+  });
+
+  it('rejects stale evidence and leaves a missing capture unknown', () => {
+    const job = activeJob('stale-evidence');
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'artifact is current', required: true,
+    });
+    const stale = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'filesystem', producer: 'test', observedAt: 100, freshUntil: 110,
+      coverage: 'full', verificationResult: 'verified', payload: { exists: true }, now: 105,
+    });
+    expect(() => jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [stale.evidenceId], state: 'verified', now: 111,
+    })).toThrow(/Stale evidence/);
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken, now: 112,
+    }).verdict).toBe('unknown');
+  });
+
+  it('produces a partial verdict from mixed evidence and never trusts unsupported prose', () => {
+    const job = activeJob('partial');
+    const verified = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'first artifact exists', required: true,
+    });
+    jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'worker prose says second is done', required: true,
+    });
+    const evidence = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'filesystem', producer: 'test', observedAt: 200, coverage: 'full',
+      verificationResult: 'verified', payload: { path: 'artifact' }, now: 201,
+    });
+    jobs.proof.checkClaim({
+      claimId: verified.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [evidence.evidenceId], state: 'verified', now: 202,
+    });
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken, now: 203,
+    }).verdict).toBe('partially_verified');
+  });
+
+  it('keeps the final verdict immutable and records late evidence for review', () => {
+    const job = activeJob('immutable');
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'artifact exists', required: true,
+    });
+    const evidence = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'filesystem', producer: 'test', observedAt: 300, coverage: 'full',
+      verificationResult: 'verified', payload: { path: 'artifact' }, now: 301,
+    });
+    jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [evidence.evidenceId], state: 'verified', now: 302,
+    });
+    const first = jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken, now: 303,
+    });
+    const late = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'review', producer: 'test', observedAt: 304, coverage: 'full',
+      verificationResult: 'failed', payload: { changed: true }, now: 304,
+    });
+    expect(late.late).toBe(true);
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken, now: 305,
+    })).toEqual(first);
+    expect(() => jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [late.evidenceId], state: 'failed', now: 306,
+    })).toThrow(/immutable/);
+  });
+
+  it('exports persisted proof as JSON and Markdown', () => {
+    const job = activeJob('export');
+    jobs.proof.createClaim({
+      jobId: job.jobId, category: 'courtesy', statement: 'explanatory note', required: false,
+    });
+    const json = jobs.proof.exportJson(job.jobId);
+    const markdown = jobs.proof.exportMarkdown(job.jobId);
+    expect(json).toMatchObject({ job: { id: job.jobId, goal: 'goal export' } });
+    expect(markdown).toContain('# Aiden Proof');
+    expect(markdown).toContain('explanatory note');
+  });
+});

--- a/tests/v4/daemon/jobProofAuthority.test.ts
+++ b/tests/v4/daemon/jobProofAuthority.test.ts
@@ -39,6 +39,22 @@ function activeJob(key: string) {
 }
 
 describe('JobProofAuthority', () => {
+  const unsafeEffect = {
+    classification: 'unsafe_mutation' as const,
+    kind: 'fixture.external',
+    target: 'fixture-target',
+    retrySafety: 'never_automatic' as const,
+    idempotencySupported: false,
+    idempotencyKey: null,
+    reconciliationSupported: false,
+    verificationSupported: false,
+    approvalRequirement: 'policy' as const,
+    approvalState: 'not_required' as const,
+    sensitiveFields: [] as string[],
+    redactionRules: ['digest_arguments'],
+    trusted: true,
+  };
+
   it('turns a clean execution with wrong observed result into a failed verdict', () => {
     const job = activeJob('wrong-result');
     const claim = jobs.proof.createClaim({
@@ -141,5 +157,112 @@ describe('JobProofAuthority', () => {
     expect(json).toMatchObject({ job: { id: job.jobId, goal: 'goal export' } });
     expect(markdown).toContain('# Aiden Proof');
     expect(markdown).toContain('explanatory note');
+  });
+
+  it('does not let failed non-contract evidence poison satisfied required claims', () => {
+    const job = activeJob('recovered-helper');
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'required artifact is exact', required: true,
+    });
+    jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'helper', producer: 'test', observedAt: 400, coverage: 'full',
+      verificationResult: 'failed', payload: { optional: true }, now: 401,
+    });
+    const required = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'filesystem.readback', producer: 'test', observedAt: 402, coverage: 'full',
+      verificationResult: 'verified', payload: { path: 'artifact', exact: true }, now: 403,
+    });
+    jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [required.evidenceId], state: 'verified', now: 404,
+    });
+
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation,
+      fenceToken: job.fenceToken, now: 405,
+    }).verdict).toBe('verified');
+  });
+
+  it('keeps an unresolved unsafe Effect from producing a verified verdict', () => {
+    const job = activeJob('unsafe-unknown');
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'required artifact is exact', required: true,
+    });
+    const evidence = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'filesystem.readback', producer: 'test', observedAt: 450, coverage: 'full',
+      verificationResult: 'verified', payload: { exact: true }, now: 451,
+    });
+    jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [evidence.evidenceId], state: 'verified', now: 452,
+    });
+    jobs.prepareToolCall({
+      toolCallId: 'unsafe_unknown_call', jobId: job.jobId, attemptId: job.attemptId,
+      generation: job.generation, fenceToken: job.fenceToken, toolName: 'external_send',
+      normalizedArgsDigest: 'digest', riskTier: 'dangerous', mutates: true,
+      effect: unsafeEffect, producer: 'test', now: 453,
+    });
+    jobs.startToolCall({
+      toolCallId: 'unsafe_unknown_call', attemptId: job.attemptId,
+      generation: job.generation, fenceToken: job.fenceToken, producer: 'test', now: 454,
+    });
+
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation,
+      fenceToken: job.fenceToken, now: 455,
+    }).verdict).toBe('partially_verified');
+  });
+
+  it('retains a crashed Attempt in proof history after a later Attempt verifies', () => {
+    const first = activeJob('attempt-history');
+    expect(jobs.recoverExpiredAttempts({
+      now: Date.now() + 31_000, instanceId: 'proof-test', producer: 'test', maxCrashes: 3,
+    })).toEqual([expect.objectContaining({ jobId: first.jobId, decision: 'retry' })]);
+    const attempts = jobs.listAttempts(first.jobId);
+    const second = attempts[1]!;
+    const lease = jobs.claimAttempt({ attemptId: second.id, ownerId: 'proof-owner-2', ttlMs: 30_000 });
+    const claim = jobs.proof.createClaim({
+      jobId: first.jobId, category: 'contract', statement: 'recovered artifact verified', required: true,
+    });
+    const evidence = jobs.proof.recordEvidence({
+      jobId: first.jobId, attemptId: second.id, generation: lease.generation!, fenceToken: lease.fenceToken!,
+      source: 'filesystem.readback', producer: 'test', observedAt: Date.now(), coverage: 'full',
+      verificationResult: 'verified', payload: { exact: true },
+    });
+    jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: second.id, generation: lease.generation!,
+      evidenceIds: [evidence.evidenceId], state: 'verified',
+    });
+
+    expect(jobs.proof.finalize({
+      jobId: first.jobId, attemptId: second.id, generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+    }).verdict).toBe('verified');
+    expect(jobs.proof.exportJson(first.jobId)).toMatchObject({
+      attempts: [
+        expect.objectContaining({ attempt_id: first.attemptId, status: 'crashed' }),
+        expect.objectContaining({ attempt_id: second.id }),
+      ],
+    });
+  });
+
+  it('rejects evidence captured before its linked Effect began', () => {
+    const job = activeJob('pre-effect-evidence');
+    db.prepare(
+      `INSERT INTO side_effect_ledger
+         (key, task_id, step, tool, args_hash, status, attempted_at, job_id, attempt_id,
+          generation, effect_state)
+       VALUES ('effect_pre', ?, 0, 'file_write', 'digest', 'attempting', 500, ?, ?, ?, 'started')`,
+    ).run(job.jobId, job.jobId, job.attemptId, job.generation);
+
+    expect(() => jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation,
+      fenceToken: job.fenceToken, effectId: 'effect_pre', source: 'filesystem.readback',
+      producer: 'test', observedAt: 499, coverage: 'full', verificationResult: 'verified',
+      payload: { exists: true }, now: 501,
+    })).toThrow(/after the linked Effect began/);
   });
 });

--- a/tests/v4/daemon/jobRecovery.test.ts
+++ b/tests/v4/daemon/jobRecovery.test.ts
@@ -13,6 +13,21 @@ describe('durable Job recovery', () => {
   let db: Database.Database;
   let engine: JobEngine;
   let sequence = 0;
+  const effect = {
+    classification: 'unsafe_mutation' as const,
+    kind: 'fixture.external',
+    target: 'fixture-target',
+    retrySafety: 'never_automatic' as const,
+    idempotencySupported: false,
+    idempotencyKey: null,
+    reconciliationSupported: false,
+    verificationSupported: false,
+    approvalRequirement: 'policy' as const,
+    approvalState: 'not_required' as const,
+    sensitiveFields: [] as string[],
+    redactionRules: ['digest_arguments'],
+    trusted: true,
+  };
 
   beforeEach(() => {
     db = new Database(':memory:');
@@ -66,7 +81,7 @@ describe('durable Job recovery', () => {
       toolCallId: 'tool_unknown', jobId: expired.jobId, attemptId: expired.attemptId,
       generation: expired.generation!, fenceToken: expired.fenceToken!,
       toolName: 'external_send', normalizedArgsDigest: 'digest', riskTier: 'dangerous',
-      mutates: true, producer: 'test', now: expired.base + 1,
+      mutates: true, effect, producer: 'test', now: expired.base + 1,
     });
     engine.startToolCall({
       toolCallId: 'tool_unknown', attemptId: expired.attemptId,
@@ -109,7 +124,7 @@ describe('durable Job recovery', () => {
       toolCallId: 'tool_prepared_only', jobId: expired.jobId, attemptId: expired.attemptId,
       generation: expired.generation!, fenceToken: expired.fenceToken!,
       toolName: 'file_write', normalizedArgsDigest: 'prepared-digest', riskTier: 'caution',
-      mutates: true, producer: 'test', now: expired.base + 1,
+      mutates: true, effect, producer: 'test', now: expired.base + 1,
     });
 
     expect(engine.recoverExpiredAttempts({
@@ -123,7 +138,7 @@ describe('durable Job recovery', () => {
       toolCallId: 'tool_committed', jobId: expired.jobId, attemptId: expired.attemptId,
       generation: expired.generation!, fenceToken: expired.fenceToken!,
       toolName: 'file_write', normalizedArgsDigest: 'committed-digest', riskTier: 'caution',
-      mutates: true, producer: 'test', now: expired.base + 1,
+      mutates: true, effect, producer: 'test', now: expired.base + 1,
     });
     engine.startToolCall({
       toolCallId: 'tool_committed', attemptId: expired.attemptId,

--- a/tests/v4/daemon/jobRecovery.test.ts
+++ b/tests/v4/daemon/jobRecovery.test.ts
@@ -96,6 +96,8 @@ describe('durable Job recovery', () => {
     expect(engine.listAttempts(expired.jobId)).toHaveLength(1);
     expect(engine.getAttempt(expired.attemptId)?.status).toBe('unknown');
     expect(engine.getJob(expired.jobId)?.status).toBe('blocked');
+    expect(db.prepare('SELECT effect_state, status FROM side_effect_ledger WHERE tool_call_id = ?')
+      .get('tool_unknown')).toEqual({ effect_state: 'unknown', status: 'unknown' });
   });
 
   it('retries a read-only tool interrupted after start', () => {

--- a/tests/v4/daemon/jobRecoverySweep.test.ts
+++ b/tests/v4/daemon/jobRecoverySweep.test.ts
@@ -4,6 +4,10 @@
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { openDaemonDb, type Db } from '../../../core/v4/daemon/db/connection';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
@@ -12,10 +16,12 @@ import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
 
 describe('durable Job recovery sweep', () => {
   let db: Db | null = null;
+  const tempDirs: string[] = [];
 
   afterEach(() => {
     db?.close();
     db = null;
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   });
 
   it('enqueues an expired read-only Attempt exactly once and repairs the recovery-to-queue crash window', () => {
@@ -77,5 +83,60 @@ describe('durable Job recovery sweep', () => {
     expect(second).toMatchObject({ expired: 0, enqueued: 0 });
     expect(db.prepare("SELECT COUNT(*) AS count FROM trigger_events WHERE source_key = ?")
       .get(`job-recovery:${admitted.jobId}`)).toEqual({ count: 1 });
+  });
+
+  it('reconciles an externally completed file effect before scheduling recovery', () => {
+    db = openDaemonDb(':memory:');
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('instance-old', 1, 'localhost', 1, 1, '4.16.1'),
+              ('instance-new', 2, 'localhost', 2, 2, '4.16.1')`,
+    ).run();
+    const engine = createJobEngine({ db });
+    const bus = createTriggerBus({ db });
+    const admitted = engine.submitJob({
+      entryPoint: 'daemon', source: 'daemon', sessionId: 'session-effect-recovery',
+      instanceId: 'instance-old', idempotencyNamespace: 'effect-recovery',
+      idempotencyKey: 'job-1', goal: 'write one file',
+    });
+    const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'worker-old', ttlMs: 10, now: 100 });
+    const dir = mkdtempSync(join(tmpdir(), 'aiden-recovery-effect-'));
+    tempDirs.push(dir);
+    const path = join(dir, 'result.txt');
+    const content = 'already written';
+    engine.prepareToolCall({
+      toolCallId: 'tool_file', jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, toolName: 'file_write',
+      normalizedArgsDigest: 'digest', riskTier: 'caution', mutates: true,
+      effect: {
+        classification: 'reconcilable_mutation', kind: 'filesystem.write', target: path,
+        retrySafety: 'reconcile_before_retry', idempotencySupported: true, idempotencyKey: 'idem-file',
+        reconciliationSupported: true, verificationSupported: true,
+        approvalRequirement: 'policy', approvalState: 'not_required', sensitiveFields: ['content'],
+        redactionRules: ['digest_arguments'], trusted: true,
+        reconciliationData: {
+          path, before: { exists: false }, expectedSize: Buffer.byteLength(content),
+          expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+        },
+      },
+      producer: 'test', now: 101,
+    });
+    engine.startToolCall({
+      toolCallId: 'tool_file', attemptId: admitted.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test', now: 102,
+    });
+    writeFileSync(path, content);
+
+    const sweep = sweepDurableJobRecovery({
+      jobEngine: engine, triggerBus: bus, instanceId: 'instance-new',
+      producer: 'recovery-sweep', now: 111,
+    });
+
+    expect(sweep).toMatchObject({ expired: 1, reconciled: 1, needsUser: 0, retried: 1, enqueued: 1 });
+    expect(engine.listEffectReconciliations('side_effect:tool_file')).toMatchObject([
+      { outcome: 'occurred', confidence: 'high', humanResolutionRequired: false },
+    ]);
+    expect(engine.listAttempts(admitted.jobId)).toHaveLength(2);
   });
 });

--- a/tests/v4/daemon/jobResourceAuthority.test.ts
+++ b/tests/v4/daemon/jobResourceAuthority.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+let db: Database.Database;
+let jobs: JobEngine;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO daemon_instances (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES ('resource-test', 1, 'localhost', ?, ?, '4.16.1')`,
+  ).run(now, now);
+  jobs = createJobEngine({ db });
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* already closed */ }
+});
+
+function submit(key: string, parentJobId?: string) {
+  return jobs.submitJob({
+    entryPoint: 'test', source: 'test', sessionId: `session-${key}`, instanceId: 'resource-test',
+    idempotencyNamespace: 'resource-test', idempotencyKey: key, requestFingerprint: key,
+    goal: key, parentJobId, rootJobId: parentJobId,
+  });
+}
+
+function claim(admission: ReturnType<typeof submit>) {
+  const lease = jobs.claimAttempt({ attemptId: admission.attemptId, ownerId: 'resource-owner', ttlMs: 30_000 });
+  if (!lease.fenceToken || lease.generation === undefined) throw new Error('lease unavailable');
+  return { generation: lease.generation, fenceToken: lease.fenceToken };
+}
+
+describe('JobResourceAuthority', () => {
+  it('atomically rejects spending beyond a durable limit and survives reconstruction', () => {
+    const job = submit('durable-budget');
+    const lease = claim(job);
+    jobs.resources.configure({ jobId: job.jobId, budgets: { tool_calls: 2 } });
+
+    for (const key of ['one', 'two']) {
+      expect(jobs.resources.debit({
+        jobId: job.jobId, attemptId: job.attemptId, generation: lease.generation,
+        fenceToken: lease.fenceToken, kind: 'tool_calls', amount: 1,
+        certainty: 'confirmed', idempotencyKey: key,
+      }).applied).toBe(true);
+    }
+    expect(jobs.resources.debit({
+      jobId: job.jobId, attemptId: job.attemptId, generation: lease.generation,
+      fenceToken: lease.fenceToken, kind: 'tool_calls', amount: 1,
+      certainty: 'confirmed', idempotencyKey: 'three',
+    })).toMatchObject({ applied: false, exhausted: true, remaining: 0 });
+
+    const reopened = createJobEngine({ db });
+    expect(reopened.resources.getBudgets(job.jobId)).toMatchObject([
+      { kind: 'tool_calls', limit: 2, used: 2, hasUnknownUsage: false },
+    ]);
+  });
+
+  it('rejects a stale worker and keeps duplicate debits idempotent', () => {
+    const job = submit('stale-budget');
+    const lease = claim(job);
+    jobs.resources.configure({ jobId: job.jobId, budgets: { model_calls: 3 } });
+    const command = {
+      jobId: job.jobId, attemptId: job.attemptId, generation: lease.generation,
+      fenceToken: lease.fenceToken, kind: 'model_calls' as const, amount: 1,
+      certainty: 'confirmed' as const, idempotencyKey: 'provider-one',
+    };
+    expect(jobs.resources.debit(command).applied).toBe(true);
+    expect(jobs.resources.debit(command)).toMatchObject({ applied: false, duplicate: true, remaining: 2 });
+    expect(() => jobs.resources.debit({ ...command, fenceToken: 'replacement-fence', idempotencyKey: 'stale' }))
+      .toThrow(/Stale worker/);
+  });
+
+  it('enforces a child lower bound for budgets and capabilities', () => {
+    const parent = submit('parent-budget');
+    jobs.resources.configure({
+      jobId: parent.jobId,
+      budgets: { model_calls: 5 },
+      capabilities: { tools: ['file_read'], paths: ['C:\\workspace'] },
+    });
+    const child = submit('child-budget', parent.jobId);
+
+    expect(() => jobs.resources.configure({
+      jobId: child.jobId, budgets: { model_calls: 6 }, capabilities: { tools: ['file_read'] },
+    })).toThrow(/exceeds parent/);
+    expect(() => jobs.resources.configure({
+      jobId: child.jobId, budgets: { model_calls: 4 }, capabilities: { tools: ['shell_exec'] },
+    })).toThrow(/capability exceeds parent/);
+    jobs.resources.configure({
+      jobId: child.jobId,
+      budgets: { model_calls: 4 },
+      capabilities: { tools: ['file_read'], paths: ['C:\\workspace\\child'] },
+    });
+    expect(jobs.resources.authorize({ jobId: child.jobId, kind: 'tool', value: 'file_read' })).toBe(true);
+    expect(jobs.resources.authorize({ jobId: child.jobId, kind: 'tool', value: 'file_write' })).toBe(false);
+  });
+
+  it('preserves unknown cost as unknown rather than zero', () => {
+    const job = submit('unknown-cost');
+    const lease = claim(job);
+    jobs.resources.configure({ jobId: job.jobId, budgets: { external_cost: null } });
+    expect(jobs.resources.debit({
+      jobId: job.jobId, attemptId: job.attemptId, generation: lease.generation,
+      fenceToken: lease.fenceToken, kind: 'external_cost', amount: null,
+      certainty: 'unknown', idempotencyKey: 'unknown-cost',
+    }).applied).toBe(true);
+    expect(jobs.resources.getBudgets(job.jobId)).toMatchObject([
+      { kind: 'external_cost', limit: null, used: 0, hasUnknownUsage: true },
+    ]);
+  });
+
+  it('enforces canonical path boundaries', () => {
+    const job = submit('path-boundary');
+    jobs.resources.configure({ jobId: job.jobId, capabilities: { paths: ['C:\\workspace\\safe'] } });
+    expect(jobs.resources.authorize({
+      jobId: job.jobId, kind: 'path', value: 'C:\\workspace\\safe\\nested\\file.txt',
+    })).toBe(true);
+    expect(jobs.resources.authorize({
+      jobId: job.jobId, kind: 'path', value: 'C:\\workspace\\safe\\..\\escape.txt',
+    })).toBe(false);
+  });
+});

--- a/tests/v4/daemon/jobResourceAuthority.test.ts
+++ b/tests/v4/daemon/jobResourceAuthority.test.ts
@@ -129,5 +129,8 @@ describe('JobResourceAuthority', () => {
     expect(jobs.resources.authorize({
       jobId: job.jobId, kind: 'path', value: 'C:\\workspace\\safe\\..\\escape.txt',
     })).toBe(false);
+    expect(jobs.resources.authorize({
+      jobId: job.jobId, kind: 'path', value: 'c:\\WORKSPACE\\safe\\nested\\case-insensitive.txt',
+    })).toBe(true);
   });
 });

--- a/tests/v4/daemon/jobWaitAuthority.test.ts
+++ b/tests/v4/daemon/jobWaitAuthority.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createJobControlAuthority, type JobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
+
+describe('durable Job waits', () => {
+  let db: Database.Database;
+  let jobs: JobEngine;
+  let controls: JobControlAuthority;
+  let job: ReturnType<JobEngine['submitJob']>;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('one', 1, 'localhost', 1, 1, '4.16.1'), ('two', 2, 'localhost', 2, 2, '4.16.1')`,
+    ).run();
+    jobs = createJobEngine({ db });
+    controls = createJobControlAuthority({ db, jobEngine: jobs });
+    job = jobs.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'session', instanceId: 'one',
+      idempotencyNamespace: 'wait', idempotencyKey: 'job', goal: 'wait safely',
+    });
+  });
+
+  afterEach(() => db.close());
+
+  it('persists every supported wait kind and survives authority reconstruction', () => {
+    const kinds = ['approval', 'clarification', 'scheduled_time', 'rate_limit_reset', 'external_event', 'child_job', 'reconciliation', 'resource_availability'] as const;
+    for (const [index, kind] of kinds.entries()) {
+      controls.waits.create({
+        jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind,
+        producer: 'test', idempotencyNamespace: 'wait-kind', idempotencyKey: String(index),
+      });
+    }
+    const restored = createJobControlAuthority({ db, jobEngine: createJobEngine({ db }) });
+    expect(restored.waits.listPending(job.jobId).map((wait) => wait.kind)).toEqual(kinds);
+  });
+
+  it('times out a deadline once and keeps append-only history', () => {
+    const wait = controls.waits.create({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'scheduled_time',
+      deadlineAt: 100, producer: 'test', idempotencyNamespace: 'deadline', idempotencyKey: 'one', now: 1,
+    }).record;
+    expect(controls.waits.expireDue(99)).toEqual([]);
+    expect(controls.waits.expireDue(100)).toEqual([wait.waitId]);
+    expect(controls.waits.expireDue(101)).toEqual([]);
+    expect(controls.waits.get(wait.waitId)?.state).toBe('timed_out');
+    expect(db.prepare('SELECT COUNT(*) AS count FROM job_wait_events WHERE wait_id = ?').get(wait.waitId))
+      .toEqual({ count: 2 });
+  });
+
+  it('deduplicates an external event and rejects a stale generation', () => {
+    const wait = controls.waits.create({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'external_event',
+      externalKey: 'delivery:42', producer: 'test', idempotencyNamespace: 'external', idempotencyKey: 'wait',
+    }).record;
+    const command = {
+      jobId: job.jobId, externalKey: 'delivery:42', attemptId: job.attemptId, generation: 1,
+      producer: 'webhook', idempotencyKey: 'event-42', resolutionRef: 'event:sha256:42',
+    };
+    expect(controls.waits.resolveExternal(command).applied).toBe(true);
+    expect(controls.waits.resolveExternal(command)).toMatchObject({ applied: false, duplicate: true });
+    expect(controls.waits.resolve({
+      waitId: wait.waitId, attemptId: job.attemptId, generation: 2,
+      producer: 'test', idempotencyKey: 'stale',
+    })).toMatchObject({ applied: false, conflict: 'terminal_state' });
+  });
+
+  it('links input received during approval to the exact durable wait', () => {
+    const wait = controls.waits.create({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'approval',
+      producer: 'test', idempotencyNamespace: 'approval', idempotencyKey: 'input-wait',
+    }).record;
+    const input = controls.inputs.receive({
+      jobId: job.jobId, targetAttemptId: job.attemptId, targetGeneration: 1,
+      sessionId: 'session', source: 'tui', kind: 'approval_response', content: 'once',
+      idempotencyNamespace: 'approval-response', idempotencyKey: 'one',
+    }).record;
+    expect(controls.inputs.claimNext({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1,
+      inputId: input.inputId, kinds: ['approval_response'],
+    })?.inputId).toBe(input.inputId);
+    expect(controls.inputs.consume({
+      inputId: input.inputId, attemptId: job.attemptId, generation: 1,
+    }).applied).toBe(true);
+    expect(controls.waits.resolve({
+      waitId: wait.waitId, attemptId: job.attemptId, generation: 1,
+      producer: 'tui', idempotencyKey: 'approval-response:one', inputId: input.inputId,
+      resolutionRef: 'approval:once',
+    }).applied).toBe(true);
+    expect(controls.waits.get(wait.waitId)).toMatchObject({
+      state: 'satisfied', resolvedByInputId: input.inputId, resolutionRef: 'approval:once',
+    });
+  });
+
+  it('adopts a pending wait onto the resumed Attempt and rejects the old generation', () => {
+    const lease = jobs.claimAttempt({ attemptId: job.attemptId, ownerId: 'worker', ttlMs: 30_000 });
+    jobs.transitionAttempt({
+      attemptId: job.attemptId, generation: 1, fenceToken: lease.fenceToken!, expectedStateVersion: lease.stateVersion!,
+      to: 'running', producer: 'test', eventIdempotencyKey: 'attempt-running',
+    });
+    jobs.transitionJob({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, fenceToken: lease.fenceToken!, expectedStateVersion: 0,
+      to: 'running', producer: 'test', eventIdempotencyKey: 'job-running',
+    });
+    const wait = controls.waits.create({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'clarification',
+      producer: 'test', idempotencyNamespace: 'clarify', idempotencyKey: 'wait',
+    }).record;
+    controls.commands.request({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'pause', source: 'test',
+      idempotencyNamespace: 'control', idempotencyKey: 'pause',
+    });
+    controls.commands.applyPendingAtBoundary({ jobId: job.jobId });
+    const resumed = controls.commands.resume({
+      jobId: job.jobId, source: 'test', instanceId: 'two', idempotencyNamespace: 'control', idempotencyKey: 'resume',
+    });
+    expect(controls.waits.get(wait.waitId)).toMatchObject({ attemptId: resumed.attemptId, generation: 2 });
+    expect(controls.waits.resolve({
+      waitId: wait.waitId, attemptId: job.attemptId, generation: 1,
+      producer: 'test', idempotencyKey: 'old-attempt',
+    })).toMatchObject({ applied: false, conflict: 'stale_generation' });
+  });
+
+  it('cancels pending waits before physical interruption and cannot revive a terminal Job', () => {
+    const wait = controls.waits.create({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'approval',
+      producer: 'test', idempotencyNamespace: 'approval', idempotencyKey: 'wait',
+    }).record;
+    controls.commands.request({
+      jobId: job.jobId, attemptId: job.attemptId, generation: 1, kind: 'cancel', source: 'test',
+      idempotencyNamespace: 'control', idempotencyKey: 'cancel',
+    });
+    expect(controls.waits.get(wait.waitId)?.state).toBe('cancelled');
+    expect(controls.waits.resolve({
+      waitId: wait.waitId, attemptId: job.attemptId, generation: 1,
+      producer: 'test', idempotencyKey: 'late',
+    })).toMatchObject({ applied: false, conflict: 'terminal_state' });
+  });
+});

--- a/tests/v4/daemon/kernelFailureInjection.test.ts
+++ b/tests/v4/daemon/kernelFailureInjection.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createActionAuthority,
+  normalizeExecutionPlan,
+  type PolicySnapshotInput,
+} from '../../../core/v4/actionAuthority';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type AdmissionResult, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { sweepDurableJobRecovery } from '../../../core/v4/daemon/jobRecoverySweep';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+
+const INSTANCE = 'failure-instance';
+const policy: PolicySnapshotInput = {
+  trustLevel: 'Assistant',
+  autonomyPolicy: 'ask_for_mutations',
+  approvalMode: 'smart',
+  toolMetadataVersion: '1',
+  sandboxPolicy: { roots: ['C:/workspace'], deny: [] },
+  networkPolicy: { allow: ['localhost'] },
+  pluginGrants: [],
+  mcpGrants: [],
+  workspaceOverrides: {},
+  jobOverrides: {},
+};
+
+type Authority = { attemptId: string; generation: number; fenceToken: string };
+
+function seedInstance(db: Database.Database): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(INSTANCE, 1, 'localhost', 1, 1, '4.16.1');
+}
+
+function open(path: string): Database.Database {
+  const db = new Database(path);
+  db.pragma('foreign_keys = ON');
+  db.pragma('busy_timeout = 100');
+  runMigrations(db);
+  seedInstance(db);
+  return db;
+}
+
+function submit(engine: JobEngine, key: string, overrides: Partial<Parameters<JobEngine['submitJob']>[0]> = {}): AdmissionResult {
+  return engine.submitJob({
+    entryPoint: 'failure-injection', source: 'test', sessionId: 'failure-session',
+    instanceId: INSTANCE, idempotencyNamespace: 'failure-injection',
+    idempotencyKey: key, requestFingerprint: key, goal: `boundary ${key}`,
+    ...overrides,
+  });
+}
+
+function claim(engine: JobEngine, admitted: AdmissionResult, now = 100, ttlMs = 10): Authority {
+  const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'failure-worker', ttlMs, now });
+  if (!lease.acquired || lease.generation === undefined || !lease.fenceToken) throw new Error('lease unavailable');
+  return { attemptId: admitted.attemptId, generation: lease.generation, fenceToken: lease.fenceToken };
+}
+
+function mutatingEffect(target: string, content = 'external result') {
+  return {
+    classification: 'reconcilable_mutation' as const,
+    kind: 'filesystem.write', target,
+    retrySafety: 'reconcile_before_retry' as const,
+    idempotencySupported: true, idempotencyKey: `effect:${target}`,
+    reconciliationSupported: true, verificationSupported: true,
+    approvalRequirement: 'policy' as const, approvalState: 'not_required' as const,
+    sensitiveFields: ['content'], redactionRules: ['digest_arguments'], trusted: true,
+    reconciliationData: {
+      path: target,
+      before: { exists: false },
+      expectedSize: Buffer.byteLength(content),
+      expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+    },
+  };
+}
+
+describe('kernel deterministic failure boundaries', () => {
+  const directories: string[] = [];
+  let db: Database.Database | null = null;
+
+  const databasePath = (): string => {
+    const directory = mkdtempSync(join(tmpdir(), 'aiden-kernel-failure-'));
+    directories.push(directory);
+    return join(directory, 'daemon.db');
+  };
+
+  const reopen = (path: string): Database.Database => {
+    db?.close();
+    db = open(path);
+    return db;
+  };
+
+  afterEach(() => {
+    try { db?.close(); } catch { /* already closed */ }
+    db = null;
+    for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('boundaries 1-3: admission is atomic and a committed queued Attempt survives reopen before claim', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+
+    db.exec("CREATE TRIGGER fail_before_job BEFORE INSERT ON tasks BEGIN SELECT RAISE(ABORT, 'before Job commit'); END");
+    expect(() => submit(engine, 'before-job')).toThrow(/before Job commit/);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 0 });
+    db.exec('DROP TRIGGER fail_before_job');
+
+    db.exec("CREATE TRIGGER fail_before_attempt BEFORE INSERT ON runs BEGIN SELECT RAISE(ABORT, 'before Attempt creation'); END");
+    expect(() => submit(engine, 'before-attempt')).toThrow(/before Attempt creation/);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM run_events').get()).toEqual({ count: 0 });
+    db.exec('DROP TRIGGER fail_before_attempt');
+
+    const admitted = submit(engine, 'before-claim');
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.getJob(admitted.jobId)).toMatchObject({ status: 'queued', activeAttemptId: admitted.attemptId });
+    expect(engine.getAttempt(admitted.attemptId)).toMatchObject({ status: 'queued', leaseId: null, generation: 1 });
+    expect(engine.listEvents(admitted.jobId).map((event) => event.type)).toEqual(['job.submitted', 'attempt.created']);
+    expect(claim(engine, admitted).generation).toBe(1);
+  });
+
+  it('boundary 4: a crash after lease claim expires safely and fences the stale worker', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const admitted = submit(engine, 'after-claim');
+    const stale = claim(engine, admitted);
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.recoverExpiredAttempts({ now: 111, instanceId: INSTANCE, producer: 'recovery', maxCrashes: 3 }))
+      .toEqual([expect.objectContaining({ jobId: admitted.jobId, decision: 'retry' })]);
+    expect(engine.listAttempts(admitted.jobId)).toEqual([
+      expect.objectContaining({ id: admitted.attemptId, status: 'crashed', generation: 1 }),
+      expect.objectContaining({ status: 'queued', generation: 2, recoveryOfAttemptId: admitted.attemptId }),
+    ]);
+    expect(engine.transitionAttempt({
+      attemptId: stale.attemptId, expectedStateVersion: 1, generation: stale.generation,
+      fenceToken: stale.fenceToken, to: 'succeeded', eventIdempotencyKey: 'late-success', producer: 'stale', now: 112,
+    })).toMatchObject({ applied: false, conflict: 'terminal_state' });
+  });
+
+  it('boundary 5: a prepared but unstarted Effect is durable and cannot be started by a stale owner', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const admitted = submit(engine, 'effect-before-execution');
+    const authority = claim(engine, admitted);
+    expect(engine.prepareToolCall({
+      toolCallId: 'tool-prepared', jobId: admitted.jobId, ...authority,
+      toolName: 'file_write', normalizedArgsDigest: 'prepared-digest', riskTier: 'caution', mutates: true,
+      effect: mutatingEffect(join(tmpdir(), 'not-written.txt')), producer: 'test', now: 101,
+    }).applied).toBe(true);
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(db.prepare('SELECT effect_state FROM side_effect_ledger WHERE tool_call_id = ?').get('tool-prepared'))
+      .toEqual({ effect_state: 'requested' });
+    expect(engine.recoverExpiredAttempts({ now: 111, instanceId: INSTANCE, producer: 'recovery', maxCrashes: 3 })[0])
+      .toMatchObject({ decision: 'retry' });
+    expect(engine.startToolCall({ toolCallId: 'tool-prepared', ...authority, producer: 'stale', now: 112 }))
+      .toMatchObject({ applied: false, conflict: 'stale_fence' });
+    expect(db.prepare('SELECT effect_state FROM side_effect_ledger WHERE tool_call_id = ?').get('tool-prepared'))
+      .toEqual({ effect_state: 'requested' });
+  });
+
+  it('boundaries 6-7: owner death during an Effect becomes unknown, while an observed file result reconciles without replay', () => {
+    const path = databasePath();
+    const directory = join(path, '..');
+    const target = join(directory, 'result.txt');
+    const content = 'external result';
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const bus = createTriggerBus({ db });
+    const admitted = submit(engine, 'external-effect');
+    const authority = claim(engine, admitted);
+    engine.prepareToolCall({
+      toolCallId: 'tool-external', jobId: admitted.jobId, ...authority,
+      toolName: 'file_write', normalizedArgsDigest: 'external-digest', riskTier: 'caution', mutates: true,
+      effect: mutatingEffect(target, content), producer: 'test', now: 101,
+    });
+    engine.startToolCall({ toolCallId: 'tool-external', ...authority, producer: 'test', now: 102 });
+    writeFileSync(target, content);
+
+    engine = createJobEngine({ db: reopen(path) });
+    const sweep = sweepDurableJobRecovery({
+      jobEngine: engine, triggerBus: createTriggerBus({ db }), instanceId: INSTANCE,
+      producer: 'recovery', now: 111,
+    });
+    expect(sweep).toMatchObject({ expired: 1, reconciled: 1, retried: 1, needsUser: 0, enqueued: 1 });
+    expect(readFileSync(target, 'utf8')).toBe(content);
+    expect(engine.listEffectReconciliations('side_effect:tool-external')).toEqual([
+      expect.objectContaining({ outcome: 'occurred', confidence: 'high', humanResolutionRequired: false }),
+    ]);
+    expect(db.prepare('SELECT effect_state FROM side_effect_ledger WHERE tool_call_id = ?').get('tool-external'))
+      .toEqual({ effect_state: 'committed' });
+    void bus;
+  });
+
+  it('boundary 8: a persisted result without evidence remains unverified after restart', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const admitted = submit(engine, 'result-before-evidence');
+    const authority = claim(engine, admitted, 100, 30_000);
+    const claimRecord = engine.proof.createClaim({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1,
+      category: 'contract', statement: 'Result exists', required: true, now: 101,
+    });
+    engine.prepareToolCall({
+      toolCallId: 'tool-result', jobId: admitted.jobId, ...authority,
+      toolName: 'file_write', normalizedArgsDigest: 'result-digest', riskTier: 'caution', mutates: true,
+      effect: mutatingEffect(join(tmpdir(), 'result-only.txt')), producer: 'test', now: 102,
+    });
+    engine.startToolCall({ toolCallId: 'tool-result', ...authority, producer: 'test', now: 103 });
+    engine.completeToolCall({
+      toolCallId: 'tool-result', ...authority, state: 'completed', sideEffectState: 'committed',
+      resultRef: 'result:durable', producer: 'test', now: 104,
+    });
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.proof.listEvidence(admitted.jobId)).toEqual([]);
+    expect(engine.proof.listClaims(admitted.jobId)).toEqual([expect.objectContaining({ claimId: claimRecord.claimId, state: 'unverified' })]);
+    expect(engine.proof.finalize({ jobId: admitted.jobId, ...authority, now: 105 })).toMatchObject({ verdict: 'unknown' });
+  });
+
+  it('boundaries 9-10: approval wait and exact approval survive reopen without authorizing changed execution', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const admitted = submit(engine, 'approval-restart');
+    const authority = claim(engine, admitted, 100, 30_000);
+    expect(engine.transitionAttempt({
+      attemptId: admitted.attemptId, expectedStateVersion: 1, generation: authority.generation,
+      fenceToken: authority.fenceToken, to: 'running', eventIdempotencyKey: 'approval-attempt-running',
+      producer: 'test', now: 101,
+    }).applied).toBe(true);
+    expect(engine.transitionJob({
+      jobId: admitted.jobId, ...authority, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'approval-job-running', producer: 'test', now: 101,
+    }).applied).toBe(true);
+    const normalized = normalizeExecutionPlan({
+      toolName: 'file_write', args: { path: 'C:/workspace/result.txt', content: 'ok' },
+      cwd: 'C:/workspace', mutates: true, riskTier: 'caution', policy,
+    });
+    const prepared = engine.prepareToolCall({
+      toolCallId: 'tool-approval', jobId: admitted.jobId, ...authority,
+      toolName: 'file_write', normalizedArgsDigest: 'approval-digest', riskTier: 'caution', mutates: true,
+      effect: { ...mutatingEffect('C:/workspace/result.txt'), approvalState: 'pending' }, producer: 'test', now: 101,
+    });
+    let actions = createActionAuthority({ db, jobEngine: engine });
+    const approval = actions.request({
+      jobId: admitted.jobId, ...authority, toolCallId: 'tool-approval', effectId: prepared.effectId,
+      toolName: 'file_write', riskTier: 'caution', riskReasons: ['filesystem write'], normalized,
+      expiresAt: 10_000, now: 102,
+    });
+    actions.markDisplayed(approval.approvalId, 102);
+
+    engine = createJobEngine({ db: reopen(path) });
+    actions = createActionAuthority({ db, jobEngine: engine });
+    expect(actions.listPending(admitted.jobId)).toEqual([expect.objectContaining({ approvalId: approval.approvalId, state: 'displayed' })]);
+    actions.decide({
+      approvalId: approval.approvalId, jobId: admitted.jobId, attemptId: admitted.attemptId,
+      generation: 1, actionDigest: normalized.actionDigest, policySnapshotId: approval.policySnapshotId,
+      decision: 'approved', decidedBy: 'user', decisionChannel: 'tui', now: 102,
+    });
+
+    engine = createJobEngine({ db: reopen(path) });
+    actions = createActionAuthority({ db, jobEngine: engine });
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId, jobId: admitted.jobId, ...authority,
+      toolCallId: 'tool-approval', effectId: prepared.effectId ?? null,
+      actionDigest: normalized.actionDigest, policySnapshotId: approval.policySnapshotId, now: 103,
+    })).toMatchObject({ authorized: true });
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId, jobId: admitted.jobId, ...authority,
+      toolCallId: 'tool-approval', effectId: prepared.effectId ?? null,
+      actionDigest: normalized.actionDigest, policySnapshotId: approval.policySnapshotId, now: 104,
+    })).toMatchObject({ authorized: false, duplicate: true });
+  });
+
+  it('boundary 11: reconciliation failure rolls back and a later exact retry records one outcome', () => {
+    const path = databasePath();
+    db = open(path);
+    const engine = createJobEngine({ db });
+    const admitted = submit(engine, 'reconciliation-crash');
+    const authority = claim(engine, admitted, 100, 30_000);
+    engine.prepareToolCall({
+      toolCallId: 'tool-reconcile-crash', jobId: admitted.jobId, ...authority,
+      toolName: 'file_write', normalizedArgsDigest: 'reconcile-digest', riskTier: 'caution', mutates: true,
+      effect: mutatingEffect('C:/workspace/reconcile.txt'), producer: 'test', now: 101,
+    });
+    engine.startToolCall({ toolCallId: 'tool-reconcile-crash', ...authority, producer: 'test', now: 102 });
+    engine.completeToolCall({
+      toolCallId: 'tool-reconcile-crash', ...authority, state: 'unknown', sideEffectState: 'unknown', producer: 'test', now: 103,
+    });
+    db.exec("CREATE TRIGGER fail_reconciliation BEFORE INSERT ON effect_reconciliations BEGIN SELECT RAISE(ABORT, 'reconciliation interrupted'); END");
+    const command = {
+      effectId: 'side_effect:tool-reconcile-crash', expectedJobStateVersion: 0,
+      outcome: 'did_not_occur' as const, confidence: 'high' as const, evidence: { checked: true },
+      retryRecommendation: 'retry' as const, humanResolutionRequired: false,
+      producer: 'recovery', idempotencyKey: 'reconcile-once', now: 104,
+    };
+    expect(() => engine.recordEffectReconciliation(command)).toThrow(/reconciliation interrupted/);
+    expect(engine.listEffectReconciliations(command.effectId)).toEqual([]);
+    expect(db.prepare('SELECT effect_state FROM side_effect_ledger WHERE key = ?').get(command.effectId))
+      .toEqual({ effect_state: 'unknown' });
+    db.exec('DROP TRIGGER fail_reconciliation');
+    expect(engine.recordEffectReconciliation(command).applied).toBe(true);
+    expect(engine.recordEffectReconciliation(command)).toMatchObject({ applied: false, duplicate: true });
+    expect(engine.listEffectReconciliations(command.effectId)).toHaveLength(1);
+  });
+
+  it('boundaries 12-13: child execution and completed child attribution survive parent aggregation restart', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const parent = submit(engine, 'parent-child');
+    const parentAuthority = claim(engine, parent, 100, 30_000);
+    expect(engine.transitionAttempt({
+      attemptId: parent.attemptId, expectedStateVersion: 1, generation: parentAuthority.generation,
+      fenceToken: parentAuthority.fenceToken, to: 'running', eventIdempotencyKey: 'parent-attempt-running',
+      producer: 'parent', now: 101,
+    }).applied).toBe(true);
+    expect(engine.transitionJob({
+      jobId: parent.jobId, ...parentAuthority, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'parent-job-running', producer: 'parent', now: 101,
+    }).applied).toBe(true);
+    const child = submit(engine, 'child-running', {
+      parentJobId: parent.jobId, rootJobId: parent.jobId,
+      childContract: { required: true, workerId: 'child-worker', capabilities: ['read'], allowedResources: {}, budget: {} },
+    });
+    const childAuthority = claim(engine, child, 100, 30_000);
+    expect(engine.transitionAttempt({
+      attemptId: child.attemptId, expectedStateVersion: 1, generation: childAuthority.generation,
+      fenceToken: childAuthority.fenceToken, to: 'running', eventIdempotencyKey: 'child-attempt-running',
+      producer: 'child', now: 102,
+    }).applied).toBe(true);
+    expect(engine.transitionJob({
+      jobId: child.jobId, ...childAuthority, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'child-job-running', producer: 'child', now: 102,
+    }).applied).toBe(true);
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.getChildContract(child.jobId)).toMatchObject({ parentJobId: parent.jobId, resultStatus: null });
+    expect(engine.recordChildResult({
+      childJobId: child.jobId, ...childAuthority, status: 'completed', evidence: { output: 'done' },
+      evidenceHandles: [{ kind: 'proof', value: 'child-proof' }], producer: 'child', idempotencyKey: 'child-result', now: 110,
+    }).applied).toBe(true);
+    expect(engine.transitionAttempt({
+      attemptId: child.attemptId, expectedStateVersion: 2, generation: childAuthority.generation,
+      fenceToken: childAuthority.fenceToken, to: 'succeeded', eventIdempotencyKey: 'child-attempt-completed',
+      producer: 'child', now: 110,
+    }).applied).toBe(true);
+    expect(engine.finalizeJob({
+      jobId: child.jobId, ...childAuthority, expectedStateVersion: 1,
+      status: 'completed', outcome: 'verified', finishReason: 'child completed', evidence: { output: 'done' },
+      eventIdempotencyKey: 'child-job-completed', producer: 'child', now: 110,
+    }).applied).toBe(true);
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.listChildContracts(parent.jobId)).toEqual([
+      expect.objectContaining({ childJobId: child.jobId, resultStatus: 'completed', evidenceHandles: [{ kind: 'proof', value: 'child-proof' }] }),
+    ]);
+    expect(engine.finalizeJob({
+      jobId: parent.jobId, ...parentAuthority, expectedStateVersion: 0,
+      status: 'completed', outcome: 'verified', finishReason: 'children aggregated', evidence: { childJobId: child.jobId },
+      eventIdempotencyKey: 'parent-final', producer: 'parent', now: 111,
+    }).applied).toBe(false);
+    expect(engine.finalizeJob({
+      jobId: parent.jobId, ...parentAuthority, expectedStateVersion: 1,
+      status: 'completed', outcome: 'verified', finishReason: 'children aggregated', evidence: { childJobId: child.jobId },
+      eventIdempotencyKey: 'parent-final-current', producer: 'parent', now: 112,
+    }).applied).toBe(true);
+  });
+
+  it('boundaries 14-15: verification resumes from evidence and a committed verdict replays after UI loss', () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const admitted = submit(engine, 'verification-ui');
+    const authority = claim(engine, admitted, 100, 30_000);
+    const claimRecord = engine.proof.createClaim({
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1,
+      category: 'contract', statement: 'Output is exact', required: true, now: 101,
+    });
+    const evidence = engine.proof.recordEvidence({
+      jobId: admitted.jobId, ...authority, source: 'test', producer: 'worker', observedAt: 102,
+      coverage: 'full', verificationResult: 'verified', payload: { exact: true }, now: 102,
+    });
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.proof.getVerdict(admitted.jobId)).toBeNull();
+    engine.proof.checkClaim({
+      claimId: claimRecord.claimId, attemptId: admitted.attemptId, generation: 1,
+      evidenceIds: [evidence.evidenceId], state: 'verified', now: 103,
+    });
+    const verdict = engine.proof.finalize({ jobId: admitted.jobId, ...authority, now: 104 });
+    expect(verdict.verdict).toBe('verified');
+
+    engine = createJobEngine({ db: reopen(path) });
+    const replay = engine.projection.rebuild(admitted.jobId);
+    expect(replay.verdict).toMatchObject({ verdict: 'verified', attempt_id: admitted.attemptId, generation: 1 });
+    expect(engine.proof.finalize({ jobId: admitted.jobId, ...authority, cancelled: true, now: 105 })).toEqual(verdict);
+    expect(engine.projection.cursor('lost-ui', admitted.jobId)).toBe(0);
+    expect(engine.projection.read('lost-ui', admitted.jobId).map((event) => event.jobSequence))
+      .toEqual(engine.listEvents(admitted.jobId).map((event) => event.jobSequence));
+  });
+
+  it('keeps an unsafe network Effect unknown after a real loopback disconnect', async () => {
+    const path = databasePath();
+    db = open(path);
+    let engine = createJobEngine({ db });
+    const admitted = submit(engine, 'network-disconnect');
+    const authority = claim(engine, admitted);
+    let received = false;
+    let server: Server | null = createServer((request) => {
+      request.on('data', () => { received = true; });
+      request.on('end', () => request.socket.destroy());
+    });
+    await new Promise<void>((resolve, reject) => {
+      server!.once('error', reject);
+      server!.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('loopback server did not bind');
+    const target = `http://127.0.0.1:${address.port}/effect`;
+    engine.prepareToolCall({
+      toolCallId: 'tool-network', jobId: admitted.jobId, ...authority,
+      toolName: 'web_submit', normalizedArgsDigest: 'network-digest', riskTier: 'dangerous', mutates: true,
+      effect: {
+        classification: 'non_reconcilable_mutation', kind: 'network.submit', target,
+        retrySafety: 'manual_only', idempotencySupported: false, idempotencyKey: null,
+        reconciliationSupported: false, verificationSupported: false,
+        approvalRequirement: 'policy', approvalState: 'not_required', sensitiveFields: ['body'],
+        redactionRules: ['digest_arguments'], trusted: true,
+      },
+      producer: 'test', now: 101,
+    });
+    engine.startToolCall({ toolCallId: 'tool-network', ...authority, producer: 'test', now: 102 });
+
+    await expect(fetch(target, { method: 'POST', body: 'received-before-disconnect' })).rejects.toThrow();
+    expect(received).toBe(true);
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+    engine.completeToolCall({
+      toolCallId: 'tool-network', ...authority, state: 'unknown', sideEffectState: 'unknown',
+      producer: 'test', now: 103,
+    });
+
+    engine = createJobEngine({ db: reopen(path) });
+    expect(engine.recoverExpiredAttempts({ now: 111, instanceId: INSTANCE, producer: 'recovery', maxCrashes: 3 }))
+      .toEqual([expect.objectContaining({ decision: 'ask_user' })]);
+    expect(engine.listEffectsRequiringReconciliation(admitted.jobId)).toEqual([
+      expect.objectContaining({ effectId: 'side_effect:tool-network', effectState: 'unknown', retrySafety: 'manual_only' }),
+    ]);
+  });
+
+  it('surfaces a real database writer lock without partial state and succeeds after release', () => {
+    const path = databasePath();
+    db = open(path);
+    const competing = new Database(path);
+    competing.pragma('foreign_keys = ON');
+    competing.pragma('busy_timeout = 1');
+    try {
+      db.exec('BEGIN EXCLUSIVE');
+      expect(() => competing.prepare(
+        `INSERT INTO daemon_instances
+           (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES ('locked-writer', 2, 'localhost', 2, 2, '4.16.1')`,
+      ).run()).toThrow(/locked|busy/i);
+      db.exec('ROLLBACK');
+      expect(competing.prepare("SELECT COUNT(*) AS count FROM daemon_instances WHERE instance_id = 'locked-writer'").get())
+        .toEqual({ count: 0 });
+      expect(competing.prepare(
+        `INSERT INTO daemon_instances
+           (instance_id, pid, hostname, started_at, last_heartbeat, version)
+         VALUES ('locked-writer', 2, 'localhost', 2, 2, '4.16.1')`,
+      ).run().changes).toBe(1);
+    } finally {
+      if (db.inTransaction) db.exec('ROLLBACK');
+      competing.close();
+    }
+  });
+});

--- a/tests/v4/daemon/kernelPerformance.test.ts
+++ b/tests/v4/daemon/kernelPerformance.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+import { performance } from 'node:perf_hooks';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+
+type Measurement = { elapsedMs: number };
+
+function measure(work: () => void): Measurement {
+  const started = performance.now();
+  work();
+  return { elapsedMs: performance.now() - started };
+}
+
+describe('durable kernel performance and query shape', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES ('performance-instance', 1, 'localhost', 1, 1, '4.16.1')`,
+    ).run();
+    engine = createJobEngine({ db });
+  });
+
+  afterEach(() => db.close());
+
+  it('keeps ordered kernel queries index-backed', () => {
+    const plan = (sql: string): string[] => (
+      db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{ detail: string }>
+    ).map((row) => row.detail);
+    const queries = [
+      "SELECT * FROM tasks WHERE status = 'running' ORDER BY created_at, id LIMIT 100",
+      "SELECT * FROM tasks WHERE session_id = 'session' ORDER BY created_at, id LIMIT 100",
+      "SELECT * FROM side_effect_ledger WHERE job_id = 'job' ORDER BY attempted_at, key",
+      "SELECT * FROM child_job_contracts WHERE parent_job_id = 'job' ORDER BY created_at, child_job_id",
+      "SELECT * FROM job_claims WHERE job_id = 'job' ORDER BY created_at, claim_id",
+      "SELECT * FROM job_evidence WHERE job_id = 'job' ORDER BY captured_at, evidence_id",
+      "SELECT * FROM run_events WHERE job_id = 'job' AND job_sequence > 100 ORDER BY job_sequence LIMIT 500",
+    ];
+
+    for (const query of queries) {
+      const details = plan(query);
+      expect(details.join(' | '), query).toMatch(/USING (?:COVERING )?INDEX/);
+      expect(details.join(' | '), query).not.toContain('USE TEMP B-TREE');
+      expect(details.join(' | '), query).not.toMatch(/^SCAN /);
+    }
+  });
+
+  it('measures realistic admission, event, graph, Effect, proof, replay, and recovery workloads', () => {
+    const admissions: ReturnType<JobEngine['submitJob']>[] = [];
+    const measurements: Record<string, number> = {};
+    measurements.admission = measure(() => {
+      for (let index = 0; index < 300; index += 1) {
+        admissions.push(engine.submitJob({
+          entryPoint: index % 2 === 0 ? 'daemon' : 'interactive', source: 'performance',
+          sessionId: `session-${index % 20}`, instanceId: 'performance-instance',
+          idempotencyNamespace: 'performance', idempotencyKey: `job-${index}`,
+          requestFingerprint: `fingerprint-${index}`, goal: `measured Job ${index}`,
+        }));
+      }
+    }).elapsedMs;
+
+    const primary = admissions[0]!;
+    const lease = engine.claimAttempt({
+      attemptId: primary.attemptId, ownerId: 'performance-worker', ttlMs: 100_000, now: 100,
+    });
+    const authority = {
+      attemptId: primary.attemptId,
+      generation: lease.generation!,
+      fenceToken: lease.fenceToken!,
+    };
+
+    measurements.events = measure(() => {
+      for (let index = 0; index < 1_500; index += 1) {
+        const result = engine.appendJobEvent({
+          jobId: primary.jobId, attemptId: primary.attemptId, generation: 1,
+          type: 'performance.observed', payload: { index }, producer: 'performance',
+          idempotencyKey: `performance-event-${index}`,
+        });
+        if (!result.applied) throw new Error(`event ${index} was not appended`);
+      }
+    }).elapsedMs;
+
+    const nodes = Array.from({ length: 120 }, (_, index) => ({
+      nodeId: `node-${index}`, kind: 'tool' as const,
+      dependsOn: index === 0 ? [] : [`node-${index - 1}`],
+    }));
+    measurements.graph = measure(() => {
+      engine.graph.create({
+        jobId: primary.jobId, planDigest: 'performance-plan', nodes,
+        producer: 'performance', idempotencyKey: 'performance-graph', now: 200,
+      });
+      expect(engine.graph.schedule({
+        jobId: primary.jobId, ...authority, producer: 'performance',
+        idempotencyKey: 'performance-schedule', now: 200,
+      })).toEqual(['node-0']);
+    }).elapsedMs;
+
+    measurements.effects = measure(() => {
+      for (let index = 0; index < 100; index += 1) {
+        const prepared = engine.prepareToolCall({
+          toolCallId: `performance-tool-${index}`, jobId: primary.jobId, ...authority,
+          toolName: 'file_write', normalizedArgsDigest: `digest-${index}`,
+          riskTier: 'caution', mutates: true, producer: 'performance', now: 201 + index,
+          effect: {
+            classification: 'reconcilable_mutation', kind: 'filesystem.write', target: `C:/workspace/${index}.txt`,
+            retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+            idempotencyKey: `performance-effect-${index}`, reconciliationSupported: true,
+            verificationSupported: true, approvalRequirement: 'policy', approvalState: 'not_required',
+            sensitiveFields: ['content'], redactionRules: ['digest_arguments'], trusted: true,
+          },
+        });
+        if (!prepared.applied) throw new Error(`Effect ${index} was not prepared`);
+      }
+      expect(engine.projection.rebuild(primary.jobId).effects).toHaveLength(100);
+    }).elapsedMs;
+
+    measurements.evidence = measure(() => {
+      for (let index = 0; index < 100; index += 1) {
+        engine.proof.createClaim({
+          jobId: primary.jobId, attemptId: primary.attemptId, generation: 1,
+          category: index % 2 === 0 ? 'contract' : 'observed',
+          statement: `measured claim ${index}`, required: index % 2 === 0, now: 400 + index,
+        });
+        engine.proof.recordEvidence({
+          jobId: primary.jobId, ...authority, source: 'performance', producer: 'performance',
+          observedAt: 400 + index, coverage: 'full', verificationResult: 'verified',
+          payload: { index }, now: 400 + index,
+        });
+      }
+      expect(engine.proof.listEvidence(primary.jobId)).toHaveLength(100);
+    }).elapsedMs;
+
+    measurements.proofExport = measure(() => {
+      const proof = engine.proof.exportJson(primary.jobId) as { claims: unknown[]; evidence: unknown[] };
+      expect(proof.claims).toHaveLength(100);
+      expect(proof.evidence).toHaveLength(100);
+      expect(engine.proof.exportMarkdown(primary.jobId)).toContain('measured claim 99');
+    }).elapsedMs;
+
+    measurements.reconstruction = measure(() => {
+      const snapshot = engine.projection.rebuild(primary.jobId);
+      expect(snapshot.events).toHaveLength(1_000);
+      expect(snapshot.attempts).toHaveLength(1);
+      expect(snapshot.claims).toHaveLength(100);
+    }).elapsedMs;
+
+    const firstPage = engine.projection.read('performance-ui', primary.jobId, 500);
+    engine.projection.acknowledge('performance-ui', primary.jobId, firstPage.at(-1)!.jobSequence, 1_000);
+    measurements.replay = measure(() => {
+      const secondPage = engine.projection.read('performance-ui', primary.jobId, 500);
+      expect(secondPage).toHaveLength(500);
+      expect(secondPage[0]!.jobSequence).toBeGreaterThan(firstPage.at(-1)!.jobSequence);
+    }).elapsedMs;
+
+    for (const admitted of admissions.slice(1, 41)) {
+      const expired = engine.claimAttempt({
+        attemptId: admitted.attemptId, ownerId: 'expired-worker', ttlMs: 10, now: 100,
+      });
+      if (!expired.acquired) throw new Error('recovery fixture lease unavailable');
+    }
+    measurements.recovery = measure(() => {
+      const recovered = engine.recoverExpiredAttempts({
+        now: 111, instanceId: 'performance-instance', producer: 'performance-recovery', maxCrashes: 3,
+      });
+      expect(recovered).toHaveLength(40);
+      expect(recovered.every((item) => item.decision === 'retry')).toBe(true);
+    }).elapsedMs;
+
+    for (const [operation, elapsedMs] of Object.entries(measurements)) {
+      expect(elapsedMs, `${operation} measured ${elapsedMs.toFixed(1)}ms`).toBeGreaterThanOrEqual(0);
+      expect(elapsedMs, `${operation} exceeded the deterministic 5s budget`).toBeLessThan(5_000);
+    }
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks').get()).toEqual({ count: 300 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM runs').get()).toEqual({ count: 340 });
+  });
+});

--- a/tests/v4/daemon/taskStore.test.ts
+++ b/tests/v4/daemon/taskStore.test.ts
@@ -258,7 +258,7 @@ describe('TaskStore — defensive JSON parses', () => {
 // ─── V14 migration smoke ─────────────────────────────────────────────
 
 describe('v14 migration — Slice 10.8 tasks table', () => {
-  it('creates the tasks table + two indexes; idempotent on re-run', () => {
+  it('creates the tasks table and current indexes; idempotent on re-run', () => {
     // Fresh DB already migrated by the beforeEach above. Just assert
     // the post-state.
     const cols = db.prepare(`PRAGMA table_info(tasks)`).all() as Array<{ name: string }>;
@@ -272,7 +272,7 @@ describe('v14 migration — Slice 10.8 tasks table', () => {
       // v4.13 Gap 3 (v17 migration) — job-card columns.
       'failure_state', 'files_touched', 'finish_reason',
       'goal', 'id', 'idempotency_key', 'idempotency_namespace',
-      'next_event_sequence', 'next_input_sequence', 'parent_task_id',
+      'next_event_sequence', 'next_input_sequence', 'next_wait_sequence', 'parent_task_id',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
       'permissions', 'policy_snapshot_id', 'principal_id', 'recovery_state',
       'request_fingerprint',
@@ -288,7 +288,9 @@ describe('v14 migration — Slice 10.8 tasks table', () => {
       'idx_tasks_idempotency',
       'idx_tasks_root_job',
       'idx_tasks_session_created',
+      'idx_tasks_session_created_id',
       'idx_tasks_status',
+      'idx_tasks_status_created_id',
     ]);
     // Re-run is idempotent (CREATE TABLE IF NOT EXISTS + version bump
     // already applied so this is effectively a no-op).

--- a/tests/v4/harness/jobEngineProcessFixture.ts
+++ b/tests/v4/harness/jobEngineProcessFixture.ts
@@ -151,6 +151,23 @@ async function main(): Promise<void> {
         normalizedArgsDigest: `${toolCallId}-digest`,
         riskTier: payload.mutates ? 'caution' : 'safe',
         mutates: payload.mutates ?? false,
+        ...(payload.mutates ? {
+          effect: {
+            classification: 'unsafe_mutation' as const,
+            kind: 'fixture.process',
+            target: 'fixture-target',
+            retrySafety: 'never_automatic' as const,
+            idempotencySupported: false,
+            idempotencyKey: null,
+            reconciliationSupported: false,
+            verificationSupported: false,
+            approvalRequirement: 'policy' as const,
+            approvalState: 'not_required' as const,
+            sensitiveFields: [] as string[],
+            redactionRules: ['digest_arguments'],
+            trusted: true,
+          },
+        } : {}),
         producer: 'process-test',
         now: (payload.now ?? Date.now()) + 1,
       });

--- a/tests/v4/moat/approvalEngine.test.ts
+++ b/tests/v4/moat/approvalEngine.test.ts
@@ -64,6 +64,34 @@ describe('ApprovalEngine — manual mode', () => {
     expect(await engine.checkApproval(writeReq())).toBe(false);
   });
 
+  it('reports one-time, session, and permanent grants as distinct scopes', async () => {
+    const once = new ApprovalEngine('manual', { promptUser: async () => 'allow' });
+    await expect(once.checkApprovalDetailed(writeReq())).resolves.toMatchObject({
+      approved: true, scope: 'once',
+    });
+
+    const sessionPrompt = vi.fn(async () => 'allow_session' as const);
+    const session = new ApprovalEngine('manual', { promptUser: sessionPrompt });
+    await expect(session.checkApprovalDetailed(writeReq())).resolves.toMatchObject({
+      approved: true, scope: 'session',
+    });
+    await expect(session.checkApprovalDetailed(writeReq())).resolves.toMatchObject({
+      approved: true, scope: 'session',
+    });
+    expect(sessionPrompt).toHaveBeenCalledOnce();
+
+    const permanentPrompt = vi.fn(async () => 'allow_always' as const);
+    const permanent = new ApprovalEngine('manual', { promptUser: permanentPrompt });
+    await expect(permanent.checkApprovalDetailed(writeReq())).resolves.toMatchObject({
+      approved: true, scope: 'permanent',
+    });
+    permanent.resetSession();
+    await expect(permanent.checkApprovalDetailed(writeReq())).resolves.toMatchObject({
+      approved: true, scope: 'permanent',
+    });
+    expect(permanentPrompt).toHaveBeenCalledOnce();
+  });
+
   it('4. allow_session adds to session allowlist; subsequent calls auto-allow', async () => {
     const promptUser = vi
       .fn()

--- a/tests/v4/promptBuilder.test.ts
+++ b/tests/v4/promptBuilder.test.ts
@@ -42,6 +42,19 @@ describe('PromptBuilder', () => {
     expect(out).toContain('/test/cwd');
   });
 
+  it('1b. exposes the authoritative temporary directory without requiring a shell lookup', async () => {
+    const pb = new PromptBuilder();
+    const out = await pb.build({
+      paths: makePaths(tmp),
+      cwd: 'C:\\work area',
+      platform: 'windows',
+      tempDir: 'C:\\Users\\test user\\AppData\\Local\\Temp',
+      skipFilesystem: true,
+    });
+    expect(out).toContain('Temporary directory: C:\\Users\\test user\\AppData\\Local\\Temp');
+    expect(out).toContain('Use this path directly; do not run a shell command to discover it.');
+  });
+
   it('2. SOUL.md slot loaded if file exists', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-pb-soul-'));
     await fs.writeFile(path.join(root, 'SOUL.md'), 'I am Aiden, a custom soul.');

--- a/tests/v4/subagent/spawnSubAgent.test.ts
+++ b/tests/v4/subagent/spawnSubAgent.test.ts
@@ -166,6 +166,12 @@ describe('spawnSubAgent — v4.6 Phase 1 contract', () => {
     expect(children).toHaveLength(1);
     expect(children[0]).toMatchObject({ parentJobId: parent.jobId, rootJobId: parent.jobId, status: 'completed' });
     expect(jobEngine.listAttempts(children[0]!.id)[0]).toMatchObject({ status: 'succeeded' });
+    expect(jobEngine.getChildContract(children[0]!.id)).toMatchObject({
+      parentJobId: parent.jobId,
+      required: true,
+      resultStatus: 'completed',
+      budget: { maxIterations: 50, timeoutMs: 600_000, providerAttempts: null },
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────────

--- a/tests/v4/tools/browser.test.ts
+++ b/tests/v4/tools/browser.test.ts
@@ -44,12 +44,11 @@ afterEach(() => {
 });
 
 describe('browser tools', () => {
-  it('1. all three are categorised as browser, mutates=false, toolset=browser', () => {
-    for (const tool of [
-      browserScreenshotTool,
-      browserExtractTool,
-      browserGetUrlTool,
-    ]) {
+  it('1. persists screenshot artifacts while extract and URL inspection remain read-only', () => {
+    expect(browserScreenshotTool.category).toBe('browser');
+    expect(browserScreenshotTool.mutates).toBe(true);
+    expect(browserScreenshotTool.toolset).toBe('browser');
+    for (const tool of [browserExtractTool, browserGetUrlTool]) {
       expect(tool.category).toBe('browser');
       expect(tool.mutates).toBe(false);
       expect(tool.toolset).toBe('browser');

--- a/tests/v4/tools/execute_code.test.ts
+++ b/tests/v4/tools/execute_code.test.ts
@@ -38,7 +38,7 @@ describe('execute_code', () => {
   it('1. is registered as an execute toolset, mutates=false', () => {
     expect(executeCodeTool.schema.name).toBe('execute_code');
     expect(executeCodeTool.category).toBe('execute');
-    expect(executeCodeTool.mutates).toBe(false);
+    expect(executeCodeTool.mutates).toBe(true);
     expect(executeCodeTool.toolset).toBe('execute');
   });
 

--- a/tests/v4/tools/openUrl.test.ts
+++ b/tests/v4/tools/openUrl.test.ts
@@ -88,6 +88,6 @@ describe('open_url — execute() validation surface', () => {
     expect(openUrlTool.schema.name).toBe('open_url');
     expect(openUrlTool.schema.inputSchema.required).toEqual(['url']);
     expect(openUrlTool.toolset).toBe('web');
-    expect(openUrlTool.mutates).toBe(false);
+    expect(openUrlTool.mutates).toBe(true);
   });
 });

--- a/tests/v4/tools/terminal.test.ts
+++ b/tests/v4/tools/terminal.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 
 import { shellExecTool } from '../../../tools/v4/terminal/shellExec';
-import { localBackendExecute } from '../../../tools/v4/backends/local';
+import { buildLocalShellInvocation, localBackendExecute } from '../../../tools/v4/backends/local';
 import {
   dockerBackendExecute,
   isDockerAvailable,
@@ -40,6 +40,42 @@ describe('shell_exec — schema', () => {
 });
 
 describe('localBackend', () => {
+  it('preserves PowerShell source exactly at the process boundary', () => {
+    const source = `Write-Output '$env:TEMP'; Write-Output \"quoted\"; Write-Output \`tick; Write-Output '₹ $ literal'`;
+    const invocation = buildLocalShellInvocation(source, 'win32');
+    expect(invocation.executable).toBe('powershell.exe');
+    expect(invocation.args.slice(0, 3)).toEqual(['-NoProfile', '-NonInteractive', '-EncodedCommand']);
+    expect(Buffer.from(invocation.args[3], 'base64').toString('utf16le')).toBe(source);
+  });
+
+  it('keeps an explicit nested PowerShell command out of an outer PowerShell parser', () => {
+    for (const executable of ['powershell', 'powershell.exe', 'pwsh', 'pwsh.exe']) {
+      const command = `${executable} -NoProfile -Command \"$env:TEMP; $env:LOCALAPPDATA\"`;
+      expect(buildLocalShellInvocation(command, 'win32')).toEqual({
+        executable: 'cmd.exe',
+        args: ['/d', '/s', '/c', command],
+        detached: false,
+      });
+    }
+  });
+
+  it.runIf(isWin)('executes direct environment lookups and special characters on Windows', async () => {
+    const marker = `space path 'single' \"double\" \`tick; Unicode-世界; literal-$`;
+    const direct = await localBackendExecute({
+      command: `Write-Output $env:TEMP; Write-Output $env:LOCALAPPDATA; Write-Output '${marker.replace(/'/g, "''")}'`,
+    });
+    expect(direct.exitCode).toBe(0);
+    expect(direct.stdout).toContain(process.env.TEMP);
+    expect(direct.stdout).toContain(process.env.LOCALAPPDATA);
+    expect(direct.stdout).toContain(marker);
+  });
+
+  it.runIf(isWin)('executes a nested Windows PowerShell environment lookup literally', async () => {
+    const nested = await localBackendExecute({ command: 'powershell -NoProfile -Command "$env:TEMP"' });
+    expect(nested.exitCode).toBe(0);
+    expect(nested.stdout.trim()).toBe(process.env.TEMP);
+  });
+
   it('2. executes a simple command', async () => {
     const r = await localBackendExecute({ command: echoCmd('hello-shell') });
     expect(r.exitCode).toBe(0);

--- a/tests/v4/workbench/jobCommands.test.ts
+++ b/tests/v4/workbench/jobCommands.test.ts
@@ -143,6 +143,9 @@ describe('Workbench durable Job commands', () => {
   it('resolves a durable approval by exact ID without treating ordinary input as consent', () => {
     const value = commands();
     const admitted = value.enqueue.enqueue({ message: 'write a file', sessionId: 'workbench-session' });
+    const lease = value.jobEngine.claimAttempt({
+      attemptId: admitted.attemptId, ownerId: 'workbench_test', ttlMs: 60_000,
+    });
     const actionAuthority = createActionAuthority({ db, jobEngine: value.jobEngine });
     const normalized = normalizeExecutionPlan({
       toolName: 'file_write', args: { path: 'result.txt' }, cwd: process.cwd(),
@@ -154,7 +157,7 @@ describe('Workbench durable Job commands', () => {
       },
     });
     const pending = actionAuthority.request({
-      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1,
+      jobId: admitted.jobId, attemptId: admitted.attemptId, generation: 1, fenceToken: lease.fenceToken!,
       toolCallId: 'workbench-tool', toolName: 'file_write', riskTier: 'caution',
       riskReasons: [], normalized,
     });

--- a/tools/v4/backends/local.ts
+++ b/tools/v4/backends/local.ts
@@ -42,6 +42,37 @@ export interface ShellExecResult {
 
 const DEFAULT_TIMEOUT = 30_000;
 
+export interface LocalShellInvocation {
+  executable: string;
+  args: string[];
+  detached: boolean;
+}
+
+const WINDOWS_SHELL_COMMAND = /^\s*(?:powershell(?:\.exe)?|pwsh(?:\.exe)?)\b/iu;
+
+/** Build a host-shell invocation without interpolating into another shell. */
+export function buildLocalShellInvocation(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): LocalShellInvocation {
+  if (platform !== 'win32') {
+    return { executable: 'bash', args: ['-lc', command], detached: true };
+  }
+  // An explicit nested PowerShell command must not pass through an outer
+  // PowerShell parser, which would expand `$env:*` before the child sees it.
+  if (WINDOWS_SHELL_COMMAND.test(command)) {
+    return { executable: 'cmd.exe', args: ['/d', '/s', '/c', command], detached: false };
+  }
+  // EncodedCommand preserves quotes, Unicode, backticks, semicolons, and
+  // literal dollar signs across the native process boundary.
+  const encoded = Buffer.from(command, 'utf16le').toString('base64');
+  return {
+    executable: 'powershell.exe',
+    args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+    detached: false,
+  };
+}
+
 export interface LocalBackendCallbacks {
   log?: (level: 'info' | 'warn' | 'error', msg: string) => void;
   /** Turn-scoped abort signal. On abort the child's whole process TREE is
@@ -100,15 +131,16 @@ export async function localBackendExecute(
       reportMissingContext('subprocess', 'shellExec');
       baseEnv = process.env;
     }
+    const invocation = buildLocalShellInvocation(command);
     const child = isWin
-      ? spawn('powershell.exe', ['-NoProfile', '-Command', command], {
+      ? spawn(invocation.executable, invocation.args, {
           cwd: args.cwd,
           env: { ...baseEnv, ...(args.env ?? {}) },
         })
       // POSIX: `detached` makes the child its own process-group leader so
       // killProcessTree can reap the GROUP (`kill(-pid)`). Windows uses
       // `taskkill /t` and needs no group. Not unref'd — we still await it.
-      : spawn('bash', ['-lc', command], {
+      : spawn(invocation.executable, invocation.args, {
           cwd: args.cwd,
           env: { ...baseEnv, ...(args.env ?? {}) },
           detached: true,

--- a/tools/v4/browser/browserScreenshot.ts
+++ b/tools/v4/browser/browserScreenshot.ts
@@ -12,10 +12,7 @@
  * context across all browser tools — no fresh browser is launched
  * per call. The screenshot file lives under `workspace/screenshots/`.
  *
- * Read-only because no DOM is mutated, even though the underlying
- * browser process is long-lived. The navigation tools (browserNavigate/
- * Click/Fill/Type/Scroll) DO mutate observable state and are gated by the
- * approval engine; this screenshot is not.
+ * Capturing does not mutate the page, but it does persist an artifact.
  *
  * Status: PHASE 7. Read-only.
  */
@@ -35,9 +32,16 @@ const _browserScreenshotTool: ToolHandler = {
     },
   },
   category: 'browser',
-  mutates: false,
+  mutates: true,
   toolset: 'browser',
   riskTier: 'safe',   // v4.4 Phase 1
+  buildPreview() {
+    return {
+      tool: 'browser_screenshot', args: {}, riskTier: 'safe',
+      sideEffects: [{ type: 'create_file', path: 'workspace/screenshots/<timestamp>.png', bytes: 0 }],
+      detectedRisks: [], summary: 'Would capture the current page to a workspace screenshot artifact.',
+    };
+  },
   async execute() {
     const r = await pwScreenshot();
     if (r.ok) return { success: true, path: r.path };

--- a/tools/v4/effectContracts.ts
+++ b/tools/v4/effectContracts.ts
@@ -3,6 +3,9 @@
  * Licensed under AGPL-3.0. See LICENSE for details.
  */
 
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+
 import type { ToolEffectContract } from '../../core/v4/effectContract';
 import type { ToolHandler } from '../../core/v4/toolRegistry';
 
@@ -32,6 +35,16 @@ const FILE_WRITE = contract({
   reconciliationSupported: true, verificationSupported: true,
   approvalRequirement: 'policy', sensitiveFields: ['content', 'patch'],
   redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['path'],
+  reconciliationData(args, cwd) {
+    const path = typeof args.path === 'string' ? resolve(cwd, args.path) : null;
+    const content = typeof args.content === 'string' ? args.content : null;
+    if (!path || content === null) return null;
+    return {
+      path,
+      expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+      expectedSize: Buffer.byteLength(content),
+    };
+  },
 });
 const FILE_MOVE = contract({
   classification: 'reconcilable_mutation', kind: 'filesystem.move',

--- a/tools/v4/effectContracts.ts
+++ b/tools/v4/effectContracts.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { ToolEffectContract } from '../../core/v4/effectContract';
+import type { ToolHandler } from '../../core/v4/toolRegistry';
+
+type ContractOptions = Omit<ToolEffectContract, 'target'> & {
+  targetFields?: readonly string[];
+  targetLabel?: string;
+};
+
+function contract(options: ContractOptions): ToolEffectContract {
+  const { targetFields = [], targetLabel, ...metadata } = options;
+  return Object.freeze({
+    ...metadata,
+    target(args) {
+      const values = targetFields
+        .map((field) => args[field])
+        .filter((value): value is string | number => typeof value === 'string' || typeof value === 'number')
+        .map(String);
+      if (values.length === 0) return targetLabel ?? null;
+      return targetLabel ? `${targetLabel}:${values.join(' -> ')}` : values.join(' -> ');
+    },
+  });
+}
+
+const FILE_WRITE = contract({
+  classification: 'reconcilable_mutation', kind: 'filesystem.write',
+  retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: ['content', 'patch'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['path'],
+});
+const FILE_MOVE = contract({
+  classification: 'reconcilable_mutation', kind: 'filesystem.move',
+  retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: [], redactionRules: ['digest_arguments'],
+  targetFields: ['source', 'destination'],
+});
+const FILE_DELETE = contract({
+  classification: 'reconcilable_mutation', kind: 'filesystem.delete',
+  retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: [], redactionRules: ['digest_arguments'],
+  targetFields: ['path'],
+});
+const ARTIFACT_WRITE = contract({
+  classification: 'idempotent_mutation', kind: 'artifact.capture',
+  retrySafety: 'same_idempotency_key', idempotencySupported: true,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'none', sensitiveFields: [], redactionRules: ['digest_arguments'],
+  targetLabel: 'runtime-artifact',
+});
+const LOCAL_PROCESS = contract({
+  classification: 'unsafe_mutation', kind: 'process.command',
+  retrySafety: 'never_automatic', idempotencySupported: false,
+  reconciliationSupported: false, verificationSupported: false,
+  approvalRequirement: 'policy', sensitiveFields: ['command', 'code', 'args', 'env'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetLabel: 'local-runtime',
+});
+const PROCESS_CONTROL = contract({
+  classification: 'reconcilable_mutation', kind: 'process.control',
+  retrySafety: 'reconcile_before_retry', idempotencySupported: false,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: ['args', 'env'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['pid'],
+});
+const BROWSER_ACTION = contract({
+  classification: 'unsafe_mutation', kind: 'browser.action',
+  retrySafety: 'never_automatic', idempotencySupported: false,
+  reconciliationSupported: false, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: ['text', 'value', 'values', 'files'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['selector', 'ref', 'url'],
+});
+const INTERNAL_STATE = contract({
+  classification: 'idempotent_mutation', kind: 'aiden.state',
+  retrySafety: 'same_idempotency_key', idempotencySupported: true,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: ['content', 'value'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['name', 'id'],
+});
+const SYSTEM_CONTROL = contract({
+  classification: 'unsafe_mutation', kind: 'system.control',
+  retrySafety: 'never_automatic', idempotencySupported: false,
+  reconciliationSupported: false, verificationSupported: false,
+  approvalRequirement: 'policy', sensitiveFields: ['text', 'keys'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['app', 'name'],
+});
+const PACKAGE_INSTALL = contract({
+  classification: 'unsafe_mutation', kind: 'package.install',
+  retrySafety: 'never_automatic', idempotencySupported: false,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'always', sensitiveFields: [], redactionRules: ['digest_arguments'],
+  targetLabel: 'runtime-package',
+});
+
+const CONTRACTS: Readonly<Record<string, ToolEffectContract>> = Object.freeze({
+  file_write: FILE_WRITE,
+  file_patch: FILE_WRITE,
+  file_delete: FILE_DELETE,
+  file_move: FILE_MOVE,
+  file_copy: { ...FILE_MOVE, kind: 'filesystem.copy' },
+  browser_screenshot: ARTIFACT_WRITE,
+  screenshot: ARTIFACT_WRITE,
+  open_url: { ...SYSTEM_CONTROL, kind: 'system.external_launch', target: (args) => typeof args.url === 'string' ? args.url : null },
+  shell_exec: LOCAL_PROCESS,
+  execute_code: LOCAL_PROCESS,
+  process_spawn: PROCESS_CONTROL,
+  process_kill: PROCESS_CONTROL,
+  browser_navigate: BROWSER_ACTION,
+  browser_click: BROWSER_ACTION,
+  browser_type: BROWSER_ACTION,
+  browser_fill: BROWSER_ACTION,
+  browser_scroll: BROWSER_ACTION,
+  browser_close: BROWSER_ACTION,
+  browser_dialog: BROWSER_ACTION,
+  browser_upload: BROWSER_ACTION,
+  memory_add: INTERNAL_STATE,
+  memory_replace: INTERNAL_STATE,
+  memory_remove: INTERNAL_STATE,
+  session_summary: INTERNAL_STATE,
+  skill_manage: INTERNAL_STATE,
+  aiden_self_update: PACKAGE_INSTALL,
+  media_key: SYSTEM_CONTROL,
+  volume_set: SYSTEM_CONTROL,
+  app_launch: SYSTEM_CONTROL,
+  app_close: SYSTEM_CONTROL,
+  clipboard_write: SYSTEM_CONTROL,
+  media_transport: SYSTEM_CONTROL,
+  app_input: SYSTEM_CONTROL,
+});
+
+export function withBuiltInEffectContract(handler: ToolHandler): ToolHandler {
+  if (handler.mutates === false) return handler;
+  const effectContract = CONTRACTS[handler.schema.name];
+  if (!effectContract) {
+    throw new Error(`Built-in mutating tool ${handler.schema.name} has no durable effect contract`);
+  }
+  return { ...handler, effectContract };
+}

--- a/tools/v4/effectContracts.ts
+++ b/tools/v4/effectContracts.ts
@@ -4,9 +4,9 @@
  */
 
 import { createHash } from 'node:crypto';
-import { resolve } from 'node:path';
 
 import type { ToolEffectContract } from '../../core/v4/effectContract';
+import { resolvePortablePath } from '../../core/v4/portablePath';
 import type { ToolHandler } from '../../core/v4/toolRegistry';
 
 type ContractOptions = Omit<ToolEffectContract, 'target'> & {
@@ -36,7 +36,7 @@ const FILE_WRITE = contract({
   approvalRequirement: 'policy', sensitiveFields: ['content', 'patch'],
   redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['path'],
   reconciliationData(args, cwd) {
-    const path = typeof args.path === 'string' ? resolve(cwd, args.path) : null;
+    const path = typeof args.path === 'string' ? resolvePortablePath(cwd, args.path) : null;
     const content = typeof args.content === 'string' ? args.content : null;
     if (!path || content === null) return null;
     return {

--- a/tools/v4/executeCode.ts
+++ b/tools/v4/executeCode.ts
@@ -73,9 +73,19 @@ export const executeCodeTool: ToolHandler = {
     },
   },
   category: 'execute',
-  mutates: false,
+  mutates: true,
   toolset: 'execute',
   riskTier: 'caution',   // v4.4 Phase 1
+  buildPreview(args) {
+    return {
+      tool: 'execute_code',
+      args: { code: '[redacted]', timeoutMs: args.timeoutMs },
+      riskTier: 'caution',
+      sideEffects: [{ type: 'shell_command', command: '[python code]', cwd: process.cwd(), backend: 'local' }],
+      detectedRisks: ['Code can change local state or access the network.'],
+      summary: 'Would execute the supplied code in a local Python process.',
+    };
+  },
   async execute(args) {
     const code = String(args.code ?? '');
     if (!code.trim()) {

--- a/tools/v4/index.ts
+++ b/tools/v4/index.ts
@@ -22,6 +22,7 @@
 
 import type { ToolHandler, ToolRegistry } from '../../core/v4/toolRegistry';
 import { withDryRun } from '../../core/v4/dryRun';
+import { withBuiltInEffectContract } from './effectContracts';
 
 import { webSearchTool } from './web/webSearch';
 import { webFetchTool } from './web/webFetch';
@@ -131,7 +132,6 @@ export function registerReadOnlyTools(registry: ToolRegistry): void {
   register(deepResearchTool);
   // Phase 16f: open_url uses shell launch (start chrome / open / xdg-open)
   // for "open X in browser" requests — bypasses Playwright detection.
-  register(openUrlTool);
   // Phase 23.4a: youtube_search returns real /watch?v= URLs scraped
   // from youtube.com/results. media-search uses it before open_url so
   // the URL provenance gate has a candidate set to validate against —
@@ -142,7 +142,6 @@ export function registerReadOnlyTools(registry: ToolRegistry): void {
   register(fileReadTool);
   register(fileListTool);
 
-  register(browserScreenshotTool);
   register(browserSnapshotTool);
   register(browserSeeTool);
   register(browserExtractTool);
@@ -166,7 +165,6 @@ export function registerReadOnlyTools(registry: ToolRegistry): void {
   register(toolResultArtifactReadTool);
 
   // Phase v4.1.2-followup-3 — computer-control read-only tools.
-  register(screenshotTool);
   register(osProcessListTool);
   register(clipboardReadTool);
   // v4.1.4-media — GSMTC session enumeration (read). Pair with
@@ -257,7 +255,7 @@ export function registerWriteTools(registry: ToolRegistry): void {
   // Write tools are where the preview path is actually hot — when
   // AIDEN_DRYRUN=1, each handler's `buildPreview` is called instead
   // of `execute`.
-  const register = (h: ToolHandler): void => registry.register(withDryRun(h));
+  const register = (h: ToolHandler): void => registry.register(withDryRun(withBuiltInEffectContract(h)));
   register(fileWriteTool);
   register(filePatchTool);
   register(fileDeleteTool);
@@ -266,6 +264,9 @@ export function registerWriteTools(registry: ToolRegistry): void {
   register(planApprovalTool);
   register(fileMoveTool);
   register(fileCopyTool);
+  register(browserScreenshotTool);
+  register(screenshotTool);
+  register(openUrlTool);
 
   register(shellExecTool);
 

--- a/tools/v4/system/screenshot.ts
+++ b/tools/v4/system/screenshot.ts
@@ -61,9 +61,17 @@ export const screenshotTool: ToolHandler = {
     },
   },
   category: 'read',
-  mutates: false,
+  mutates: true,
   toolset: 'system',
   riskTier: 'safe',   // v4.4 Phase 1
+  buildPreview(_args, ctx) {
+    return {
+      tool: 'screenshot', args: {}, riskTier: 'safe',
+      sideEffects: [{ type: 'create_file', path: path.join(ctx.paths.root, 'screenshots', '<timestamp>.png'), bytes: 0 }],
+      detectedRisks: ['The captured image may contain private on-screen information.'],
+      summary: 'Would capture the primary display to a local screenshot artifact.',
+    };
+  },
   async execute(_args, ctx) {
     if (!isWindows()) return windowsOnlyError('screenshot');
     if (!ctx.paths) {

--- a/tools/v4/web/openUrl.ts
+++ b/tools/v4/web/openUrl.ts
@@ -77,9 +77,20 @@ export const openUrlTool: ToolHandler = {
     },
   },
   category: 'network',
-  mutates: false,
+  mutates: true,
   toolset: 'web',
   riskTier: 'safe',   // v4.4 Phase 1
+  buildPreview(args) {
+    const url = typeof args.url === 'string' ? args.url : '';
+    return {
+      tool: 'open_url',
+      args: { url },
+      riskTier: 'safe',
+      sideEffects: [{ type: 'app_control', action: 'open_url', target: url }],
+      detectedRisks: [],
+      summary: `Would open ${url || 'the requested URL'} in the default browser.`,
+    };
+  },
   async execute(args) {
     const url = String(args.url ?? '').trim();
     if (!isLaunchableUrl(url)) {


### PR DESCRIPTION
## Summary

- establishes one canonical durable lifecycle authority across production entry points;
- preserves Job and Attempt fencing, leases, cancellation ordering, and terminal-state protection;
- adds durable effect reconciliation, execution graphs, waits, exact approvals, child supervision, budgets, proof, verdicts, and replayable projections;
- verifies successful file mutations through fresh, exact readback linked to the authoritative Effect;
- preserves append-only reconciliation order when records share a timestamp;
- preserves queued input across finalization and restart boundaries and displays durable input identities;
- preserves Windows shell source exactly across nested environment lookup and quoting;
- aligns settled activity labels, separator ownership, Markdown spacing, startup notices, and shutdown ordering;
- adds migration, failure-injection, performance, compatibility, and packaged-runtime coverage.

## Compatibility

- package version remains 4.16.1;
- existing Job, Attempt, event, approval, and public API identities remain compatible;
- terminal and Workbench surfaces remain projections over durable runtime state;
- no task-graph scheduler, distributed worker system, or TUI redesign is included.

## Validation

- Typecheck passed
- Production build passed
- Deterministic Node 22 suite: 6,958 passed, 39 skipped
- Integration suite: 43 passed, 9 skipped
- Focused lifecycle, proof, terminal, queue, approval, shutdown, migration, reconciliation, and failure-injection matrices passed
- Windows PTY suite: 27 passed
- Packaged global install and fresh package-runner version/help passed
- Packaged interactive response, file-read, `/usage`, `/queue`, and ordered `/quit` flow passed
- Diff, NUL, secret, attribution, package-content, temporary-data, and Aiden-process cleanup checks passed
- CI run 30247448706 passed on Windows, macOS, and Ubuntu with Node 20 and Node 22
- Build, typecheck, security, CodeQL, CLA, and labeling checks passed

## Physical Windows acceptance

Physical Windows acceptance completed successfully in Windows Terminal.

Validated:
- `/cls` hides the previous transcript;
- old rows do not reappear after later commands;
- conversation context remains available after clearing;
- `/activity` remains functional;
- `/quit` returns cleanly to PowerShell;
- session distillation and summary are written;
- no visible interactive Aiden process remains.

The remaining blank terminal region after `/cls` is recorded as non-blocking P2 visual polish. It does not indicate data loss, state corruption, process leakage, or broken normal operation.