### PR TITLE
feat(tui): add durable operator interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: ${{ matrix.os }} · Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -67,6 +67,7 @@ export class ActivityRegistry {
       name: string,
       args: unknown,
       read: () => ActivitySnapshot,
+      id: string,
     ) => ToolRowHandle,
     private readonly now: () => number = Date.now,
     private readonly createTurnRow?: (verb: string) => LiveActivityRowHandle,
@@ -117,7 +118,7 @@ export class ActivityRegistry {
       handle: undefined as unknown as ToolRowHandle,
     };
     this.entries.set(id, entry);
-    entry.handle = this.createRow(name, args, () => this.snapshot(id));
+    entry.handle = this.createRow(name, args, () => this.snapshot(id), id);
     entry.state = 'running';
     if (this.modalDepth > 0) entry.handle.pause();
     this.ensureTicker();

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -4101,6 +4101,8 @@ export async function runQuery(
   });
 }
 
+let interactiveSessionCompleted = false;
+
 async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void> {
   const runtime = await buildAgentRuntime(cliOpts, opts);
   const resumedActiveState = runtime.resumeSessionId
@@ -4211,15 +4213,22 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
     replArtifactStore: runtime.replArtifactStore,
   };
 
-  if (cliOpts.tui) {
-    await runTuiMode({
-      sessionOpts: sessionOpts as any,
-      skinName:
-        runtime.config.getValue<string>('display.skin', 'default') ?? 'default',
-    });
-  } else {
-    const session = new ChatSession(sessionOpts as any);
-    await session.run();
+  try {
+    if (cliOpts.tui) {
+      await runTuiMode({
+        sessionOpts: sessionOpts as any,
+        skinName:
+          runtime.config.getValue<string>('display.skin', 'default') ?? 'default',
+      });
+    } else {
+      const session = new ChatSession(sessionOpts as any);
+      await session.run();
+    }
+  } finally {
+    // Terminal ownership ends with the interactive session, before service
+    // teardown. This prevents a referenced Windows console reader from keeping
+    // the process alive while a resource-free cleanup promise is still pending.
+    releaseInteractiveStdin();
   }
   if (runtime.mcpClient) {
     await runtime.mcpClient.closeAll().catch(() => undefined);
@@ -4232,6 +4241,31 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
   // and never throws.
   await runtime.channelManager.stopAll().catch(() => undefined);
   runtime.store.close?.();
+  releaseInteractiveOutput();
+  interactiveSessionCompleted = true;
+}
+
+/**
+ * The interactive session is finished and no later owner may consume terminal
+ * input. Pausing restores cooked input state; unreferencing the TTY reader lets
+ * the host shell resume even when Windows keeps the console reader allocated.
+ */
+export function releaseInteractiveStdin(
+  stdin: NodeJS.ReadStream = process.stdin,
+): void {
+  try { stdin.pause(); } catch { /* shutdown is already committed */ }
+  try { stdin.unref(); } catch { /* not every injected stream owns a native handle */ }
+}
+
+/** Release Windows TTY output references after every cleanup and final write. */
+export function releaseInteractiveOutput(
+  stdout: NodeJS.WriteStream = process.stdout,
+  stderr: NodeJS.WriteStream = process.stderr,
+): void {
+  try { stdout.unref(); } catch { /* redirected streams may not own a TTY handle */ }
+  if (stderr !== stdout) {
+    try { stderr.unref(); } catch { /* redirected streams may not own a TTY handle */ }
+  }
 }
 
 // ─── setup ─────────────────────────────────────────────────────────────
@@ -4452,6 +4486,10 @@ async function runSkillsSubcommand(
 if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   main(process.argv).then((code) => {
+    // Interactive shutdown has already released terminal ownership and awaited
+    // every service/store cleanup. Exit explicitly because Node 20 can retain a
+    // completed ConPTY process even after all TTY handles are unreferenced.
+    if (interactiveSessionCompleted) process.exit(code);
     process.exitCode = code;
   });
 }

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -35,6 +35,7 @@ import { ChatSession } from './chatSession';
 import { runTuiMode } from './aidenTUI';
 import { Display } from './display';
 import { SkinEngine } from './skinEngine';
+import { initializeEffectiveTheme } from './themeCompatibility';
 import { CommandRegistry } from './commandRegistry';
 import { CliCallbacks } from './callbacks';
 // Tier-3.1 (v4.1-tier3.1) — re-export the build fingerprint so the
@@ -1567,6 +1568,15 @@ export async function buildAgentRuntime(
   }
 
   const skin = new SkinEngine();
+  const effectiveTheme = initializeEffectiveTheme(
+    paths.root,
+    config.getValue<string>('display.skin', 'default'),
+    skin,
+  );
+  if (effectiveTheme.source === 'legacy-migration' && effectiveTheme.persisted) {
+    config.set('display.skin', 'default');
+    await config.save().catch(() => undefined);
+  }
   // Headless one-shot: route ALL display output to stderr so stdout carries
   // only the agent's answer (pipeable). Nothing streams to `display` during a
   // headless turn (runConversation is called bare), but any boot-time notice

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -77,6 +77,8 @@ export interface AidenPromptConfig {
   fixedComposer?: {
     update: (value: string, hint: string, cursorIndex: number) => void;
     ready?: () => void;
+    scroll?: (deltaRows: number) => void;
+    follow?: () => void;
   };
 }
 
@@ -228,6 +230,10 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
       sequenceLength: (key as typeof key & { sequence?: string }).sequence?.length ?? 0,
       lineLength: rl.line.length,
     });
+
+    if (key.name === 'pageup') { config.fixedComposer?.scroll?.(8); return; }
+    if (key.name === 'pagedown') { config.fixedComposer?.scroll?.(-8); return; }
+    if (key.ctrl && key.name === 'end') { config.fixedComposer?.follow?.(); return; }
 
     // ── Submit ──
     if (isEnterKey(key)) {

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -79,6 +79,7 @@ export interface PromptApi {
   select(opts: {
     message: string;
     choices: { name: string; value: string }[];
+    default?: string;
   }, context?: { input?: ModalStdin }): Promise<string>;
   confirm(opts: { message: string; default?: boolean }, context?: { input?: ModalStdin }): Promise<boolean>;
   /** v4.11 — free-text line input (for the clarify tool's open answers). */
@@ -150,6 +151,12 @@ function decisionChoicesFor(req: ApprovalRequest): { name: string; value: Approv
   }
   choices.push({ name: 'Deny', value: 'deny' });
   return choices;
+}
+
+function defaultDecisionFor(req: ApprovalRequest): ApprovalDecision {
+  return req.riskTier === 'safe' && req.effects?.irreversible !== true
+    ? 'allow'
+    : 'deny';
 }
 
 const KNOWN_TIERS: ReadonlySet<RiskTier> = new Set(['safe', 'caution', 'dangerous']);
@@ -294,7 +301,10 @@ export class CliCallbacks {
     this.skillTeacher = opts.skillTeacher;
     this.resolveToolInteraction = opts.resolveToolInteraction;
     this.activities = new ActivityRegistry(
-      (name, args, read) => this.display.toolRow(name, args, read, { externalTicker: true }),
+      (name, args, read, id) => this.display.toolRow(name, args, read, {
+        externalTicker: true,
+        activityId: id,
+      }),
       Date.now,
       (verb) => this.display.liveActivityRow(verb),
     );
@@ -592,7 +602,15 @@ export class CliCallbacks {
       choice = await prompts.select({
         message: 'Decision',
         choices: decisionChoicesFor(req),
+        default: defaultDecisionFor(req),
       }, stdin ? { input: stdin } : undefined);
+
+      if (choice !== 'deny' && req.effects?.irreversible === true) {
+        const confirmation = await prompts.input({
+          message: 'Type ALLOW to confirm this irreversible action',
+        }, stdin ? { input: stdin } : undefined);
+        if (confirmation !== 'ALLOW') return 'deny';
+      }
     } catch {
       // The prompt was interrupted (Ctrl+C / the turn ended) before the user
       // answered. Fail closed — the tool does NOT run — but report it as an

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -937,19 +937,13 @@ function badgeForTier(tier?: RiskTier): string {
 
 // ─── Phase 22 Task 5B — boxed approval prompt ─────────────────────────
 
-// Args limit kept under the visible content width (BOX_WIDTH minus the
-// 1-char gutter on each side and the ` Args: ` label) so the explicit
-// ellipsis we append surfaces inside the box. Setting this above the
-// visible budget would let `boxLine`'s hard truncation eat the ellipsis
-// and the user wouldn't see they were viewing a partial value.
-
 /**
  * Render an approval request with the Aiden-native framed-panel chrome
  * (Slice 6) — orange left bar, no closing corners, footer hint always
  * present. Token-sourced from cli/v4/design/tokens.ts. Returns the
- * multi-line string; caller writes it. Args are truncated to
- * APPROVAL_ARGS_LIMIT chars for display only; the full args stay with
- * the tool call. Colour discipline: brand (bar + title + key glyphs),
+ * multi-line string; caller writes it. The default view shows bounded,
+ * redacted decision facts while the full arguments stay with the tool
+ * call. Colour discipline: brand (bar + title + key glyphs),
  * tier-semantic (badge), muted (everything else) — ≤3 distinct colours.
  */
 export function renderApprovalBox(req: ApprovalRequest, display: Display): string {
@@ -971,24 +965,23 @@ export function renderApprovalBox(req: ApprovalRequest, display: Display): strin
   const line = (content: string): string => `${prefix}${truncateVisible(content, contentWidth)}`;
   const divider = display.muted(glyphs.chrome.hLine.repeat(contentWidth));
 
-  let argsPreview = '';
-  try { argsPreview = JSON.stringify(req.args); }
-  catch { argsPreview = String(req.args); }
-  const argsValueWidth = Math.max(1, contentWidth - (columns >= 48 ? 12 : 5));
-  if (argsPreview.length > argsValueWidth) {
-    argsPreview = truncateApproval(argsPreview, argsValueWidth);
-  }
-
   // Key-value rows. Key column padded to 12 cells for vertical alignment.
   const KEY_W = columns >= 48 ? 12 : 5;
   const kv = (k: string, v: string): string =>
     `${display.muted(k.padEnd(KEY_W))}${v}`;
 
   const lines: string[] = [
-    line(kv('tool', req.toolName)),
+    line(kv('action', req.toolName)),
   ];
+  const target = [req.args.path, req.args.file, req.args.target, req.args.url]
+    .find((value): value is string => typeof value === 'string' && value.trim().length > 0);
+  const cwd = typeof req.args.cwd === 'string' && req.args.cwd.trim() ? req.args.cwd : null;
+  if (target) lines.push(line(kv('target', truncateApproval(redactApprovalTarget(target), Math.max(1, contentWidth - KEY_W)))));
+  if (cwd) lines.push(line(kv('cwd', truncateApproval(cwd, Math.max(1, contentWidth - KEY_W)))));
+  lines.push(line(kv('risk', req.riskTier ?? 'unclassified')));
+  lines.push(line(kv('reversible', req.effects?.irreversible === true ? 'no' : req.effects ? 'yes' : 'unknown')));
+  lines.push(line(kv('network', req.effects?.network ? 'external' : req.effects ? 'none declared' : 'unknown')));
   if (req.reason) lines.push(line(kv('reason', req.reason)));
-  lines.push(line(kv('args', argsPreview)));
   // v4.10 Slice 10.6 — surface fine-grained effects when the tool
   // declared them. Renders as a comma-separated list of flag names
   // (only the truthy ones). Tools without effects keep the pre-10.6
@@ -1002,7 +995,7 @@ export function renderApprovalBox(req: ApprovalRequest, display: Display): strin
     if (e.externalSpend) flags.push('external-spend');
     if (e.irreversible)  flags.push('irreversible');
     if (flags.length > 0) {
-      lines.push(line(kv('effects', flags.join(', '))));
+      lines.push(line(kv('effect', flags.join(', '))));
     }
   }
   lines.push(line(divider));
@@ -1014,6 +1007,22 @@ export function renderApprovalBox(req: ApprovalRequest, display: Display): strin
   // newline, so producing '\n<panel>\n' yields one blank above + one
   // blank below once the caller's own '\n' lands.
   return '\n' + lines.join('\n') + '\n';
+}
+
+function redactApprovalTarget(value: string): string {
+  if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(value)) {
+    try {
+      const parsed = new URL(value);
+      parsed.username = '';
+      parsed.password = '';
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString();
+    } catch { /* fall through to plain-value redaction */ }
+  }
+  return value
+    .replace(/(?:bearer\s+)[^\s]+/giu, 'Bearer [redacted]')
+    .replace(/\b(?:gsk_|sk-)[A-Za-z0-9_-]+\b/gu, '[redacted]');
 }
 
 function truncateApproval(value: string, width: number): string {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -1144,7 +1144,8 @@ export class ChatSession implements ChatSessionLike {
     let frameModeOn = false;
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      frameModeOn = (require('./frame') as typeof import('./frame')).isFrameModeRequested();
+      const frame = require('./frame') as typeof import('./frame');
+      frameModeOn = frame.shouldUseFrameComposer(undefined, this.usesFixedBottomRegion());
     } catch { /* frame module unavailable → treat as legacy */ }
     const pasteBootAction = decidePasteBootAction({
       isTty:        !!stdout?.isTTY,
@@ -1890,8 +1891,8 @@ export class ChatSession implements ChatSessionLike {
     // block below regardless of how the turn ended.
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { isFrameModeRequested, pauseFrame } = require('./frame') as typeof import('./frame');
-      if (isFrameModeRequested()) await pauseFrame();
+      const { shouldUseFrameComposer, pauseFrame } = require('./frame') as typeof import('./frame');
+      if (shouldUseFrameComposer(undefined, this.usesFixedBottomRegion())) await pauseFrame();
     } catch { /* frame module is best-effort; never break a turn */ }
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -3465,8 +3466,8 @@ export class ChatSession implements ChatSessionLike {
       // turn ended (success, error, throw).
       try {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { isFrameModeRequested, resumeFrame } = require('./frame') as typeof import('./frame');
-        if (isFrameModeRequested()) await resumeFrame();
+        const { shouldUseFrameComposer, resumeFrame } = require('./frame') as typeof import('./frame');
+        if (shouldUseFrameComposer(undefined, this.usesFixedBottomRegion())) await resumeFrame();
       } catch { /* never break a turn on frame cleanup */ }
       turnIdleDiagnostic('turn.finally.complete', {
         turnId,
@@ -4265,7 +4266,9 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
   // legacy aidenPrompt path is untouched and stays the default.
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const frameMod = require('./frame') as typeof import('./frame');
-  const frameModeOn = frameMod.isFrameModeRequested();
+  const fixedBottomRegion = typeof opts.display?.fixedBottomRegionEnabled === 'function'
+    && opts.display.fixedBottomRegionEnabled();
+  const frameModeOn = frameMod.shouldUseFrameComposer(undefined, fixedBottomRegion);
 
   return {
     async readLine(prompt, readOpts) {
@@ -4296,8 +4299,6 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
           }
           return value ?? '';
         }
-        const fixedBottomRegion = typeof opts.display?.fixedBottomRegionEnabled === 'function'
-          && opts.display.fixedBottomRegionEnabled();
         const promptOutput = fixedBottomRegion
           ? new Writable({
               write(_chunk, _encoding, done) {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -3514,7 +3514,7 @@ export class ChatSession implements ChatSessionLike {
     const tier = resolveStartupDashboardTier(columns);
     const version = AIDEN_VERSION;
     const startupTrust = this.opts.approvalEngine?.getAutonomyPolicy?.()?.level ?? 'Assistant';
-    const includeDetails = tier === 'wide' || tier === 'medium';
+    const includeDetails = tier !== 'minimal';
     const toolsCount = includeDetails ? this.opts.toolRegistry.list().length : undefined;
     let skillsLoaded: number | undefined;
     if (includeDetails) {
@@ -3533,6 +3533,7 @@ export class ChatSession implements ChatSessionLike {
         muted: (value) => display.muted(value),
         text: (value) => display.applyColors(value, 'agent'),
         success: (value) => display.success_(value),
+        info: (value) => display.applyColors(value, 'accent'),
       },
       data: {
         trust: startupTrust,
@@ -3564,7 +3565,14 @@ export class ChatSession implements ChatSessionLike {
       },
     });
     const notices = prepareStartupNotices(this.opts.startupNotices ?? [], this.opts.commandRegistry);
-    const noticeLines = renderStartupNoticeLines(notices, { columns });
+    const noticeLines = renderStartupNoticeLines(notices, {
+      columns,
+      style: {
+        warning: (value) => display.applyColors(value, 'warn'),
+        text: (value) => display.applyColors(value, 'agent'),
+        command: (value) => display.applyColors(value, 'accent'),
+      },
+    });
     if (noticeLines.length > 0) {
       display.write(`\n${noticeLines.join('\n')}\n`);
     }
@@ -3636,7 +3644,11 @@ export class ChatSession implements ChatSessionLike {
         // which fires the mutation listener → the name reaches the prompt.
         onboarded = await renderOnboardingIntro({
           paths:  this.opts.paths,
-          out:    process.stdout,
+          write:  (text) => { this.opts.display.write(text); },
+          style: {
+            accent: (text) => this.opts.display.applyColors(text, 'accent'),
+            muted: (text) => this.opts.display.applyColors(text, 'muted'),
+          },
           memory: this.opts.memoryManager,
         });
         if (!onboarded) {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -1320,7 +1320,7 @@ export class ChatSession implements ChatSessionLike {
           // separator; acquiring another composer never adds one.
           if (typeof result.rerun === 'string' && result.rerun.length > 0) {
             await this.runAgentTurn(result.rerun);
-          } else {
+          } else if (!result.suppressSeparator) {
             this.opts.display.printTurnSeparator();
           }
           // Phase 23.6 — v3 doesn't print a status footer after slash
@@ -2898,6 +2898,7 @@ export class ChatSession implements ChatSessionLike {
           {
             finishReason:   result.finishReason,
             toolCallTrace:  result.toolCallTrace,
+            assistantContent: result.finalContent,
             declaredStatus,
           },
           {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -574,6 +574,17 @@ export function bootSourceLabel(
 }
 
 export class ChatSession implements ChatSessionLike {
+  private readonly projectedWarnings = new Set<string>();
+
+  private reportRuntimeWarning(component: string, error: unknown): void {
+    turnIdleDiagnostic('runtime.warning', {
+      component,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    if (this.projectedWarnings.has(component)) return;
+    this.projectedWarnings.add(component);
+    this.opts.display.warn(`Runtime persistence warning · ${component}. Durable details remain available through /trace.`);
+  }
   private updateExitRequested = false;
   history: Message[] = [];
   private sessionId: string | null = null;
@@ -790,6 +801,45 @@ export class ChatSession implements ChatSessionLike {
     // resurrecting pre-clear turns via /undo would be surprising.
     this.undoStack = [];
   }
+  startNewSession(): string | null {
+    this.clearHistory();
+    try {
+      const session = this.opts.sessionManager.startSession({
+        providerId: this.currentProviderId,
+        modelId: this.currentModelId,
+      });
+      this.sessionId = session.id;
+      this.totalUsage = { inputTokens: 0, outputTokens: 0 };
+      this.compressionCount = 0;
+      if (this.opts.replParentRunRef) {
+        this.opts.replParentRunRef.sessionId = null;
+        this.opts.replParentRunRef.chatSessionId = session.id;
+      }
+      this.opts.sessionManager.persistActiveState(session.id, {
+        messages: [],
+        compressionCount: 0,
+        cumulativeUsage: { inputTokens: 0, outputTokens: 0 },
+        budgetState: this.budgetState,
+      });
+      return session.id;
+    } catch {
+      return null;
+    }
+  }
+  deleteStoredSession(idOrTitle?: string): { deletedId: string; replacementId: string | null } | null {
+    const target = idOrTitle
+      ? this.opts.sessionManager.resumeById(idOrTitle)
+      : this.sessionId ? this.opts.sessionManager.resumeById(this.sessionId) : null;
+    if (!target) return null;
+
+    let replacementId: string | null = null;
+    if (target.id === this.sessionId) {
+      replacementId = this.startNewSession();
+      if (!replacementId) return null;
+    }
+    if (!this.opts.sessionManager.deleteSession(target.id)) return null;
+    return { deletedId: target.id, replacementId };
+  }
   /**
    * v4.11 Slice B — restore the history captured before the most recent
    * turn (in-memory only). Returns false when there's nothing to undo.
@@ -896,6 +946,15 @@ export class ChatSession implements ChatSessionLike {
         if (record.kind !== 'message' || record.content === null) continue;
         this.duringTurnInput.enqueue(record.content);
         this.durableQueueInputIds.push(record.inputId);
+      }
+    }
+    if (this.opts.jobEngine && typeof this.opts.jobEngine.listJobs === 'function') {
+      const activeStates = new Set(['queued', 'running', 'waiting', 'paused', 'cancelling', 'unknown', 'crashed', 'recovering']);
+      for (const job of this.opts.jobEngine.listJobs({ sessionId: this.sessionId, limit: 100 })) {
+        if (!activeStates.has(job.status)) continue;
+        const attempt = job.activeAttemptId ? this.opts.jobEngine.getAttempt(job.activeAttemptId) : null;
+        const identity = attempt ? ` · ${attempt.id} · gen ${attempt.generation}` : '';
+        this.opts.display.restoreDurableActivity(job.id, `◆ ${job.goal} · ${job.status}${identity}`);
       }
     }
 
@@ -1134,7 +1193,7 @@ export class ChatSession implements ChatSessionLike {
     // counter so a mid-stream resize doesn't try to erase rows that
     // the hard-clear already removed. See `resetStreamFrameForResize`
     // in display.ts for the rationale.
-    const restoreResizeGuard = this.opts.promptApi
+    const restoreResizeGuard = this.opts.promptApi || this.usesFixedBottomRegion()
       ? (): void => { /* test prompt API: skip */ }
       : installResizeGuard({
           onCleared: () => {
@@ -1202,6 +1261,7 @@ export class ChatSession implements ChatSessionLike {
             agent: this.opts.agent,
             pluginLoader: this.opts.pluginLoader,
             channelManager: this.opts.channelManager,
+            jobEngine: this.opts.jobEngine,
             // v4.12 /commands slice — /home working-directory change seam.
             setWorkingDir: this.opts.setWorkingDir,
             // v4.9.2 Slice 3 — UX-rebuilt confirmation primitive.
@@ -1973,6 +2033,38 @@ export class ChatSession implements ChatSessionLike {
             } catch { /* defensive */ }
             return;
           }
+          if (word === '/status') {
+            const target = this.activeDurableTarget;
+            const identity = target
+              ? `${target.jobId} · ${target.attemptId} · gen ${target.generation}`
+              : 'no active durable identity';
+            this.opts.display.info(`Active turn · ${identity} · ${this.duringTurnInput.busyHint()}`);
+            return;
+          }
+          if (word === '/queue') {
+            const entries = this.listQueueEntries();
+            if (entries.length === 0) this.opts.display.dim('Queue empty.');
+            else for (const [index, entry] of entries.entries()) {
+              this.opts.display.dim(`${index + 1}. ${entry.inputId ?? 'pending'} · ${entry.message}`);
+            }
+            return;
+          }
+          if (word === '/cancel' || word === '/interrupt') {
+            const target = this.activeDurableTarget;
+            if (target && this.opts.jobControlAuthority) {
+              this.opts.jobControlAuthority.commands.request({
+                ...target,
+                kind: word === '/cancel' ? 'cancel' : 'interrupt',
+                source: 'tui',
+                reason: `user requested ${word.slice(1)}`,
+                idempotencyNamespace: `tui-control:${this.sessionId}`,
+                idempotencyKey: `${word.slice(1)}:${target.attemptId}:${++this.durableInputOrdinal}`,
+              });
+            }
+            this.opts.display.dim(word === '/cancel' ? 'Cancellation requested.' : 'Interruption requested.');
+            requestTurnCancel(this.currentAbortController);
+            return;
+          }
           const target = this.activeDurableTarget;
           let durableInputId: string | null = null;
           if (target && this.opts.jobControlAuthority) {
@@ -2061,6 +2153,8 @@ export class ChatSession implements ChatSessionLike {
           requestTurnCancel(this.currentAbortController);
         },
         onCtrlC:  () => { try { (process as NodeJS.Process).emit('SIGINT'); } catch { /* defensive */ } },
+        onScroll: (deltaRows) => { this.opts.display.scrollTranscript(deltaRows); },
+        onFollow: () => { this.opts.display.followTranscript(); },
         // Slice 2c — paint the live during-turn buffer so the user sees their
         // keystrokes (not blind), labelled with what Enter will do. Empty
         // buffer (initial, or the reset after submit/cancel) clears the row.
@@ -2150,6 +2244,7 @@ export class ChatSession implements ChatSessionLike {
         attemptId: lifecycleContext.handle.attemptId,
         generation: lifecycleContext.handle.generation,
       };
+      this.opts.display.removeDurableActivity(lifecycleContext.handle.jobId);
     } else if (replRunStore && replInstanceId && this.sessionId) {
       try {
         replRunId = replRunStore.create({
@@ -2163,10 +2258,7 @@ export class ChatSession implements ChatSessionLike {
           replParentRunRef.sessionId = this.sessionId;
         }
       } catch (err) {
-        // Logged once per turn; the user's chat is not interrupted.
-        // eslint-disable-next-line no-console
-        console.warn('[runs] failed to write REPL parent-run row:',
-          err instanceof Error ? err.message : String(err));
+        this.reportRuntimeWarning('run admission', err);
         replRunId = null;
       }
     }
@@ -2227,9 +2319,7 @@ export class ChatSession implements ChatSessionLike {
           status:    'active',
         });
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn('[tasks] failed to write REPL task row:',
-          err instanceof Error ? err.message : String(err));
+        this.reportRuntimeWarning('Job admission', err);
         replTaskId = null;
       }
     }
@@ -2775,9 +2865,7 @@ export class ChatSession implements ChatSessionLike {
             completedAt:  Date.now(),
           });
         } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn('[runs] failed to finalize REPL parent-run row:',
-            err instanceof Error ? err.message : String(err));
+          this.reportRuntimeWarning('run finalization', err);
         }
       }
       // v4.13 Gap 1 — verify-before-done gate. The model narrates; the
@@ -2875,9 +2963,7 @@ export class ChatSession implements ChatSessionLike {
         }
         result.taskOutcome = _taskOutcome;
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn('[tasks] failed to compute finalization:',
-          err instanceof Error ? err.message : String(err));
+        this.reportRuntimeWarning('verification finalization', err);
       }
 
       if (lifecycleContext && _fin) {
@@ -2926,9 +3012,7 @@ export class ChatSession implements ChatSessionLike {
           }
           replTaskStore.finalizeVerification(replTaskId, fin.status, fin.evidence, fin.jobCard);
         } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn('[tasks] failed to finalize REPL task row:',
-            err instanceof Error ? err.message : String(err));
+          this.reportRuntimeWarning('Job finalization', err);
         }
       }
 
@@ -2999,9 +3083,7 @@ export class ChatSession implements ChatSessionLike {
               this.opts.replTaskStore.appendArtifactId(replTaskId, artifactId);
             }
           } catch (err) {
-            // eslint-disable-next-line no-console
-            console.warn('[artifacts] capture failed:',
-              err instanceof Error ? err.message : String(err));
+            this.reportRuntimeWarning('artifact capture', err);
           }
         }
       }
@@ -3241,9 +3323,7 @@ export class ChatSession implements ChatSessionLike {
             completedAt:  Date.now(),
           });
         } catch (e2) {
-          // eslint-disable-next-line no-console
-          console.warn('[runs] failed to mark REPL parent-run failed:',
-            e2 instanceof Error ? e2.message : String(e2));
+          this.reportRuntimeWarning('run failure transition', e2);
         }
       }
       // v4.10 Slice 10.8 — symmetric task-lite failure transition.
@@ -3254,9 +3334,7 @@ export class ChatSession implements ChatSessionLike {
         try {
           replTaskStore.setStatus(replTaskId, 'failed');
         } catch (e3) {
-          // eslint-disable-next-line no-console
-          console.warn('[tasks] failed to mark REPL task failed:',
-            e3 instanceof Error ? e3.message : String(e3));
+          this.reportRuntimeWarning('Job failure transition', e3);
         }
       }
       if (replParentRunRef) {
@@ -3335,7 +3413,10 @@ export class ChatSession implements ChatSessionLike {
         modalPauseDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
       });
       lifecycleContext?.handle.signal.removeEventListener('abort', abortFromLifecycle);
-      if (this.activeDurableTarget?.attemptId === jobAttemptId) this.activeDurableTarget = null;
+      if (this.activeDurableTarget?.attemptId === jobAttemptId) {
+        this.opts.display.removeDurableActivity(this.activeDurableTarget.jobId);
+        this.activeDurableTarget = null;
+      }
       // v4.11 Slice 3 — release the per-turn cancel handles. ORDER
       // MATTERS:
       //   1. Drop activeTurnId FIRST so any late callbacks already
@@ -3578,7 +3659,12 @@ export class ChatSession implements ChatSessionLike {
         if (!onboarded) {
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { renderFirstRunHint } = require('./repl/firstRunHint') as typeof import('./repl/firstRunHint');
-          await renderFirstRunHint({ paths: this.opts.paths, out: process.stdout });
+          const firstRunOut = {
+            isTTY: process.stdout.isTTY,
+            columns: process.stdout.columns,
+            write: (text: string) => { this.opts.display.write(text); return true; },
+          } as unknown as NodeJS.WriteStream;
+          await renderFirstRunHint({ paths: this.opts.paths, out: firstRunOut });
         }
       }
     } catch { /* never let a missing marker crash boot */ }
@@ -4235,6 +4321,8 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
                 ready: () => {
                   emitComposerReadyForTests((marker) => opts.display?.writeAfterComposerCursor(marker));
                 },
+                scroll: (deltaRows) => opts.display?.scrollTranscript(deltaRows),
+                follow: () => opts.display?.followTranscript(),
               }
             : undefined,
         }, { output: promptOutput });

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -3137,25 +3137,6 @@ export class ChatSession implements ChatSessionLike {
         this.opts.display.taskOutcome(_taskOutcome);
       }
 
-      if (replRunId !== null) {
-        const turnUsage = currentProviderAttemptLedger()?.project({ runId: String(replRunId) });
-        if (turnUsage && turnUsage.physicalAttempts > 0) {
-          const reportedInput = turnUsage.providerInputTokens || turnUsage.estimatedInputTokens;
-          const reportedOutput = turnUsage.providerOutputTokens || turnUsage.estimatedOutputTokens;
-          const toolBytesSaved = Math.max(0, turnUsage.rawToolResultBytes - turnUsage.transmittedToolResultBytes);
-          const savings = [
-            toolBytesSaved > 0 ? `${toolBytesSaved.toLocaleString()} tool bytes externalized` : null,
-            turnUsage.deferredSchemaCount > 0 ? `${turnUsage.deferredSchemaCount} schemas deferred` : null,
-          ].filter((value): value is string => value !== null);
-          const cost = turnUsage.unknownCostAttempts > 0
-            ? 'cost unknown'
-            : `$${turnUsage.knownCostAmount.toFixed(4)} estimated`;
-          this.opts.display.dim(
-            `Usage: ${turnUsage.physicalAttempts} provider attempt${turnUsage.physicalAttempts === 1 ? '' : 's'} · ${reportedInput} in / ${reportedOutput} out · ${cost}${savings.length > 0 ? ` · ${savings.join(', ')}` : ''}`,
-          );
-        }
-      }
-
       // v4.1.6 Polish 2 — post-render skill-proposal handler.
       // The agent loop now SKIPS the inquirer prompt when a
       // prompt callback is wired, surfacing the SkillProposal

--- a/cli/v4/commandRegistry.ts
+++ b/cli/v4/commandRegistry.ts
@@ -42,6 +42,10 @@ export interface ChatSessionLike {
   history: Message[];
   setHistory(messages: Message[]): void;
   clearHistory(): void;
+  /** Start a new persisted conversation when the runtime supports it. */
+  startNewSession?(): string | null;
+  /** Delete one stored conversation after the command layer confirms intent. */
+  deleteStoredSession?(idOrTitle?: string): { deletedId: string; replacementId: string | null } | null;
   getCurrentProvider(): string;
   getCurrentModel(): string;
   setProvider(providerId: string, modelId: string): Promise<void>;
@@ -118,6 +122,8 @@ export interface SlashCommandContext {
    * lifecycle without spinning up a separate API server process.
    */
   channelManager?: ChannelManager;
+  /** Read-only durable Job projections used by local operator views. */
+  jobEngine?: import('../../core/v4/daemon/jobEngine').JobEngine;
   /**
    * Phase 17: prompt-the-user hook used by /plugins install for the
    * permission summary confirmation. Returns true to grant, false to

--- a/cli/v4/commandRegistry.ts
+++ b/cli/v4/commandRegistry.ts
@@ -163,6 +163,8 @@ export interface SlashCommandResult {
    * no rerun.
    */
   rerun?: string;
+  /** Command already owns the complete viewport transition. */
+  suppressSeparator?: boolean;
 }
 
 export type SlashCommandHandler = (
@@ -312,7 +314,7 @@ export class CommandRegistry {
   async execute(
     input: string,
     ctx: Omit<SlashCommandContext, 'args' | 'rawArgs' | 'registry'>,
-  ): Promise<{ handled: boolean; exit?: boolean; clearHistory?: boolean; rerun?: string }> {
+  ): Promise<{ handled: boolean; exit?: boolean; clearHistory?: boolean; rerun?: string; suppressSeparator?: boolean }> {
     const parsed = this.parse(input);
     if (!parsed) return { handled: false };
 
@@ -336,7 +338,13 @@ export class CommandRegistry {
     const raw = (await cmd.handler(fullCtx)) as SlashCommandResult | void;
     const result: SlashCommandResult = raw ? raw : {};
     this.recordRecent(cmd.name);
-    return { handled: true, exit: result.exit, clearHistory: result.clearHistory, rerun: result.rerun };
+    return {
+      handled: true,
+      exit: result.exit,
+      clearHistory: result.clearHistory,
+      rerun: result.rerun,
+      ...(result.suppressSeparator ? { suppressSeparator: true } : {}),
+    };
   }
 
   private closestVisibleCommand(input: string): string | null {

--- a/cli/v4/commands/clear.ts
+++ b/cli/v4/commands/clear.ts
@@ -19,13 +19,12 @@ export const clear: SlashCommand = {
     const id = ctx.session?.startNewSession?.() ?? null;
     if (id) {
       ctx.display.clearScreen();
-      ctx.display.success(`New chat started · ${id}`);
+      ctx.display.success('New chat started');
       ctx.display.dim('Previous Jobs and proof remain available through /jobs and /trace.');
-      ctx.display.dim('History cleared.');
-      return { clearHistory: true };
+      return { clearHistory: true, suppressSeparator: true };
     }
     if (ctx.session) ctx.session.clearHistory();
-    ctx.display.dim('History cleared. Persisted session switching is unavailable in this runtime.');
-    return { clearHistory: true };
+    ctx.display.dim('Conversation reset in this runtime. Durable Jobs and proof are unchanged.');
+    return { clearHistory: true, suppressSeparator: true };
   },
 };

--- a/cli/v4/commands/clear.ts
+++ b/cli/v4/commands/clear.ts
@@ -12,12 +12,20 @@ import type { SlashCommand } from '../commandRegistry';
 
 export const clear: SlashCommand = {
   name: 'clear',
-  description: 'Clear conversation history.',
+  description: 'Start a clean conversation; durable Jobs and proof remain available.',
   category: 'system',
   icon: '*',
   handler: async (ctx) => {
+    const id = ctx.session?.startNewSession?.() ?? null;
+    if (id) {
+      ctx.display.clearScreen();
+      ctx.display.success(`New chat started · ${id}`);
+      ctx.display.dim('Previous Jobs and proof remain available through /jobs and /trace.');
+      ctx.display.dim('History cleared.');
+      return { clearHistory: true };
+    }
     if (ctx.session) ctx.session.clearHistory();
-    ctx.display.dim('History cleared.');
+    ctx.display.dim('History cleared. Persisted session switching is unavailable in this runtime.');
     return { clearHistory: true };
   },
 };

--- a/cli/v4/commands/cls.ts
+++ b/cli/v4/commands/cls.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import type { SlashCommand } from '../commandRegistry';
+
+export const cls: SlashCommand = {
+  name: 'cls',
+  aliases: ['redraw'],
+  description: 'Repaint only the terminal; session and durable state are unchanged.',
+  category: 'system',
+  icon: '◇',
+  handler: async (ctx) => {
+    ctx.display.clearScreen();
+    return {};
+  },
+};

--- a/cli/v4/commands/cls.ts
+++ b/cli/v4/commands/cls.ts
@@ -14,6 +14,6 @@ export const cls: SlashCommand = {
   icon: '◇',
   handler: async (ctx) => {
     ctx.display.clearScreen();
-    return {};
+    return { suppressSeparator: true };
   },
 };

--- a/cli/v4/commands/help.ts
+++ b/cli/v4/commands/help.ts
@@ -42,6 +42,9 @@ export type Subsection = (typeof SUBSECTION_ORDER)[number];
 export const SUBSECTION_MAP: Readonly<Record<string, Subsection>> = {
   // ── Session ── conversation lifecycle
   clear: 'Session',
+  new: 'Session',
+  cls: 'Session',
+  session: 'Session',
   compress: 'Session',
   save: 'Session',
   title: 'Session',
@@ -126,6 +129,13 @@ export const SUBSECTION_MAP: Readonly<Record<string, Subsection>> = {
   // v4.12 /commands slice — /home (working dir) + /activity (inline roll-up).
   home: 'System',
   activity: 'System',
+  jobs: 'System',
+  job: 'System',
+  attempts: 'System',
+  effects: 'System',
+  evidence: 'System',
+  proof: 'System',
+  approvals: 'System',
 
   // ── Authentication ──
   auth: 'Authentication',

--- a/cli/v4/commands/history.ts
+++ b/cli/v4/commands/history.ts
@@ -30,7 +30,7 @@ const HISTORY_FILENAME = '.aiden_history';
 
 export const history: SlashCommand = {
   name:        'history',
-  description: 'List or clear the on-disk prompt history.',
+  description: 'Clears command/prompt recall history. Does not clear the conversation.',
   category:    'system',
   handler: async (ctx) => {
     const sub = (ctx.args[0] ?? 'list').toLowerCase();

--- a/cli/v4/commands/index.ts
+++ b/cli/v4/commands/index.ts
@@ -82,6 +82,10 @@ import { greeter } from './greeter';
 import { mcp } from './mcpManage';
 // v4.12 /commands slice — /home working-directory show/change.
 import { home } from './home';
+import { approvals, attempts, effects, evidence, job, jobs, proof } from './operatorViews';
+import { cls } from './cls';
+import { newSession } from './newSession';
+import { session } from './session';
 
 export {
   help,
@@ -149,6 +153,16 @@ export {
   hooks,
   mcp,
   home,
+  jobs,
+  job,
+  attempts,
+  effects,
+  evidence,
+  proof,
+  approvals,
+  cls,
+  newSession,
+  session,
 };
 
 /** All built-in system commands, in canonical order. */
@@ -223,6 +237,16 @@ export const allCommands: SlashCommand[] = [
   greeter,
   // v4.12 /commands slice — /home working-directory show/change.
   home,
+  jobs,
+  job,
+  attempts,
+  effects,
+  evidence,
+  proof,
+  approvals,
+  cls,
+  newSession,
+  session,
   clear,
   quit,
 ];

--- a/cli/v4/commands/newSession.ts
+++ b/cli/v4/commands/newSession.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import type { SlashCommand } from '../commandRegistry';
+import { clear } from './clear';
+
+export const newSession: SlashCommand = {
+  name: 'new',
+  description: 'Alias for /clear: start a clean conversation and retain durable work.',
+  category: 'system',
+  icon: '+',
+  handler: clear.handler,
+};

--- a/cli/v4/commands/operatorViews.ts
+++ b/cli/v4/commands/operatorViews.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import type { SlashCommand, SlashCommandContext } from '../commandRegistry';
+import type { JobRecord } from '../../../core/v4/daemon/jobEngine';
+
+function recentJobs(ctx: SlashCommandContext, limit = 20): JobRecord[] {
+  if (!ctx.jobEngine) return [];
+  return ctx.jobEngine.listJobs({ sessionId: ctx.session?.getSessionId?.(), limit });
+}
+
+function targetJob(ctx: SlashCommandContext): JobRecord | null {
+  if (!ctx.jobEngine) return null;
+  const requested = ctx.args[0];
+  return requested ? ctx.jobEngine.getJob(requested) : recentJobs(ctx, 1)[0] ?? null;
+}
+
+function snapshotFor(ctx: SlashCommandContext): ReturnType<NonNullable<SlashCommandContext['jobEngine']>['projection']['rebuild']> | null {
+  const job = targetJob(ctx);
+  return job && ctx.jobEngine ? ctx.jobEngine.projection.rebuild(job.id) : null;
+}
+
+function unavailable(ctx: SlashCommandContext): void {
+  ctx.display.warn('Durable Job state is unavailable in this runtime.');
+}
+
+function value(row: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const candidate = row[key];
+    if (candidate !== null && candidate !== undefined && String(candidate).length > 0) return String(candidate);
+  }
+  return 'unknown';
+}
+
+function renderJob(ctx: SlashCommandContext, job: JobRecord): void {
+  const snapshot = ctx.jobEngine!.projection.rebuild(job.id);
+  ctx.display.write(`\n◆ Job ${job.id}\n`);
+  ctx.display.write(`  goal        ${job.goal}\n`);
+  ctx.display.write(`  state       ${job.status}${job.terminalOutcome ? ` · ${job.terminalOutcome}` : ''}\n`);
+  ctx.display.write(`  generation  ${Math.max(0, ...snapshot.attempts.map((attempt) => attempt.generation))}\n`);
+  ctx.display.write(`  attempts    ${snapshot.attempts.length}\n`);
+  ctx.display.write(`  effects     ${snapshot.effects.length}\n`);
+  ctx.display.write(`  approvals   ${snapshot.approvals.length}\n`);
+  ctx.display.write(`  evidence    ${snapshot.evidence.length}\n`);
+  ctx.display.write(`  verdict     ${snapshot.verdict ? value(snapshot.verdict, 'outcome', 'verdict', 'state') : 'pending'}\n`);
+  for (const attempt of snapshot.attempts) {
+    const lease = attempt.leaseOwner ? ` · owner ${attempt.leaseOwner}` : '';
+    ctx.display.write(`  └─ ${attempt.id} · ${attempt.status} · gen ${attempt.generation}${lease}\n`);
+  }
+}
+
+export const jobs: SlashCommand = {
+  name: 'jobs',
+  description: 'Inspect durable Jobs, Attempts, Effects, and current outcomes.',
+  category: 'system',
+  icon: '◆',
+  handler: async (ctx) => {
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    const requested = ctx.args[0];
+    if (!requested) {
+      const rows = recentJobs(ctx);
+      if (rows.length === 0) { ctx.display.dim('No durable Jobs for this session.'); return {}; }
+      ctx.display.write('\n◆ Jobs\n');
+      for (const job of rows) {
+        const active = job.activeAttemptId ? ` · attempt ${job.activeAttemptId}` : '';
+        const outcome = job.terminalOutcome ? ` · ${job.terminalOutcome}` : '';
+        ctx.display.write(`  ${job.id} · ${job.status}${outcome}${active}\n`);
+      }
+      ctx.display.dim('Use /job <job-id> for Attempts, Effects, approvals, and verdict.');
+      return {};
+    }
+    const job = ctx.jobEngine.getJob(requested);
+    if (!job) { ctx.display.warn(`Job not found: ${requested}`); return {}; }
+    renderJob(ctx, job);
+    return {};
+  },
+};
+
+export const job: SlashCommand = {
+  name: 'job',
+  description: 'Inspect one durable Job and its authoritative state.',
+  category: 'system',
+  icon: '◆',
+  handler: async (ctx) => {
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    const selected = targetJob(ctx);
+    if (!selected) { ctx.display.warn(ctx.args[0] ? `Job not found: ${ctx.args[0]}` : 'No durable Job is available to inspect.'); return {}; }
+    renderJob(ctx, selected);
+    return {};
+  },
+};
+
+export const attempts: SlashCommand = {
+  name: 'attempts',
+  description: 'Inspect durable Attempts for a Job.',
+  category: 'system',
+  icon: '↻',
+  handler: async (ctx) => {
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    const snapshot = snapshotFor(ctx);
+    if (!snapshot) { ctx.display.dim('No durable Job is available to inspect.'); return {}; }
+    ctx.display.write(`\n↻ Attempts · ${snapshot.job.id}\n`);
+    for (const attempt of snapshot.attempts) {
+      const lease = attempt.leaseOwner ? ` · lease ${attempt.leaseOwner}` : '';
+      ctx.display.write(`  ${attempt.id} · ${attempt.status} · attempt ${attempt.attemptNumber} · gen ${attempt.generation}${lease}\n`);
+    }
+    if (snapshot.attempts.length === 0) ctx.display.dim('No durable Attempts.');
+    return {};
+  },
+};
+
+export const effects: SlashCommand = {
+  name: 'effects',
+  description: 'Inspect durable real-world Effects and reconciliation state.',
+  category: 'system',
+  icon: '⚙',
+  handler: async (ctx) => {
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    const snapshot = snapshotFor(ctx);
+    if (!snapshot) { ctx.display.dim('No durable Job is available to inspect.'); return {}; }
+    ctx.display.write(`\n⚙ Effects · ${snapshot.job.id}\n`);
+    for (const effect of snapshot.effects) {
+      ctx.display.write(`  ${value(effect, 'key', 'effect_id', 'id')} · ${value(effect, 'effect_state', 'state', 'status')} · ${value(effect, 'kind', 'effect_kind')} · retry ${value(effect, 'retry_safety', 'retrySafety')}\n`);
+    }
+    if (snapshot.effects.length === 0) ctx.display.dim('No durable Effects.');
+    return {};
+  },
+};
+
+export const evidence: SlashCommand = {
+  name: 'evidence',
+  description: 'Inspect durable evidence records without changing their verdict.',
+  category: 'system',
+  icon: '✓',
+  handler: async (ctx) => {
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    const snapshot = snapshotFor(ctx);
+    if (!snapshot) { ctx.display.dim('No durable Job is available to inspect.'); return {}; }
+    ctx.display.write(`\n✓ Evidence · ${snapshot.job.id}\n`);
+    for (const item of snapshot.evidence) {
+      ctx.display.write(`  ${value(item, 'evidence_id', 'id')} · ${value(item, 'verification_result', 'state')} · ${value(item, 'coverage')} · ${value(item, 'source')}\n`);
+    }
+    if (snapshot.evidence.length === 0) ctx.display.dim('No durable evidence.');
+    return {};
+  },
+};
+
+export const proof: SlashCommand = {
+  name: 'proof',
+  description: 'Inspect durable evidence, claims, and final verdict for a Job.',
+  category: 'system',
+  icon: '✓',
+  handler: async (ctx) => {
+    const job = targetJob(ctx);
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    if (!job) { ctx.display.dim('No durable Job is available to inspect.'); return {}; }
+    const snapshot = ctx.jobEngine.projection.rebuild(job.id);
+    ctx.display.write(`\n✓ Proof · ${job.id}\n`);
+    ctx.display.write(`  claims    ${snapshot.claims.length}\n`);
+    ctx.display.write(`  evidence  ${snapshot.evidence.length}\n`);
+    ctx.display.write(`  verdict   ${snapshot.verdict ? value(snapshot.verdict, 'outcome', 'verdict', 'state') : 'pending'}\n`);
+    if (snapshot.verdict) {
+      const reason = value(snapshot.verdict, 'reason', 'summary', 'finish_reason');
+      if (reason !== 'unknown') ctx.display.write(`  reason    ${reason}\n`);
+    }
+    return {};
+  },
+};
+
+export const approvals: SlashCommand = {
+  name: 'approvals',
+  description: 'Inspect exact-action approval records for durable Jobs.',
+  category: 'system',
+  icon: '!',
+  handler: async (ctx) => {
+    if (!ctx.jobEngine) { unavailable(ctx); return {}; }
+    const requested = ctx.args[0];
+    const jobsToInspect = requested
+      ? [ctx.jobEngine.getJob(requested)].filter((job): job is JobRecord => job !== null)
+      : recentJobs(ctx);
+    const rows = jobsToInspect.flatMap((job) => (
+      ctx.jobEngine!.projection.rebuild(job.id).approvals.map((approval) => ({ job, approval }))
+    ));
+    if (rows.length === 0) { ctx.display.dim('No durable approval records.'); return {}; }
+    ctx.display.write('\n! Approvals\n');
+    for (const { job, approval } of rows) {
+      const id = value(approval, 'approval_id', 'id');
+      const state = value(approval, 'state', 'status');
+      const risk = value(approval, 'risk_level', 'risk');
+      ctx.display.write(`  ${id} · ${state} · ${risk} · job ${job.id}\n`);
+    }
+    return {};
+  },
+};

--- a/cli/v4/commands/operatorViews.ts
+++ b/cli/v4/commands/operatorViews.ts
@@ -37,6 +37,7 @@ function value(row: Record<string, unknown>, ...keys: string[]): string {
 
 function renderJob(ctx: SlashCommandContext, job: JobRecord): void {
   const snapshot = ctx.jobEngine!.projection.rebuild(job.id);
+  const workers = ctx.jobEngine!.listChildContracts(job.id);
   ctx.display.write(`\n◆ Job ${job.id}\n`);
   ctx.display.write(`  goal        ${job.goal}\n`);
   ctx.display.write(`  state       ${job.status}${job.terminalOutcome ? ` · ${job.terminalOutcome}` : ''}\n`);
@@ -49,6 +50,16 @@ function renderJob(ctx: SlashCommandContext, job: JobRecord): void {
   for (const attempt of snapshot.attempts) {
     const lease = attempt.leaseOwner ? ` · owner ${attempt.leaseOwner}` : '';
     ctx.display.write(`  └─ ${attempt.id} · ${attempt.status} · gen ${attempt.generation}${lease}\n`);
+  }
+  if (workers.length > 0) {
+    ctx.display.write('  workers\n');
+    workers.forEach((contract, index) => {
+      const child = ctx.jobEngine!.getJob(contract.childJobId);
+      const branch = index === workers.length - 1 ? '└─' : '├─';
+      const status = child?.status ?? contract.resultStatus ?? 'waiting';
+      const goal = child?.goal ? ` · ${child.goal}` : '';
+      ctx.display.write(`  ${branch} ${contract.workerId} · ${status}${goal}\n`);
+    });
   }
 }
 

--- a/cli/v4/commands/session.ts
+++ b/cli/v4/commands/session.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import type { SlashCommand } from '../commandRegistry';
+
+export const session: SlashCommand = {
+  name: 'session',
+  description: 'Delete a stored conversation; durable Jobs and proof are preserved.',
+  category: 'system',
+  icon: '◇',
+  handler: async (ctx) => {
+    const sub = (ctx.args[0] ?? '').toLowerCase();
+    if (sub !== 'delete') {
+      ctx.display.info('Usage: /session delete [session-id] --yes');
+      return {};
+    }
+    if (!ctx.args.includes('--yes')) {
+      ctx.display.warn('Session deletion requires confirmation.');
+      ctx.display.dim('Run `/session delete [session-id] --yes`. Durable Jobs, Effects, and Proof are preserved.');
+      return {};
+    }
+    if (!ctx.session?.deleteStoredSession) {
+      ctx.display.warn('Stored-session deletion is unavailable in this runtime.');
+      return {};
+    }
+    const requested = ctx.args.slice(1).find((arg) => arg !== '--yes');
+    const result = ctx.session.deleteStoredSession(requested);
+    if (!result) {
+      ctx.display.warn(requested ? `Session not found: ${requested}` : 'The active session could not be deleted.');
+      return {};
+    }
+    ctx.display.success(`Stored session deleted · ${result.deletedId}`);
+    ctx.display.dim('Durable Jobs, Effects, and Proof remain available.');
+    if (result.replacementId) ctx.display.dim(`New active session · ${result.replacementId}`);
+    return { clearHistory: result.replacementId !== null };
+  },
+};

--- a/cli/v4/commands/skin.ts
+++ b/cli/v4/commands/skin.ts
@@ -12,6 +12,7 @@
  * `/skin reload`       re-read the active skin from disk (live iteration)
  */
 import type { SlashCommand } from '../commandRegistry';
+import { theme } from './theme';
 
 export const skin: SlashCommand = {
   name: 'skin',
@@ -19,90 +20,23 @@ export const skin: SlashCommand = {
   category: 'system',
   icon: '🎨',
   handler: async (ctx) => {
-    // v4.9.0 Slice 1a — /skin is now an alias for the new /theme system.
-    // The legacy color skins (~/.aiden/skins/*.yaml, RGB-tuple format)
-    // continue to work alongside the new theme system; /skin still
-    // manages the SkinEngine palette. Theme tokens (panel chrome,
-    // status footer glyphs, shimmer) are controlled by /theme.
     ctx.display.warn(
-      '/skin is deprecated in v4.9 — use /theme for full visual customisation. ' +
-      '/skin continues to work for legacy colour skins.',
+      '/skin is deprecated — use /theme. Legacy names now select the matching effective theme.',
     );
-    const engine = ctx.skin;
-    if (!engine) {
-      ctx.display.warn('Skin engine not wired in this context.');
-      return {};
-    }
     const target = ctx.rawArgs.trim();
-
-    if (target === 'reload') {
-      try {
-        await engine.reload();
-        ctx.display.success(`Skin reloaded: ${engine.getActive().name}`);
-      } catch (err) {
-        ctx.display.printError(
-          `Skin reload failed: ${err instanceof Error ? err.message : String(err)}`,
-          'Check the yaml syntax in your skins directory.',
-        );
-      }
-      return {};
-    }
-
-    if (!target) {
-      // discover() is idempotent; safe to call on every list.
-      try {
-        await engine.discover();
-      } catch {
-        // non-fatal — built-in defaults remain
-      }
-      const summary = engine.list();
-      const current = engine.getActive().name;
-      ctx.display.info(`Active skin: ${current}`);
-      ctx.display.info('Available skins:');
-      for (const s of summary) {
-        const marker = s.name === current ? '*' : ' ';
-        const tag =
-          s.source === 'user'
-            ? ' (user)'
-            : s.source === 'bundled-yaml'
-              ? ' (yaml)'
-              : '';
-        const desc = s.description ? ` — ${s.description}` : '';
-        ctx.display.write(`  ${marker} ${s.name}${tag}${desc}\n`);
-      }
-      return {};
-    }
-
-    // Switch path. Try discovery first so user yaml is recognised.
-    try {
-      await engine.discover();
-    } catch {
-      // ignore
-    }
-    const before = engine.getActive().name;
-    const known = engine.listSkins().includes(target);
-    if (!known) {
-      // Try loading from disk (covers the case where discover missed a file).
-      const loaded = await engine.loadSkin(target);
-      if (loaded.name === before && before !== target) {
-        ctx.display.printError(
-          `Unknown skin '${target}'.`,
-          'Run /skin to see available names.',
-        );
-        return {};
-      }
-      ctx.display.success(`Skin: ${loaded.name}`);
-      return {};
-    }
-    const result = engine.setActive(target);
-    if (result.name !== target) {
+    const mapped = target === '' ? 'list'
+      : target === 'reload' ? 'reload'
+      : target === 'default' ? 'set aiden-ember'
+      : target === 'monochrome' ? 'set monochrome'
+      : target === 'light' ? 'set light'
+      : null;
+    if (!mapped) {
       ctx.display.printError(
-        `Unknown skin '${target}'.`,
-        'Run /skin to see available names.',
+        `Legacy skin '${target}' has no effective-theme mapping.`,
+        'Use /theme list and /theme set <name>.',
       );
       return {};
     }
-    ctx.display.success(`Skin: ${result.name}`);
-    return {};
+    return theme.handler({ ...ctx, rawArgs: mapped });
   },
 };

--- a/cli/v4/commands/theme.ts
+++ b/cli/v4/commands/theme.ts
@@ -183,8 +183,9 @@ export const theme: SlashCommand = {
       for (const w of warnings) ctx.display.warn(`theme: ${w}`);
       if (parsed) {
         applyTheme(parsed, themePath);
+        ctx.skin?.setActive('default');
         ctx.display.success(
-          `✓ Theme set to ${name} (${sourceLabel}). Run /theme reset to revert to default.`,
+          `Theme set to ${name} (${sourceLabel}). Run /theme reset to revert to default.`,
         );
       } else {
         ctx.display.printError(
@@ -208,6 +209,7 @@ export const theme: SlashCommand = {
       for (const w of warnings) ctx.display.warn(`theme: ${w}`);
       if (parsed) {
         applyTheme(parsed, themePath);
+        ctx.skin?.setActive('default');
         ctx.display.success(`Theme reloaded: ${parsed.name}`);
       } else {
         ctx.display.printError(
@@ -232,6 +234,7 @@ export const theme: SlashCommand = {
         }
       }
       resetToDefault();
+      ctx.skin?.setActive('default');
       ctx.display.success('Theme reset to bundled default.');
       return {};
     }

--- a/cli/v4/commands/theme.ts
+++ b/cli/v4/commands/theme.ts
@@ -184,6 +184,7 @@ export const theme: SlashCommand = {
       if (parsed) {
         applyTheme(parsed, themePath);
         ctx.skin?.setActive('default');
+        ctx.display.refreshTheme?.();
         ctx.display.success(
           `Theme set to ${name} (${sourceLabel}). Run /theme reset to revert to default.`,
         );
@@ -210,6 +211,7 @@ export const theme: SlashCommand = {
       if (parsed) {
         applyTheme(parsed, themePath);
         ctx.skin?.setActive('default');
+        ctx.display.refreshTheme?.();
         ctx.display.success(`Theme reloaded: ${parsed.name}`);
       } else {
         ctx.display.printError(
@@ -235,6 +237,7 @@ export const theme: SlashCommand = {
       }
       resetToDefault();
       ctx.skin?.setActive('default');
+      ctx.display.refreshTheme?.();
       ctx.display.success('Theme reset to bundled default.');
       return {};
     }

--- a/cli/v4/commands/theme.ts
+++ b/cli/v4/commands/theme.ts
@@ -83,8 +83,9 @@ export const theme: SlashCommand = {
 
     if (sub === '' || sub === 'show') {
       const current = getCurrentName();
+      const displayCurrent = current === 'default' ? 'aiden-ember' : current;
       const active  = getActivePath();
-      ctx.display.info(`Active theme: ${current}`);
+      ctx.display.info(`Active theme: ${displayCurrent}`);
       if (active) {
         ctx.display.info(`Source: ${active}`);
       } else if (themePath) {
@@ -96,10 +97,11 @@ export const theme: SlashCommand = {
 
     if (sub === 'list') {
       const current  = getCurrentName();
+      const displayCurrent = current === 'default' ? 'aiden-ember' : current;
       const bundled  = listBundled();
       const userDir  = userThemesDir(ctx as { paths?: { root?: string } | null });
       const userList = listUserThemes(userDir);
-      ctx.display.info(`Active theme: ${current}`);
+      ctx.display.info(`Active theme: ${displayCurrent}`);
       ctx.display.info('Available themes:');
       const labelW = Math.max(
         ...bundled.map((b) => b.name.length),
@@ -107,7 +109,7 @@ export const theme: SlashCommand = {
         4,
       );
       for (const b of bundled) {
-        const marker = b.name === current ? '●' : '○';
+        const marker = b.name === displayCurrent ? '●' : '○';
         const padded = b.name.padEnd(labelW);
         ctx.display.info(`  ${marker} ${padded}  (bundled)  ${b.description}`);
       }
@@ -122,8 +124,9 @@ export const theme: SlashCommand = {
       return {};
     }
 
-    if (sub.startsWith('set ') || sub === 'set') {
-      const name = sub.replace(/^set\s*/, '').trim();
+    const directTheme = isBundled(sub) ? sub : null;
+    if (sub.startsWith('set ') || sub === 'set' || directTheme) {
+      const name = directTheme ?? sub.replace(/^set\s*/, '').trim();
       if (!name) {
         ctx.display.printError(
           'Usage: /theme set <name>',

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -21,6 +21,7 @@ import {
   initialOperatorProjection,
   reduceOperatorProjection,
   transcriptSource,
+  visibleTranscriptSource,
   type OperatorActivityState,
   type OperatorProjectionState,
 } from './operatorProjection';
@@ -30,6 +31,7 @@ const SAVE = `${ESC}7`;
 const RESTORE = `${ESC}8`;
 const SAVE_TRANSCRIPT = `${ESC}[s`;
 const RESTORE_TRANSCRIPT = `${ESC}[u`;
+const CLEAR_PHYSICAL_VIEWPORT = `${ESC}[?25l${ESC}[r${ESC}[3J${ESC}[2J${ESC}[H`;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
 const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
@@ -301,6 +303,7 @@ export class BottomRegion {
   private projection: OperatorProjectionState = initialOperatorProjection();
   private projectionIdentity = 0;
   private rebuildTranscriptOnActivation = false;
+  private viewportClearPending = false;
   private static readonly MAX_TRANSCRIPT_CHARS = 250_000;
 
   constructor(
@@ -326,6 +329,10 @@ export class BottomRegion {
     // transcript before repainting the footer.
     const rebuildTranscript = this.rebuildTranscriptOnActivation;
     this.rebuildTranscriptOnActivation = false;
+    if (this.viewportClearPending) {
+      this.paintClearedViewport();
+      return;
+    }
     this.paintAll(rebuildTranscript);
   }
 
@@ -410,13 +417,54 @@ export class BottomRegion {
   }
 
   newEventsBelow(): number {
-    return this.projection.newEventsBelow;
+    return this.projection.viewport.newEventsBelow;
   }
 
-  /** Clear only the visual transcript; durable/session state is untouched. */
+  /** Start a new physical viewport while retaining semantic transcript state. */
+  clearViewport(): void {
+    this.renderGeneration += 1;
+    if (this.trailingResize) clearImmediate(this.trailingResize);
+    this.trailingResize = null;
+    this.resizeBurstActive = false;
+    this.projection = reduceOperatorProjection(this.projection, { type: 'viewport.clear' });
+    this.lastFrame = '';
+    this.geometry = null;
+    this.laneRows = 0;
+    this.rebuildTranscriptOnActivation = false;
+    this.viewportClearPending = true;
+    if (this.active) this.paintClearedViewport();
+  }
+
+  /** Existing importer compatibility. */
   clearTranscript(): void {
-    this.projection = reduceOperatorProjection(this.projection, { type: 'transcript.clear' });
-    if (this.active) this.paintAll(true);
+    this.clearViewport();
+  }
+
+  viewportSnapshot(): {
+    epoch: number;
+    hiddenBeforeSequence: number;
+    scrollOffset: number;
+    stickyTail: boolean;
+    selectedRow: string | null;
+    cachedWidth: number | null;
+    cachedHeight: number | null;
+    retainedTranscriptRows: number;
+    visibleTranscriptRows: number;
+  } {
+    const width = Math.max(1, (this.projection.viewport.cachedWidth ?? this.sink.cols()) - 1);
+    const retainedSource = transcriptSource(this.projection);
+    const visibleSource = visibleTranscriptSource(this.projection);
+    return {
+      epoch: this.projection.viewport.epoch,
+      hiddenBeforeSequence: this.projection.viewport.hiddenBeforeSequence,
+      scrollOffset: this.projection.viewport.scrollOffset,
+      stickyTail: this.projection.viewport.stickyTail,
+      selectedRow: this.projection.viewport.selectedRow,
+      cachedWidth: this.projection.viewport.cachedWidth,
+      cachedHeight: this.projection.viewport.cachedHeight,
+      retainedTranscriptRows: retainedSource ? wrapTranscriptText(retainedSource, width).length : 0,
+      visibleTranscriptRows: visibleSource ? wrapTranscriptText(visibleSource, width).length : 0,
+    };
   }
 
   /**
@@ -485,18 +533,18 @@ export class BottomRegion {
       kind: 'system',
       sourceText: text,
     });
-    let transcript = transcriptSource(this.projection);
-    if (transcript.length > BottomRegion.MAX_TRANSCRIPT_CHARS) {
-      transcript = transcript.slice(-BottomRegion.MAX_TRANSCRIPT_CHARS);
-      this.projection = {
-        ...this.projection,
-        transcript: [{
-          id: `transcript:${++this.projectionIdentity}`,
-          kind: 'system',
-          sourceText: transcript,
-          sequence: this.projection.eventSequence,
-        }],
-      };
+    if (transcriptSource(this.projection).length > BottomRegion.MAX_TRANSCRIPT_CHARS) {
+      let remaining = BottomRegion.MAX_TRANSCRIPT_CHARS;
+      const retained: Array<OperatorProjectionState['transcript'][number]> = [];
+      for (let index = this.projection.transcript.length - 1; index >= 0 && remaining > 0; index -= 1) {
+        const item = this.projection.transcript[index];
+        const sourceText = item.sourceText.length <= remaining
+          ? item.sourceText
+          : item.sourceText.slice(-remaining);
+        retained.unshift(sourceText === item.sourceText ? item : { ...item, sourceText });
+        remaining -= sourceText.length;
+      }
+      this.projection = { ...this.projection, transcript: retained };
     }
   }
 
@@ -504,12 +552,12 @@ export class BottomRegion {
     const bottom = Math.max(0, this.sink.rows() - surface.laneRows);
     if (bottom === 0) return '';
     const width = Math.max(1, this.sink.cols() - 1);
-    const rows = wrapTranscriptText(transcriptSource(this.projection), width);
-    const end = Math.max(0, rows.length - this.projection.scrollOffset);
+    const rows = wrapTranscriptText(visibleTranscriptSource(this.projection), width);
+    const end = Math.max(0, rows.length - this.projection.viewport.scrollOffset);
     const visible = rows.slice(Math.max(0, end - bottom), end);
-    if (!this.projection.followTail && bottom > 0) {
-      const indicator = this.projection.newEventsBelow > 0
-        ? `↓ ${this.projection.newEventsBelow} new events below · End to follow`
+    if (!this.projection.viewport.stickyTail && bottom > 0) {
+      const indicator = this.projection.viewport.newEventsBelow > 0
+        ? `↓ ${this.projection.viewport.newEventsBelow} new events below · End to follow`
         : '↓ End to follow live output';
       if (visible.length === bottom) visible[visible.length - 1] = indicator;
       else visible.push(indicator);
@@ -593,11 +641,17 @@ export class BottomRegion {
 
   private paintAll(rebuildTranscript = false): void {
     if (!this.active) return;
+    const epoch = this.projection.viewport.epoch;
+    this.projection = reduceOperatorProjection(this.projection, {
+      type: 'viewport.measure', width: this.sink.cols(), height: this.sink.rows(),
+    });
     const surface = this.surface();
     const frame = surface.lines.join('\n');
     const geometry = this.establishGeometry(surface.laneRows);
     if (!geometry && frame === this.lastFrame && !rebuildTranscript) {
-      this.sink.write(`${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`);
+      if (epoch === this.projection.viewport.epoch) {
+        this.sink.write(`${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`);
+      }
       return;
     }
     this.lastFrame = frame;
@@ -608,7 +662,32 @@ export class BottomRegion {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });
     sequence += `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`;
-    this.sink.write(sequence);
+    if (epoch === this.projection.viewport.epoch) this.sink.write(sequence);
+  }
+
+  private paintClearedViewport(): void {
+    if (!this.active) return;
+    const epoch = this.projection.viewport.epoch;
+    this.projection = reduceOperatorProjection(this.projection, {
+      type: 'viewport.measure', width: this.sink.cols(), height: this.sink.rows(),
+    });
+    const surface = this.surface();
+    this.laneRows = surface.laneRows;
+    this.geometry = {
+      rows: this.sink.rows(),
+      cols: this.sink.cols(),
+      laneRows: surface.laneRows,
+      topRow: Math.max(1, this.sink.rows() - surface.laneRows + 1),
+    };
+    this.lastFrame = surface.lines.join('\n');
+    this.viewportClearPending = false;
+    const topRow = this.sink.rows() - surface.laneRows + 1;
+    let sequence = `${CLEAR_PHYSICAL_VIEWPORT}${reserveSeq(this.sink.rows(), surface.laneRows)}${SAVE_TRANSCRIPT}`;
+    surface.lines.forEach((line, index) => {
+      sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
+    });
+    sequence += `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`;
+    if (epoch === this.projection.viewport.epoch) this.sink.write(sequence);
   }
 
   private reanchor(): void {
@@ -621,6 +700,7 @@ export class BottomRegion {
 
   private onResize(): void {
     if (!this.active) return;
+    const epoch = this.projection.viewport.epoch;
     if (!this.resizeBurstActive) {
       this.resizeBurstActive = true;
       this.reanchor();
@@ -628,6 +708,7 @@ export class BottomRegion {
     if (this.trailingResize) clearImmediate(this.trailingResize);
     this.trailingResize = setImmediate(() => {
       this.trailingResize = null;
+      if (!this.active || epoch !== this.projection.viewport.epoch) return;
       this.resizeBurstActive = false;
       this.reanchor();
     });

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -78,6 +78,16 @@ export function fitLane(text: string, cols: number): string {
 
 type StatusSource = string | (() => string);
 
+export interface BottomRegionStyle {
+  brand(value: string): string;
+  muted(value: string): string;
+}
+
+const PLAIN_BOTTOM_STYLE: BottomRegionStyle = {
+  brand: (value) => value,
+  muted: (value) => value,
+};
+
 /** ANSI-aware front truncation used as the final no-wrap status guard. */
 function fitStatus(text: string, cols: number): string {
   const width = Math.max(4, cols);
@@ -236,6 +246,7 @@ export function renderBottomSurface(
   cols: number,
   composerSource: ComposerSource,
   status: string,
+  style: BottomRegionStyle = PLAIN_BOTTOM_STYLE,
 ): RenderedSurface {
   const composer = normalizeComposer(composerSource);
   // Leave the final physical cell unused so Windows ConPTY never enters its
@@ -255,9 +266,10 @@ export function renderBottomSurface(
   const titleRoom = Math.max(1, outerWidth - 5);
   const fittedTitle = terminalWidth(title) <= titleRoom ? title : fitStatus(title, titleRoom);
   const topPrefix = `╭─ ${fittedTitle} `;
-  const top = `${topPrefix}${'─'.repeat(Math.max(0, outerWidth - terminalWidth(topPrefix) - 1))}╮`;
-  const body = content.map((line) => `│ ${padVisible(line, innerWidth)} │`);
-  const bottom = `╰${'─'.repeat(Math.max(0, outerWidth - 2))}╯`;
+  const topTail = `${'─'.repeat(Math.max(0, outerWidth - terminalWidth(topPrefix) - 1))}╮`;
+  const top = `${style.muted('╭─ ')}${style.brand(fittedTitle)}${style.muted(` ${topTail}`)}`;
+  const body = content.map((line) => `${style.muted('│')} ${padVisible(line, innerWidth)} ${style.muted('│')}`);
+  const bottom = style.muted(`╰${'─'.repeat(Math.max(0, outerWidth - 2))}╯`);
   const fittedStatus = fitStatus(status, outerWidth);
   const topRow = rows - laneRows + 1;
   return {
@@ -291,7 +303,10 @@ export class BottomRegion {
   private rebuildTranscriptOnActivation = false;
   private static readonly MAX_TRANSCRIPT_CHARS = 250_000;
 
-  constructor(private readonly sink: LaneSink) {}
+  constructor(
+    private readonly sink: LaneSink,
+    private readonly style: BottomRegionStyle = PLAIN_BOTTOM_STYLE,
+  ) {}
 
   isActive(): boolean {
     return this.active;
@@ -442,6 +457,7 @@ export class BottomRegion {
       this.sink.cols(),
       this.composerSource,
       rawStatus,
+      this.style,
     );
     const availableWidth = Math.max(1, this.sink.cols() - 1);
     const allLive = activeActivityRows(this.projection).flatMap((activity) => (

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -16,6 +16,15 @@
  * never emits terminal-control sequences.
  */
 
+import {
+  activeActivityRows,
+  initialOperatorProjection,
+  reduceOperatorProjection,
+  transcriptSource,
+  type OperatorActivityState,
+  type OperatorProjectionState,
+} from './operatorProjection';
+
 const ESC = '\x1b';
 const SAVE = `${ESC}7`;
 const RESTORE = `${ESC}8`;
@@ -24,6 +33,7 @@ const RESTORE_TRANSCRIPT = `${ESC}[u`;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
 const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+const TERMINAL_CONTROL_PATTERN = /\x1b(?:\][^\x07]*(?:\x07|\x1b\\)|\[[?0-9;]*[A-Za-z]|[78])/gu;
 
 function terminalWidth(text: string): number {
   return stringWidth(text.replace(ANSI_PATTERN, ''));
@@ -98,6 +108,25 @@ function fitStatus(text: string, cols: number): string {
 
 function padVisible(text: string, width: number): string {
   return `${text}${' '.repeat(Math.max(0, width - terminalWidth(text)))}`;
+}
+
+function wrapTranscriptText(text: string, width: number): string[] {
+  const plain = text.replace(TERMINAL_CONTROL_PATTERN, '').replace(/\r/g, '');
+  const rows: string[] = [];
+  for (const logical of plain.split('\n')) {
+    let row = '';
+    for (const character of Array.from(logical)) {
+      if (row && terminalWidth(row + character) > width) {
+        rows.push(row);
+        row = character;
+      } else {
+        row += character;
+      }
+    }
+    rows.push(row);
+  }
+  if (plain.endsWith('\n')) rows.pop();
+  return rows;
 }
 
 interface WrappedDraft {
@@ -182,6 +211,13 @@ interface RenderedSurface {
   cursorCol: number;
 }
 
+interface SurfaceGeometry {
+  rows: number;
+  cols: number;
+  laneRows: number;
+  topRow: number;
+}
+
 function normalizeComposer(source: ComposerSource): BottomComposerSurface {
   return typeof source === 'string'
     ? { draft: source, mode: 'idle' }
@@ -246,6 +282,13 @@ export class BottomRegion {
   private laneRows = 0;
   private lastFrame = '';
   private unsubResize: (() => void) | null = null;
+  private geometry: SurfaceGeometry | null = null;
+  private resizeBurstActive = false;
+  private trailingResize: ReturnType<typeof setImmediate> | null = null;
+  private renderGeneration = 0;
+  private projection: OperatorProjectionState = initialOperatorProjection();
+  private projectionIdentity = 0;
+  private static readonly MAX_TRANSCRIPT_CHARS = 250_000;
 
   constructor(private readonly sink: LaneSink) {}
 
@@ -257,11 +300,12 @@ export class BottomRegion {
   activate(composer: ComposerSource, status: StatusSource = this.statusSource): void {
     this.composerSource = composer;
     this.statusSource = status;
+    const resumingOwnership = !this.active;
     if (!this.active) {
       this.active = true;
-      this.unsubResize = this.sink.onResize(() => this.reanchor());
+      this.unsubResize = this.sink.onResize(() => this.onResize());
     }
-    this.paintAll();
+    this.paintAll(resumingOwnership && this.projection.transcript.length > 0);
   }
 
   /** Backward-compatible composer update. */
@@ -277,11 +321,89 @@ export class BottomRegion {
     this.paintAll();
   }
 
+  /** Project one identity-backed live row above the composer. */
+  setLiveRow(id: string, text: string): void {
+    const normalized = text.replace(/\r?\n$/u, '');
+    const current = this.projection.activities[id];
+    const next = reduceOperatorProjection(this.projection, current
+      ? { type: 'activity.progress', id, generation: current.generation, summary: normalized }
+      : {
+          type: 'activity.upsert',
+          activity: {
+            id, parentId: null, jobId: null, attemptId: null, generation: 0,
+            startedSequence: this.projection.eventSequence + 1,
+            state: 'running', startedAt: Date.now(), endedAt: null,
+            summary: normalized, detailsRef: null,
+          },
+        });
+    if (next === this.projection) return;
+    this.projection = next;
+    if (this.active) this.paintAll();
+  }
+
+  /** Hide a live row without adding it to transcript history. */
+  removeLiveRow(id: string): void {
+    const next = reduceOperatorProjection(this.projection, { type: 'activity.remove', id });
+    if (next === this.projection) return;
+    this.projection = next;
+    if (this.active) this.paintAll();
+  }
+
+  /** Replace a live row with its final transcript row exactly once. */
+  settleLiveRow(
+    id: string,
+    text: string,
+    state: Extract<OperatorActivityState,
+      'succeeded' | 'failed' | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale'> = 'succeeded',
+  ): void {
+    const current = this.projection.activities[id];
+    if (current) {
+      this.projection = reduceOperatorProjection(this.projection, {
+        type: 'activity.terminal', id, generation: current.generation,
+        state, summary: text, endedAt: Date.now(),
+      });
+      this.projection = reduceOperatorProjection(this.projection, { type: 'activity.remove', id });
+    }
+    const terminal = text.endsWith('\n') ? text : `${text}\n`;
+    this.recordTranscript(terminal);
+    if (!this.active) {
+      this.sink.write(terminal);
+      return;
+    }
+    this.sink.write(`${RESTORE_TRANSCRIPT}${terminal}${SAVE_TRANSCRIPT}`);
+    this.paintAll();
+  }
+
+  /** Move the transcript viewport away from or toward the live tail. */
+  scrollTranscript(deltaRows: number): void {
+    this.projection = reduceOperatorProjection(this.projection, {
+      type: 'viewport.scroll', delta: deltaRows,
+    });
+    if (this.active) this.paintAll(true);
+  }
+
+  /** Return transcript projection to sticky-tail mode. */
+  followTranscript(): void {
+    this.projection = reduceOperatorProjection(this.projection, { type: 'viewport.follow' });
+    if (this.active) this.paintAll(true);
+  }
+
+  newEventsBelow(): number {
+    return this.projection.newEventsBelow;
+  }
+
+  /** Clear only the visual transcript; durable/session state is untouched. */
+  clearTranscript(): void {
+    this.projection = reduceOperatorProjection(this.projection, { type: 'transcript.clear' });
+    if (this.active) this.paintAll(true);
+  }
+
   /**
    * Write flowing output in the scrollable transcript, then return the hardware
    * cursor to the draft insertion point without repainting or mutating draft.
    */
   writeAbove(text: string): void {
+    this.recordTranscript(text);
     if (!this.active) {
       this.sink.write(text);
       return;
@@ -309,12 +431,76 @@ export class BottomRegion {
     const rawStatus = typeof this.statusSource === 'function'
       ? this.statusSource()
       : this.statusSource;
-    return renderBottomSurface(
+    const composer = renderBottomSurface(
       this.sink.rows(),
       this.sink.cols(),
       this.composerSource,
       rawStatus,
     );
+    const availableWidth = Math.max(1, this.sink.cols() - 1);
+    const allLive = activeActivityRows(this.projection).flatMap((activity) => (
+      activity.summary.split('\n').map((line) => fitStatus(line, availableWidth))
+    ));
+    const maxLiveRows = Math.max(0, this.sink.rows() - composer.laneRows);
+    const hiddenLiveRows = Math.max(0, allLive.length - maxLiveRows);
+    const live = hiddenLiveRows > 0 && maxLiveRows > 0
+      ? [fitStatus(`… ${hiddenLiveRows + 1} more active`, availableWidth), ...allLive.slice(-(maxLiveRows - 1))]
+      : maxLiveRows === 0 ? [] : allLive.slice(-maxLiveRows);
+    return {
+      lines: [...live, ...composer.lines],
+      laneRows: composer.laneRows + live.length,
+      cursorRow: composer.cursorRow,
+      cursorCol: composer.cursorCol,
+    };
+  }
+
+  private recordTranscript(text: string): void {
+    const semantic = text.replace(TERMINAL_CONTROL_PATTERN, '');
+    if (!/[^\s]/u.test(semantic)) return;
+    this.projection = reduceOperatorProjection(this.projection, {
+      type: 'transcript.append',
+      id: `transcript:${++this.projectionIdentity}`,
+      kind: 'system',
+      sourceText: text,
+    });
+    let transcript = transcriptSource(this.projection);
+    if (transcript.length > BottomRegion.MAX_TRANSCRIPT_CHARS) {
+      transcript = transcript.slice(-BottomRegion.MAX_TRANSCRIPT_CHARS);
+      this.projection = {
+        ...this.projection,
+        transcript: [{
+          id: `transcript:${++this.projectionIdentity}`,
+          kind: 'system',
+          sourceText: transcript,
+          sequence: this.projection.eventSequence,
+        }],
+      };
+    }
+  }
+
+  private transcriptFrame(surface: RenderedSurface): string {
+    const bottom = Math.max(0, this.sink.rows() - surface.laneRows);
+    if (bottom === 0) return '';
+    const width = Math.max(1, this.sink.cols() - 1);
+    const rows = wrapTranscriptText(transcriptSource(this.projection), width);
+    const end = Math.max(0, rows.length - this.projection.scrollOffset);
+    const visible = rows.slice(Math.max(0, end - bottom), end);
+    if (!this.projection.followTail && bottom > 0) {
+      const indicator = this.projection.newEventsBelow > 0
+        ? `↓ ${this.projection.newEventsBelow} new events below · End to follow`
+        : '↓ End to follow live output';
+      if (visible.length === bottom) visible[visible.length - 1] = indicator;
+      else visible.push(indicator);
+    }
+    const start = bottom - visible.length + 1;
+    let sequence = '';
+    for (let row = 1; row <= bottom; row += 1) {
+      sequence += `${ESC}[${row};1H${ESC}[2K`;
+    }
+    visible.forEach((line, index) => {
+      sequence += `${ESC}[${start + index};1H${fitStatus(line, width)}`;
+    });
+    return sequence;
   }
 
   private clearOwnedRows(count: number): string {
@@ -325,10 +511,40 @@ export class BottomRegion {
     return sequence;
   }
 
+  private clearDamagedUnion(previous: SurfaceGeometry | null, next: SurfaceGeometry): string {
+    const physicalRows = this.sink.rows();
+    const rows = new Set<number>();
+    const add = (geometry: SurfaceGeometry | null): void => {
+      if (!geometry) return;
+      for (let row = geometry.topRow; row <= geometry.rows; row += 1) {
+        if (row >= 1 && row <= physicalRows) rows.add(row);
+      }
+    };
+    add(previous);
+    add(next);
+    return [...rows]
+      .sort((a, b) => a - b)
+      .map((row) => `${ESC}[${row};1H${ESC}[2K`)
+      .join('');
+  }
+
   private establishGeometry(nextRows: number): string {
-    if (this.laneRows === nextRows && this.laneRows > 0) return '';
+    const physicalRows = this.sink.rows();
+    const physicalCols = this.sink.cols();
+    const nextGeometry: SurfaceGeometry = {
+      rows: physicalRows,
+      cols: physicalCols,
+      laneRows: nextRows,
+      topRow: Math.max(1, physicalRows - nextRows + 1),
+    };
+    const previousGeometry = this.geometry;
+    const dimensionsChanged = previousGeometry !== null && (
+      previousGeometry.rows !== physicalRows || previousGeometry.cols !== physicalCols
+    );
+    if (this.laneRows === nextRows && this.laneRows > 0 && !dimensionsChanged) return '';
     const previousRows = this.laneRows;
     this.laneRows = nextRows;
+    this.geometry = nextGeometry;
     if (previousRows === 0) {
       // Make physical room before reserving the footer. Painting directly over
       // the last rows would destroy startup/transcript content already there.
@@ -345,12 +561,15 @@ export class BottomRegion {
     const makeRoom = growth > 0
       ? `${ESC}[${previousTranscriptBottom};1H${'\n'.repeat(growth)}`
       : '';
+    const clear = dimensionsChanged
+      ? this.clearDamagedUnion(previousGeometry, nextGeometry)
+      : this.clearOwnedRows(Math.max(previousRows, nextRows));
     return `${RESTORE_TRANSCRIPT}${makeRoom}${ESC}[r` +
-      `${this.clearOwnedRows(Math.max(previousRows, nextRows))}` +
+      `${clear}` +
       `${reserveSeq(this.sink.rows(), nextRows)}${SAVE_TRANSCRIPT}`;
   }
 
-  private paintAll(): void {
+  private paintAll(rebuildTranscript = false): void {
     if (!this.active) return;
     const surface = this.surface();
     const frame = surface.lines.join('\n');
@@ -362,6 +581,7 @@ export class BottomRegion {
     this.lastFrame = frame;
     const topRow = this.sink.rows() - surface.laneRows + 1;
     let sequence = geometry;
+    if (rebuildTranscript) sequence += this.transcriptFrame(surface);
     surface.lines.forEach((line, index) => {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });
@@ -371,11 +591,24 @@ export class BottomRegion {
 
   private reanchor(): void {
     if (!this.active) return;
-    const previousRows = this.laneRows;
+    const generation = ++this.renderGeneration;
     this.lastFrame = '';
-    this.laneRows = 0;
-    this.sink.write(`${RESTORE_TRANSCRIPT}${ESC}[r${this.clearOwnedRows(previousRows)}`);
-    this.paintAll();
+    this.paintAll(true);
+    if (generation !== this.renderGeneration) return;
+  }
+
+  private onResize(): void {
+    if (!this.active) return;
+    if (!this.resizeBurstActive) {
+      this.resizeBurstActive = true;
+      this.reanchor();
+    }
+    if (this.trailingResize) clearImmediate(this.trailingResize);
+    this.trailingResize = setImmediate(() => {
+      this.trailingResize = null;
+      this.resizeBurstActive = false;
+      this.reanchor();
+    });
   }
 
   /** Release and clear the complete surface exactly once. */
@@ -386,8 +619,12 @@ export class BottomRegion {
     );
     this.unsubResize?.();
     this.unsubResize = null;
+    if (this.trailingResize) clearImmediate(this.trailingResize);
+    this.trailingResize = null;
+    this.resizeBurstActive = false;
     this.active = false;
     this.laneRows = 0;
+    this.geometry = null;
     this.lastFrame = '';
   }
 }

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -574,7 +574,7 @@ export class BottomRegion {
     const surface = this.surface();
     const frame = surface.lines.join('\n');
     const geometry = this.establishGeometry(surface.laneRows);
-    if (!geometry && frame === this.lastFrame) {
+    if (!geometry && frame === this.lastFrame && !rebuildTranscript) {
       this.sink.write(`${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`);
       return;
     }
@@ -615,7 +615,7 @@ export class BottomRegion {
   deactivate(): void {
     if (!this.active) return;
     this.sink.write(
-      `${RESTORE_TRANSCRIPT}${ESC}[r${this.clearOwnedRows(this.laneRows)}`,
+      `${RESTORE_TRANSCRIPT}${SAVE}${ESC}[r${this.clearOwnedRows(this.laneRows)}${RESTORE}`,
     );
     this.unsubResize?.();
     this.unsubResize = null;

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -288,6 +288,7 @@ export class BottomRegion {
   private renderGeneration = 0;
   private projection: OperatorProjectionState = initialOperatorProjection();
   private projectionIdentity = 0;
+  private rebuildTranscriptOnActivation = false;
   private static readonly MAX_TRANSCRIPT_CHARS = 250_000;
 
   constructor(private readonly sink: LaneSink) {}
@@ -300,12 +301,17 @@ export class BottomRegion {
   activate(composer: ComposerSource, status: StatusSource = this.statusSource): void {
     this.composerSource = composer;
     this.statusSource = status;
-    const resumingOwnership = !this.active;
     if (!this.active) {
       this.active = true;
       this.unsubResize = this.sink.onResize(() => this.onResize());
     }
-    this.paintAll(resumingOwnership && this.projection.transcript.length > 0);
+    // Transcript written before first activation already exists physically.
+    // A balanced modal release is different: the modal temporarily owns the
+    // same terminal rows, so restoring ownership must reconstruct the semantic
+    // transcript before repainting the footer.
+    const rebuildTranscript = this.rebuildTranscriptOnActivation;
+    this.rebuildTranscriptOnActivation = false;
+    this.paintAll(rebuildTranscript);
   }
 
   /** Backward-compatible composer update. */
@@ -623,6 +629,7 @@ export class BottomRegion {
     this.trailingResize = null;
     this.resizeBurstActive = false;
     this.active = false;
+    this.rebuildTranscriptOnActivation = true;
     this.laneRows = 0;
     this.geometry = null;
     this.lastFrame = '';

--- a/cli/v4/design/tokens.ts
+++ b/cli/v4/design/tokens.ts
@@ -301,6 +301,16 @@ export const spacing = {
     groups:       1,
     /** Blank rows between top-level sections (boot card → REPL → events). */
     sections:     2,
+    /** Blank rows between transcript messages. */
+    messages:     1,
+    /** Blank rows around compact activity groups. */
+    activity:     0,
+    /** Blank rows around modal surfaces. */
+    modal:        1,
+    /** Blank rows between transcript tail and the fixed footer. */
+    transcriptToFooter: 0,
+    /** Narrow layouts compact major boundaries to this many rows. */
+    compact:      1,
   },
 } as const;
 

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -43,6 +43,7 @@ import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
 import { recoveryActionsForOutcome } from './recoveryActions';
 import type { OperatorActivityState } from './operatorProjection';
+import { AIDEN_LOGO_LINES } from '../../core/v4/ui/identity';
 
 const DISPLAY_ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
 
@@ -382,15 +383,6 @@ export interface AgentTurnOptions {
   reasoning?: string;
 }
 
-const AIDEN_BANNER = String.raw`
-█████╗  ██╗██████╗ ███████╗███╗   ██╗
-██╔══██╗██║██╔══██╗██╔════╝████╗  ██║
-███████║██║██║  ██║█████╗  ██╔██╗ ██║
-██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║
-██║  ██║██║██████╔╝███████╗██║ ╚████║
-╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝
-`;
-
 /**
  * v4.9.0 pre-ship UI hotfix — pure context-bar helpers. Extracted
  * for testability + to fix the "always empty" symptom. Scale:
@@ -478,10 +470,8 @@ export class Display {
    */
   banner(_version = '4.0.0', _opts: { tip?: string } = {}): string {
     const sk = this.skin;
-    const lines = AIDEN_BANNER.split('\n').map((l) =>
-      l ? `  ${sk.applyColors(l, 'brand')}` : '',
-    );
-    return `${lines.join('\n')}\n`;
+    const lines = AIDEN_LOGO_LINES.map((line) => `  ${sk.applyColors(line, 'brand')}`);
+    return `\n${lines.join('\n')}\n\n`;
   }
 
   /** Print the banner. `opts.tip` accepted for backward compat; unused. */

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -2663,11 +2663,11 @@ export class Display {
 
   /** Clear the visual transcript while retaining composer and status state. */
   clearScreen(): void {
-    if (this.composerLane?.isActive()) {
-      this.composerLane.clearTranscript();
+    if (this.composerLane) {
+      this.composerLane.clearViewport();
       return;
     }
-    if (this.out.isTTY) this.out.write('\x1b[2J\x1b[H');
+    if (this.out.isTTY) this.out.write('\x1b[3J\x1b[2J\x1b[H');
   }
 
   private projectedStreamText(formatted: boolean): string {

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -42,6 +42,7 @@ import { renderCapabilityCard } from './display/capabilityCard';
 import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
 import { recoveryActionsForOutcome } from './recoveryActions';
+import type { OperatorActivityState } from './operatorProjection';
 
 const DISPLAY_ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
 
@@ -441,11 +442,13 @@ export class Display {
   // Modal prompts need the full terminal surface while they own stdin. This
   // depth pauses only composer painting and retains the exact draft/hint.
   private composerSurfacePauseDepth = 0;
+  private nextLiveRowIdentity = 0;
 
   constructor(opts: { skin?: SkinEngine; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream } = {}) {
     this.skin = opts.skin ?? getSkinEngine();
     this.out = opts.stdout ?? process.stdout;
     this.err = opts.stderr ?? process.stderr;
+    if (composerLaneEnabled() && this.out.isTTY) this.composerLane = new ComposerLane(this.laneSink());
     try {
       marked.setOptions({ renderer: new TerminalRenderer() as never });
     } catch {
@@ -1112,6 +1115,26 @@ export class Display {
    * apart from emitting `text\n` once.
    */
   startSpinner(text: string): SpinnerHandle {
+    const screenOwner = this.composerLane?.isActive() ? this.composerLane : null;
+    if (screenOwner) {
+      const rowId = `command:${++this.nextLiveRowIdentity}`;
+      let current = text;
+      let stopped = false;
+      screenOwner.setLiveRow(rowId, `⚙ ${current}`);
+      return {
+        setText: (next: string): void => {
+          if (stopped) return;
+          current = next;
+          screenOwner.setLiveRow(rowId, `⚙ ${current}`);
+        },
+        stop: (finalText?: string): void => {
+          if (stopped) return;
+          stopped = true;
+          if (finalText) screenOwner.settleLiveRow(rowId, finalText);
+          else screenOwner.removeLiveRow(rowId);
+        },
+      };
+    }
     const skin = this.skin;
     const frames = skin.getActive().glyphs?.spinner ?? ['|', '/', '-', '\\'];
     const isTty = !!this.out.isTTY;
@@ -1201,6 +1224,40 @@ export class Display {
     initialVerb: string = 'thinking',
     opts: { waveBar?: boolean } = {},
   ): ActivityIndicatorHandle {
+    const screenOwner = this.composerLane?.isActive() ? this.composerLane : null;
+    if (screenOwner) {
+      const rowId = `command-activity:${++this.nextLiveRowIdentity}`;
+      let verb = initialVerb;
+      let paused = false;
+      let stopped = false;
+      const paint = (): void => screenOwner.setLiveRow(rowId, `⚙ ${verb}`);
+      paint();
+      return {
+        pause: (): void => {
+          if (stopped || paused) return;
+          paused = true;
+          screenOwner.removeLiveRow(rowId);
+        },
+        resume: (next?: string): void => {
+          if (stopped) return;
+          if (next) verb = next;
+          paused = false;
+          paint();
+        },
+        setVerb: (next: string): void => {
+          if (stopped) return;
+          verb = next;
+          if (!paused) paint();
+        },
+        stop: (): void => {
+          if (stopped) return;
+          stopped = true;
+          screenOwner.removeLiveRow(rowId);
+        },
+        isPaused: (): boolean => paused,
+        isStopped: (): boolean => stopped,
+      };
+    }
     const sk     = this.skin;
     const out    = this.out;
     const isTty  = !!out.isTTY;
@@ -1498,6 +1555,8 @@ export class Display {
     let invalidated = false;
     let lastBody = '';
     let frameIndex = 0;
+    const rowId = `provider:${++this.nextLiveRowIdentity}`;
+    const screenOwner = this.composerLane?.isActive() ? this.composerLane : null;
 
     const animation = (width: number): string => {
       if (width >= 60) {
@@ -1525,6 +1584,12 @@ export class Display {
     };
     const erase = (): void => {
       if (!printed || !isTty) return;
+      if (screenOwner) {
+        screenOwner.removeLiveRow(rowId);
+        printed = false;
+        lastBody = '';
+        return;
+      }
       this.writeOutput('\x1b[1A\x1b[2K\r');
       printed = false;
       lastBody = '';
@@ -1535,9 +1600,10 @@ export class Display {
       if (typeof frame === 'number') frameIndex = frame;
       const next = body();
       if (printed && !invalidated && next === lastBody) return;
-      this.writeOutput(printed
-        ? `\x1b[1A\x1b[2K\r${next}\x1b[1B\r`
-        : `${next}\n`);
+      if (screenOwner) screenOwner.setLiveRow(rowId, next);
+      else this.writeOutput(printed
+          ? `\x1b[1A\x1b[2K\r${next}\x1b[1B\r`
+          : `${next}\n`);
       printed = true;
       invalidated = false;
       lastBody = next;
@@ -1594,7 +1660,7 @@ export class Display {
     name: string,
     args: unknown,
     readActivity?: () => ActivitySnapshot,
-    opts: { externalTicker?: boolean } = {},
+    opts: { externalTicker?: boolean; activityId?: string } = {},
   ): ToolRowHandle {
     // v4.1.5 Phase 1d (Q-Q2-a) — TRAIL_HIDE_TOOLS suppression.
     //
@@ -1709,6 +1775,8 @@ export class Display {
     const out = this.out;
     const writeOutput = (text: string): void => this.writeOutput(text);
     const isTty = !!out.isTTY;
+    const screenOwner = this.composerLane?.isActive() ? this.composerLane : null;
+    const rowId = opts.activityId ?? `tool:${++this.nextLiveRowIdentity}`;
     // Keep a two-cell safety margin. Windows ConPTY can report the cursor
     // width one cell beyond the last safe printable column; filling that cell
     // sets the terminal's pending-wrap flag and makes the next repaint walk
@@ -1750,9 +1818,18 @@ export class Display {
       return `${truncateVisible(body, width)}\n`;
     };
 
-    const replaceLast = (row: string, settle = false): void => {
+    const replaceLast = (
+      row: string,
+      settle = false,
+      terminalState: Extract<OperatorActivityState,
+        'succeeded' | 'failed' | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale'> = 'succeeded',
+    ): void => {
       const fitted = fitTerminalRow(row);
-      if (isTty && printed) {
+      if (screenOwner) {
+        const body = fitted.endsWith('\n') ? fitted.slice(0, -1) : fitted;
+        if (settle) screenOwner.settleLiveRow(rowId, body, terminalState);
+        else screenOwner.setLiveRow(rowId, body);
+      } else if (isTty && printed) {
         const body = fitted.endsWith('\n') ? fitted.slice(0, -1) : fitted;
         this.writeOutput(settle
           ? `\x1b[1A\x1b[2K\r${body}\n`
@@ -1764,6 +1841,11 @@ export class Display {
 
     // Erase the last printed line (TTY only).
     const eraseLast = (): void => {
+      if (screenOwner) {
+        screenOwner.removeLiveRow(rowId);
+        printed = false;
+        return;
+      }
       if (isTty && printed) {
         this.writeOutput('\x1b[1A\x1b[2K\r');
         printed = false;
@@ -1773,7 +1855,13 @@ export class Display {
     const writeFinal = (suffix: string, kind: ColorKindForBracket): void => {
       stopTick();
       turnIdleDiagnostic('activity.row.final', { name });
-      replaceLast(outcomeRow(suffix, kind), true);
+      const terminalState = /^denied\b/u.test(suffix) ? 'denied'
+        : /^cancelled\b/u.test(suffix) ? 'cancelled'
+        : /^timed out\b/u.test(suffix) ? 'timed_out'
+        : /^unknown\b/u.test(suffix) ? 'unknown'
+        : /^(?:fail|failed|blocked|partial|empty (?:fail|retry))\b/u.test(suffix) ? 'failed'
+        : 'succeeded';
+      replaceLast(outcomeRow(suffix, kind), true, terminalState);
     };
 
     const startRunningTick = (): void => {
@@ -1796,7 +1884,12 @@ export class Display {
       // its own newline-fencing + in-place rerender of the just-streamed
       // chunk so this row lands cleanly on its own line below.
       this.commitStreamChunk();
-      this.writeOutput(fitTerminalRow(runningRow()));
+      if (screenOwner) {
+        const initial = fitTerminalRow(runningRow());
+        screenOwner.setLiveRow(rowId, initial.endsWith('\n') ? initial.slice(0, -1) : initial);
+      } else {
+        this.writeOutput(fitTerminalRow(runningRow()));
+      }
       printed = true;
       // v4.1.3-essentials: start the live-elapsed ticker. Fires every
       // 1s; first tick at +1s, when `runningRow()` starts emitting the
@@ -1969,7 +2062,9 @@ export class Display {
         if (settled || !pausedRow) return;
         pausedRow = false;
         if (!isTty) return;
-        writeOutput(fitTerminalRow(runningRow()));
+        const resumed = fitTerminalRow(runningRow());
+        if (screenOwner) screenOwner.setLiveRow(rowId, resumed.endsWith('\n') ? resumed.slice(0, -1) : resumed);
+        else writeOutput(resumed);
         printed = true;
         startRunningTick();
       },
@@ -2140,7 +2235,7 @@ export class Display {
 
   /** Route flowing output through the fixed-region owner while it is active. */
   private writeOutput(text: string): void {
-    if (this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()) {
+    if (this.composerLane) {
       this.composerLane.writeAbove(text);
       return;
     }
@@ -2515,6 +2610,67 @@ export class Display {
   // reprints the formatted output.
   private streamBuffer = '';
   private streamLineCount = 0;
+  private streamProjectionSequence = 0;
+  private streamProjectionId = '';
+  private streamProjectionHeaderPending = false;
+
+  private projectedStreamOwner(): ComposerLane | null {
+    return this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()
+      ? this.composerLane
+      : null;
+  }
+
+  /** Scroll only the transcript viewport; composer and live rows remain fixed. */
+  scrollTranscript(deltaRows: number): void {
+    this.composerLane?.scrollTranscript(deltaRows);
+  }
+
+  /** Restore sticky-tail transcript following. */
+  followTranscript(): void {
+    this.composerLane?.followTranscript();
+  }
+
+  /** Rebuild one live row from durable state before the interactive surface mounts. */
+  restoreDurableActivity(id: string, summary: string): void {
+    this.composerLane?.setLiveRow(`durable:${id}`, summary);
+  }
+
+  removeDurableActivity(id: string): void {
+    this.composerLane?.removeLiveRow(`durable:${id}`);
+  }
+
+  /** Clear the visual transcript while retaining composer and status state. */
+  clearScreen(): void {
+    if (this.composerLane?.isActive()) {
+      this.composerLane.clearTranscript();
+      return;
+    }
+    if (this.out.isTTY) this.out.write('\x1b[2J\x1b[H');
+  }
+
+  private projectedStreamText(formatted: boolean): string {
+    let body = this.streamBuffer;
+    if (formatted && body) {
+      try {
+        body = this.applyFrameToRendered(this.markdown(body).trimEnd());
+      } catch { /* raw streamed text remains the honest fallback */ }
+    } else {
+      body = body.split('\n').map((line) => `  ${line}`).join('\n');
+    }
+    return `${this.streamProjectionHeaderPending ? this.agentHeader().trimEnd() + '\n' : ''}${body}`;
+  }
+
+  private settleProjectedStream(owner: ComposerLane): void {
+    if (this.streamBuffer) {
+      owner.settleLiveRow(this.streamProjectionId, this.projectedStreamText(true));
+      this.streamProjectionHeaderPending = false;
+    } else {
+      owner.removeLiveRow(this.streamProjectionId);
+    }
+    this.streamBuffer = '';
+    this.streamLineCount = 0;
+    this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
+  }
 
   /**
    * v4.1.4 reply-quality polish (Q-ResizeReflow Option B): zero the
@@ -2535,6 +2691,7 @@ export class Display {
    */
   resetStreamFrameForResize(): void {
     if (!this.streamHeaderShown) return;
+    if (this.projectedStreamOwner()) return;
     this.streamLineCount = 0;
     this.streamBuffer = '';
     // Header was wiped by the hard-clear too — let the next
@@ -2554,17 +2711,26 @@ export class Display {
    */
   streamPartial(text: string): void {
     if (!text) return;
+    const projectedOwner = this.projectedStreamOwner();
     if (!this.streamHeaderShown) {
       // Phase 26.2.3 — share the `▎ Aiden` header with non-streaming
       // agentTurn so streamed + non-streamed responses open identically.
-      this.writeOutput(this.agentHeader());
+      if (!projectedOwner) this.writeOutput(this.agentHeader());
       this.streamHeaderShown = true;
       this.streamBuffer = '';
       this.streamLineCount = 0;
+      this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
+      this.streamProjectionHeaderPending = true;
       this.uiEventsFiredThisTurn = false;
       // agentHeader emits trailing `\n\n`; cursor is at col 0 of a fresh
       // line, so the very next chunk needs the leading indent.
       this.streamLastEndedNewline = true;
+    }
+    if (projectedOwner) {
+      this.streamBuffer += text;
+      this.streamLastEndedNewline = text.endsWith('\n');
+      projectedOwner.setLiveRow(this.streamProjectionId, this.projectedStreamText(false));
+      return;
     }
     // v4.8.0 Slice 7 hotfix #3 — inject a 2-cell indent at every line
     // start so streamed content aligns with the ▎ bar in agentHeader.
@@ -2761,6 +2927,12 @@ export class Display {
    */
   private commitStreamChunk(): void {
     if (!this.streamHeaderShown) return;
+    const projectedOwner = this.projectedStreamOwner();
+    if (projectedOwner) {
+      this.settleProjectedStream(projectedOwner);
+      this.streamLastEndedNewline = true;
+      return;
+    }
     // Ensure the streamed chunk ends with a newline so the interrupt
     // row doesn't stick to mid-token text from the prior delta.
     if (!this.streamLastEndedNewline) {
@@ -2838,6 +3010,15 @@ export class Display {
    */
   streamComplete(): void {
     if (!this.streamHeaderShown) return;
+    const projectedOwner = this.projectedStreamOwner();
+    if (projectedOwner) {
+      this.settleProjectedStream(projectedOwner);
+      this.streamHeaderShown = false;
+      this.streamLastEndedNewline = false;
+      this.streamProjectionHeaderPending = false;
+      this.uiEventsFiredThisTurn = false;
+      return;
+    }
     if (!this.streamLastEndedNewline) {
       this.writeOutput('\n');
       this.streamLineCount += 1;

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -41,7 +41,6 @@ import {
 import { renderCapabilityCard } from './display/capabilityCard';
 import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
-import { recoveryActionsForOutcome } from './recoveryActions';
 import type { OperatorActivityState } from './operatorProjection';
 import { AIDEN_LOGO_LINES } from '../../core/v4/ui/identity';
 
@@ -440,7 +439,9 @@ export class Display {
     this.skin = opts.skin ?? getSkinEngine();
     this.out = opts.stdout ?? process.stdout;
     this.err = opts.stderr ?? process.stderr;
-    if (composerLaneEnabled() && this.out.isTTY) this.composerLane = new ComposerLane(this.laneSink());
+    if (composerLaneEnabled() && this.out.isTTY) {
+      this.composerLane = new ComposerLane(this.laneSink(), this.laneStyle());
+    }
     try {
       marked.setOptions({ renderer: new TerminalRenderer() as never });
     } catch {
@@ -2314,6 +2315,15 @@ export class Display {
     return composerLaneEnabled() && !!this.out.isTTY;
   }
 
+  /** Repaint the owned interactive surface after an effective theme change. */
+  refreshTheme(): void {
+    if (this.composerLane?.isActive()) {
+      this.paintComposerSurface();
+      return;
+    }
+    this.composerRepaint?.();
+  }
+
   /** Release all fixed bottom-region state for full-session teardown. */
   releaseBottomRegion(): void {
     this.composerSurfacePauseDepth = 0;
@@ -2366,7 +2376,9 @@ export class Display {
   private paintComposerSurface(): void {
     if (this.composerSurfacePauseDepth > 0) return;
     if (composerLaneEnabled() && this.out.isTTY) {
-      if (!this.composerLane) this.composerLane = new ComposerLane(this.laneSink());
+      if (!this.composerLane) {
+        this.composerLane = new ComposerLane(this.laneSink(), this.laneStyle());
+      }
       const content = this.composerContent();
       const hasStatus = typeof this.statusFooterSource === 'function'
         || this.statusFooterSource.length > 0;
@@ -2393,6 +2405,13 @@ export class Display {
     if (this.composerSurfacePauseDepth === 0) return;
     this.composerSurfacePauseDepth -= 1;
     if (this.composerSurfacePauseDepth === 0) this.paintComposerSurface();
+  }
+
+  private laneStyle(): { brand(value: string): string; muted(value: string): string } {
+    return {
+      brand: (value) => this.skin.applyColors(value, 'brand'),
+      muted: (value) => this.skin.applyColors(value, 'muted'),
+    };
   }
 
   /** Wire the lane to this display's real terminal stream + resize events. */
@@ -2489,13 +2508,26 @@ export class Display {
 
   /** Render the single structured outcome owned by turn finalization. */
   taskOutcome(outcome: TaskOutcomePresentation): void {
-    const details = outcome.taskId ? ` · Task: ${outcome.taskId}` : '';
-    const recovery = recoveryActionsForOutcome(outcome)[0];
-    const next = recovery?.command ? ` · Next: ${recovery.command}` : recovery?.instruction ? ` · ${recovery.instruction}` : '';
-    const text = `${outcome.label}${outcome.summary ? ` · ${outcome.summary}` : ''}${details}${next}`;
-    if (outcome.severity === 'success') this.success(text);
-    else if (outcome.severity === 'error' || outcome.severity === 'warning') this.warn(text);
-    else this.dim(text);
+    const taskId = outcome.taskId && terminalVisibleLength(outcome.taskId) > 13
+      ? `${outcome.taskId.slice(0, 8)}…${outcome.taskId.slice(-4)}`
+      : outcome.taskId;
+    const details = taskId ? ` · Task: ${taskId}` : '';
+    const projection = (() => {
+      switch (outcome.kind) {
+        case 'verified': return { glyph: '✓', label: outcome.label, role: 'success' as const };
+        case 'failed':
+        case 'timed_out': return { glyph: '×', label: outcome.label, role: 'error' as const };
+        case 'unverified_required': return { glyph: '?', label: 'Outcome unknown', role: 'warn' as const };
+        case 'cancelled': return { glyph: '■', label: outcome.label, role: 'muted' as const };
+        case 'completed_limited':
+        case 'partial':
+        case 'denied': return { glyph: '!', label: outcome.label, role: 'warn' as const };
+        case 'completed': return { glyph: '✓', label: outcome.label, role: 'success' as const };
+      }
+    })();
+    const summary = outcome.summary ? ` · ${outcome.summary}` : '';
+    const glyph = this.skin.applyColors(projection.glyph, projection.role);
+    this.writeOutput(`${glyph} ${projection.label}${summary}${details}\n`);
   }
 
   /**

--- a/cli/v4/frame/index.ts
+++ b/cli/v4/frame/index.ts
@@ -38,6 +38,18 @@ export function isFrameModeRequested(displayConfig?: { renderer?: string }): boo
 }
 
 /**
+ * The fixed bottom region is the authoritative interactive surface whenever it
+ * is available. The transient Ink composer remains a compatibility renderer
+ * for installations that explicitly disable the fixed surface.
+ */
+export function shouldUseFrameComposer(
+  displayConfig: { renderer?: string } | undefined,
+  fixedBottomRegion: boolean,
+): boolean {
+  return isFrameModeRequested(displayConfig) && !fixedBottomRegion;
+}
+
+/**
  * Read one line through the frame composer. Wraps the
  * pause-legacy-indicator dance so chatSession doesn't have to know
  * about it.

--- a/cli/v4/onboarding/disclaimer.ts
+++ b/cli/v4/onboarding/disclaimer.ts
@@ -23,7 +23,7 @@
 
 import * as readline from 'node:readline';
 
-import { renderBanner } from '../../../core/v4/ui/banner';
+import { renderTitleLine } from '../../../core/v4/ui/banner';
 import { c, separator, termWidth } from '../../../core/v4/ui/theme';
 import { VERSION } from '../../../core/version';
 
@@ -107,7 +107,9 @@ function renderDisclaimerBody(version: string): string {
   const w = termWidth();
   const innerW = Math.min(w - 4, 70);
   const body: string[] = [];
-  body.push(renderBanner({ version }));
+  // Fresh setup and the normal session run in the same process. Keep setup's
+  // identity compact so the canonical six-row startup wordmark has one owner.
+  body.push(`\n  ${renderTitleLine(version)}\n\n`);
 
   // Slice 10c framed-panel chrome. Orange bar at col 2; content + 2
   // inner spaces; muted `─` divider between sections.

--- a/cli/v4/onboarding/speakFirst.ts
+++ b/cli/v4/onboarding/speakFirst.ts
@@ -54,6 +54,13 @@ export interface OnboardingMemory {
 export interface OnboardingOptions {
   paths:  AidenPaths;
   out?:   NodeJS.WriteStream;
+  /** Route visible text through the active presentation owner. */
+  write?: (text: string) => void;
+  /** Effective interactive theme supplied by the owning display. */
+  style?: {
+    accent(value: string): string;
+    muted(value: string): string;
+  };
   /** Injectable fs for tests. */
   fsImpl?: typeof fs;
   /** Injectable stdin for tests. Default: process.stdin. */
@@ -187,6 +194,8 @@ function defaultReadAnswer(
  */
 export async function renderOnboardingIntro(opts: OnboardingOptions): Promise<boolean> {
   const out    = opts.out    ?? process.stdout;
+  const write  = opts.write  ?? ((text: string) => { out.write(text); });
+  const style  = opts.style  ?? { accent: c.accent, muted: c.muted };
   const fsImpl = opts.fsImpl ?? fs;
   const input  = opts.input  ?? process.stdin;
   if (!out.isTTY) return false;
@@ -196,10 +205,10 @@ export async function renderOnboardingIntro(opts: OnboardingOptions): Promise<bo
   // One question only — just the name. Light, optional. The question is
   // written HERE (not by the reader) so it's always on screen, whichever
   // reader captures the line.
-  out.write(
+  write(
     '\n' +
-    `  ${c.accent("Hi — I'm Aiden.")} ` +
-    `${c.muted("I run right here on your machine, and I'll remember what matters as we work.")}\n\n` +
+    `  ${style.accent("Hi — I'm Aiden.")} ` +
+    `${style.muted("I run right here on your machine, and I'll remember what matters as we work.")}\n\n` +
     '  What should I call you? ',
   );
 
@@ -210,7 +219,7 @@ export async function renderOnboardingIntro(opts: OnboardingOptions): Promise<bo
   } catch {
     name = null;   // reader fault → graceful no-name
   }
-  out.write('\n');   // close the question line before the acknowledgement
+  write('\n');   // close the question line before the acknowledgement
 
   // Mark shown BEFORE the store so a store failure can never trigger a re-ask.
   await markOnboardingShown(opts.paths, fsImpl);
@@ -223,14 +232,14 @@ export async function renderOnboardingIntro(opts: OnboardingOptions): Promise<bo
     } catch {
       stored = false;   // store best-effort; never crash boot
     }
-    out.write(
+    write(
       stored
-        ? `  ${c.muted(`Good to meet you, ${name}. I'll remember that.`)}\n\n`
-        : `  ${c.muted(`Good to meet you, ${name}.`)}\n\n`,
+        ? `  ${style.muted(`Good to meet you, ${name}. I'll remember that.`)}\n\n`
+        : `  ${style.muted(`Good to meet you, ${name}.`)}\n\n`,
     );
   } else {
     // Skipped / empty / non-interactive → graceful, no store, never re-asks.
-    out.write(`  ${c.muted("No problem — just say the word when you're ready.")}\n\n`);
+    write(`  ${style.muted("No problem — just say the word when you're ready.")}\n\n`);
   }
   return true;
 }

--- a/cli/v4/operatorProjection.ts
+++ b/cli/v4/operatorProjection.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+
+export type OperatorActivityState =
+  | 'scheduled' | 'preparing' | 'awaiting_approval' | 'running' | 'waiting'
+  | 'retrying' | 'reconciling' | 'verifying' | 'succeeded' | 'failed'
+  | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale';
+
+export type TranscriptKind = 'user' | 'assistant' | 'activity' | 'notice' | 'system';
+
+export interface TranscriptProjection {
+  id: string;
+  kind: TranscriptKind;
+  sourceText: string;
+  sequence: number;
+}
+
+export interface ActivityProjection {
+  id: string;
+  parentId: string | null;
+  jobId: string | null;
+  attemptId: string | null;
+  generation: number;
+  startedSequence: number;
+  state: OperatorActivityState;
+  startedAt: number;
+  endedAt: number | null;
+  summary: string;
+  detailsRef: string | null;
+}
+
+export interface OperatorProjectionState {
+  transcript: readonly TranscriptProjection[];
+  activities: Readonly<Record<string, ActivityProjection>>;
+  eventSequence: number;
+  followTail: boolean;
+  scrollOffset: number;
+  newEventsBelow: number;
+}
+
+export type OperatorProjectionEvent =
+  | { type: 'transcript.append'; id: string; kind: TranscriptKind; sourceText: string }
+  | { type: 'transcript.replace'; id: string; sourceText: string }
+  | { type: 'transcript.clear' }
+  | { type: 'activity.upsert'; activity: ActivityProjection }
+  | { type: 'activity.progress'; id: string; generation: number; summary: string }
+  | { type: 'activity.terminal'; id: string; generation: number; state: Extract<OperatorActivityState,
+      'succeeded' | 'failed' | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale'>;
+      summary: string; endedAt: number }
+  | { type: 'activity.remove'; id: string }
+  | { type: 'viewport.scroll'; delta: number }
+  | { type: 'viewport.follow' };
+
+const TERMINAL_ACTIVITY_STATES = new Set<OperatorActivityState>([
+  'succeeded', 'failed', 'denied', 'interrupted', 'cancelled', 'timed_out', 'unknown', 'stale',
+]);
+
+export function initialOperatorProjection(): OperatorProjectionState {
+  return {
+    transcript: [], activities: {}, eventSequence: 0,
+    followTail: true, scrollOffset: 0, newEventsBelow: 0,
+  };
+}
+
+export function reduceOperatorProjection(
+  state: OperatorProjectionState,
+  event: OperatorProjectionEvent,
+): OperatorProjectionState {
+  const nextSequence = state.eventSequence + 1;
+  switch (event.type) {
+    case 'transcript.append': {
+      if (state.transcript.some((item) => item.id === event.id)) return state;
+      return {
+        ...state,
+        eventSequence: nextSequence,
+        transcript: [...state.transcript, {
+          id: event.id,
+          kind: event.kind,
+          sourceText: event.sourceText,
+          sequence: nextSequence,
+        }],
+        newEventsBelow: state.followTail ? 0 : state.newEventsBelow + 1,
+      };
+    }
+    case 'transcript.replace': {
+      const index = state.transcript.findIndex((item) => item.id === event.id);
+      if (index < 0 || state.transcript[index].sourceText === event.sourceText) return state;
+      const transcript = [...state.transcript];
+      transcript[index] = { ...transcript[index], sourceText: event.sourceText };
+      return { ...state, eventSequence: nextSequence, transcript };
+    }
+    case 'transcript.clear':
+      return { ...state, eventSequence: nextSequence, transcript: [], newEventsBelow: 0 };
+    case 'activity.upsert': {
+      const current = state.activities[event.activity.id];
+      if (current && (
+        current.generation > event.activity.generation
+        || TERMINAL_ACTIVITY_STATES.has(current.state)
+      )) return state;
+      return {
+        ...state,
+        eventSequence: nextSequence,
+        activities: { ...state.activities, [event.activity.id]: { ...event.activity } },
+      };
+    }
+    case 'activity.progress': {
+      const current = state.activities[event.id];
+      if (!current || current.generation !== event.generation || TERMINAL_ACTIVITY_STATES.has(current.state)) {
+        return state;
+      }
+      if (current.summary === event.summary) return state;
+      return {
+        ...state,
+        eventSequence: nextSequence,
+        activities: { ...state.activities, [event.id]: { ...current, summary: event.summary } },
+      };
+    }
+    case 'activity.terminal': {
+      const current = state.activities[event.id];
+      if (!current || current.generation !== event.generation || TERMINAL_ACTIVITY_STATES.has(current.state)) {
+        return state;
+      }
+      return {
+        ...state,
+        eventSequence: nextSequence,
+        activities: {
+          ...state.activities,
+          [event.id]: { ...current, state: event.state, summary: event.summary, endedAt: event.endedAt },
+        },
+      };
+    }
+    case 'activity.remove': {
+      if (!state.activities[event.id]) return state;
+      const activities = { ...state.activities };
+      delete activities[event.id];
+      return { ...state, eventSequence: nextSequence, activities };
+    }
+    case 'viewport.scroll': {
+      const scrollOffset = Math.max(0, state.scrollOffset + event.delta);
+      return {
+        ...state,
+        followTail: scrollOffset === 0,
+        scrollOffset,
+        newEventsBelow: scrollOffset === 0 ? 0 : state.newEventsBelow,
+      };
+    }
+    case 'viewport.follow':
+      return { ...state, followTail: true, scrollOffset: 0, newEventsBelow: 0 };
+  }
+}
+
+export function activeActivityRows(state: OperatorProjectionState): ActivityProjection[] {
+  return Object.values(state.activities)
+    .filter((activity) => !TERMINAL_ACTIVITY_STATES.has(activity.state))
+    .sort((left, right) => left.startedSequence - right.startedSequence || left.id.localeCompare(right.id));
+}
+
+export function transcriptSource(state: OperatorProjectionState): string {
+  return state.transcript.map((item) => item.sourceText).join('');
+}

--- a/cli/v4/operatorProjection.ts
+++ b/cli/v4/operatorProjection.ts
@@ -33,19 +33,28 @@ export interface ActivityProjection {
   detailsRef: string | null;
 }
 
+export interface ViewportProjectionState {
+  epoch: number;
+  hiddenBeforeSequence: number;
+  scrollOffset: number;
+  stickyTail: boolean;
+  selectedRow: string | null;
+  cachedWidth: number | null;
+  cachedHeight: number | null;
+  newEventsBelow: number;
+}
+
 export interface OperatorProjectionState {
   transcript: readonly TranscriptProjection[];
   activities: Readonly<Record<string, ActivityProjection>>;
   eventSequence: number;
-  followTail: boolean;
-  scrollOffset: number;
-  newEventsBelow: number;
+  viewport: ViewportProjectionState;
 }
 
 export type OperatorProjectionEvent =
   | { type: 'transcript.append'; id: string; kind: TranscriptKind; sourceText: string }
   | { type: 'transcript.replace'; id: string; sourceText: string }
-  | { type: 'transcript.clear' }
+  | { type: 'viewport.clear' }
   | { type: 'activity.upsert'; activity: ActivityProjection }
   | { type: 'activity.progress'; id: string; generation: number; summary: string }
   | { type: 'activity.terminal'; id: string; generation: number; state: Extract<OperatorActivityState,
@@ -53,7 +62,8 @@ export type OperatorProjectionEvent =
       summary: string; endedAt: number }
   | { type: 'activity.remove'; id: string }
   | { type: 'viewport.scroll'; delta: number }
-  | { type: 'viewport.follow' };
+  | { type: 'viewport.follow' }
+  | { type: 'viewport.measure'; width: number; height: number };
 
 const TERMINAL_ACTIVITY_STATES = new Set<OperatorActivityState>([
   'succeeded', 'failed', 'denied', 'interrupted', 'cancelled', 'timed_out', 'unknown', 'stale',
@@ -62,7 +72,16 @@ const TERMINAL_ACTIVITY_STATES = new Set<OperatorActivityState>([
 export function initialOperatorProjection(): OperatorProjectionState {
   return {
     transcript: [], activities: {}, eventSequence: 0,
-    followTail: true, scrollOffset: 0, newEventsBelow: 0,
+    viewport: {
+      epoch: 0,
+      hiddenBeforeSequence: 0,
+      scrollOffset: 0,
+      stickyTail: true,
+      selectedRow: null,
+      cachedWidth: null,
+      cachedHeight: null,
+      newEventsBelow: 0,
+    },
   };
 }
 
@@ -83,7 +102,10 @@ export function reduceOperatorProjection(
           sourceText: event.sourceText,
           sequence: nextSequence,
         }],
-        newEventsBelow: state.followTail ? 0 : state.newEventsBelow + 1,
+        viewport: {
+          ...state.viewport,
+          newEventsBelow: state.viewport.stickyTail ? 0 : state.viewport.newEventsBelow + 1,
+        },
       };
     }
     case 'transcript.replace': {
@@ -93,8 +115,21 @@ export function reduceOperatorProjection(
       transcript[index] = { ...transcript[index], sourceText: event.sourceText };
       return { ...state, eventSequence: nextSequence, transcript };
     }
-    case 'transcript.clear':
-      return { ...state, eventSequence: nextSequence, transcript: [], newEventsBelow: 0 };
+    case 'viewport.clear':
+      return {
+        ...state,
+        eventSequence: nextSequence,
+        viewport: {
+          epoch: state.viewport.epoch + 1,
+          hiddenBeforeSequence: nextSequence,
+          scrollOffset: 0,
+          stickyTail: true,
+          selectedRow: null,
+          cachedWidth: null,
+          cachedHeight: null,
+          newEventsBelow: 0,
+        },
+      };
     case 'activity.upsert': {
       const current = state.activities[event.activity.id];
       if (current && (
@@ -140,16 +175,28 @@ export function reduceOperatorProjection(
       return { ...state, eventSequence: nextSequence, activities };
     }
     case 'viewport.scroll': {
-      const scrollOffset = Math.max(0, state.scrollOffset + event.delta);
+      const scrollOffset = Math.max(0, state.viewport.scrollOffset + event.delta);
       return {
         ...state,
-        followTail: scrollOffset === 0,
-        scrollOffset,
-        newEventsBelow: scrollOffset === 0 ? 0 : state.newEventsBelow,
+        viewport: {
+          ...state.viewport,
+          stickyTail: scrollOffset === 0,
+          scrollOffset,
+          newEventsBelow: scrollOffset === 0 ? 0 : state.viewport.newEventsBelow,
+        },
       };
     }
     case 'viewport.follow':
-      return { ...state, followTail: true, scrollOffset: 0, newEventsBelow: 0 };
+      return {
+        ...state,
+        viewport: { ...state.viewport, stickyTail: true, scrollOffset: 0, newEventsBelow: 0 },
+      };
+    case 'viewport.measure':
+      if (state.viewport.cachedWidth === event.width && state.viewport.cachedHeight === event.height) return state;
+      return {
+        ...state,
+        viewport: { ...state.viewport, cachedWidth: event.width, cachedHeight: event.height },
+      };
   }
 }
 
@@ -161,4 +208,11 @@ export function activeActivityRows(state: OperatorProjectionState): ActivityProj
 
 export function transcriptSource(state: OperatorProjectionState): string {
   return state.transcript.map((item) => item.sourceText).join('');
+}
+
+export function visibleTranscriptSource(state: OperatorProjectionState): string {
+  return state.transcript
+    .filter((item) => item.sequence > state.viewport.hiddenBeforeSequence)
+    .map((item) => item.sourceText)
+    .join('');
 }

--- a/cli/v4/skinEngine.ts
+++ b/cli/v4/skinEngine.ts
@@ -45,6 +45,11 @@ export function detectSkinColorDepth(
   if (!terminal.isTTY) return 'truecolor';
   if (/truecolor|24bit/iu.test(env.COLORTERM ?? '') || env.WT_SESSION || env.TERM_PROGRAM) return 'truecolor';
   if (/256color/iu.test(env.TERM ?? '')) return '256';
+  // Node enables virtual-terminal processing for interactive Windows streams.
+  // Modern Windows console hosts therefore accept 24-bit SGR even when they do
+  // not publish WT_SESSION or COLORTERM. Treating that ordinary PowerShell case
+  // as 16-color mapped the orange brand to bright red.
+  if (terminal.platform === 'win32') return 'truecolor';
   return '16';
 }
 
@@ -89,7 +94,9 @@ function ansiRgb(
   if (depth === '256') return `\x1b[38;5;${rgbTo256(r, g, b)}m${text}\x1b[39m`;
   if (depth === '16') {
     const semanticCode: Partial<Record<ColorKind, number>> = {
-      brand: 91, accent: 91, heading: 91, user: 91,
+      // ANSI 16 has no orange. Dark amber is the closest restrained fallback;
+      // it avoids turning the brand into bright red or painting the UI yellow.
+      brand: 33, accent: 33, heading: 33, user: 33,
       success: 92, warn: 93, degraded: 93, error: 31,
       tool: 96, session: 96, agent: 97, muted: 37,
       tertiary: 90, metric_turn: 95,

--- a/cli/v4/skinEngine.ts
+++ b/cli/v4/skinEngine.ts
@@ -28,21 +28,42 @@ import yaml from 'js-yaml';
 
 // v4.9.0 Slice 1a hotfix — read live theme overrides from tokens.ts.
 import { colors as liveColors } from './design/tokens';
-import { getActivePath as getActiveThemePath } from '../../core/v4/theme/themeRegistry';
+import {
+  getActivePath as getActiveThemePath,
+  getCurrentName as getCurrentThemeName,
+} from '../../core/v4/theme/themeRegistry';
 
 export type SkinColorDepth = 'truecolor' | '256' | '16' | 'none';
 
 export function detectSkinColorDepth(
   env: NodeJS.ProcessEnv = process.env,
-  terminal: { isTTY?: boolean; platform?: NodeJS.Platform } = {
+  terminal: {
+    isTTY?: boolean;
+    platform?: NodeJS.Platform;
+    getColorDepth?: () => number;
+  } = {
     isTTY: process.stdout.isTTY,
     platform: process.platform,
+    getColorDepth: typeof process.stdout.getColorDepth === 'function'
+      ? () => process.stdout.getColorDepth()
+      : undefined,
   },
 ): SkinColorDepth {
   const forced = env.AIDEN_FORCE_COLOR_DEPTH?.toLowerCase();
   if (forced === 'truecolor' || forced === '256' || forced === '16' || forced === 'none') return forced;
   if ((env.NO_COLOR != null && env.NO_COLOR !== '') || env.FORCE_COLOR === '0') return 'none';
+  if (env.FORCE_COLOR === '3') return 'truecolor';
+  if (env.FORCE_COLOR === '2') return '256';
+  if (env.FORCE_COLOR === '1') return '16';
   if (!terminal.isTTY) return 'truecolor';
+  let reportedDepth: number | undefined;
+  try { reportedDepth = terminal.getColorDepth?.(); } catch { /* use environment fallback */ }
+  if (reportedDepth !== undefined) {
+    if (reportedDepth >= 24) return 'truecolor';
+    if (reportedDepth >= 8) return '256';
+    if (reportedDepth >= 4) return '16';
+    return 'none';
+  }
   if (/truecolor|24bit/iu.test(env.COLORTERM ?? '') || env.WT_SESSION || env.TERM_PROGRAM) return 'truecolor';
   if (/256color/iu.test(env.TERM ?? '')) return '256';
   // Node enables virtual-terminal processing for interactive Windows streams.
@@ -132,6 +153,8 @@ const COLOR_KIND_TO_TOKEN_PATH: Partial<Record<string, string>> = {
   tertiary:    'content.tertiary',
   metric_turn: 'metrics.turnCount',
   degraded:    'semantic.warn',
+  agent:       'content.primary',
+  user:        'brand.primary',
 };
 
 function hexToRgb(hex: string): [number, number, number] | null {
@@ -452,10 +475,10 @@ export class SkinEngine {
     // ~/.aiden/theme.yaml override every paint surface that routes
     // through SkinEngine (Aiden reply chrome, panel bars, status
     // footer text, tool rows) without requiring users to also
-    // re-author a parallel ~/.aiden/skins/<name>.yaml. When no user
-    // theme is active, the legacy skin RGB path runs unchanged —
-    // preserves /skin custom-palette users from regression.
-    if (getActiveThemePath() !== null) {
+    // re-author a parallel ~/.aiden/skins/<name>.yaml. The bundled
+    // aiden-ember theme is also applied without a user-file path, so
+    // current theme identity participates in the authority check.
+    if (getActiveThemePath() !== null || getCurrentThemeName() !== 'default') {
       const dotted = COLOR_KIND_TO_TOKEN_PATH[kind];
       if (dotted) {
         const hex = readDottedPath(liveColors, dotted);

--- a/cli/v4/skinEngine.ts
+++ b/cli/v4/skinEngine.ts
@@ -30,8 +30,72 @@ import yaml from 'js-yaml';
 import { colors as liveColors } from './design/tokens';
 import { getActivePath as getActiveThemePath } from '../../core/v4/theme/themeRegistry';
 
-/** Wrap text with a 24-bit ANSI foreground colour. */
-function ansiRgb(text: string, r: number, g: number, b: number): string {
+export type SkinColorDepth = 'truecolor' | '256' | '16' | 'none';
+
+export function detectSkinColorDepth(
+  env: NodeJS.ProcessEnv = process.env,
+  terminal: { isTTY?: boolean; platform?: NodeJS.Platform } = {
+    isTTY: process.stdout.isTTY,
+    platform: process.platform,
+  },
+): SkinColorDepth {
+  const forced = env.AIDEN_FORCE_COLOR_DEPTH?.toLowerCase();
+  if (forced === 'truecolor' || forced === '256' || forced === '16' || forced === 'none') return forced;
+  if ((env.NO_COLOR != null && env.NO_COLOR !== '') || env.FORCE_COLOR === '0') return 'none';
+  if (!terminal.isTTY) return 'truecolor';
+  if (/truecolor|24bit/iu.test(env.COLORTERM ?? '') || env.WT_SESSION || env.TERM_PROGRAM) return 'truecolor';
+  if (/256color/iu.test(env.TERM ?? '')) return '256';
+  return '16';
+}
+
+function rgbTo256(r: number, g: number, b: number): number {
+  if (r === g && g === b) {
+    if (r < 8) return 16;
+    if (r > 248) return 231;
+    return Math.round(((r - 8) / 247) * 24) + 232;
+  }
+  return 16 + 36 * Math.round(r / 51) + 6 * Math.round(g / 51) + Math.round(b / 51);
+}
+
+const ANSI16: ReadonlyArray<readonly [number, number, number, number]> = [
+  [0, 0, 0, 30], [128, 0, 0, 31], [0, 128, 0, 32], [128, 128, 0, 33],
+  [0, 0, 128, 34], [128, 0, 128, 35], [0, 128, 128, 36], [192, 192, 192, 37],
+  [128, 128, 128, 90], [255, 0, 0, 91], [0, 255, 0, 92], [255, 255, 0, 93],
+  [0, 0, 255, 94], [255, 0, 255, 95], [0, 255, 255, 96], [255, 255, 255, 97],
+];
+
+function rgbTo16(r: number, g: number, b: number): number {
+  let selected = ANSI16[0]!;
+  let distance = Number.POSITIVE_INFINITY;
+  for (const candidate of ANSI16) {
+    const next = (r - candidate[0]) ** 2 + (g - candidate[1]) ** 2 + (b - candidate[2]) ** 2;
+    if (next < distance) {
+      selected = candidate;
+      distance = next;
+    }
+  }
+  return selected[3];
+}
+
+function ansiRgb(
+  text: string,
+  r: number,
+  g: number,
+  b: number,
+  depth: SkinColorDepth,
+  kind?: ColorKind,
+): string {
+  if (depth === 'none') return text;
+  if (depth === '256') return `\x1b[38;5;${rgbTo256(r, g, b)}m${text}\x1b[39m`;
+  if (depth === '16') {
+    const semanticCode: Partial<Record<ColorKind, number>> = {
+      brand: 91, accent: 91, heading: 91, user: 91,
+      success: 92, warn: 93, degraded: 93, error: 31,
+      tool: 96, session: 96, agent: 97, muted: 37,
+      tertiary: 90, metric_turn: 95,
+    };
+    return `\x1b[${semanticCode[kind!] ?? rgbTo16(r, g, b)}m${text}\x1b[39m`;
+  }
   return `\x1b[38;2;${r};${g};${b}m${text}\x1b[39m`;
 }
 
@@ -123,7 +187,7 @@ const DEFAULT_SKIN: SkinDefinition = {
   colors: {
     brand: BRAND_ORANGE,
     accent: BRAND_ORANGE,
-    user: [0x4e, 0xc9, 0xb0], // teal — user input
+    user: BRAND_ORANGE, // user input shares the Aiden brand accent
     agent: [0xe0, 0xe0, 0xe0], // off-white — agent reply
     tool: [0x9c, 0xdc, 0xfe], // cyan — tool calls
     error: [0xf4, 0x47, 0x47],
@@ -172,7 +236,7 @@ const LIGHT_SKIN: SkinDefinition = {
   colors: {
     brand: [0xc4, 0x42, 0x10],
     accent: [0xc4, 0x42, 0x10],
-    user: [0x00, 0x66, 0x55],
+    user: [0xc4, 0x42, 0x10],
     agent: [0x20, 0x20, 0x20],
     tool: [0x00, 0x55, 0x88],
     error: [0xb0, 0x10, 0x10],
@@ -243,6 +307,8 @@ export interface SkinEngineOptions {
    * for tests and `NO_COLOR`-aware deployments.
    */
   forceMono?: boolean;
+  /** Override terminal capability detection for deterministic rendering. */
+  colorDepth?: SkinColorDepth;
 }
 
 export type SkinSource = 'bundled-builtin' | 'bundled-yaml' | 'user';
@@ -277,6 +343,7 @@ export class SkinEngine {
   private readonly bundledDir: string;
   private readonly onError?: (msg: string) => void;
   private readonly forceMono: boolean;
+  private readonly colorDepth: SkinColorDepth;
   private readonly cache = new Map<string, SkinDefinition>();
   private readonly sourceMap = new Map<string, SkinSource>();
   private readonly fileMap = new Map<string, string>();
@@ -289,6 +356,7 @@ export class SkinEngine {
     this.forceMono =
       opts.forceMono ??
       (process.env.NO_COLOR != null && process.env.NO_COLOR !== '');
+    this.colorDepth = opts.colorDepth ?? detectSkinColorDepth();
     for (const name of Object.keys(BUNDLED)) {
       this.cache.set(name, BUNDLED[name]);
       this.sourceMap.set(name, 'bundled-builtin');
@@ -386,13 +454,13 @@ export class SkinEngine {
         const hex = readDottedPath(liveColors, dotted);
         if (typeof hex === 'string') {
           const rgb = hexToRgb(hex);
-          if (rgb) return ansiRgb(text, rgb[0], rgb[1], rgb[2]);
+          if (rgb) return ansiRgb(text, rgb[0], rgb[1], rgb[2], this.colorDepth, kind);
         }
       }
     }
     const rgb = this.current.colors[kind];
     if (!rgb) return text;
-    return ansiRgb(text, rgb[0], rgb[1], rgb[2]);
+    return ansiRgb(text, rgb[0], rgb[1], rgb[2], this.colorDepth, kind);
   }
 
   /** List all skin names currently cached (bundled + previously loaded). */

--- a/cli/v4/startupDashboard.ts
+++ b/cli/v4/startupDashboard.ts
@@ -127,6 +127,42 @@ function fit(value: string, width: number): string {
   return fitStartupLine(value, Math.max(1, width));
 }
 
+/** Wrap plain startup copy without dropping words or splitting wide glyphs. */
+function wrapPlain(value: string, maxWidth: number): string[] {
+  const width = Math.max(1, Math.floor(maxWidth));
+  const words = value.trim().split(/\s+/u).filter(Boolean);
+  if (words.length === 0) return [''];
+  const lines: string[] = [];
+  let line = '';
+  const pushLongWord = (word: string): string => {
+    let rest = word;
+    while (startupVisibleWidth(rest) > width) {
+      let chunk = '';
+      for (const point of rest) {
+        if (startupVisibleWidth(chunk + point) > width) break;
+        chunk += point;
+      }
+      lines.push(chunk);
+      rest = rest.slice(chunk.length);
+    }
+    return rest;
+  };
+  for (const rawWord of words) {
+    const word = startupVisibleWidth(rawWord) > width ? pushLongWord(rawWord) : rawWord;
+    if (!word) continue;
+    if (!line) {
+      line = word;
+    } else if (startupVisibleWidth(`${line} ${word}`) <= width) {
+      line += ` ${word}`;
+    } else {
+      lines.push(line);
+      line = word;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.length > 0 ? lines : [''];
+}
+
 function pad(value: string, width: number): string {
   const fitted = fit(value, width);
   return fitted + ' '.repeat(Math.max(0, width - startupVisibleWidth(fitted)));
@@ -253,36 +289,36 @@ function renderMediumSections(
 function renderProject(
   data: StartupProjectData,
   style: StartupDashboardStyle,
-  tier: StartupDashboardTier,
+  _tier: StartupDashboardTier,
   width: number,
 ): string[] {
   const identity = clean(data.identity) ?? 'Built solo';
-  if (tier === 'wide') {
-    const frameWidth = Math.min(width, 72);
-    const inside = Math.max(1, frameWidth - 2);
-    const rows = [
-      `${style.brand('♥')}  ${style.text(identity)}`,
-      '',
-      clean(data.github) ? `${style.brand('GitHub:'.padEnd(10))}${style.text(data.github!)}` : undefined,
-      clean(data.website) ? `${style.brand('Web:'.padEnd(10))}${style.text(data.website!)}` : undefined,
-      clean(data.contact) ? `${style.brand('Contact:'.padEnd(10))}${style.text(data.contact!)}` : undefined,
-    ].filter((entry): entry is string => entry !== undefined);
-    return [
-      style.muted(`╭${'─'.repeat(inside)}╮`),
-      ...rows.map((row) => `${style.muted('│')}${pad(` ${row}`, inside)}${style.muted('│')}`),
-      style.muted(`╰${'─'.repeat(inside)}╯`),
-    ];
-  }
-  if (tier === 'medium') {
-    return [
-      `${style.brand('♥')} ${style.text(identity)}`,
-      ...[clean(data.github), clean(data.website), clean(data.contact)]
-        .filter((entry): entry is string => !!entry)
-        .map((entry) => fit(style.muted(entry), width)),
-    ];
-  }
-  const repo = clean(data.github)?.replace(/^github\.com\//, '') ?? clean(data.website) ?? '';
-  return [fit(`${style.brand('♥')} ${style.muted(`${identity.toLowerCase()}${repo ? ` · ${repo}` : ''}`)}`, width)];
+  const frameWidth = Math.max(4, Math.min(width, 72));
+  const inside = Math.max(2, frameWidth - 2);
+  const contentWidth = Math.max(1, inside - 2);
+  const rows: string[] = [`♥  ${identity}`, ''];
+  const addDetail = (label: string, value: string | undefined): void => {
+    if (!value) return;
+    const labelWidth = Math.min(9, contentWidth);
+    const firstPrefix = `${label}:`.padEnd(labelWidth);
+    const continuationPrefix = ' '.repeat(labelWidth);
+    const valueWidth = Math.max(1, contentWidth - labelWidth);
+    const wrapped = wrapPlain(value, valueWidth);
+    wrapped.forEach((line, index) => rows.push(`${index === 0 ? firstPrefix : continuationPrefix}${line}`));
+  };
+  addDetail('GitHub', clean(data.github));
+  addDetail('Web', clean(data.website));
+  addDetail('Contact', clean(data.contact));
+  return [
+    style.muted(`╭${'─'.repeat(inside)}╮`),
+    ...rows.map((row) => {
+      const colored = row.startsWith('♥')
+        ? `${style.brand('♥')}${style.text(row.slice(1))}`
+        : style.text(row);
+      return `${style.muted('│')} ${pad(colored, contentWidth)} ${style.muted('│')}`;
+    }),
+    style.muted(`╰${'─'.repeat(inside)}╯`),
+  ];
 }
 
 function normalizeBanner(banner: string | undefined, width: number): string[] {
@@ -298,15 +334,13 @@ export function renderStartupDashboard(options: RenderStartupDashboardOptions): 
   const tier = resolveStartupDashboardTier(options.columns);
   const data = options.data;
   const lines: string[] = [];
-  const bannerLines = tier === 'wide' || tier === 'medium'
-    ? normalizeBanner(options.banner, width)
-    : [];
+  const bannerLines = normalizeBanner(options.banner, width);
 
   if (bannerLines.length > 0) {
     lines.push(...bannerLines, style.muted('Autonomous AI Engine'), '');
   } else {
-    lines.push(style.brand('AIDEN'));
-    if (tier !== 'minimal') lines.push(style.muted('Autonomous AI Engine'));
+    lines.push(style.brand('Aiden'));
+    lines.push(style.muted('Autonomous AI Engine'));
   }
 
   lines.push(statusLine(data, style, tier, width));
@@ -321,8 +355,12 @@ export function renderStartupDashboard(options: RenderStartupDashboardOptions): 
   }
 
   lines.push(...renderProject(data.project, style, tier, width));
-  if (clean(data.greeting)) lines.push('', fit(style.text(data.greeting!), width));
-  if (clean(data.helper)) lines.push(fit(style.muted(data.helper!), width));
+  if (clean(data.greeting)) {
+    lines.push('', ...wrapPlain(data.greeting!, width).map((line) => style.text(line)));
+  }
+  if (clean(data.helper)) {
+    lines.push(...wrapPlain(data.helper!, width).map((line) => style.muted(line)));
+  }
 
   return {
     tier,

--- a/cli/v4/startupDashboard.ts
+++ b/cli/v4/startupDashboard.ts
@@ -55,6 +55,7 @@ export interface StartupDashboardStyle {
   muted(value: string): string;
   text(value: string): string;
   success(value: string): string;
+  info?(value: string): string;
 }
 
 export interface RenderStartupDashboardOptions {
@@ -74,6 +75,7 @@ const PLAIN_STYLE: StartupDashboardStyle = {
   muted: (value) => value,
   text: (value) => value,
   success: (value) => value,
+  info: (value) => value,
 };
 
 export function startupVisibleWidth(value: string): number {
@@ -82,8 +84,8 @@ export function startupVisibleWidth(value: string): number {
 
 export function resolveStartupDashboardTier(columns: number): StartupDashboardTier {
   const width = Number.isFinite(columns) ? Math.max(1, Math.floor(columns)) : 80;
-  if (width >= 100) return 'wide';
-  if (width >= 64) return 'medium';
+  if (width >= 80) return 'wide';
+  if (width >= 56) return 'medium';
   if (width >= 32) return 'narrow';
   return 'minimal';
 }
@@ -185,20 +187,23 @@ function statusLine(
   tier: StartupDashboardTier,
   width: number,
 ): string {
-  const dot = style.success('●');
+  const info = style.info ?? style.text;
+  const healthy = style.success('●');
+  const trustGlyph = info('◇');
+  const modelGlyph = info('◆');
   const model = data.providerReady ? clean(data.model) ?? 'not configured' : 'not configured';
-  const segments = tier === 'wide'
+  const segments = tier === 'wide' && width >= 98
     ? [
-        `${dot} ${style.muted('core')} ${style.text('online')}`,
-        `${dot} ${style.muted('trust')} ${style.text(clean(data.trust) ?? 'Assistant')}`,
-        `${dot} ${style.muted('model')} ${style.text(model)}`,
-        clean(data.memory) ? `${dot} ${style.muted('memory')} ${style.text(data.memory!)}` : undefined,
-        clean(data.version) ? `${dot} ${style.text(`v${data.version}`)}` : undefined,
+        `${healthy} ${style.muted('core')} ${style.success('online')}`,
+        `${trustGlyph} ${style.muted('trust')} ${info(clean(data.trust) ?? 'Assistant')}`,
+        `${modelGlyph} ${style.muted('model')} ${info(model)}`,
+        clean(data.memory) ? `${healthy} ${style.muted('memory')} ${style.success(data.memory!)}` : undefined,
+        clean(data.version) ? style.muted(`v${data.version}`) : undefined,
       ]
     : [
-        `${dot} ${style.text(clean(data.trust) ?? 'Assistant')}`,
-        `${style.text(model)}`,
-        clean(data.memory) ? style.muted(`memory ${data.memory}`) : undefined,
+        `${trustGlyph} ${info(clean(data.trust) ?? 'Assistant')}`,
+        `${modelGlyph} ${info(model)}`,
+        clean(data.memory) ? `${healthy} ${style.success(`memory ${data.memory}`)}` : undefined,
         clean(data.version) ? style.muted(`v${data.version}`) : undefined,
       ];
   return fit(segments.filter((entry): entry is string => !!entry).join(' · '), width);
@@ -232,9 +237,10 @@ function renderKeyValue(
   style: StartupDashboardStyle,
   width: number,
   keyWidth = 10,
+  valueStyle: (value: string) => string = style.text,
 ): string {
   const label = style.muted(key.padEnd(keyWidth));
-  return fit(label + style.text(value), width);
+  return fit(label + valueStyle(value), width);
 }
 
 function renderWideSections(
@@ -252,9 +258,16 @@ function renderWideSections(
     return [style.brand('Capabilities'), ...right.map(([key, value]) => renderKeyValue(key, value, style, width))];
   }
 
-  const separator = '    ';
+  const separator = style.muted(' │ ');
   const columnWidth = Math.max(1, Math.floor((width - startupVisibleWidth(separator)) / 2));
-  const leftLines = [style.brand('Environment'), ...left.map(([key, value]) => renderKeyValue(key, value, style, columnWidth))];
+  const leftLines = [style.brand('Environment'), ...left.map(([key, value]) => renderKeyValue(
+    key,
+    value,
+    style,
+    columnWidth,
+    10,
+    key === 'tools' || key === 'skills' ? style.success : style.text,
+  ))];
   const rightLines = [style.brand('Capabilities'), ...right.map(([key, value]) => renderKeyValue(key, value, style, columnWidth))];
   const count = Math.max(leftLines.length, rightLines.length);
   return Array.from({ length: count }, (_, index) =>
@@ -266,22 +279,24 @@ function renderMediumSections(
   style: StartupDashboardStyle,
   width: number,
 ): string[] {
-  const environment = data.environment;
   const lines: string[] = [];
-  const summary = [clean(environment?.os), clean(environment?.shell), clean(environment?.runtime)]
-    .filter((entry): entry is string => !!entry);
-  const counts = [countLabel(environment?.tools, 'tools'), countLabel(environment?.skills, 'skills')]
-    .filter((entry): entry is string => !!entry);
-  if (summary.length > 0 || counts.length > 0) {
+  const environment = environmentRows(data.environment);
+  if (environment.length > 0) {
     lines.push(style.brand('Environment'));
-    if (summary.length > 0) lines.push(fit(style.text(summary.join(' · ')), width));
-    if (counts.length > 0) lines.push(fit(style.muted(counts.join(' · ')), width));
+    lines.push(...environment.map(([key, value]) => renderKeyValue(
+      key,
+      value,
+      style,
+      width,
+      10,
+      key === 'tools' || key === 'skills' ? style.success : style.text,
+    )));
   }
-  const capabilities = capabilityRows(data.capabilities).map(([, value]) => value);
+  const capabilities = capabilityRows(data.capabilities);
   if (capabilities.length > 0) {
     if (lines.length > 0) lines.push('');
     lines.push(style.brand('Capabilities'));
-    lines.push(fit(style.text(Object.keys(data.capabilities ?? {}).join(' · ')), width));
+    lines.push(...capabilities.map(([key, value]) => renderKeyValue(key, value, style, width)));
   }
   return lines;
 }
@@ -347,7 +362,7 @@ export function renderStartupDashboard(options: RenderStartupDashboardOptions): 
   lines.push(statusLine(data, style, tier, width));
   if (clean(data.persistedModelNote)) lines.push(style.muted(fit(data.persistedModelNote!, width)));
 
-  if (tier === 'wide' || tier === 'medium') {
+  if (tier === 'wide' || tier === 'medium' || tier === 'narrow') {
     lines.push('', style.muted('─'.repeat(width)), '');
     lines.push(...(tier === 'wide'
       ? renderWideSections(data, style, width)

--- a/cli/v4/startupDashboard.ts
+++ b/cli/v4/startupDashboard.ts
@@ -293,7 +293,8 @@ function renderProject(
   width: number,
 ): string[] {
   const identity = clean(data.identity) ?? 'Built solo';
-  const frameWidth = Math.max(4, Math.min(width, 72));
+  const indent = width >= 36 ? '  ' : '';
+  const frameWidth = Math.max(4, Math.min(width - startupVisibleWidth(indent), 72));
   const inside = Math.max(2, frameWidth - 2);
   const contentWidth = Math.max(1, inside - 2);
   const rows: string[] = [`♥  ${identity}`, ''];
@@ -310,14 +311,14 @@ function renderProject(
   addDetail('Web', clean(data.website));
   addDetail('Contact', clean(data.contact));
   return [
-    style.muted(`╭${'─'.repeat(inside)}╮`),
+    `${indent}${style.muted(`╭${'─'.repeat(inside)}╮`)}`,
     ...rows.map((row) => {
       const colored = row.startsWith('♥')
         ? `${style.brand('♥')}${style.text(row.slice(1))}`
         : style.text(row);
-      return `${style.muted('│')} ${pad(colored, contentWidth)} ${style.muted('│')}`;
+      return `${indent}${style.muted('│')} ${pad(colored, contentWidth)} ${style.muted('│')}`;
     }),
-    style.muted(`╰${'─'.repeat(inside)}╯`),
+    `${indent}${style.muted(`╰${'─'.repeat(inside)}╯`)}`,
   ];
 }
 

--- a/cli/v4/startupNotices.ts
+++ b/cli/v4/startupNotices.ts
@@ -26,6 +26,11 @@ export interface StartupNotice {
 
 export interface StartupNoticeRenderOptions {
   columns: number;
+  style?: {
+    warning(value: string): string;
+    text(value: string): string;
+    command(value: string): string;
+  };
 }
 
 const SAFE_MARGIN = 2;
@@ -383,53 +388,26 @@ export function renderStartupNoticeLines(
   if (notices.length === 0) return [];
   const width = safeWidth(opts.columns);
   const tier = resolveStartupDashboardTier(opts.columns);
+  const style = opts.style ?? {
+    warning: (value: string) => value,
+    text: (value: string) => value,
+    command: (value: string) => value,
+  };
   const lines: string[] = [];
 
-  if (tier === 'wide') {
-    lines.push('Setup and notices', '');
+  if (tier !== 'minimal') {
     for (const n of notices) {
-      lines.push(fit(`! ${n.title}`, width));
-      if (n.detail) lines.push(fit(`  ${n.detail}`, width));
-      if (n.command) lines.push(fit(`  Run: ${n.command}`, width));
-      lines.push('');
-    }
-    if (lines[lines.length - 1] === '') lines.pop();
-    return lines;
-  }
-
-  if (tier === 'medium') {
-    lines.push('Notices');
-    for (const n of notices) {
-      const action = n.command ? `: ${n.command}` : n.detail ? `: ${n.detail}` : '';
-      const combined = `! ${n.title}${action}`;
-      if (startupNoticeVisibleWidth(combined) <= width) {
-        lines.push(combined);
-      } else {
-        lines.push(fit(`! ${n.title}`, width));
-        if (n.command) lines.push(fit(`  Run: ${n.command}`, width));
-        else if (n.detail) lines.push(fit(`  ${n.detail}`, width));
-      }
-    }
-    return lines;
-  }
-
-  if (tier === 'narrow') {
-    for (const n of notices) {
-      const action = n.command ? `: ${n.command}` : '';
-      const combined = `! ${compactTitle(n)}${action}`;
-      if (startupNoticeVisibleWidth(combined) <= width) {
-        lines.push(combined);
-      } else {
-        lines.push(fit(`! ${compactTitle(n)}`, width));
-        if (n.command) lines.push(fit(`  Run: ${n.command}`, width));
-      }
+      const title = tier === 'narrow' ? compactTitle(n) : n.title;
+      lines.push(fit(`${style.warning('!')} ${style.text(title)}`, width));
+      if (n.command) lines.push(fit(`  ${style.command(n.command)}`, width));
+      else if (n.detail) lines.push(fit(`  ${style.text(n.detail)}`, width));
     }
     return lines;
   }
 
   const first = notices.find((n) => n.blocking || n.severity !== 'info') ?? notices[0];
-  lines.push(fit('! Setup required', width));
-  lines.push(fit(`Run ${first.command ?? '/doctor'}`, width));
+  lines.push(fit(`${style.warning('!')} ${style.text('Setup required')}`, width));
+  lines.push(fit(style.command(first.command ?? '/doctor'), width));
   return lines;
 }
 

--- a/cli/v4/startupNotices.ts
+++ b/cli/v4/startupNotices.ts
@@ -401,7 +401,14 @@ export function renderStartupNoticeLines(
     lines.push('Notices');
     for (const n of notices) {
       const action = n.command ? `: ${n.command}` : n.detail ? `: ${n.detail}` : '';
-      lines.push(fit(`! ${n.title}${action}`, width));
+      const combined = `! ${n.title}${action}`;
+      if (startupNoticeVisibleWidth(combined) <= width) {
+        lines.push(combined);
+      } else {
+        lines.push(fit(`! ${n.title}`, width));
+        if (n.command) lines.push(fit(`  Run: ${n.command}`, width));
+        else if (n.detail) lines.push(fit(`  ${n.detail}`, width));
+      }
     }
     return lines;
   }
@@ -409,7 +416,13 @@ export function renderStartupNoticeLines(
   if (tier === 'narrow') {
     for (const n of notices) {
       const action = n.command ? `: ${n.command}` : '';
-      lines.push(fit(`! ${compactTitle(n)}${action}`, width));
+      const combined = `! ${compactTitle(n)}${action}`;
+      if (startupNoticeVisibleWidth(combined) <= width) {
+        lines.push(combined);
+      } else {
+        lines.push(fit(`! ${compactTitle(n)}`, width));
+        if (n.command) lines.push(fit(`  Run: ${n.command}`, width));
+      }
     }
     return lines;
   }

--- a/cli/v4/themeCompatibility.ts
+++ b/cli/v4/themeCompatibility.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { getYaml } from '../../core/v4/theme/bundledThemes';
+import { loadThemeFile, parseThemeYaml } from '../../core/v4/theme/themeLoader';
+import { applyTheme, resetToDefault } from '../../core/v4/theme/themeRegistry';
+import type { SkinEngine } from './skinEngine';
+
+const LEGACY_THEME_MAP: Readonly<Record<string, string>> = Object.freeze({
+  default: 'aiden-ember',
+  monochrome: 'monochrome',
+  light: 'light',
+});
+
+export interface EffectiveThemeInitialization {
+  name: string;
+  source: 'theme-file' | 'legacy-migration' | 'bundled-default';
+  themePath: string;
+  persisted: boolean;
+}
+
+/** Resolve persisted visual state before any interactive startup output. */
+export function initializeEffectiveTheme(
+  root: string,
+  legacySkin: string | null | undefined,
+  skin: SkinEngine,
+): EffectiveThemeInitialization {
+  const themePath = path.join(root, 'theme.yaml');
+  skin.setActive('default');
+
+  if (existsSync(themePath)) {
+    const { parsed } = loadThemeFile(themePath);
+    if (parsed) {
+      applyTheme(parsed, themePath);
+      return { name: parsed.name, source: 'theme-file', themePath, persisted: true };
+    }
+  }
+
+  const legacy = (legacySkin ?? 'default').trim().toLowerCase();
+  const name = LEGACY_THEME_MAP[legacy] ?? 'aiden-ember';
+  const yamlText = getYaml(name as 'aiden-ember' | 'monochrome' | 'light');
+  const parsed = yamlText ? parseThemeYaml(yamlText).parsed : null;
+  if (!parsed) {
+    resetToDefault();
+    return { name: 'aiden-ember', source: 'bundled-default', themePath, persisted: false };
+  }
+
+  if (legacy !== 'default' && LEGACY_THEME_MAP[legacy]) {
+    try {
+      mkdirSync(root, { recursive: true });
+      writeFileSync(themePath, yamlText!, 'utf8');
+      applyTheme(parsed, themePath);
+      return { name: parsed.name, source: 'legacy-migration', themePath, persisted: true };
+    } catch {
+      applyTheme(parsed, null);
+      return { name: parsed.name, source: 'legacy-migration', themePath, persisted: false };
+    }
+  }
+
+  applyTheme(parsed, null);
+  return { name: parsed.name, source: 'bundled-default', themePath, persisted: false };
+}

--- a/cli/v4/turnInputListener.ts
+++ b/cli/v4/turnInputListener.ts
@@ -46,6 +46,10 @@ export interface TurnInputCallbacks {
    * current buffer, so the live composer can repaint what the user typed.
    */
   onBufferChange?: (buffer: string) => void;
+  /** Scroll the transcript without transferring composer ownership. */
+  onScroll?: (deltaRows: number) => void;
+  /** Return the transcript to sticky-tail mode. */
+  onFollow?: () => void;
 }
 
 /** Non-text keys that must never land in the line buffer. */
@@ -82,6 +86,9 @@ export function makeKeypressHandler(cb: TurnInputCallbacks): (str: string | unde
     if (seq === PASTE_END   || k.name === 'paste-end')   { pasting = false; return; }
 
     if (k.ctrl && k.name === 'c') { buffer = ''; pasting = false; cb.onCtrlC(); notify(prev); return; }
+    if (k.name === 'pageup') { cb.onScroll?.(8); return; }
+    if (k.name === 'pagedown') { cb.onScroll?.(-8); return; }
+    if (k.ctrl && k.name === 'end') { cb.onFollow?.(); return; }
     // Only a BARE ESC cancels — a CSI sequence (paste marker, arrow) does not.
     if (k.name === 'escape' && (seq === '\x1b' || seq === '')) { buffer = ''; pasting = false; cb.onEscape(); notify(prev); return; }
     if (k.name === 'return' || k.name === 'enter') {

--- a/core/v4/sessionManager.ts
+++ b/core/v4/sessionManager.ts
@@ -223,6 +223,14 @@ export class SessionManager {
     return this.store.listSessions(opts);
   }
 
+  /** Delete one stored conversation and its messages. Durable Job data is
+   * owned by the Job Engine and is intentionally outside this operation. */
+  deleteSession(id: string): boolean {
+    if (!this.store.getSession(id)) return false;
+    this.store.deleteSession(id);
+    return true;
+  }
+
   // ── Internals ────────────────────────────────────────────────────────
 
   private findByExactTitle(title: string): SessionRecord | null {

--- a/core/v4/taskVerification.ts
+++ b/core/v4/taskVerification.ts
@@ -326,6 +326,18 @@ export function decideTaskVerdict(
     // complete on its own terms. (Read evidence still recorded above.)
     return { verdict: 'completed', handles, failures };
   }
+  // A clean process exit proves that the process ran; it does not prove the
+  // user's requested real-world outcome. Goal proof must come from an
+  // independent readback or a durable required claim, never stdout alone.
+  const hasProcessOnlyEvidence = mutating.some((entry) => {
+    if (entry.name !== 'shell_exec' && entry.name !== 'execute_code') return false;
+    if (!isOk(entry)) return false;
+    return !extractEvidenceHandles(entry).some((handle) =>
+      handle.verified && handle.kind !== 'exit_code' && handle.kind !== 'note');
+  });
+  if (hasProcessOnlyEvidence) {
+    return { verdict: 'completed_unverified', handles, failures };
+  }
   // No unresolved failures left. Completed iff every mutating entry is
   // verified-ok OR a superseded failure; a low_signal/unknown mutation is an
   // honest downgrade (never silently upgraded).
@@ -432,6 +444,8 @@ export function computeTaskFinalization(
   turn: {
     finishReason:   string;
     toolCallTrace?: HonestyTraceEntry[];
+    /** Final assistant response, consulted only for an explicit failure admission. */
+    assistantContent?: string | null;
     /** Model-declared ui_task_done status ('success'/'failure'/…), when seen. */
     declaredStatus?: string | null;
   },
@@ -513,6 +527,21 @@ export function computeTaskFinalization(
       status:   'failed',
       outcome:  deriveVerificationOutcome('failed', decision.handles, decision.failures, turn.finishReason),
       evidence: { ...buildEvidenceEnvelope(decision, { now: opts?.now }), verdict: 'failed', ...declinedExtra },
+      jobCard,
+    };
+  }
+  const assistantReportedFailure = typeof turn.assistantContent === 'string'
+    && /\b(?:I\s+(?:could\s+not|couldn't|was\s+unable\s+to|failed\s+to)\s+(?:complete|finish|perform|execute|create|write|update|delete|run|satisfy|verify)|the\s+(?:task|operation)\s+failed)\b/iu
+      .test(turn.assistantContent);
+  if (assistantReportedFailure) {
+    return {
+      status:   'failed',
+      outcome:  deriveVerificationOutcome('failed', decision.handles, decision.failures, 'assistant_reported_failure'),
+      evidence: {
+        ...buildEvidenceEnvelope(decision, { reportedFailure: 'assistant_reported_failure', now: opts?.now }),
+        verdict: 'failed',
+        ...declinedExtra,
+      },
       jobCard,
     };
   }

--- a/core/v4/theme/bundledThemes.ts
+++ b/core/v4/theme/bundledThemes.ts
@@ -23,9 +23,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-/** Bundled theme names, sorted to give `/theme list` a stable order. */
-export const BUNDLED_NAMES = ['default', 'monochrome', 'light', 'tokyo-night', 'dracula'] as const;
-export type BundledName = typeof BUNDLED_NAMES[number];
+/** Aiden-native bundled themes shown by `/theme list`. */
+export const BUNDLED_NAMES = ['aiden-ember', 'midnight', 'aurora', 'monochrome', 'high-contrast'] as const;
+/** Previously shipped identifiers remain resolvable for persisted configuration compatibility. */
+export const LEGACY_BUNDLED_NAMES = ['default', 'light', 'tokyo-night', 'dracula'] as const;
+export type BundledName = typeof BUNDLED_NAMES[number] | typeof LEGACY_BUNDLED_NAMES[number];
 
 /**
  * Walk up from `__dirname` looking for the repo root that holds the
@@ -86,6 +88,10 @@ export interface BundledSummary {
 }
 
 const DESCRIPTIONS: Record<BundledName, string> = {
+  'aiden-ember': "Aiden's warm orange identity on a restrained dark surface.",
+  midnight:      'Restrained blue and gray accents for low-light terminals.',
+  aurora:        'Cool luminous accents with clear semantic contrast.',
+  'high-contrast': 'Accessibility-focused contrast and bright state boundaries.',
   default:       "Aiden's signature brand-orange theme on a dark terminal.",
   monochrome:    'Pure greyscale. Semantic accents retained for error/success readability.',
   light:         'Light terminal. Dark text on light background. Brand orange accent.',
@@ -101,7 +107,7 @@ export function listBundled(): BundledSummary[] {
 }
 
 export function isBundled(name: string): name is BundledName {
-  return (BUNDLED_NAMES as readonly string[]).includes(name);
+  return ([...BUNDLED_NAMES, ...LEGACY_BUNDLED_NAMES] as readonly string[]).includes(name);
 }
 
 /** Test-only reset of the themes-dir cache. */

--- a/core/v4/ui/banner.ts
+++ b/core/v4/ui/banner.ts
@@ -34,20 +34,12 @@
  */
 
 import { c, dim, termWidth, getColorDepth } from './theme';
+import { AIDEN_LOGO_LINES } from './identity';
 
 /**
- * The block-style AIDEN ASCII. Copied from cli/v4/display.ts so this
- * module has zero coupling to the skin-engine display surface. 6 rows,
- * widest row = 36 cells.
+ * The canonical block-style AIDEN ASCII. Six rows, widest row = 36 cells.
  */
-const AIDEN_ART = String.raw`
-█████╗  ██╗██████╗ ███████╗███╗   ██╗
-██╔══██╗██║██╔══██╗██╔════╝████╗  ██║
-███████║██║██║  ██║█████╗  ██╔██╗ ██║
-██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║
-██║  ██║██║██████╔╝███████╗██║ ╚████║
-╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝
-`.trim().split('\n');
+const AIDEN_ART = AIDEN_LOGO_LINES;
 
 const ART_WIDTH = 36;
 

--- a/core/v4/ui/banner.ts
+++ b/core/v4/ui/banner.ts
@@ -106,15 +106,6 @@ export function renderBanner(opts: BannerOptions): string {
   // inside a closed box collides with the asymmetric orange-bar
   // language used by every other v4.8.0 surface.
   //
-  // v4.8.0 Slice 10c — emit raw 24-bit truecolor for the AIDEN art
-  // instead of routing through `c.primary` (which depth-detects via
-  // theme.ts and degrades to 256-color or 16-color when COLORTERM is
-  // unset — common on Windows ConPTY). Result on those terminals was
-  // a washed-out / grey AIDEN that didn't match the boot card's
-  // skinEngine-painted brand orange. Forcing truecolor here brings
-  // disclaimer + setupWizard banner in line with the boot card.
-  const ORANGE_ON  = '\x1b[38;2;255;107;53m';
-  const COLOR_OFF  = '\x1b[39m';
   const inner = w - 2;
   const artPad = Math.max(0, Math.floor((inner - ART_WIDTH) / 2));
 
@@ -122,7 +113,7 @@ export function renderBanner(opts: BannerOptions): string {
   lines.push('');
   for (const row of AIDEN_ART) {
     const padded = rpad(' '.repeat(artPad) + row, inner);
-    lines.push(`  ${ORANGE_ON}${padded}${COLOR_OFF}`);
+    lines.push(`  ${c.primary(padded)}`);
   }
   lines.push('');
   lines.push('  ' + dim(c.muted(versionLine)));

--- a/core/v4/ui/identity.ts
+++ b/core/v4/ui/identity.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+
+/** Canonical six-row Aiden wordmark shared by every presentation adapter. */
+export const AIDEN_LOGO_LINES = Object.freeze([
+  '█████╗  ██╗██████╗ ███████╗███╗   ██╗',
+  '██╔══██╗██║██╔══██╗██╔════╝████╗  ██║',
+  '███████║██║██║  ██║█████╗  ██╔██╗ ██║',
+  '██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║',
+  '██║  ██║██║██████╔╝███████╗██║ ╚████║',
+  '╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝',
+] as const);
+
+export const AIDEN_LOGO_TEXT = AIDEN_LOGO_LINES.join('\n');

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Writable } from 'node:stream';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { renderBottomSurface } from '../../../cli/v4/composerLane';
 import { TerminalScreen } from '../harness/terminalScreen';
 
 class ScreenStream extends Writable {
@@ -39,6 +40,24 @@ class ScreenStream extends Writable {
 }
 
 const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
+
+it('applies the active theme to the composer title and restrained frame without changing geometry', () => {
+  const renderStyled = renderBottomSurface as unknown as (...args: unknown[]) => ReturnType<typeof renderBottomSurface>;
+  const styled = renderStyled(
+    24,
+    80,
+    { draft: 'hello', mode: 'idle' },
+    '◆ provider · model',
+    {
+      brand: (value: string) => `\x1b[31m${value}\x1b[39m`,
+      muted: (value: string) => `\x1b[90m${value}\x1b[39m`,
+    },
+  );
+  const text = styled.lines.join('\n');
+  expect(text).toContain('\x1b[31m▲ You\x1b[39m');
+  expect(text).toContain('\x1b[90m╭─ \x1b[39m');
+  expect(styled.cursorCol).toBe(8);
+});
 
 afterEach(() => {
   if (previousLaneSetting === undefined) delete process.env.AIDEN_COMPOSER_LANE;

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -214,3 +214,133 @@ describe('boxed fixed bottom region resize', () => {
     expect(screen.cursorPosition().row).toBe(surface.bottom - 1);
   });
 });
+
+function semanticGap(lines: string[], before: string, after: string): number {
+  const beforeRow = lines.findLastIndex((line) => line.includes(before));
+  const afterRow = lines.findLastIndex((line) => line.includes(after));
+  expect(beforeRow, `missing semantic row: ${before}`).toBeGreaterThanOrEqual(0);
+  expect(afterRow, `missing semantic row: ${after}`).toBeGreaterThan(beforeRow);
+  return afterRow - beforeRow - 1;
+}
+
+describe('compact hybrid transcript geometry', () => {
+  it.each([16, 24, 35, 45, 60])(
+    'keeps provider activity adjacent to a short prompt at %i rows',
+    (rows) => {
+      delete process.env.AIDEN_COMPOSER_LANE;
+      const { display, screen } = createDisplay(100, rows);
+      display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+      display.setIdleComposer('', 'Type your message · /help');
+      display.submitIdleComposer('compact provider request', 'Type your message · /help');
+      display.setBusyHint('Enter → queue · Ctrl+C stop');
+      const provider = display.liveActivityRow('calling provider');
+
+      expect(semanticGap(screen.lines(), 'compact provider request', 'calling provider')).toBeLessThanOrEqual(1);
+      provider.stop();
+    },
+  );
+
+  it('keeps provider activity adjacent to the final wrapped prompt row', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(44, 45);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer(
+      'wrapped request keeps every semantic neighbor close FINAL-PROMPT-LINE',
+      'Type your message · /help',
+    );
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+
+    expect(semanticGap(screen.lines(), 'FINAL-PROMPT-LINE', 'calling provider')).toBeLessThanOrEqual(1);
+    provider.stop();
+  });
+
+  it('keeps compact spacing while terminal height changes during provider activity', async () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen, stream } = createDisplay(100, 24);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer('resize provider request', 'Type your message · /help');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+
+    for (const rows of [60, 16, 35]) {
+      stream.resize(100, rows);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(semanticGap(screen.lines(), 'resize provider request', 'calling provider')).toBeLessThanOrEqual(1);
+    }
+    provider.stop();
+  });
+
+  it('keeps provider and tool activity in semantic order without filler rows', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(100, 45);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer('inspect the package manifest', 'Type your message · /help');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+    const tool = display.toolRow('file_read', { path: 'package.json' }, undefined, {
+      activityId: 'activity_package_read',
+    });
+
+    const lines = screen.lines();
+    expect(semanticGap(lines, 'inspect the package manifest', 'calling provider')).toBeLessThanOrEqual(1);
+    expect(semanticGap(lines, 'calling provider', 'package.json')).toBe(0);
+    tool.ok(20);
+    provider.stop();
+  });
+
+  it('places the final response immediately after the active provider phase', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(100, 35);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer('return one concise answer', 'Type your message · /help');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+    expect(semanticGap(screen.lines(), 'return one concise answer', 'calling provider')).toBeLessThanOrEqual(1);
+
+    provider.stop();
+    display.write(display.agentHeader());
+    display.write('FINAL COMPACT RESPONSE\n');
+    expect(semanticGap(screen.lines(), 'return one concise answer', 'Aiden')).toBeLessThanOrEqual(1);
+    expect(semanticGap(screen.lines(), 'Aiden', 'FINAL COMPACT RESPONSE')).toBeLessThanOrEqual(1);
+  });
+
+  it('opens approval at the active semantic boundary and restores the footer', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(100, 35);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer('request a guarded action', 'Type your message · /help');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+    expect(semanticGap(screen.lines(), 'request a guarded action', 'calling provider')).toBeLessThanOrEqual(1);
+
+    provider.stop();
+    display.pauseComposerSurface();
+    display.write('Approval required\n');
+    expect(semanticGap(screen.lines(), 'request a guarded action', 'Approval required')).toBeLessThanOrEqual(1);
+    display.resumeComposerSurface();
+    expect(screen.lines().at(-1)).toContain('provider');
+  });
+
+  it.each(['clear', 'cls'])('starts a compact provider block after /%s projection reset', (command) => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(100, 35);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer('OLD VISIBLE REQUEST', 'Type your message · /help');
+    display.clearScreen();
+    if (command === 'clear') display.success('New chat started');
+    display.submitIdleComposer(`request after ${command}`, 'Type your message · /help');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+
+    expect(screen.snapshot()).not.toContain('OLD VISIBLE REQUEST');
+    expect(semanticGap(screen.lines(), `request after ${command}`, 'calling provider')).toBeLessThanOrEqual(1);
+    provider.stop();
+  });
+});

--- a/tests/v4/cli/boxedDoctorApproval.test.ts
+++ b/tests/v4/cli/boxedDoctorApproval.test.ts
@@ -217,19 +217,20 @@ describe('renderApprovalBox (Phase 22 Task 5B)', () => {
   it('Slice 6 hotfix: key column is consistently aligned across all rows', () => {
     const display = makeDisplay({ mono: true });
     const out = stripAnsi(renderApprovalBox(SAMPLE_REQ as any, display));
-    // Pull the col-index where each key starts. tool/reason/args must
+    // Pull the col-index where each key starts. Structured decision facts must
     // share the same x position.
-    const keyCols = ['tool', 'reason', 'args']
+    const keyCols = ['action', 'risk', 'reason']
       .map(k => out.split('\n').find(l => l.includes(k))?.indexOf(k) ?? -1);
     expect(new Set(keyCols).size).toBe(1);
   });
 
-  it('renders key/value rows for tool, reason, and args', () => {
+  it('renders structured decision facts without exposing raw arguments', () => {
     const display = makeDisplay({ mono: true });
     const out = stripAnsi(renderApprovalBox(SAMPLE_REQ as any, display));
-    expect(out).toMatch(/tool\s+file_delete/);
+    expect(out).toMatch(/action\s+file_delete/);
+    expect(out).toMatch(/target\s+C:\\Users\\shiva\\backups\\old\.zip/);
     expect(out).toMatch(/reason\s+destructive operation/);
-    expect(out).toMatch(/args\s+\{"path":"C:\\\\Users\\\\shiva\\\\backups\\\\old\.zip"\}/);
+    expect(out).not.toMatch(/args\s+\{/);
   });
 
   it('omits the reason row when no reason is supplied', () => {
@@ -237,14 +238,15 @@ describe('renderApprovalBox (Phase 22 Task 5B)', () => {
     const noReason = { ...SAMPLE_REQ, reason: undefined };
     const out = stripAnsi(renderApprovalBox(noReason as any, display));
     expect(out).not.toMatch(/^.*reason\s+/m);
-    expect(out).toMatch(/tool\s+file_delete/);
+    expect(out).toMatch(/action\s+file_delete/);
   });
 
-  it('truncates oversized args with an ellipsis', () => {
+  it('does not render oversized raw arguments', () => {
     const display = makeDisplay({ mono: true });
     const big = { ...SAMPLE_REQ, args: { blob: 'x'.repeat(500) } };
     const out = stripAnsi(renderApprovalBox(big as any, display));
-    expect(out).toMatch(/args\s+\{"blob":"x+…/);
+    expect(out).not.toContain('x'.repeat(20));
+    expect(out).not.toMatch(/args\s+/);
   });
 
   it('Slice 6 hotfix: footer hint matches the inquirer mechanic (arrow nav)', () => {
@@ -274,7 +276,7 @@ describe('renderApprovalBox (Phase 22 Task 5B)', () => {
     const lines = out.split('\n').filter(Boolean);
     expect(lines.length).toBeGreaterThan(0);
     expect(Math.max(...lines.map((line) => line.length))).toBeLessThanOrEqual(columns - 1);
-    expect(out).toContain('tool');
+    expect(out).toContain('action');
     expect(out).toContain('file_delete');
   });
 });

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -312,7 +312,10 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         } else if (state === 'approval' && plain.includes('Decision')) {
           state = 'tool';
           frames.approval = screen.snapshot();
-          setTimeout(() => child!.write('\r'), 250);
+          setTimeout(() => {
+            child!.write('\x1b[A');
+            setTimeout(() => child!.write('\r'), 150);
+          }, 250);
         } else if (
           state === 'tool'
           && /running[\s\S]*Start-Sleep/i.test(plain)
@@ -370,7 +373,15 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
     await completion;
 
     const plain = stripAnsi(output);
-    const ids = [...new Set(plain.match(/input_[a-zA-Z0-9_-]+/g) ?? [])];
+    const evidenceDir = process.env.AIDEN_ACCEPTANCE_EVIDENCE_DIR;
+    if (evidenceDir) {
+      await fs.mkdir(evidenceDir, { recursive: true });
+      await fs.writeFile(
+        path.join(evidenceDir, `busy-queue-${columns}-columns.txt`),
+        Object.entries(frames).map(([name, frame]) => `--- ${name} ---\n${frame}`).join('\n\n'),
+        'utf8',
+      );
+    }
     expect(firstComposer).toContain('▲ You · queue mode');
     expect(secondComposer).toContain('▲ You · queue mode');
     expect(firstStatus).toContain('custom_openai');
@@ -403,23 +414,17 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         expect(lines.slice(0, surface.top).filter((line) => line.includes('custom_openai'))).toHaveLength(0);
       }
     }
-    expect(ids).toHaveLength(2);
-    expect(ids[0]).not.toBe(ids[1]);
-    const queuedRuns = plain.match(/running queued: QUEUE (?:ONE|TWO)/g) ?? [];
+    const renderedIds = [...new Set(
+      frames.secondQueue.match(/input_[a-zA-Z0-9_-]+/g) ?? [],
+    )];
+    expect(renderedIds).toHaveLength(2);
+    expect(renderedIds[0]).not.toBe(renderedIds[1]);
+    const queuedRuns = frames.queueEmpty.match(/running queued: QUEUE (?:ONE|TWO)/g) ?? [];
     expect(queuedRuns).toEqual(['running queued: QUEUE ONE', 'running queued: QUEUE TWO']);
     expect(queuedRequestContents).toEqual(['QUEUE ONE', 'QUEUE TWO']);
     expect(providerCallsBeforeExit).toBe(4);
     expect(frames.queueEmpty).toMatch(/queue is empty/i);
 
-    const evidenceDir = process.env.AIDEN_ACCEPTANCE_EVIDENCE_DIR;
-    if (evidenceDir) {
-      await fs.mkdir(evidenceDir, { recursive: true });
-      await fs.writeFile(
-        path.join(evidenceDir, `busy-queue-${columns}-columns.txt`),
-        Object.entries(frames).map(([name, frame]) => `--- ${name} ---\n${frame}`).join('\n\n'),
-        'utf8',
-      );
-    }
   }, 75_000);
 
   it('preserves an exact multiline busy submission through resize and provider handoff', async () => {
@@ -665,7 +670,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
           modalStart = output.length;
           setTimeout(() => {
             modalEnd = output.length;
-            pressDownThenEnter(child!, 1);
+            child!.write('\r');
           }, 350);
         } else if (state === 'denying' && plain.includes('RESIZE APPROVAL COMPLETE') && readyCount >= 2) {
           state = 'normal';

--- a/tests/v4/cli/callbacks.test.ts
+++ b/tests/v4/cli/callbacks.test.ts
@@ -127,6 +127,7 @@ describe('CliCallbacks.promptApproval', () => {
       args: { command: 'rm -rf /' },
       riskTier: 'dangerous',
       reason: 'destructive command',
+      effects: {},
     });
     expect(decision).toBe('allow');
     const out = output();
@@ -135,8 +136,12 @@ describe('CliCallbacks.promptApproval', () => {
     // no "Approval needed" title (Phase 2.5 event row owns the headline).
     // v4.8.0 Slice 11c — panel bar swapped ▎ → │ (universal-font glyph).
     expect(out).toMatch(/│/);
-    expect(out).toMatch(/tool\s+shell_exec/);
+    expect(out).toMatch(/action\s+shell_exec/);
     expect(out).toMatch(/reason\s+destructive command/);
+    expect(out).toMatch(/risk\s+dangerous/);
+    expect(out).toMatch(/reversible\s+yes/i);
+    expect(out).not.toMatch(/args\s+\{/);
+    expect(out).not.toContain('rm -rf /');
     expect(out).not.toMatch(/┌── Approval required /);
   });
 
@@ -152,6 +157,22 @@ describe('CliCallbacks.promptApproval', () => {
       args: { path: '/tmp/x' },
     });
     expect(d).toBe('allow_session');
+  });
+
+  it('redacts credentials and query data from approval targets', async () => {
+    const { display, output } = makeDisplay();
+    const cb = new CliCallbacks({
+      display,
+      promptModule: mockPrompts([{ kind: 'select', value: 'deny' }]),
+    });
+    await cb.promptApproval({
+      toolName: 'network_send', category: 'network',
+      args: { url: 'https://user:secret@example.test/action?token=provider_secret_value#fragment' },
+      riskTier: 'dangerous', effects: { network: true },
+    });
+    const rendered = output();
+    expect(rendered).toContain('https://example.test/action');
+    expect(rendered).not.toMatch(/secret|provider_secret_value|token=|fragment/u);
   });
 
   it('reports an interrupt (Ctrl+C) as "interrupted", not a fabricated Deny', async () => {

--- a/tests/v4/cli/callbacks.test.ts
+++ b/tests/v4/cli/callbacks.test.ts
@@ -52,6 +52,69 @@ function mockPrompts(answers: { kind: 'select' | 'confirm' | 'input'; value: any
 }
 
 describe('CliCallbacks.promptApproval', () => {
+  it.each([
+    ['safe reversible actions', 'safe', false, 'allow'],
+    ['caution actions', 'caution', false, 'deny'],
+    ['dangerous actions', 'dangerous', false, 'deny'],
+    ['unclassified actions', undefined, false, 'deny'],
+    ['irreversible safe actions', 'safe', true, 'deny'],
+  ] as const)('uses a safe default for %s', async (_label, riskTier, irreversible, expected) => {
+    const { display } = makeDisplay();
+    let capturedDefault: string | undefined;
+    const prompts: PromptApi = {
+      async select(opts) {
+        capturedDefault = opts.default;
+        return 'deny';
+      },
+      async confirm() { return false; },
+      async input() { return ''; },
+    };
+    const cb = new CliCallbacks({ display, promptModule: prompts });
+
+    await cb.promptApproval({
+      toolName: 'test_tool',
+      category: 'execute',
+      args: {},
+      riskTier,
+      effects: irreversible ? { irreversible: true } : undefined,
+    });
+
+    expect(capturedDefault).toBe(expected);
+  });
+
+  it('requires deliberate typed confirmation for an irreversible action', async () => {
+    const { display } = makeDisplay();
+    const denied = new CliCallbacks({
+      display,
+      promptModule: mockPrompts([
+        { kind: 'select', value: 'allow' },
+        { kind: 'input', value: 'allow' },
+      ]),
+    });
+    await expect(denied.promptApproval({
+      toolName: 'publish',
+      category: 'network',
+      args: {},
+      riskTier: 'dangerous',
+      effects: { irreversible: true },
+    })).resolves.toBe('deny');
+
+    const allowed = new CliCallbacks({
+      display,
+      promptModule: mockPrompts([
+        { kind: 'select', value: 'allow' },
+        { kind: 'input', value: 'ALLOW' },
+      ]),
+    });
+    await expect(allowed.promptApproval({
+      toolName: 'publish',
+      category: 'network',
+      args: {},
+      riskTier: 'dangerous',
+      effects: { irreversible: true },
+    })).resolves.toBe('allow');
+  });
+
   it('renders the approval card with risk tier and reason', async () => {
     const { display, output } = makeDisplay();
     const cb = new CliCallbacks({

--- a/tests/v4/cli/canonicalIdentity.test.ts
+++ b/tests/v4/cli/canonicalIdentity.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { Writable } from 'node:stream';
+
+import { AIDEN_LOGO_LINES, AIDEN_LOGO_TEXT } from '../../../core/v4/ui/identity';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+
+describe('canonical Aiden identity', () => {
+  it('keeps the established six-line wordmark byte-for-byte stable', () => {
+    expect(AIDEN_LOGO_LINES).toHaveLength(6);
+    expect(createHash('sha256').update(AIDEN_LOGO_TEXT).digest('hex')).toBe(
+      'b8fdf0e24b1010acfc61ebf344798e8fe82cc4a76dcf5c2d7a8ff55b6144ddc4',
+    );
+  });
+
+  it('renders the display banner from the canonical source without extra logo rows', () => {
+    const out = new Writable({ write(_chunk, _encoding, callback) { callback(); } }) as NodeJS.WriteStream;
+    const display = new Display({ stdout: out, skin: new SkinEngine({ forceMono: true }) });
+    const rows = display.banner().split('\n').filter((line) => line.trim().length > 0)
+      .map((line) => line.slice(2));
+    expect(rows).toEqual([...AIDEN_LOGO_LINES]);
+  });
+
+  it('defines the block wordmark in one production source file', () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const files: string[] = [];
+    const visit = (directory: string): void => {
+      for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const full = path.join(directory, entry.name);
+        if (entry.isDirectory()) visit(full);
+        else if (entry.isFile() && entry.name.endsWith('.ts')) files.push(full);
+      }
+    };
+    visit(path.join(repoRoot, 'cli', 'v4'));
+    visit(path.join(repoRoot, 'core', 'v4'));
+    const definitions = files.filter((file) => readFileSync(file, 'utf8').includes(AIDEN_LOGO_LINES[0]));
+    expect(definitions.map((file) => path.relative(repoRoot, file))).toEqual([
+      path.join('core', 'v4', 'ui', 'identity.ts'),
+    ]);
+  });
+});

--- a/tests/v4/cli/canonicalIdentity.test.ts
+++ b/tests/v4/cli/canonicalIdentity.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { Writable } from 'node:stream';
 
 import { AIDEN_LOGO_LINES, AIDEN_LOGO_TEXT } from '../../../core/v4/ui/identity';
+import { renderBanner } from '../../../core/v4/ui/banner';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 
@@ -44,5 +45,18 @@ describe('canonical Aiden identity', () => {
     expect(definitions.map((file) => path.relative(repoRoot, file))).toEqual([
       path.join('core', 'v4', 'ui', 'identity.ts'),
     ]);
+  });
+
+  it('does not force color when the terminal requests monochrome output', () => {
+    const previous = process.env.NO_COLOR;
+    process.env.NO_COLOR = '1';
+    try {
+      const rendered = renderBanner({ version: '4.16.1', width: 80 });
+      expect(rendered).not.toContain('\x1b[');
+      for (const line of AIDEN_LOGO_LINES) expect(rendered).toContain(line);
+    } finally {
+      if (previous === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = previous;
+    }
   });
 });

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -20,6 +20,8 @@ import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
 import { currentJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
+import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
+import { setProviderAttemptLedger } from '../../../providers/v4/providerAttemptAccounting';
 
 function mkDisplay() {
   const chunks: string[] = [];
@@ -654,6 +656,46 @@ describe('ChatSession — v4.6 Phase 2Q-B REPL parent-run row', () => {
     // Ref cleared after the turn so cross-turn spawns get NULL parent.
     expect(ref.runId).toBeNull();
     expect(ref.sessionId).toBeNull();
+  });
+
+  it('keeps expanded provider accounting out of the ordinary transcript', async () => {
+    const ledger = new ProviderAttemptLedger(':memory:');
+    const { display, out } = mkDisplay();
+    const { agent } = mkAgent({ finalContent: 'ordinary response' });
+    const { store } = mkFakeRunStore();
+    const ref: { runId: number | null; sessionId: string | null } = { runId: null, sessionId: null };
+    ledger.append({
+      callId: 'call_visible_usage', parentCallId: null, sessionId: 'sess-abc-123', taskId: null,
+      runId: '100', jobId: null, attemptId: null, attemptGeneration: null,
+      entryPoint: 'cli', purpose: 'primary', providerConfigured: 'groq', providerActual: 'groq',
+      modelConfigured: 'model', modelActual: 'model', apiMode: 'chat_completions', transport: 'https',
+      attemptIndex: 0, fallbackIndex: 0, credentialLabelRedacted: null, status: 'success', errorClass: null,
+      startedAt: 1, completedAt: 2, estimatedInputTokens: 12, estimatedOutputTokens: 4,
+      estimatedSchemaTokens: 0, estimatedImageTokens: 0, providerInputTokens: 12,
+      providerOutputTokens: 4, providerCacheReadTokens: 0, providerCacheWriteTokens: 0,
+      providerReasoningTokens: 0, requestBytes: 10, responseBytes: 10, usageSource: 'provider_reported',
+      costAmount: null, costCurrency: null, costStatus: 'unknown', costSource: null,
+      contextSnapshotId: null, toolSchemaSnapshotId: null, coreSchemaCount: 0, mcpSchemaCount: 0,
+      pluginSchemaCount: 0, deferredSchemaCount: 0, serializedSchemaBytes: 0, selectedProfile: null,
+      selectedMode: 'balanced', rawToolResultBytes: 0, transmittedToolResultBytes: 0,
+      memoryTokens: 0, userProfileTokens: 0, projectMemoryTokens: 0, skillIndexTokens: 0,
+      loadedSkillTokens: 0,
+    });
+    setProviderAttemptLedger(ledger);
+    try {
+      const session = new ChatSession(buildOpts({
+        display, agent: agent as never,
+        promptApi: mkPromptApi({ inputs: ['hello', '/quit'] }),
+        replRunStore: store, replInstanceId: 'inst-test', replParentRunRef: ref,
+      }));
+      await session.run();
+      const transcript = out.join('');
+      expect(transcript).toContain('ordinary response');
+      expect(transcript).not.toMatch(/^Usage: .*provider attempt/mu);
+    } finally {
+      setProviderAttemptLedger(null);
+      ledger.close();
+    }
   });
 
   it('writes failed status on agent throw and clears the ref', async () => {

--- a/tests/v4/cli/commands.test.ts
+++ b/tests/v4/cli/commands.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Writable } from 'node:stream';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import { CommandRegistry } from '../../../cli/v4/commandRegistry';
@@ -28,6 +31,7 @@ import {
   quit,
 } from '../../../cli/v4/commands';
 import { ApprovalEngine } from '../../../moat/approvalEngine';
+import { getCurrentName, resetToDefault } from '../../../core/v4/theme/themeRegistry';
 
 function stripAnsi(s: string): string {
   // eslint-disable-next-line no-control-regex
@@ -573,37 +577,56 @@ describe('/skin', () => {
     const skinEngine = new SkinEngine({ forceMono: true });
     const { ctx, output } = makeCtx({ skin: skinEngine });
     await skin.handler(ctx as any);
-    expect(output()).toMatch(/default/);
+    expect(output()).toMatch(/aiden-ember/);
     expect(output()).toMatch(/monochrome/);
   });
 
-  it('switches to a known skin', async () => {
+  it('maps a known legacy skin into effective theme authority', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'aiden-skin-command-'));
     const skinEngine = new SkinEngine({ forceMono: true });
     const { ctx, output } = makeCtx({
       skin: skinEngine,
+      paths: { root },
       rawArgs: 'monochrome',
     });
-    await skin.handler(ctx as any);
-    expect(skinEngine.getActive().name).toBe('monochrome');
-    expect(output()).toMatch(/Skin: monochrome/);
+    try {
+      await skin.handler(ctx as any);
+      expect(skinEngine.getActive().name).toBe('default');
+      expect(getCurrentName()).toBe('monochrome');
+      expect(output()).toMatch(/Theme set to monochrome/);
+    } finally {
+      resetToDefault();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
-  it('reload re-reads the active skin from disk', async () => {
+  it('reload re-reads the effective theme from disk', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'aiden-skin-reload-'));
+    writeFileSync(path.join(root, 'theme.yaml'), 'name: reloaded\ncolors:\n  brand:\n    primary: "#123456"\n');
     const skinEngine = new SkinEngine({ forceMono: true });
-    const reloadSpy = vi.spyOn(skinEngine, 'reload');
-    const { ctx, output } = makeCtx({ skin: skinEngine, rawArgs: 'reload' });
-    await skin.handler(ctx as any);
-    expect(reloadSpy).toHaveBeenCalled();
-    expect(output()).toMatch(/Skin reloaded/);
+    const { ctx, output } = makeCtx({ skin: skinEngine, paths: { root }, rawArgs: 'reload' });
+    try {
+      await skin.handler(ctx as any);
+      expect(getCurrentName()).toBe('reloaded');
+      expect(output()).toMatch(/Theme reloaded/);
+    } finally {
+      resetToDefault();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('reports an actionable error when reload fails', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'aiden-skin-reload-error-'));
+    writeFileSync(path.join(root, 'theme.yaml'), 'name: : invalid');
     const skinEngine = new SkinEngine({ forceMono: true });
-    vi.spyOn(skinEngine, 'reload').mockRejectedValueOnce(new Error('bad yaml'));
-    const { ctx, output } = makeCtx({ skin: skinEngine, rawArgs: 'reload' });
-    await skin.handler(ctx as any);
-    expect(output()).toMatch(/reload failed/i);
-    expect(output()).toMatch(/yaml/);
+    const { ctx, output } = makeCtx({ skin: skinEngine, paths: { root }, rawArgs: 'reload' });
+    try {
+      await skin.handler(ctx as any);
+      expect(output()).toMatch(/parse failed/i);
+    } finally {
+      resetToDefault();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('rejects an unknown skin name with an actionable error', async () => {
@@ -612,7 +635,7 @@ describe('/skin', () => {
     const { ctx, output } = makeCtx({ skin: skinEngine, rawArgs: 'totally-fake' });
     await skin.handler(ctx as any);
     expect(skinEngine.getActive().name).toBe(before);
-    expect(output()).toMatch(/Unknown skin/);
+    expect(output()).toMatch(/has no effective-theme mapping/);
   });
 });
 

--- a/tests/v4/cli/commands.test.ts
+++ b/tests/v4/cli/commands.test.ts
@@ -62,7 +62,7 @@ function makeCtx(over: Record<string, unknown> = {}) {
 }
 
 describe('barrel exports', () => {
-  it('allCommands has 58 entries with unique names', () => {
+  it('allCommands has 68 entries with unique names', () => {
     // Phase 16b.3 added /identity (17 → 18).
     // Phase 16b.4 added /debug-prompt (18 → 19).
     // Phase 16c added /streaming (19 → 20).
@@ -99,9 +99,10 @@ describe('barrel exports', () => {
     // v4.12.1 Pillar 4 Slice 2b added /redirect (55 → 56).
     // v4.14 added /auto (one-command Partner opt-in) (56 → 57).
     // v4.14 added /mode (friendly trust-level viewer/switcher) (57 → 58).
-    expect(allCommands.length).toBe(59);
+    // Operator views and conversation/screen controls add eleven commands.
+    expect(allCommands.length).toBe(69);
     const names = new Set(allCommands.map((c) => c.name));
-    expect(names.size).toBe(59);
+    expect(names.size).toBe(69);
   });
 
   it('every command exposes name, description, category', () => {

--- a/tests/v4/cli/commands.test.ts
+++ b/tests/v4/cli/commands.test.ts
@@ -755,7 +755,7 @@ describe('/clear and /quit', () => {
     });
     const res = await clear.handler(ctx as any);
     expect(clearHistory).toHaveBeenCalled();
-    expect(res).toEqual({ clearHistory: true });
+    expect(res).toEqual({ clearHistory: true, suppressSeparator: true });
   });
 
   it('quit signals exit', async () => {

--- a/tests/v4/cli/commands/skin-deprecation.test.ts
+++ b/tests/v4/cli/commands/skin-deprecation.test.ts
@@ -3,8 +3,20 @@
  *
  * /skin still works but prints a deprecation pointer to /theme.
  */
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { skin } from '../../../../cli/v4/commands/skin';
+import { SkinEngine } from '../../../../cli/v4/skinEngine';
+import { getCurrentName, resetToDefault } from '../../../../core/v4/theme/themeRegistry';
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  resetToDefault();
+  for (const directory of cleanup.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
 
 describe('/skin deprecation banner — Slice 1a', () => {
   it('prints deprecation warning regardless of subcommand', async () => {
@@ -16,9 +28,36 @@ describe('/skin deprecation banner — Slice 1a', () => {
       skin: undefined, // forces the early-return after the warning
       display: {
         warn: (m: string) => warns.push(m),
+        info: () => undefined,
+        write: () => undefined,
+        success: () => undefined,
+        printError: () => undefined,
       },
     } as unknown as Parameters<typeof skin.handler>[0];
     await skin.handler(ctx);
     expect(warns.some((m) => /deprecated/.test(m) && /\/theme/.test(m))).toBe(true);
+  });
+
+  it('maps legacy names into the effective theme without activating a second palette', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'aiden-skin-compat-'));
+    cleanup.push(root);
+    const engine = new SkinEngine({ forceMono: false });
+    const output: string[] = [];
+    const ctx = {
+      args: ['monochrome'], rawArgs: 'monochrome', paths: { root }, skin: engine,
+      display: {
+        warn: (message: string) => output.push(message),
+        success: (message: string) => output.push(message),
+        info: (message: string) => output.push(message),
+        write: (message: string) => output.push(message),
+        printError: (message: string) => output.push(message),
+      },
+    } as unknown as Parameters<typeof skin.handler>[0];
+
+    await skin.handler(ctx);
+
+    expect(getCurrentName()).toBe('monochrome');
+    expect(engine.getActive().name).toBe('default');
+    expect(output.join('\n')).not.toContain('✓ ✓');
   });
 });

--- a/tests/v4/cli/commands/theme-list-set.test.ts
+++ b/tests/v4/cli/commands/theme-list-set.test.ts
@@ -1,15 +1,16 @@
 /**
- * tests/v4/cli/commands/theme-list-set.test.ts — v4.9.0 Slice 1b.
- *
- * Coverage for /theme list and /theme set <name>.
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+
 import { theme } from '../../../../cli/v4/commands/theme';
 import { resetToDefault, getCurrentName } from '../../../../core/v4/theme/themeRegistry';
 import { parseThemeYaml } from '../../../../core/v4/theme/themeLoader';
+import { getYaml, listBundled } from '../../../../core/v4/theme/bundledThemes';
 
 interface CapturedDisplay {
   info: string[];
@@ -23,148 +24,116 @@ function mkCtx(overrides: { paths?: { root: string } | null; rawArgs?: string })
   return {
     captured,
     ctx: {
-      args: [],
-      rawArgs: overrides.rawArgs ?? '',
-      paths: overrides.paths,
+      args: [], rawArgs: overrides.rawArgs ?? '', paths: overrides.paths,
       display: {
-        info:        (m: string) => captured.info.push(m),
-        warn:        (m: string) => captured.warn.push(m),
-        success:     (m: string) => captured.success.push(m),
-        printError:  (m: string, s?: string) => captured.errors.push({ msg: m, suggestion: s }),
+        info: (message: string) => captured.info.push(message),
+        warn: (message: string) => captured.warn.push(message),
+        success: (message: string) => captured.success.push(message),
+        printError: (message: string, suggestion?: string) => captured.errors.push({ msg: message, suggestion }),
       },
     } as unknown as Parameters<typeof theme.handler>[0],
   };
 }
 
-describe('/theme list + /theme set — Slice 1b', () => {
+describe('Aiden-native bundled themes', () => {
   let dir: string;
   beforeEach(() => {
-    dir = mkdtempSync(path.join(os.tmpdir(), 'aiden-theme-1b-'));
+    dir = mkdtempSync(path.join(os.tmpdir(), 'aiden-theme-'));
     resetToDefault();
   });
   afterEach(() => {
-    try { rmSync(dir, { recursive: true, force: true }); } catch { /* noop */ }
+    rmSync(dir, { recursive: true, force: true });
     resetToDefault();
   });
 
-  it('/theme list shows 5 bundled themes, marks default as active', async () => {
+  it('/theme list shows the five public bundled themes', async () => {
     const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'list' });
     await theme.handler(ctx);
     const output = captured.info.join('\n');
-    expect(output).toMatch(/Active theme: default/);
-    expect(output).toMatch(/●\s+default\s+\(bundled\)/);
-    expect(output).toMatch(/○\s+monochrome\s+\(bundled\)/);
-    expect(output).toMatch(/○\s+light\s+\(bundled\)/);
-    expect(output).toMatch(/○\s+tokyo-night\s+\(bundled\)/);
-    expect(output).toMatch(/○\s+dracula\s+\(bundled\)/);
+    for (const name of ['aiden-ember', 'midnight', 'aurora', 'monochrome', 'high-contrast']) {
+      expect(output).toContain(name);
+      expect(output).toContain('(bundled)');
+    }
+    expect(output).not.toContain('tokyo-night');
+    expect(output).not.toContain('dracula');
   });
 
   it('/theme list includes user themes when present', async () => {
     const userDir = path.join(dir, 'themes');
     mkdirSync(userDir, { recursive: true });
-    writeFileSync(
-      path.join(userDir, 'my-custom.yaml'),
-      'name: "my-custom"\ndescription: "User test"\n',
-      'utf8',
-    );
+    writeFileSync(path.join(userDir, 'my-custom.yaml'), 'name: "my-custom"\ndescription: "User test"\n', 'utf8');
     const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'list' });
     await theme.handler(ctx);
-    const output = captured.info.join('\n');
-    expect(output).toMatch(/my-custom\s+\(user\)\s+User test/);
+    expect(captured.info.join('\n')).toMatch(/my-custom\s+\(user\)\s+User test/);
   });
 
-  it('/theme set tokyo-night copies bundled YAML and applies', async () => {
-    const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set tokyo-night' });
+  it('/theme set midnight copies bundled YAML and applies it', async () => {
+    const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set midnight' });
     await theme.handler(ctx);
     const themeFile = path.join(dir, 'theme.yaml');
     expect(existsSync(themeFile)).toBe(true);
-    const written = readFileSync(themeFile, 'utf8');
-    expect(written).toMatch(/name:\s*"tokyo-night"/);
-    expect(getCurrentName()).toBe('tokyo-night');
-    expect(captured.success.some((l) => /tokyo-night.*bundled/.test(l))).toBe(true);
+    expect(readFileSync(themeFile, 'utf8')).toMatch(/name:\s*"midnight"/);
+    expect(getCurrentName()).toBe('midnight');
+    expect(captured.success.some((line) => /midnight.*bundled/.test(line))).toBe(true);
   });
 
-  it('/theme set dracula switches from a prior bundled theme', async () => {
-    const tn = mkCtx({ paths: { root: dir }, rawArgs: 'set tokyo-night' });
-    await theme.handler(tn.ctx);
-    expect(getCurrentName()).toBe('tokyo-night');
-    const dr = mkCtx({ paths: { root: dir }, rawArgs: 'set dracula' });
-    await theme.handler(dr.ctx);
-    expect(getCurrentName()).toBe('dracula');
-  });
-
-  it('/theme set default re-applies the bundled default', async () => {
-    const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set default' });
+  it('/theme <name> is a direct local selection alias', async () => {
+    const { ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'aurora' });
     await theme.handler(ctx);
-    expect(getCurrentName()).toBe('default');
-    expect(captured.success.some((l) => /default.*bundled/.test(l))).toBe(true);
+    expect(getCurrentName()).toBe('aurora');
   });
 
-  it('/theme set nonexistent → error with bundled list', async () => {
+  it('keeps previously persisted bundled identifiers resolvable', async () => {
+    const { ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set tokyo-night' });
+    await theme.handler(ctx);
+    expect(getCurrentName()).toBe('tokyo-night');
+    expect(getYaml('default')).not.toBe(null);
+    expect(getYaml('dracula')).not.toBe(null);
+  });
+
+  it('/theme set nonexistent reports only the public bundled choices', async () => {
     const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set bogus' });
     await theme.handler(ctx);
-    expect(captured.errors.length).toBe(1);
-    expect(captured.errors[0].msg).toMatch(/not found.*bogus/i);
-    expect(captured.errors[0].suggestion).toMatch(/default.*monochrome.*light.*tokyo-night.*dracula/);
+    expect(captured.errors).toHaveLength(1);
+    expect(captured.errors[0].suggestion).toMatch(/aiden-ember.*midnight.*aurora.*monochrome.*high-contrast/);
   });
 
-  it('/theme set <user-theme-name> resolves to ~/.aiden/themes/ when no bundled match', async () => {
+  it('/theme set resolves a user theme', async () => {
     const userDir = path.join(dir, 'themes');
     mkdirSync(userDir, { recursive: true });
-    writeFileSync(
-      path.join(userDir, 'shiva.yaml'),
-      'name: "shiva"\ncolors:\n  brand:\n    primary: "#00FF00"\n',
-      'utf8',
-    );
-    const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set shiva' });
+    writeFileSync(path.join(userDir, 'personal.yaml'), 'name: "personal"\ncolors:\n  brand:\n    primary: "#00FF00"\n', 'utf8');
+    const { ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set personal' });
     await theme.handler(ctx);
-    expect(getCurrentName()).toBe('shiva');
-    expect(captured.success.some((l) => /shiva.*user/.test(l))).toBe(true);
+    expect(getCurrentName()).toBe('personal');
   });
 
-  it('/theme set with no name → usage error', async () => {
+  it('/theme set with no name reports usage', async () => {
     const { captured, ctx } = mkCtx({ paths: { root: dir }, rawArgs: 'set' });
     await theme.handler(ctx);
-    expect(captured.errors.length).toBe(1);
     expect(captured.errors[0].msg).toMatch(/Usage: \/theme set/);
   });
 });
 
-// ── Bundled theme regression — every YAML parses + has required keys ──
+describe('bundled theme files', () => {
+  const names = ['aiden-ember', 'midnight', 'aurora', 'monochrome', 'high-contrast'] as const;
 
-import { listBundled, getYaml } from '../../../../core/v4/theme/bundledThemes';
-
-describe('bundled themes — Slice 1b', () => {
-  it('all 5 bundled themes resolve on disk', () => {
-    expect(listBundled().map((b) => b.name).sort()).toEqual(
-      ['default', 'dracula', 'light', 'monochrome', 'tokyo-night'].sort(),
-    );
+  it('resolves exactly five public themes', () => {
+    expect(listBundled().map((item) => item.name)).toEqual(names);
   });
 
-  for (const name of ['default', 'monochrome', 'light', 'tokyo-night', 'dracula'] as const) {
-    it(`themes/${name}.yaml parses cleanly with no warnings`, () => {
+  for (const name of names) {
+    it(`${name} parses cleanly and declares the complete color surface`, () => {
       const yaml = getYaml(name);
       expect(yaml).not.toBe(null);
       const { parsed, warnings } = parseThemeYaml(yaml!);
-      expect(parsed).not.toBe(null);
-      expect(parsed!.name).toBe(name);
-      // No hex / leaf-type warnings — every value parses cleanly.
+      expect(parsed?.name).toBe(name);
       expect(warnings).toEqual([]);
-    });
-
-    it(`themes/${name}.yaml declares all required color paths`, () => {
-      const yaml = getYaml(name);
-      const { parsed } = parseThemeYaml(yaml!);
-      const required = [
-        'brand.primary', 'brand.muted',
-        'content.primary', 'content.secondary', 'content.tertiary',
+      for (const required of [
+        'brand.primary', 'brand.muted', 'content.primary', 'content.secondary', 'content.tertiary',
         'semantic.success', 'semantic.warn', 'semantic.error', 'semantic.info',
         'metrics.model', 'metrics.tokens', 'metrics.timer', 'metrics.turnCount',
         'surface.bg', 'surface.elevated', 'surface.border', 'surface.divider',
-      ];
-      for (const path of required) {
-        expect(parsed!.colorOverrides[path], `missing ${path} in ${name}`).toMatch(/^#[0-9A-Fa-f]{3,6}$/);
-      }
+      ]) expect(parsed!.colorOverrides[required], `missing ${required} in ${name}`).toMatch(/^#[0-9A-Fa-f]{6}$/);
     });
   }
 });

--- a/tests/v4/cli/commands/theme-list-set.test.ts
+++ b/tests/v4/cli/commands/theme-list-set.test.ts
@@ -17,10 +17,11 @@ interface CapturedDisplay {
   warn: string[];
   success: string[];
   errors: Array<{ msg: string; suggestion?: string }>;
+  refreshes: number;
 }
 
 function mkCtx(overrides: { paths?: { root: string } | null; rawArgs?: string }) {
-  const captured: CapturedDisplay = { info: [], warn: [], success: [], errors: [] };
+  const captured: CapturedDisplay = { info: [], warn: [], success: [], errors: [], refreshes: 0 };
   return {
     captured,
     ctx: {
@@ -30,6 +31,7 @@ function mkCtx(overrides: { paths?: { root: string } | null; rawArgs?: string })
         warn: (message: string) => captured.warn.push(message),
         success: (message: string) => captured.success.push(message),
         printError: (message: string, suggestion?: string) => captured.errors.push({ msg: message, suggestion }),
+        refreshTheme: () => { captured.refreshes += 1; },
       },
     } as unknown as Parameters<typeof theme.handler>[0],
   };
@@ -75,6 +77,7 @@ describe('Aiden-native bundled themes', () => {
     expect(readFileSync(themeFile, 'utf8')).toMatch(/name:\s*"midnight"/);
     expect(getCurrentName()).toBe('midnight');
     expect(captured.success.some((line) => /midnight.*bundled/.test(line))).toBe(true);
+    expect(captured.refreshes).toBe(1);
   });
 
   it('/theme <name> is a direct local selection alias', async () => {

--- a/tests/v4/cli/compactTranscript.pty.test.ts
+++ b/tests/v4/cli/compactTranscript.pty.test.ts
@@ -71,12 +71,17 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
     const screen = new TerminalScreen(columns, 60);
     const preloadPath = path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs');
     const cliPath = path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
-    const command = ['&', quotePowerShellLiteral(process.execPath), '-r',
-      quotePowerShellLiteral(preloadPath), quotePowerShellLiteral(cliPath)].join(' ');
+    const exitMarker = '__AIDEN_COMPACT_EXIT__';
+    const command = [
+      '&', quotePowerShellLiteral(process.execPath), '-r',
+      quotePowerShellLiteral(preloadPath), quotePowerShellLiteral(cliPath),
+      `; $aidenExitCode = $LASTEXITCODE; Write-Output "${exitMarker}$aidenExitCode"; exit $aidenExitCode`,
+    ].join(' ');
     child = pty.spawn('powershell.exe', [
       '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command,
     ], {
       cwd, cols: columns, rows: 60,
+      useConptyDll: true,
       env: {
         ...process.env,
         AIDEN_HOME: aidenHome,
@@ -98,16 +103,52 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
     const heights = [60, 45, 35, 24, 16];
     await new Promise<void>((resolve, reject) => {
       let timeout: ReturnType<typeof setTimeout> | null = null;
+      let exitProbe: ReturnType<typeof setInterval> | null = null;
+      let settled = false;
+      let dataSubscription: { dispose(): void } | null = null;
+      let exitSubscription: { dispose(): void } | null = null;
+      const shellPid = child!.pid;
+      const finish = (error?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        if (exitProbe) clearInterval(exitProbe);
+        dataSubscription?.dispose();
+        exitSubscription?.dispose();
+        child = null;
+        if (error) reject(error);
+        else resolve();
+      };
+      const observeShellExit = (): void => {
+        if (exitProbe) return;
+        // Repeated ConPTY resizes can occasionally lose the adapter's exit
+        // callback. The shell marker proves the CLI returned code 0; the PID
+        // probe then verifies that the host process actually terminated.
+        exitProbe = setInterval(() => {
+          try {
+            process.kill(shellPid, 0);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ESRCH') finish();
+            else finish(error as Error);
+          }
+        }, 25);
+      };
       const armTimeout = (ms: number): void => {
         if (timeout) clearTimeout(timeout);
-        timeout = setTimeout(() => reject(new Error(
+        timeout = setTimeout(() => finish(new Error(
           `compact transcript timeout (${state}, calls=${provider?.callCount() ?? -1}):\n${screen.snapshot()}\nRAW:\n${raw.slice(-4000)}`,
         )), ms);
       };
       armTimeout(30_000);
-      child!.onData((chunk) => {
+      dataSubscription = child!.onData((chunk) => {
         raw += chunk;
         screen.write(chunk);
+        if (state === 'exit' && raw.includes(`${exitMarker}0`)) observeShellExit();
+        const failedExit = raw.match(new RegExp(`${exitMarker}(-?\\d+)`));
+        if (failedExit && failedExit[1] !== '0') {
+          finish(new Error(`compact transcript shell reported exit ${failedExit[1]}`));
+          return;
+        }
         const readyCount = raw.split(COMPOSER_READY_TOKEN).length - 1;
         const rendered = screen.snapshot();
         if (state === 'boot' && readyCount >= 1) {
@@ -138,14 +179,12 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
         } else if (state === 'response' && rendered.includes('COMPACT TRANSCRIPT COMPLETE') && readyCount >= 2) {
           state = 'exit';
           armTimeout(20_000);
-          setTimeout(() => typeLine(child!, '/exit'), 250);
+          setTimeout(() => typeLine(child!, '/quit'), 250);
         }
       });
-      child!.onExit(({ exitCode }) => {
-        if (timeout) clearTimeout(timeout);
-        child = null;
-        if (state === 'exit' && exitCode === 0) resolve();
-        else reject(new Error(`compact transcript exited ${exitCode} in ${state}`));
+      exitSubscription = child!.onExit(({ exitCode }) => {
+        if (state === 'exit' && exitCode === 0) finish();
+        else finish(new Error(`compact transcript exited ${exitCode} in ${state}`));
       });
     });
 

--- a/tests/v4/cli/compactTranscript.pty.test.ts
+++ b/tests/v4/cli/compactTranscript.pty.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as pty from 'node-pty';
+import { startMockProvider, type MockProvider } from '../harness/mockProvider';
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+let child: RunningPty | null = null;
+let provider: MockProvider | null = null;
+const cleanup: string[] = [];
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function typeLine(terminal: RunningPty, value: string): void {
+  terminal.write(value);
+  terminal.write('\r');
+}
+
+function semanticGap(frame: string, before: string, after: string): number {
+  const lines = frame.split('\n');
+  const beforeRow = lines.findLastIndex((line) => line.includes(before));
+  const afterRow = lines.findLastIndex((line) => line.includes(after));
+  expect(beforeRow, `missing ${before}\n${frame}`).toBeGreaterThanOrEqual(0);
+  expect(afterRow, `missing ${after}\n${frame}`).toBeGreaterThan(beforeRow);
+  return afterRow - beforeRow - 1;
+}
+
+afterEach(async () => {
+  if (child) {
+    try { child.kill(); } catch { /* already exited */ }
+    child = null;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  if (provider) {
+    await provider.stop();
+    provider = null;
+  }
+  await Promise.all(cleanup.splice(0).map(
+    (directory) => fs.rm(directory, { recursive: true, force: true }).catch(() => undefined),
+  ));
+});
+
+describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcript', () => {
+  it.each([100, 44])('keeps prompt and provider activity adjacent at %i columns across live height changes', async (columns) => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-compact-transcript-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-compact-transcript-cwd-'));
+    cleanup.push(aidenHome, cwd);
+    provider = await startMockProvider({
+      modelId: 'custom-default',
+      headerDelayMs: 8_000,
+      responseText: 'COMPACT TRANSCRIPT COMPLETE',
+      chunkDelayMs: 5,
+    });
+    await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'compact-transcript\n', 'utf8');
+    await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+      'model:', '  provider: custom_openai', '  modelId: custom-default',
+      'providers:', '  custom_openai:', '    apiKey: compact-transcript-key',
+      'display:', '  streaming: true', '  renderer: frame',
+    ].join('\n') + '\n', 'utf8');
+
+    const screen = new TerminalScreen(columns, 60);
+    const preloadPath = path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs');
+    const cliPath = path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
+    const command = ['&', quotePowerShellLiteral(process.execPath), '-r',
+      quotePowerShellLiteral(preloadPath), quotePowerShellLiteral(cliPath)].join(' ');
+    child = pty.spawn('powershell.exe', [
+      '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command,
+    ], {
+      cwd, cols: columns, rows: 60,
+      env: {
+        ...process.env,
+        AIDEN_HOME: aidenHome,
+        AIDEN_TEST_REPO_ROOT: repoRoot,
+        AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl,
+        CUSTOM_OPENAI_API_KEY: 'compact-transcript-key',
+        AIDEN_NO_UPDATE_CHECK: '1',
+        AIDEN_TEST_COMPOSER_READY: '1',
+        AIDEN_RENDERER: 'frame',
+        TELEGRAM_BOT_TOKEN: '',
+        FORCE_COLOR: '0',
+        NO_COLOR: '1',
+      },
+    });
+
+    let raw = '';
+    let state = 'boot';
+    const frames = new Map<number, string>();
+    const heights = [60, 45, 35, 24, 16];
+    await new Promise<void>((resolve, reject) => {
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      const armTimeout = (ms: number): void => {
+        if (timeout) clearTimeout(timeout);
+        timeout = setTimeout(() => reject(new Error(
+          `compact transcript timeout (${state}, calls=${provider?.callCount() ?? -1}):\n${screen.snapshot()}\nRAW:\n${raw.slice(-4000)}`,
+        )), ms);
+      };
+      armTimeout(30_000);
+      child!.onData((chunk) => {
+        raw += chunk;
+        screen.write(chunk);
+        const readyCount = raw.split(COMPOSER_READY_TOKEN).length - 1;
+        const rendered = screen.snapshot();
+        if (state === 'boot' && readyCount >= 1) {
+          state = 'provider';
+          armTimeout(20_000);
+          setTimeout(() => typeLine(child!, 'COMPACT HEIGHT REQUEST'), 250);
+        } else if (state === 'provider' && rendered.includes('calling provider')) {
+          state = 'resizing';
+          armTimeout(20_000);
+          let index = 0;
+          const capture = (): void => {
+            const rows = heights[index]!;
+            if (index > 0) {
+              child!.resize(columns, rows);
+              screen.resize(columns, rows);
+            }
+            setTimeout(() => {
+              frames.set(rows, screen.snapshot());
+              index += 1;
+              if (index < heights.length) capture();
+              else {
+                state = 'response';
+                armTimeout(20_000);
+              }
+            }, 150);
+          };
+          capture();
+        } else if (state === 'response' && rendered.includes('COMPACT TRANSCRIPT COMPLETE') && readyCount >= 2) {
+          state = 'exit';
+          armTimeout(20_000);
+          setTimeout(() => typeLine(child!, '/exit'), 250);
+        }
+      });
+      child!.onExit(({ exitCode }) => {
+        if (timeout) clearTimeout(timeout);
+        child = null;
+        if (state === 'exit' && exitCode === 0) resolve();
+        else reject(new Error(`compact transcript exited ${exitCode} in ${state}`));
+      });
+    });
+
+    expect([...frames.keys()]).toEqual(heights);
+    for (const [rows, frame] of frames) {
+      expect(semanticGap(frame, 'COMPACT HEIGHT REQUEST', 'calling provider'), `${rows} rows\n${frame}`)
+        .toBeLessThanOrEqual(1);
+    }
+  }, 90_000);
+});

--- a/tests/v4/cli/compactTranscript.pty.test.ts
+++ b/tests/v4/cli/compactTranscript.pty.test.ts
@@ -4,6 +4,7 @@
  */
 import { afterEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import * as pty from 'node-pty';
@@ -16,13 +17,17 @@ let child: RunningPty | null = null;
 let provider: MockProvider | null = null;
 const cleanup: string[] = [];
 
-function quotePowerShellLiteral(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
 function typeLine(terminal: RunningPty, value: string): void {
   terminal.write(value);
   terminal.write('\r');
+}
+
+function processTableContains(pid: number): boolean {
+  const rows = execFileSync(
+    'tasklist.exe', ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'],
+    { encoding: 'utf8', windowsHide: true },
+  );
+  return new RegExp(`^"[^"]+","${pid}",`, 'm').test(rows);
 }
 
 function semanticGap(frame: string, before: string, after: string): number {
@@ -71,17 +76,8 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
     const screen = new TerminalScreen(columns, 60);
     const preloadPath = path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs');
     const cliPath = path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
-    const exitMarker = '__AIDEN_COMPACT_EXIT__';
-    const command = [
-      '&', quotePowerShellLiteral(process.execPath), '-r',
-      quotePowerShellLiteral(preloadPath), quotePowerShellLiteral(cliPath),
-      `; $aidenExitCode = $LASTEXITCODE; Write-Output "${exitMarker}$aidenExitCode"; exit $aidenExitCode`,
-    ].join(' ');
-    child = pty.spawn('powershell.exe', [
-      '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command,
-    ], {
+    child = pty.spawn(process.execPath, ['-r', preloadPath, cliPath], {
       cwd, cols: columns, rows: 60,
-      useConptyDll: true,
       env: {
         ...process.env,
         AIDEN_HOME: aidenHome,
@@ -107,7 +103,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
       let settled = false;
       let dataSubscription: { dispose(): void } | null = null;
       let exitSubscription: { dispose(): void } | null = null;
-      const shellPid = child!.pid;
+      const childPid = child!.pid;
       const finish = (error?: Error): void => {
         if (settled) return;
         settled = true;
@@ -119,19 +115,20 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
         if (error) reject(error);
         else resolve();
       };
-      const observeShellExit = (): void => {
+      const observeChildExit = (): void => {
         if (exitProbe) return;
         // Repeated ConPTY resizes can occasionally lose the adapter's exit
-        // callback. The shell marker proves the CLI returned code 0; the PID
-        // probe then verifies that the host process actually terminated.
+        // callback. Verify the built CLI process disappeared directly, while
+        // requiring its clean Goodbye boundary so a crash cannot pass.
         exitProbe = setInterval(() => {
           try {
-            process.kill(shellPid, 0);
+            if (processTableContains(childPid)) return;
+            if (raw.includes('Goodbye.')) finish();
+            else finish(new Error('compact transcript process exited before clean CLI shutdown'));
           } catch (error) {
-            if ((error as NodeJS.ErrnoException).code === 'ESRCH') finish();
-            else finish(error as Error);
+            finish(error as Error);
           }
-        }, 25);
+        }, 250);
       };
       const armTimeout = (ms: number): void => {
         if (timeout) clearTimeout(timeout);
@@ -143,12 +140,6 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
       dataSubscription = child!.onData((chunk) => {
         raw += chunk;
         screen.write(chunk);
-        if (state === 'exit' && raw.includes(`${exitMarker}0`)) observeShellExit();
-        const failedExit = raw.match(new RegExp(`${exitMarker}(-?\\d+)`));
-        if (failedExit && failedExit[1] !== '0') {
-          finish(new Error(`compact transcript shell reported exit ${failedExit[1]}`));
-          return;
-        }
         const readyCount = raw.split(COMPOSER_READY_TOKEN).length - 1;
         const rendered = screen.snapshot();
         if (state === 'boot' && readyCount >= 1) {
@@ -179,6 +170,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
         } else if (state === 'response' && rendered.includes('COMPACT TRANSCRIPT COMPLETE') && readyCount >= 2) {
           state = 'exit';
           armTimeout(20_000);
+          observeChildExit();
           setTimeout(() => typeLine(child!, '/quit'), 250);
         }
       });

--- a/tests/v4/cli/composerHandoff.pty.test.ts
+++ b/tests/v4/cli/composerHandoff.pty.test.ts
@@ -84,20 +84,6 @@ function typeLikeKeyboard(terminal: RunningPty, text: string, submitDelayMs = 10
   writeNext();
 }
 
-function pressDownThenEnter(terminal: RunningPty, count: number): void {
-  let remaining = count;
-  const next = (): void => {
-    if (remaining > 0) {
-      remaining -= 1;
-      terminal.write('\x1b[B');
-      setTimeout(next, 80);
-    } else {
-      terminal.write('\r');
-    }
-  };
-  next();
-}
-
 function stripAnsi(value: string): string {
   return value
     // eslint-disable-next-line no-control-regex
@@ -344,7 +330,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI turn-to-composer handof
         }
         if (!denied && plain.includes('Decision')) {
           denied = true;
-          setTimeout(() => pressDownThenEnter(child!, 3), 200);
+          setTimeout(() => child!.write('\r'), 200);
         }
         if (!nextSent && readyCount >= 2 && plain.includes('DENIAL COMPLETE')) {
           nextSent = true;

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -130,6 +130,34 @@ describe('ComposerLane — lifecycle', () => {
     expect(out).toMatch(/\x1b\[22;\d+H\x1b\[\?25h$/);
   });
 
+  it('rebuilds the semantic transcript when ownership resumes after a modal', () => {
+    const s = mockSink();
+    const lane = new ComposerLane(s);
+    lane.activate('Type your message');
+    lane.writeAbove('  ▲ You  run a slow safe tool\n');
+    lane.deactivate();
+    lane.writeAbove('Approval required\nDecision: Once\n');
+
+    const beforeResume = s.text().length;
+    lane.activate('Enter → queue', 'provider · model');
+    const resumedOutput = s.text().slice(beforeResume);
+
+    expect(resumedOutput).toContain('run a slow safe tool');
+    expect(resumedOutput).toContain('Approval required');
+  });
+
+  it('does not replay transcript bytes for a status-only refresh', () => {
+    const s = mockSink();
+    const lane = new ComposerLane(s);
+    lane.activate('Type your message', 'provider · 0ms');
+    lane.writeAbove('one durable transcript row\n');
+    const beforeStatus = s.text().length;
+
+    lane.paintStatus('provider · 1s');
+
+    expect(s.text().slice(beforeStatus)).not.toContain('one durable transcript row');
+  });
+
   it('resize re-reserves the region for the new height and repaints in place', () => {
     const s = mockSink(24);
     const lane = new ComposerLane(s);

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -173,6 +173,51 @@ describe('ComposerLane — lifecycle', () => {
     expect(resized).toContain('provider');
   });
 
+  it('physically resets the viewport once and preserves transcript behind an epoch boundary', () => {
+    const s = mockSink(24, 80);
+    const lane = new ComposerLane(s);
+    lane.activate({ draft: '', mode: 'idle' }, 'provider · model · ready');
+    lane.writeAbove('startup row\nprior user row\nprior assistant row\n');
+    lane.scrollTranscript(12);
+    const before = s.text().length;
+
+    lane.clearTranscript();
+
+    const clearOutput = s.text().slice(before);
+    expect(clearOutput).toContain(`${ESC}[3J${ESC}[2J${ESC}[H`);
+    expect(clearOutput).not.toContain('startup row');
+    expect(clearOutput).not.toContain('prior assistant row');
+    expect(clearOutput.match(/╭─ ▲ You/gu)).toHaveLength(1);
+    expect(clearOutput.match(/provider/gu)).toHaveLength(1);
+    expect(lane.viewportSnapshot()).toMatchObject({
+      epoch: 1,
+      scrollOffset: 0,
+      stickyTail: true,
+      selectedRow: null,
+      cachedWidth: 80,
+      cachedHeight: 24,
+      retainedTranscriptRows: 3,
+      visibleTranscriptRows: 0,
+    });
+  });
+
+  it('discards a trailing resize repaint captured before the viewport epoch changed', async () => {
+    const s = mockSink(24, 80);
+    const lane = new ComposerLane(s);
+    lane.activate({ draft: '', mode: 'idle' }, 'provider · model · ready');
+    lane.writeAbove('must stay hidden\n');
+    s.setCols(44);
+    s.fireResize(24);
+    lane.clearTranscript();
+    const afterClear = s.text().length;
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const lateOutput = s.text().slice(afterClear);
+    expect(lateOutput).not.toContain('must stay hidden');
+    expect(lane.viewportSnapshot()).toMatchObject({ epoch: 1, cachedWidth: 44, cachedHeight: 24 });
+  });
+
   it('resize re-reserves the region for the new height and repaints in place', () => {
     const s = mockSink(24);
     const lane = new ComposerLane(s);

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -158,6 +158,21 @@ describe('ComposerLane — lifecycle', () => {
     expect(s.text().slice(beforeStatus)).not.toContain('one durable transcript row');
   });
 
+  it('clears only the viewport projection and never replays it after resize', () => {
+    const s = mockSink(24, 80);
+    const lane = new ComposerLane(s);
+    lane.activate('draft remains', 'provider · model');
+    lane.writeAbove('old conversation row\n');
+    lane.clearTranscript();
+    const afterClear = s.text().length;
+    s.setCols(44);
+    s.fireResize(24);
+    const resized = s.text().slice(afterClear);
+    expect(resized).not.toContain('old conversation row');
+    expect(resized).toContain('draft remains');
+    expect(resized).toContain('provider');
+  });
+
   it('resize re-reserves the region for the new height and repaints in place', () => {
     const s = mockSink(24);
     const lane = new ComposerLane(s);

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -209,9 +209,59 @@ describe('Display Phase 14b helpers', () => {
       inspectable: true,
       prominent: true,
     });
-    expect(chunks.join('')).toContain('Could not verify required outcome · Task: 7');
-    expect(chunks.join('')).toContain('Next: /status');
-    expect(chunks.join('').match(/Could not verify required outcome/g)).toHaveLength(1);
+    expect(chunks.join('')).toContain('? Outcome unknown · Task: 7');
+    expect(chunks.join('')).not.toContain('Next:');
+    expect(chunks.join('').match(/Outcome unknown/g)).toHaveLength(1);
+  });
+
+  it.each([
+    ['verified', 'success', 'Verified', '✓ Verified'],
+    ['completed_limited', 'warning', 'Completed · limited evidence', '! Completed · limited evidence'],
+    ['failed', 'error', 'Failed', '× Failed'],
+    ['unverified_required', 'error', 'Could not verify required outcome', '? Outcome unknown'],
+    ['cancelled', 'info', 'Cancelled', '■ Cancelled'],
+  ] as const)('renders the compact %s verdict badge', (kind, severity, label, expected) => {
+    const { d, chunks } = captureDisplay();
+    d.taskOutcome({
+      kind,
+      severity,
+      label,
+      evidenceCount: 0,
+      hasRequiredEvidenceGap: kind === 'unverified_required',
+      executionStarted: true,
+      inspectable: false,
+      prominent: kind === 'failed' || kind === 'unverified_required',
+      requiredCompletedCount: 0,
+      requiredDeniedCount: 0,
+      requiredFailedCount: 0,
+      requiredSkippedCount: 0,
+      requiredUnresolvedCount: 0,
+      optionalDeniedCount: 0,
+    });
+    expect(chunks.join('')).toBe(`${expected}\n`);
+  });
+
+  it('abbreviates the task identity in the compact verdict row', () => {
+    const { d, chunks } = captureDisplay();
+    d.taskOutcome({
+      kind: 'verified',
+      severity: 'success',
+      label: 'Verified',
+      taskId: 'task_0123456789abcdef',
+      evidenceCount: 1,
+      hasRequiredEvidenceGap: false,
+      executionStarted: true,
+      inspectable: true,
+      prominent: false,
+      requiredCompletedCount: 1,
+      requiredDeniedCount: 0,
+      requiredFailedCount: 0,
+      requiredSkippedCount: 0,
+      requiredUnresolvedCount: 0,
+      optionalDeniedCount: 0,
+    });
+    expect(chunks.join('')).toContain('Task: task_012…cdef');
+    expect(chunks.join('')).not.toContain('task_0123456789abcdef');
   });
   function captureDisplay() {
     const chunks: string[] = [];

--- a/tests/v4/cli/frame/framePty.test.ts
+++ b/tests/v4/cli/frame/framePty.test.ts
@@ -111,6 +111,7 @@ async function spawnFrameAiden(busyTickMs = 300): Promise<AidenTerm> {
     env: {
       GROQ_API_KEY:               'aiden-frame-pty-fake-key',
       AIDEN_RENDERER:             'frame',
+      AIDEN_COMPOSER_LANE:        '0',
       AIDEN_FRAME_BUSY_TICK_MS:   String(busyTickMs),
     },
   });

--- a/tests/v4/cli/frame/index.test.ts
+++ b/tests/v4/cli/frame/index.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   isFrameModeRequested,
   pauseLegacyIndicator,
+  shouldUseFrameComposer,
 } from '../../../../cli/v4/frame';
 
 type Globals = typeof globalThis & { __aiden_legacy_indicator_paused?: boolean };
@@ -53,6 +54,18 @@ describe('isFrameModeRequested', () => {
   it('unknown env value falls back to config', () => {
     process.env.AIDEN_RENDERER = 'sparkle';
     expect(isFrameModeRequested({ renderer: 'frame' })).toBe(true);
+  });
+});
+
+describe('shouldUseFrameComposer', () => {
+  it('keeps the fixed bottom region as the sole interactive owner', () => {
+    process.env.AIDEN_RENDERER = 'frame';
+    expect(shouldUseFrameComposer(undefined, true)).toBe(false);
+  });
+
+  it('retains the transient frame composer behind the fixed-surface opt-out', () => {
+    process.env.AIDEN_RENDERER = 'frame';
+    expect(shouldUseFrameComposer(undefined, false)).toBe(true);
   });
 });
 

--- a/tests/v4/cli/interactionDecision.pty.test.ts
+++ b/tests/v4/cli/interactionDecision.pty.test.ts
@@ -206,7 +206,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           state = 'clear-before-allow';
           commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-before-allow' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 4) {
+        } else if (state === 'clear-before-allow' && stripAnsi(output.slice(commandStart)).includes('New chat started') && readyCount >= 4) {
           state = 'single-allow-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request approved command');
@@ -226,7 +226,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           state = 'clear-after-single';
           commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-after-single' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 6) {
+        } else if (state === 'clear-after-single' && stripAnsi(output.slice(commandStart)).includes('New chat started') && readyCount >= 6) {
           state = 'batch-valid-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request partial batch');
@@ -246,7 +246,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           state = 'clear-after-retry';
           commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-after-retry' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 8) {
+        } else if (state === 'clear-after-retry' && stripAnsi(output.slice(commandStart)).includes('New chat started') && readyCount >= 8) {
           state = 'batch-cancel-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request cancelled batch');
@@ -263,7 +263,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           state = 'clear-after-cancel';
           commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-after-cancel' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 10) {
+        } else if (state === 'clear-after-cancel' && stripAnsi(output.slice(commandStart)).includes('New chat started') && readyCount >= 10) {
           state = 'batch-none-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request denied batch');

--- a/tests/v4/cli/interactionDecision.pty.test.ts
+++ b/tests/v4/cli/interactionDecision.pty.test.ts
@@ -34,6 +34,12 @@ function stripAnsi(value: string): string {
     .replace(/\r/g, '');
 }
 
+function currentTurn(output: string, prompt: string): string {
+  const marker = `▲ You  ${prompt}`;
+  const start = output.lastIndexOf(marker);
+  return start >= 0 ? output.slice(start) : output;
+}
+
 afterEach(async () => {
   if (child) {
     try { child.kill(); } catch { /* already exited */ }
@@ -162,6 +168,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
     let output = '';
     let state = 'boot';
     let turnStart = 0;
+    let commandStart = 0;
     const settled: Record<string, string> = {};
 
     await new Promise<void>((resolve, reject) => {
@@ -182,42 +189,44 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           state = 'single-settle';
           setTimeout(() => child!.write('\x03'), 250);
         } else if (state === 'single-settle' && plain.slice(turnStart).includes('Cancelled') && readyCount >= 2) {
-          settled.single = plain.slice(turnStart);
+          settled.single = currentTurn(plain, 'request interrupted write');
           state = 'single-denial-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request explicitly denied command');
         } else if (state === 'single-denial-prompt' && plain.slice(turnStart).includes('Decision')) {
           state = 'single-denial-settle';
-          setTimeout(() => {
-            child!.write('\x1b[B');
-            setTimeout(() => child!.write('\r'), 150);
-          }, 250);
+          setTimeout(() => child!.write('\r'), 250);
         } else if (
           state === 'single-denial-settle'
           && provider!.callCount() >= 3
           && plain.slice(turnStart).includes('Denied · Task:')
           && readyCount >= 3
         ) {
-          settled.denial = plain.slice(turnStart);
+          settled.denial = currentTurn(plain, 'request explicitly denied command');
           state = 'clear-before-allow';
+          commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-before-allow' && plain.match(/History cleared\./g)?.length === 1 && readyCount >= 4) {
+        } else if (state === 'clear-before-allow' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 4) {
           state = 'single-allow-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request approved command');
         } else if (state === 'single-allow-prompt' && plain.slice(turnStart).includes('Decision')) {
           state = 'single-allow-settle';
-          setTimeout(() => child!.write('\r'), 250);
+          setTimeout(() => {
+            child!.write('\x1b[A');
+            setTimeout(() => child!.write('\r'), 150);
+          }, 250);
         } else if (
           state === 'single-allow-settle'
           && provider!.callCount() >= 5
           && plain.slice(turnStart).includes('Completed · Task:')
           && readyCount >= 5
         ) {
-          settled.allow = plain.slice(turnStart);
+          settled.allow = currentTurn(plain, 'request approved command');
           state = 'clear-after-single';
+          commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-after-single' && plain.match(/History cleared\./g)?.length === 2 && readyCount >= 6) {
+        } else if (state === 'clear-after-single' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 6) {
           state = 'batch-valid-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request partial batch');
@@ -233,10 +242,11 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           && /(?:Partially completed|Verified) · Task:/.test(plain.slice(turnStart))
           && readyCount >= 7
         ) {
-          settled.retry = plain.slice(turnStart);
+          settled.retry = currentTurn(plain, 'request partial batch');
           state = 'clear-after-retry';
+          commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-after-retry' && plain.match(/History cleared\./g)?.length === 3 && readyCount >= 8) {
+        } else if (state === 'clear-after-retry' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 8) {
           state = 'batch-cancel-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request cancelled batch');
@@ -249,10 +259,11 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           && plain.slice(turnStart).includes('Cancelled · Task:')
           && readyCount >= 9
         ) {
-          settled.cancel = plain.slice(turnStart);
+          settled.cancel = currentTurn(plain, 'request cancelled batch');
           state = 'clear-after-cancel';
+          commandStart = output.length;
           typeLine(child!, '/clear');
-        } else if (state === 'clear-after-cancel' && plain.match(/History cleared\./g)?.length === 4 && readyCount >= 10) {
+        } else if (state === 'clear-after-cancel' && stripAnsi(output.slice(commandStart)).includes('History cleared.') && readyCount >= 10) {
           state = 'batch-none-prompt';
           turnStart = plain.length;
           typeLine(child!, 'request denied batch');
@@ -265,7 +276,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
           && plain.slice(turnStart).includes('Denied · Task:')
           && readyCount >= 11
         ) {
-          settled.none = plain.slice(turnStart);
+          settled.none = currentTurn(plain, 'request denied batch');
           state = 'queue';
           typeLine(child!, '/queue');
         } else if (state === 'queue' && /queue is empty/i.test(plain)) {

--- a/tests/v4/cli/interactiveWriterContract.test.ts
+++ b/tests/v4/cli/interactiveWriterContract.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const PRESENTATION_ADAPTERS = [
+  'cli/v4/startupDashboard.ts',
+  'cli/v4/startupNotices.ts',
+  'cli/v4/commands/theme.ts',
+  'cli/v4/commands/skin.ts',
+  'cli/v4/commands/clear.ts',
+  'cli/v4/commands/newSession.ts',
+  'cli/v4/commands/cls.ts',
+] as const;
+
+describe('interactive writer ownership', () => {
+  it.each(PRESENTATION_ADAPTERS)('%s routes user-visible output through Display', (file) => {
+    const source = readFileSync(path.resolve(__dirname, '../../..', file), 'utf8');
+    expect(source).not.toMatch(/process\.(?:stdout|stderr)\.write\s*\(/u);
+    expect(source).not.toMatch(/console\.(?:log|warn|error)\s*\(/u);
+  });
+});

--- a/tests/v4/cli/interactiveWriterContract.test.ts
+++ b/tests/v4/cli/interactiveWriterContract.test.ts
@@ -22,4 +22,12 @@ describe('interactive writer ownership', () => {
     expect(source).not.toMatch(/process\.(?:stdout|stderr)\.write\s*\(/u);
     expect(source).not.toMatch(/console\.(?:log|warn|error)\s*\(/u);
   });
+
+  it('routes onboarding startup output through the session display owner', () => {
+    const source = readFileSync(path.resolve(__dirname, '../../..', 'cli/v4/chatSession.ts'), 'utf8');
+    const start = source.indexOf('async renderStartupCard()');
+    const end = source.indexOf('private async maybeShowBootUpdatePrompt()', start);
+    const startup = source.slice(start, end);
+    expect(startup).not.toMatch(/out:\s*process\.stdout/u);
+  });
 });

--- a/tests/v4/cli/onboarding/speakFirst.test.ts
+++ b/tests/v4/cli/onboarding/speakFirst.test.ts
@@ -90,6 +90,24 @@ describe('shouldOnboard — trigger guard', () => {
 });
 
 describe('renderOnboardingIntro', () => {
+  it('uses the injected interactive theme authority for visible startup text', async () => {
+    const { out } = ttyOut(true);
+    const chunks: string[] = [];
+    await renderOnboardingIntro({
+      paths,
+      out,
+      write: (text) => { chunks.push(text); },
+      style: {
+        accent: (value) => `<accent>${value}</accent>`,
+        muted: (value) => `<muted>${value}</muted>`,
+      },
+      readAnswer: async () => null,
+    } as never);
+    const text = chunks.join('');
+    expect(text).toContain(`<accent>Hi — I'm Aiden.</accent>`);
+    expect(text).toContain('<muted>I run right here on your machine');
+  });
+
   it('brand-new + TTY: paints the calm intro, asks ONE thing (the name)', async () => {
     const { out, text } = ttyOut(true);
     const fired = await renderOnboardingIntro({ paths, out, readAnswer: async () => null });

--- a/tests/v4/cli/operatorCommands.test.ts
+++ b/tests/v4/cli/operatorCommands.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { cls } from '../../../cli/v4/commands/cls';
+import { newSession } from '../../../cli/v4/commands/newSession';
+import { clear } from '../../../cli/v4/commands/clear';
+import { session } from '../../../cli/v4/commands/session';
+
+describe('operator screen and conversation commands', () => {
+  it('/cls clears only the visual screen', async () => {
+    const clearScreen = vi.fn();
+    const clearHistory = vi.fn();
+    await cls.handler({ display: { clearScreen }, session: { clearHistory } } as never);
+    expect(clearScreen).toHaveBeenCalledTimes(1);
+    expect(clearHistory).not.toHaveBeenCalled();
+  });
+
+  it('/clear starts a new persisted conversation and preserves durable history', async () => {
+    const clearScreen = vi.fn();
+    const success = vi.fn();
+    const dim = vi.fn();
+    const result = await clear.handler({
+      display: { clearScreen, success, dim },
+      session: { startNewSession: () => 'session_new' },
+    } as never);
+    expect(clearScreen).toHaveBeenCalledTimes(1);
+    expect(success).toHaveBeenCalledWith('New chat started · session_new');
+    expect(dim).toHaveBeenCalledWith('Previous Jobs and proof remain available through /jobs and /trace.');
+    expect(result).toEqual({ clearHistory: true });
+  });
+
+  it('/new is an exact alias for /clear', async () => {
+    const clearScreen = vi.fn();
+    const success = vi.fn();
+    const dim = vi.fn();
+    const result = await newSession.handler({
+      display: { clearScreen, success, dim },
+      session: { startNewSession: () => 'session_new' },
+    } as never);
+    expect(result).toEqual({ clearHistory: true });
+    expect(success).toHaveBeenCalledWith('New chat started · session_new');
+  });
+
+  it('retains bounded legacy behavior for injected sessions without persistence', async () => {
+    const clearHistory = vi.fn();
+    const dim = vi.fn();
+    const result = await clear.handler({ display: { dim }, session: { clearHistory } } as never);
+    expect(clearHistory).toHaveBeenCalledTimes(1);
+    expect(dim).toHaveBeenCalledWith('History cleared. Persisted session switching is unavailable in this runtime.');
+    expect(result).toEqual({ clearHistory: true });
+  });
+
+  it('/session delete requires an explicit confirmation', async () => {
+    const warn = vi.fn();
+    const dim = vi.fn();
+    const deleteStoredSession = vi.fn();
+    await session.handler({
+      args: ['delete'], display: { warn, dim }, session: { deleteStoredSession },
+    } as never);
+    expect(deleteStoredSession).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('Session deletion requires confirmation.');
+  });
+
+  it('/session delete removes only the selected stored conversation', async () => {
+    const success = vi.fn();
+    const dim = vi.fn();
+    const deleteStoredSession = vi.fn(() => ({ deletedId: 'session_old', replacementId: null }));
+    const result = await session.handler({
+      args: ['delete', 'session_old', '--yes'],
+      display: { success, dim },
+      session: { deleteStoredSession },
+    } as never);
+    expect(deleteStoredSession).toHaveBeenCalledWith('session_old');
+    expect(success).toHaveBeenCalledWith('Stored session deleted · session_old');
+    expect(dim).toHaveBeenCalledWith('Durable Jobs, Effects, and Proof remain available.');
+    expect(result).toEqual({ clearHistory: false });
+  });
+});

--- a/tests/v4/cli/operatorCommands.test.ts
+++ b/tests/v4/cli/operatorCommands.test.ts
@@ -15,9 +15,10 @@ describe('operator screen and conversation commands', () => {
   it('/cls clears only the visual screen', async () => {
     const clearScreen = vi.fn();
     const clearHistory = vi.fn();
-    await cls.handler({ display: { clearScreen }, session: { clearHistory } } as never);
+    const result = await cls.handler({ display: { clearScreen }, session: { clearHistory } } as never);
     expect(clearScreen).toHaveBeenCalledTimes(1);
     expect(clearHistory).not.toHaveBeenCalled();
+    expect(result).toEqual({ suppressSeparator: true });
   });
 
   it('/clear starts a new persisted conversation and preserves durable history', async () => {
@@ -29,9 +30,10 @@ describe('operator screen and conversation commands', () => {
       session: { startNewSession: () => 'session_new' },
     } as never);
     expect(clearScreen).toHaveBeenCalledTimes(1);
-    expect(success).toHaveBeenCalledWith('New chat started · session_new');
+    expect(success).toHaveBeenCalledWith('New chat started');
     expect(dim).toHaveBeenCalledWith('Previous Jobs and proof remain available through /jobs and /trace.');
-    expect(result).toEqual({ clearHistory: true });
+    expect(dim).not.toHaveBeenCalledWith('History cleared.');
+    expect(result).toEqual({ clearHistory: true, suppressSeparator: true });
   });
 
   it('/new is an exact alias for /clear', async () => {
@@ -42,8 +44,8 @@ describe('operator screen and conversation commands', () => {
       display: { clearScreen, success, dim },
       session: { startNewSession: () => 'session_new' },
     } as never);
-    expect(result).toEqual({ clearHistory: true });
-    expect(success).toHaveBeenCalledWith('New chat started · session_new');
+    expect(result).toEqual({ clearHistory: true, suppressSeparator: true });
+    expect(success).toHaveBeenCalledWith('New chat started');
   });
 
   it('retains bounded legacy behavior for injected sessions without persistence', async () => {
@@ -51,8 +53,9 @@ describe('operator screen and conversation commands', () => {
     const dim = vi.fn();
     const result = await clear.handler({ display: { dim }, session: { clearHistory } } as never);
     expect(clearHistory).toHaveBeenCalledTimes(1);
-    expect(dim).toHaveBeenCalledWith('History cleared. Persisted session switching is unavailable in this runtime.');
-    expect(result).toEqual({ clearHistory: true });
+    expect(dim).toHaveBeenCalledWith('Conversation reset in this runtime. Durable Jobs and proof are unchanged.');
+    expect(dim).not.toHaveBeenCalledWith(expect.stringMatching(/History cleared/));
+    expect(result).toEqual({ clearHistory: true, suppressSeparator: true });
   });
 
   it('/session delete requires an explicit confirmation', async () => {

--- a/tests/v4/cli/operatorPerformance.test.ts
+++ b/tests/v4/cli/operatorPerformance.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { Writable } from 'node:stream';
+import { performance } from 'node:perf_hooks';
+import { describe, expect, it } from 'vitest';
+
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+class MeasuredScreenStream extends Writable {
+  isTTY = true;
+  columns = 100;
+  rows = 30;
+  writes = 0;
+  bytes = 0;
+  readonly screen = new TerminalScreen(this.columns, this.rows);
+
+  constructor() {
+    super({
+      write: (chunk, _encoding, done) => {
+        const text = chunk.toString();
+        this.writes += 1;
+        this.bytes += Buffer.byteLength(text);
+        this.screen.write(text);
+        done();
+      },
+    });
+  }
+}
+
+function harness() {
+  const stream = new MeasuredScreenStream();
+  const display = new Display({
+    stdout: stream as unknown as NodeJS.WriteStream,
+    skin: new SkinEngine({ forceMono: true }),
+  });
+  display.setStatusFooter('◆ provider · model │ ◉ context 2k/32k │ ⧖ 4s');
+  display.setIdleComposer('', 'Type your message · /help');
+  return { display, stream };
+}
+
+describe('operator screen performance boundaries', () => {
+  it('virtualizes ten thousand transcript rows without replaying them on a status frame', () => {
+    const { display, stream } = harness();
+    const transcript = Array.from({ length: 10_000 }, (_, index) => `row ${index}`).join('\n') + '\n';
+    display.write(transcript);
+    const writesBefore = stream.writes;
+    const bytesBefore = stream.bytes;
+    const started = performance.now();
+
+    display.setStatusFooter('◆ provider · model │ ◉ context 3k/32k │ ⧖ 5s');
+
+    const elapsedMs = performance.now() - started;
+    expect(stream.writes - writesBefore).toBe(1);
+    expect(stream.bytes - bytesBefore).toBeLessThan(20_000);
+    expect(Number.isFinite(elapsedMs)).toBe(true);
+    expect(stream.screen.lines().at(-1)).toContain('context 3k/32k');
+  });
+
+  it('keeps a one-megabyte tool payload out of the live terminal frame', () => {
+    const { display, stream } = harness();
+    const bytesBefore = stream.bytes;
+    const row = display.toolRow('file_read', {
+      path: 'C:\\workspace\\result.txt',
+      content: 'x'.repeat(1_000_000),
+    }, undefined, { activityId: 'large-output' });
+
+    expect(stream.bytes - bytesBefore).toBeLessThan(20_000);
+    expect(stream.screen.snapshot()).toContain('result.txt');
+    expect(stream.screen.snapshot()).not.toContain('x'.repeat(1_000));
+    row.ok(1);
+  });
+
+  it('bounds fifty concurrent activities to the available live viewport', () => {
+    const { display, stream } = harness();
+    const rows = Array.from({ length: 50 }, (_, index) => display.toolRow(
+      'file_read',
+      { path: `C:\\workspace\\file-${index}.txt` },
+      undefined,
+      { activityId: `activity-${index}` },
+    ));
+
+    expect(stream.screen.snapshot()).toContain('more active');
+    expect(stream.screen.lines().filter((line) => line.includes('file-')).length).toBeLessThanOrEqual(25);
+    for (const row of rows) row.ok(1);
+  });
+});

--- a/tests/v4/cli/operatorProjection.test.ts
+++ b/tests/v4/cli/operatorProjection.test.ts
@@ -11,6 +11,7 @@ import {
   initialOperatorProjection,
   reduceOperatorProjection,
   transcriptSource,
+  visibleTranscriptSource,
   type ActivityProjection,
   type OperatorProjectionState,
 } from '../../../cli/v4/operatorProjection';
@@ -125,8 +126,8 @@ describe('operator projection', () => {
     state = reduceOperatorProjection(state, {
       type: 'transcript.append', id: 'n1', kind: 'notice', sourceText: 'later\n',
     });
-    expect(state.followTail).toBe(false);
-    expect(state.newEventsBelow).toBe(1);
+    expect(state.viewport.stickyTail).toBe(false);
+    expect(state.viewport.newEventsBelow).toBe(1);
   });
 
   it('End-style follow returns to the live tail and clears the counter', () => {
@@ -137,6 +138,45 @@ describe('operator projection', () => {
       type: 'transcript.append', id: 'n1', kind: 'notice', sourceText: 'later\n',
     });
     state = reduceOperatorProjection(state, { type: 'viewport.follow' });
-    expect(state).toMatchObject({ followTail: true, scrollOffset: 0, newEventsBelow: 0 });
+    expect(state.viewport).toMatchObject({ stickyTail: true, scrollOffset: 0, newEventsBelow: 0 });
+  });
+
+  it('starts a new viewport epoch without deleting durable transcript projection', () => {
+    let state = initialOperatorProjection();
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'startup', kind: 'notice', sourceText: 'canonical startup\n',
+    });
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'turn', kind: 'assistant', sourceText: 'prior answer\n',
+    });
+    state = reduceOperatorProjection(state, { type: 'viewport.scroll', delta: 20 });
+
+    const priorEpoch = state.viewport.epoch;
+    const cleared = reduceOperatorProjection(state, { type: 'viewport.clear' });
+
+    expect(cleared.transcript).toEqual(state.transcript);
+    expect(transcriptSource(cleared)).toBe('canonical startup\nprior answer\n');
+    expect(visibleTranscriptSource(cleared)).toBe('');
+    expect(cleared.viewport).toMatchObject({
+      epoch: priorEpoch + 1,
+      scrollOffset: 0,
+      stickyTail: true,
+      selectedRow: null,
+      cachedWidth: null,
+      cachedHeight: null,
+    });
+  });
+
+  it('shows only transcript committed after the current viewport boundary', () => {
+    let state = reduceOperatorProjection(initialOperatorProjection(), {
+      type: 'transcript.append', id: 'old', kind: 'system', sourceText: 'old row\n',
+    });
+    state = reduceOperatorProjection(state, { type: 'viewport.clear' });
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'new', kind: 'user', sourceText: 'new prompt\n',
+    });
+
+    expect(transcriptSource(state)).toBe('old row\nnew prompt\n');
+    expect(visibleTranscriptSource(state)).toBe('new prompt\n');
   });
 });

--- a/tests/v4/cli/operatorProjection.test.ts
+++ b/tests/v4/cli/operatorProjection.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  activeActivityRows,
+  initialOperatorProjection,
+  reduceOperatorProjection,
+  transcriptSource,
+  type ActivityProjection,
+  type OperatorProjectionState,
+} from '../../../cli/v4/operatorProjection';
+
+function activity(id: string, generation = 1, startedSequence = 1): ActivityProjection {
+  return {
+    id, parentId: null, jobId: 'job_1', attemptId: 'attempt_1', generation,
+    startedSequence, state: 'running', startedAt: 10, endedAt: null,
+    summary: `${id} running`, detailsRef: null,
+  };
+}
+
+function add(state: OperatorProjectionState, value: ActivityProjection): OperatorProjectionState {
+  return reduceOperatorProjection(state, { type: 'activity.upsert', activity: value });
+}
+
+describe('operator projection', () => {
+  it('keeps transcript source content in ordered semantic blocks', () => {
+    let state = initialOperatorProjection();
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'u1', kind: 'user', sourceText: 'hello\n',
+    });
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'a1', kind: 'assistant', sourceText: 'world\n',
+    });
+    expect(transcriptSource(state)).toBe('hello\nworld\n');
+  });
+
+  it('deduplicates replayed transcript identities', () => {
+    let state = initialOperatorProjection();
+    const event = { type: 'transcript.append', id: 'n1', kind: 'notice', sourceText: 'once\n' } as const;
+    state = reduceOperatorProjection(state, event);
+    expect(reduceOperatorProjection(state, event)).toBe(state);
+  });
+
+  it('replaces one streaming block without duplicating it', () => {
+    let state = initialOperatorProjection();
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'a1', kind: 'assistant', sourceText: 'part',
+    });
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.replace', id: 'a1', sourceText: 'part complete',
+    });
+    expect(state.transcript).toHaveLength(1);
+    expect(transcriptSource(state)).toBe('part complete');
+  });
+
+  it('orders same-name activities by sequence and stable identity', () => {
+    let state = initialOperatorProjection();
+    state = add(state, activity('tool_b', 1, 2));
+    state = add(state, activity('tool_a', 1, 1));
+    expect(activeActivityRows(state).map((row) => row.id)).toEqual(['tool_a', 'tool_b']);
+  });
+
+  it('ignores progress from a stale generation', () => {
+    let state = add(initialOperatorProjection(), activity('tool_1', 2));
+    const next = reduceOperatorProjection(state, {
+      type: 'activity.progress', id: 'tool_1', generation: 1, summary: 'stale',
+    });
+    expect(next).toBe(state);
+  });
+
+  it('does not replace a newer generation with an older activity', () => {
+    let state = add(initialOperatorProjection(), activity('tool_1', 2));
+    const next = add(state, activity('tool_1', 1));
+    expect(next).toBe(state);
+  });
+
+  it('makes terminal state monotonic against late progress', () => {
+    let state = add(initialOperatorProjection(), activity('tool_1'));
+    state = reduceOperatorProjection(state, {
+      type: 'activity.terminal', id: 'tool_1', generation: 1,
+      state: 'failed', summary: 'failed', endedAt: 20,
+    });
+    const next = reduceOperatorProjection(state, {
+      type: 'activity.progress', id: 'tool_1', generation: 1, summary: 'running again',
+    });
+    expect(next).toBe(state);
+    expect(state.activities.tool_1.state).toBe('failed');
+  });
+
+  it('makes duplicate terminal events idempotent', () => {
+    let state = add(initialOperatorProjection(), activity('tool_1'));
+    const event = {
+      type: 'activity.terminal', id: 'tool_1', generation: 1,
+      state: 'succeeded', summary: 'done', endedAt: 20,
+    } as const;
+    state = reduceOperatorProjection(state, event);
+    expect(reduceOperatorProjection(state, event)).toBe(state);
+  });
+
+  it('removes a projected row without mutating the prior snapshot', () => {
+    const prior = add(initialOperatorProjection(), activity('tool_1'));
+    const next = reduceOperatorProjection(prior, { type: 'activity.remove', id: 'tool_1' });
+    expect(prior.activities.tool_1).toBeDefined();
+    expect(next.activities.tool_1).toBeUndefined();
+  });
+
+  it('does not project terminal activities into the live region', () => {
+    let state = add(initialOperatorProjection(), activity('tool_1'));
+    state = reduceOperatorProjection(state, {
+      type: 'activity.terminal', id: 'tool_1', generation: 1,
+      state: 'unknown', summary: 'outcome unknown', endedAt: 20,
+    });
+    expect(activeActivityRows(state)).toEqual([]);
+  });
+
+  it('freezes the viewport and counts new transcript events below', () => {
+    let state = reduceOperatorProjection(initialOperatorProjection(), {
+      type: 'viewport.scroll', delta: 8,
+    });
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'n1', kind: 'notice', sourceText: 'later\n',
+    });
+    expect(state.followTail).toBe(false);
+    expect(state.newEventsBelow).toBe(1);
+  });
+
+  it('End-style follow returns to the live tail and clears the counter', () => {
+    let state = reduceOperatorProjection(initialOperatorProjection(), {
+      type: 'viewport.scroll', delta: 8,
+    });
+    state = reduceOperatorProjection(state, {
+      type: 'transcript.append', id: 'n1', kind: 'notice', sourceText: 'later\n',
+    });
+    state = reduceOperatorProjection(state, { type: 'viewport.follow' });
+    expect(state).toMatchObject({ followTail: true, scrollOffset: 0, newEventsBelow: 0 });
+  });
+});

--- a/tests/v4/cli/operatorScreenResize.test.ts
+++ b/tests/v4/cli/operatorScreenResize.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { Writable } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+class ResizableScreenStream extends Writable {
+  isTTY = true;
+
+  constructor(
+    readonly screen: TerminalScreen,
+    public columns: number,
+    public rows: number,
+  ) {
+    super({
+      write: (chunk, _encoding, done) => {
+        screen.write(chunk);
+        done();
+      },
+    });
+  }
+
+  resize(columns: number, rows: number): void {
+    this.columns = columns;
+    this.rows = rows;
+    this.screen.resize(columns, rows);
+    this.emit('resize');
+  }
+}
+
+const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
+
+afterEach(() => {
+  if (previousLaneSetting === undefined) delete process.env.AIDEN_COMPOSER_LANE;
+  else process.env.AIDEN_COMPOSER_LANE = previousLaneSetting;
+});
+
+function harness(columns = 100, rows = 30) {
+  delete process.env.AIDEN_COMPOSER_LANE;
+  const screen = new TerminalScreen(columns, rows);
+  const stream = new ResizableScreenStream(screen, columns, rows);
+  const display = new Display({
+    stdout: stream as unknown as NodeJS.WriteStream,
+    skin: new SkinEngine({ forceMono: true }),
+  });
+  display.setStatusFooter('◆ provider · model │ ◉ context 2k/32k │ ⧖ 4s');
+  display.setIdleComposer('draft 世界', 'Type your message · /help', 5);
+  return { display, screen, stream };
+}
+
+function assertOneCurrentSurface(
+  screen: TerminalScreen,
+  expectedDraft = 'draft 世界',
+): void {
+  const lines = screen.lines();
+  const composerRows = lines.filter((line) => line.startsWith('╭─ ▲ You'));
+  const statusRows = lines.filter((line) => line.includes('◆ provider'));
+  const bottomBorders = lines.filter((line) => line.startsWith('╰─'));
+  expect(composerRows, screen.snapshot()).toHaveLength(1);
+  expect(statusRows, screen.snapshot()).toHaveLength(1);
+  expect(bottomBorders, screen.snapshot()).toHaveLength(1);
+  expect(lines.at(-1), screen.snapshot()).toContain('◆ provider');
+  expect(lines.at(-2), screen.snapshot()).toMatch(/^╰─/u);
+  expect(lines.join('\n'), screen.snapshot()).toContain(expectedDraft);
+}
+
+async function settleResize(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe('operator screen resize transactions', () => {
+  it.each([
+    [160, 45], [120, 35], [100, 30], [80, 24], [60, 20], [44, 16],
+  ])('keeps the essential surface bounded at %ix%i', async (columns, rows) => {
+    const { screen, stream } = harness();
+    stream.resize(columns, rows);
+    await settleResize();
+    assertOneCurrentSurface(screen);
+    for (const line of screen.lines()) expect(line.length).toBeLessThanOrEqual(columns);
+  });
+
+  it('heals the old and new footer geometry through the physical resize sequence', async () => {
+    const { screen, stream } = harness();
+    assertOneCurrentSurface(screen);
+
+    for (const [columns, rows] of [[150, 45], [80, 24], [150, 45]] as const) {
+      stream.resize(columns, rows);
+      await settleResize();
+      assertOneCurrentSurface(screen);
+    }
+  });
+
+  it.each([
+    ['width increase', 150, 30],
+    ['width decrease', 80, 30],
+    ['height increase', 100, 45],
+    ['height decrease', 100, 20],
+    ['wide to narrow', 44, 16],
+  ])('preserves one semantic surface after %s', async (_label, columns, rows) => {
+    const { screen, stream } = harness();
+    stream.resize(columns, rows);
+    await settleResize();
+    assertOneCurrentSurface(screen);
+    expect(screen.cursorPosition().col).toBe(2 + 5);
+  });
+
+  it('preserves queue draft and one tool identity across a resize burst', async () => {
+    const { display, screen, stream } = harness();
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    display.setComposer('QUEUE ONE', 'queue');
+    const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 15' });
+
+    for (const [columns, rows] of [[120, 35], [60, 20], [160, 45], [44, 16], [100, 30]] as const) {
+      stream.resize(columns, rows);
+    }
+    await settleResize();
+
+    assertOneCurrentSurface(screen, 'QUEUE ONE');
+    expect(screen.lines().filter((line) => line.includes('Start-Sleep'))).toHaveLength(1);
+    expect(screen.lines().filter((line) => line.includes('▲ You · queue mode'))).toHaveLength(1);
+    tool.ok(15_000);
+  });
+
+  it('restores a submitted user row after a modal before a tool expands the live region', () => {
+    const { display, screen } = harness();
+    display.submitIdleComposer('run a slow safe tool', 'Type your message');
+    display.pauseComposerSurface();
+    display.write('Approval required\nDecision: Once\n');
+    display.resumeComposerSurface();
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+
+    const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 4' });
+
+    expect(
+      screen.lines().filter((line) => line.includes('run a slow safe tool')),
+      screen.snapshot(),
+    ).toHaveLength(1);
+    assertOneCurrentSurface(screen, '');
+    tool.ok(4_000);
+  });
+
+  it('keeps one provider activity across wide-narrow-wide resize', async () => {
+    const { display, screen, stream } = harness(160, 45);
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const activity = display.liveActivityRow('calling provider');
+    activity.refresh(1);
+    expect(screen.lines().slice(0, -4).filter((line) => line.includes('provider'))).toHaveLength(1);
+
+    stream.resize(44, 16);
+    activity.refresh(2);
+    await settleResize();
+    expect(screen.lines().slice(0, -4).filter((line) => line.includes('provider'))).toHaveLength(1);
+
+    stream.resize(160, 45);
+    activity.refresh(3);
+    await settleResize();
+    expect(screen.lines().slice(0, -4).filter((line) => line.includes('provider'))).toHaveLength(1);
+    assertOneCurrentSurface(screen, '');
+    activity.stop();
+  });
+
+  it('reflows one assistant stream block and archives it once on completion', async () => {
+    const { display, screen, stream } = harness(100, 30);
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    display.streamPartial('A streamed response with **structured text** that remains one block.');
+    stream.resize(44, 16);
+    await settleResize();
+    expect(screen.lines().filter((line) => line.includes('Aiden'))).toHaveLength(1);
+    expect(screen.snapshot()).toContain('streamed response');
+
+    stream.resize(120, 35);
+    await settleResize();
+    display.streamComplete();
+    stream.resize(80, 24);
+    await settleResize();
+    expect(screen.lines().filter((line) => line.includes('Aiden'))).toHaveLength(1);
+    expect(screen.snapshot()).toContain('structured text');
+    assertOneCurrentSurface(screen, '');
+  });
+
+  it('preserves a multiline Unicode draft and insertion cursor through resize', async () => {
+    const { display, screen, stream } = harness(80, 24);
+    const draft = 'first line\n  second 世界 line';
+    display.setIdleComposer(draft, 'Type your message', 8);
+    stream.resize(44, 16);
+    await settleResize();
+    const narrowCursor = screen.cursorPosition();
+    expect(screen.snapshot()).toContain('first line');
+    expect(narrowCursor.row).toBeGreaterThanOrEqual(0);
+    stream.resize(100, 30);
+    await settleResize();
+    expect(screen.snapshot()).toContain('second 世界 line');
+    expect(screen.cursorPosition().col).toBe(2 + 8);
+  });
+
+  it('restores one current surface after resize while a modal owns the terminal', async () => {
+    const { display, screen, stream } = harness();
+    display.pauseComposerSurface();
+    stream.resize(44, 16);
+    display.write('Approval required\n');
+    display.resumeComposerSurface();
+    await settleResize();
+
+    assertOneCurrentSurface(screen);
+    expect(screen.lines().filter((line) => line.includes('Approval required'))).toHaveLength(1);
+  });
+
+  it('does not archive animation frames when resize happens around settlement', async () => {
+    const { display, screen, stream } = harness();
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const tool = display.toolRow('shell_exec', { command: 'Start-Sleep -Seconds 15' });
+    stream.resize(150, 45);
+    tool.ok(15_000);
+    stream.resize(80, 24);
+    await settleResize();
+
+    assertOneCurrentSurface(screen, '');
+    expect(screen.lines().filter((line) => line.includes('running'))).toHaveLength(0);
+    expect(screen.lines().filter((line) => line.includes('Start-Sleep'))).toHaveLength(1);
+  });
+
+  it('virtualizes fifty active rows without overwriting composer or status', () => {
+    const { display, screen } = harness(60, 20);
+    const handles = Array.from({ length: 50 }, (_, index) => (
+      display.toolRow('file_read', { path: `C:\\workspace\\file-${index}.txt` }, undefined, { activityId: `activity_${index}` })
+    ));
+    assertOneCurrentSurface(screen);
+    expect(screen.snapshot()).toContain('more active');
+    expect(screen.lines().filter((line) => line.includes('file-')).length).toBeLessThanOrEqual(15);
+    for (const handle of handles) handle.ok(1);
+    assertOneCurrentSurface(screen);
+  });
+});

--- a/tests/v4/cli/operatorViews.test.ts
+++ b/tests/v4/cli/operatorViews.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { CommandRegistry } from '../../../cli/v4/commandRegistry';
+import { approvals, attempts, effects, evidence, job as jobView, jobs, proof } from '../../../cli/v4/commands/operatorViews';
+import type { JobEngine, JobRecord } from '../../../core/v4/daemon/jobEngine';
+
+function setup(args: string[] = []) {
+  let output = '';
+  const stdout = new Writable({ write(chunk, _encoding, done) { output += String(chunk); done(); } });
+  const display = new Display({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    skin: new SkinEngine({ forceMono: true }),
+  });
+  const job: JobRecord = {
+    id: 'job_1', status: 'completed', stateVersion: 3, activeAttemptId: null,
+    rootJobId: 'job_1', parentJobId: null, sessionId: 'session_1', goal: 'read a file',
+    entryPoint: 'repl', source: 'user', terminalAt: 30,
+    terminalOutcome: 'verified', finishReason: 'complete', nextEventSequence: 5,
+  };
+  const snapshot = {
+    job,
+    attempts: [{
+      rowId: 1, id: 'attempt_1', jobId: 'job_1', status: 'completed',
+      attemptNumber: 1, generation: 2, stateVersion: 2, leaseId: null,
+      leaseOwner: null, leaseExpiresAt: null, leaseHeartbeatAt: null,
+      fenceToken: 'fence_1', recoveryOfAttemptId: null,
+    }],
+    children: [], inputs: [], waits: [],
+    approvals: [{ approval_id: 'approval_1', state: 'denied', risk_level: 'high' }],
+    effects: [{ effect_id: 'effect_1', effect_state: 'unknown', kind: 'filesystem', retry_safety: 'unsafe' }],
+    evidence: [{ evidence_id: 'evidence_1', verification_result: 'verified', coverage: 'full', source: 'file_readback' }],
+    claims: [{ claim_id: 'claim_1' }],
+    verdict: { outcome: 'verified', reason: 'file read confirmed' }, budgets: [], events: [],
+  };
+  const engine = {
+    getJob: (id: string) => id === job.id ? job : null,
+    listJobs: () => [job],
+    projection: { rebuild: () => snapshot },
+  } as unknown as JobEngine;
+  return {
+    context: {
+      args, rawArgs: args.join(' '), display, registry: new CommandRegistry(),
+      jobEngine: engine,
+      session: { getSessionId: () => 'session_1' },
+    },
+    output: () => output,
+  };
+}
+
+describe('durable operator views', () => {
+  it('lists durable Jobs without creating a second state source', async () => {
+    const h = setup();
+    await jobs.handler(h.context as never);
+    expect(h.output()).toContain('job_1 · completed · verified');
+  });
+
+  it('shows Attempts, Effects, approvals, evidence, and verdict from one rebuild', async () => {
+    const h = setup(['job_1']);
+    await jobs.handler(h.context as never);
+    expect(h.output()).toContain('attempts    1');
+    expect(h.output()).toContain('effects     1');
+    expect(h.output()).toContain('approvals   1');
+    expect(h.output()).toContain('evidence    1');
+    expect(h.output()).toContain('attempt_1 · completed · gen 2');
+  });
+
+  it('shows proof from durable claims, evidence, and verdict', async () => {
+    const h = setup(['job_1']);
+    await proof.handler(h.context as never);
+    expect(h.output()).toContain('claims    1');
+    expect(h.output()).toContain('verdict   verified');
+    expect(h.output()).toContain('file read confirmed');
+  });
+
+  it('shows exact approval identity and durable decision state', async () => {
+    const h = setup(['job_1']);
+    await approvals.handler(h.context as never);
+    expect(h.output()).toContain('approval_1 · denied · high · job job_1');
+  });
+
+  it('supports a singular Job detail view', async () => {
+    const h = setup(['job_1']);
+    await jobView.handler(h.context as never);
+    expect(h.output()).toContain('◆ Job job_1');
+    expect(h.output()).toContain('goal        read a file');
+  });
+
+  it('projects Attempts, Effects, and evidence from the same durable snapshot', async () => {
+    const attemptHarness = setup(['job_1']);
+    await attempts.handler(attemptHarness.context as never);
+    expect(attemptHarness.output()).toContain('attempt_1 · completed · attempt 1 · gen 2');
+
+    const effectHarness = setup(['job_1']);
+    await effects.handler(effectHarness.context as never);
+    expect(effectHarness.output()).toContain('effect_1 · unknown · filesystem · retry unsafe');
+
+    const evidenceHarness = setup(['job_1']);
+    await evidence.handler(evidenceHarness.context as never);
+    expect(evidenceHarness.output()).toContain('evidence_1 · verified · full · file_readback');
+  });
+
+  it('degrades honestly when durable Job state is unavailable', async () => {
+    const h = setup();
+    delete (h.context as { jobEngine?: JobEngine }).jobEngine;
+    await jobs.handler(h.context as never);
+    expect(h.output()).toContain('Durable Job state is unavailable');
+  });
+});

--- a/tests/v4/cli/operatorViews.test.ts
+++ b/tests/v4/cli/operatorViews.test.ts
@@ -44,6 +44,7 @@ function setup(args: string[] = []) {
   const engine = {
     getJob: (id: string) => id === job.id ? job : null,
     listJobs: () => [job],
+    listChildContracts: () => [],
     projection: { rebuild: () => snapshot },
   } as unknown as JobEngine;
   return {
@@ -92,6 +93,32 @@ describe('durable operator views', () => {
     await jobView.handler(h.context as never);
     expect(h.output()).toContain('◆ Job job_1');
     expect(h.output()).toContain('goal        read a file');
+  });
+
+  it('renders worker assignments from durable child contracts', async () => {
+    const h = setup(['job_1']);
+    const engine = h.context.jobEngine as unknown as {
+      getJob: (id: string) => JobRecord | null;
+      listChildContracts: () => Array<{
+        childJobId: string; workerId: string; resultStatus: string | null;
+      }>;
+    };
+    const child: JobRecord = {
+      id: 'job_child', status: 'running', stateVersion: 1, activeAttemptId: 'attempt_child',
+      rootJobId: 'job_1', parentJobId: 'job_1', sessionId: 'session_1',
+      goal: 'validate Windows', entryPoint: 'worker', source: 'parent', terminalAt: null,
+      terminalOutcome: null, finishReason: null, nextEventSequence: 1,
+    };
+    const originalGetJob = engine.getJob;
+    engine.getJob = (id) => id === child.id ? child : originalGetJob(id);
+    engine.listChildContracts = () => [{
+      childJobId: child.id, workerId: 'worker-windows', resultStatus: null,
+    }];
+
+    await jobView.handler(h.context as never);
+
+    expect(h.output()).toContain('workers');
+    expect(h.output()).toContain('worker-windows · running · validate Windows');
   });
 
   it('projects Attempts, Effects, and evidence from the same durable snapshot', async () => {

--- a/tests/v4/cli/render/promptBoundary.test.ts
+++ b/tests/v4/cli/render/promptBoundary.test.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { Writable } from 'node:stream';
 import { Display } from '../../../../cli/v4/display';
 import { SkinEngine } from '../../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../../harness/terminalScreen';
 
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '');
 
@@ -33,5 +34,38 @@ describe('prompt-zone rule boundaries', () => {
     const dispatch = src.indexOf('await this.runAgentTurn(input, inputAlreadyPersisted, queuedDurableInputId)');
     expect(dispatch).toBeGreaterThan(0);
     expect(src.slice(Math.max(0, dispatch - 500), dispatch)).not.toMatch(/display\.rule\(\)/);
+  });
+
+  it.each([
+    'hi',
+    'a long wrapped submission '.repeat(8),
+    'Unicode नमस्ते 世界 🚀',
+    'first line\n\n  indented second line',
+  ])('keeps the submitted prompt immutable when a turn rule is painted', (value) => {
+    class ScreenStream extends Writable {
+      isTTY = true;
+      columns = 44;
+      rows = 18;
+      constructor(readonly screen: TerminalScreen) {
+        super({ write: (chunk, _encoding, callback) => { screen.write(chunk); callback(); } });
+      }
+    }
+    const screen = new TerminalScreen(44, 18);
+    const out = new ScreenStream(screen) as unknown as NodeJS.WriteStream;
+    const display = new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out });
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message');
+    display.submitIdleComposer(value, 'Type your message');
+    display.printTurnSeparator();
+
+    const lines = screen.lines();
+    const composerTop = lines.findLastIndex((line) => line.startsWith('╭─ ▲ You'));
+    const transcript = lines.slice(0, composerTop);
+    const submittedRows = transcript.filter((line) => (
+      line.includes('▲ You') || line.includes('indented second') || line.includes('Unicode')
+    ));
+    expect(submittedRows.length, screen.snapshot()).toBeGreaterThan(0);
+    expect(submittedRows.every((line) => !line.includes('─')), screen.snapshot()).toBe(true);
+    expect(transcript.some((line) => /^\s*─{10,}\s*$/u.test(line)), screen.snapshot()).toBe(true);
   });
 });

--- a/tests/v4/cli/responsiveActivity.test.ts
+++ b/tests/v4/cli/responsiveActivity.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ActivityRegistry } from '../../../cli/v4/activityRegistry';
 import { Display, type LiveActivityRowHandle, type ToolRowHandle } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../harness/terminalScreen';
 
 function stripAnsi(value: string): string {
   return value
@@ -104,7 +105,16 @@ describe('responsive registry-owned turn activity', () => {
   });
 
   it('clamps the complete provider row at 120, 44, and 100 columns', () => {
-    const { out, chunks } = makeOutput(120);
+    const screen = new TerminalScreen(120, 30);
+    const out = new Writable({
+      write(chunk, _encoding, callback) {
+        screen.write(chunk);
+        callback();
+      },
+    }) as Writable & { isTTY?: boolean; columns?: number; rows?: number };
+    out.isTTY = true;
+    out.columns = 120;
+    out.rows = 30;
     const display = new Display({
       stdout: out as unknown as NodeJS.WriteStream,
       skin: new SkinEngine({ forceMono: true }),
@@ -112,16 +122,17 @@ describe('responsive registry-owned turn activity', () => {
     display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
     const row = display.liveActivityRow('calling provider');
     const assertLatestFrameFits = (width: number): void => {
-      const frames = chunks.flatMap((chunk) => stripAnsi(chunk).split('\n'))
-        .filter((line) => line.includes('provider'));
-      expect(frames.length).toBeGreaterThan(0);
-      expect(frames.at(-1)!.length).toBeLessThanOrEqual(width - 2);
+      const frames = screen.lines().filter((line) => line.includes('provider'));
+      expect(frames).toHaveLength(1);
+      expect(frames[0].length).toBeLessThanOrEqual(width - 1);
     };
     assertLatestFrameFits(120);
     out.columns = 44;
+    screen.resize(44, 30);
     row.refresh();
     assertLatestFrameFits(44);
     out.columns = 100;
+    screen.resize(100, 30);
     row.refresh();
     assertLatestFrameFits(100);
     row.stop();

--- a/tests/v4/cli/skinEngine.yaml.test.ts
+++ b/tests/v4/cli/skinEngine.yaml.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
-import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { SkinEngine, detectSkinColorDepth } from '../../../cli/v4/skinEngine';
 
 async function makeTmp(prefix: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -190,5 +190,35 @@ describe('SkinEngine muted color (v4.1.4 reply-quality polish)', () => {
     const engine = new SkinEngine({ forceMono: true });
     const out = engine.applyColors('dim row', 'muted');
     expect(out).toBe('dim row');
+  });
+});
+
+describe('SkinEngine terminal color capability', () => {
+  it('detects truecolor, 256-color, 16-color, and monochrome terminals', () => {
+    expect(detectSkinColorDepth({ COLORTERM: 'truecolor' }, { isTTY: true, platform: 'win32' })).toBe('truecolor');
+    expect(detectSkinColorDepth({ TERM: 'xterm-256color' }, { isTTY: true, platform: 'linux' })).toBe('256');
+    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32' })).toBe('16');
+    expect(detectSkinColorDepth({ NO_COLOR: '1' }, { isTTY: true, platform: 'win32' })).toBe('none');
+  });
+
+  it.each([
+    ['truecolor', '\\x1b[38;2;'],
+    ['256', '\\x1b[38;5;'],
+    ['16', '\\x1b['],
+  ] as const)('renders semantic colors through the %s fallback', (depth, prefix) => {
+    const engine = new SkinEngine({ colorDepth: depth });
+    const brand = engine.applyColors('brand', 'brand');
+    const success = engine.applyColors('success', 'success');
+    const warning = engine.applyColors('warning', 'warn');
+    const failure = engine.applyColors('failure', 'error');
+    expect(brand).toContain(prefix.replace('\\x1b', '\x1b'));
+    const codes = [brand, success, warning, failure]
+      .map((value) => value.match(/^\x1b\[[^m]+m/u)?.[0]);
+    expect(new Set(codes).size).toBe(4);
+  });
+
+  it('keeps the user label on the Aiden brand accent', () => {
+    const engine = new SkinEngine({ colorDepth: 'truecolor' });
+    expect(engine.applyColors('You', 'user')).toContain('\x1b[38;2;255;107;53m');
   });
 });

--- a/tests/v4/cli/skinEngine.yaml.test.ts
+++ b/tests/v4/cli/skinEngine.yaml.test.ts
@@ -197,8 +197,12 @@ describe('SkinEngine terminal color capability', () => {
   it('detects truecolor, 256-color, 16-color, and monochrome terminals', () => {
     expect(detectSkinColorDepth({ COLORTERM: 'truecolor' }, { isTTY: true, platform: 'win32' })).toBe('truecolor');
     expect(detectSkinColorDepth({ TERM: 'xterm-256color' }, { isTTY: true, platform: 'linux' })).toBe('256');
-    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32' })).toBe('truecolor');
+    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32', getColorDepth: () => 24 } as never)).toBe('truecolor');
+    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32', getColorDepth: () => 8 } as never)).toBe('256');
+    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32', getColorDepth: () => 4 } as never)).toBe('16');
     expect(detectSkinColorDepth({ NO_COLOR: '1' }, { isTTY: true, platform: 'win32' })).toBe('none');
+    expect(detectSkinColorDepth({ FORCE_COLOR: '2' }, { isTTY: true, platform: 'win32' })).toBe('256');
+    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'linux', getColorDepth: () => { throw new Error('unsupported'); } })).toBe('16');
   });
 
   it('uses a restrained amber brand fallback when 16-color mode is explicit', () => {

--- a/tests/v4/cli/skinEngine.yaml.test.ts
+++ b/tests/v4/cli/skinEngine.yaml.test.ts
@@ -197,8 +197,16 @@ describe('SkinEngine terminal color capability', () => {
   it('detects truecolor, 256-color, 16-color, and monochrome terminals', () => {
     expect(detectSkinColorDepth({ COLORTERM: 'truecolor' }, { isTTY: true, platform: 'win32' })).toBe('truecolor');
     expect(detectSkinColorDepth({ TERM: 'xterm-256color' }, { isTTY: true, platform: 'linux' })).toBe('256');
-    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32' })).toBe('16');
+    expect(detectSkinColorDepth({}, { isTTY: true, platform: 'win32' })).toBe('truecolor');
     expect(detectSkinColorDepth({ NO_COLOR: '1' }, { isTTY: true, platform: 'win32' })).toBe('none');
+  });
+
+  it('uses a restrained amber brand fallback when 16-color mode is explicit', () => {
+    const engine = new SkinEngine({ colorDepth: '16' });
+    expect(engine.applyColors('Aiden', 'brand')).toContain('\x1b[33m');
+    expect(engine.applyColors('body', 'agent')).toContain('\x1b[97m');
+    expect(engine.applyColors('ok', 'success')).toContain('\x1b[92m');
+    expect(engine.applyColors('failed', 'error')).toContain('\x1b[31m');
   });
 
   it.each([

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -155,8 +155,8 @@ describe('responsive startup status rows', () => {
 describe('responsive startup dashboard integration', () => {
   it.each([
     { columns: 120, tier: 'wide', sections: true, frame: true },
-    { columns: 80, tier: 'medium', sections: true, frame: true },
-    { columns: 48, tier: 'narrow', sections: false, frame: true },
+    { columns: 80, tier: 'wide', sections: true, frame: true },
+    { columns: 48, tier: 'narrow', sections: true, frame: true },
     { columns: 20, tier: 'minimal', sections: false, frame: true },
   ])('renders the $tier transcript once at $columns columns', async ({ columns, sections, frame }) => {
     const { session, chunks } = buildSession('Partner', columns);
@@ -174,7 +174,7 @@ describe('responsive startup dashboard integration', () => {
     if (sections) {
       expect(output).toMatch(/77 (?:loaded|tools)/);
       expect(output).toMatch(/76 (?:loaded|skills)/);
-      expect(output).toContain('memory active');
+      if (columns >= 60) expect(output).toContain('memory active');
     }
     for (const line of output.split(/\r?\n/)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(Math.max(1, columns - 2));

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -155,15 +155,15 @@ describe('responsive startup status rows', () => {
 describe('responsive startup dashboard integration', () => {
   it.each([
     { columns: 120, tier: 'wide', sections: true, frame: true },
-    { columns: 80, tier: 'medium', sections: true, frame: false },
-    { columns: 48, tier: 'narrow', sections: false, frame: false },
-    { columns: 20, tier: 'minimal', sections: false, frame: false },
+    { columns: 80, tier: 'medium', sections: true, frame: true },
+    { columns: 48, tier: 'narrow', sections: false, frame: true },
+    { columns: 20, tier: 'minimal', sections: false, frame: true },
   ])('renders the $tier transcript once at $columns columns', async ({ columns, sections, frame }) => {
     const { session, chunks } = buildSession('Partner', columns);
     await session.renderStartupCard();
     const output = stripAnsi(chunks.join(''));
 
-    const logo = sections ? /Autonomous AI Engine/g : /AIDEN/g;
+    const logo = columns >= 44 ? /Autonomous AI Engine/g : /^Aiden$/gm;
     expect(output.match(logo)).toHaveLength(1);
     expect(output).toContain('Partner');
     expect(output).toContain('llama-3.3-70b-versatile'.slice(0, columns >= 48 ? 8 : 3));

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -8,6 +8,15 @@ import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
 import { TerminalScreen } from '../harness/terminalScreen';
 
+const CANONICAL_LOGO = [
+  '█████╗  ██╗██████╗ ███████╗███╗   ██╗',
+  '██╔══██╗██║██╔══██╗██╔════╝████╗  ██║',
+  '███████║██║██║  ██║█████╗  ██╔██╗ ██║',
+  '██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║',
+  '██║  ██║██║██████╔╝███████╗██║ ╚████║',
+  '╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝',
+] as const;
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
 
@@ -125,6 +134,17 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dashboard', () => {
+  it('emits the canonical six-line logo exactly once before composer ownership begins', async () => {
+    provider = await startMockProvider({ modelId: 'custom-default' });
+    const startup = await launch(100);
+    const physical = startup.plain();
+
+    for (const row of CANONICAL_LOGO) {
+      expect(physical.split(row)).toHaveLength(2);
+    }
+    expect(physical).not.toMatch(/\x1b\[3[13]m/u);
+  }, 30_000);
+
   it('selects wide, medium, and narrow transcript tiers without resize duplication', async () => {
     provider = await startMockProvider({ modelId: 'custom-default' });
 

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -103,7 +103,7 @@ async function launch(columns: number, paused = false): Promise<{
 
 function dashboardLines(output: string): string[] {
   const lines = output.split(/\r?\n/);
-  const start = lines.findIndex((line) => line.includes('█████╗') || /^\s*AIDEN\s*$/.test(line));
+  const start = lines.findIndex((line) => line.includes('█████╗') || /^\s*Aiden\s*$/.test(line));
   const end = lines.findIndex((line, index) => index >= start && line.startsWith('╭─ ▲ You'));
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
@@ -155,19 +155,25 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     expect(mediumRendered).toContain('Environment');
     expect(mediumRendered).toContain('Capabilities');
     expect(mediumRendered).toContain('github.com/taracodlabs/aiden');
-    expect(dashboardLines(mediumRendered).join('\n')).not.toContain('╭');
+    expect(dashboardLines(mediumRendered).join('\n')).toContain('╭');
+    expect(mediumRendered).toContain('GitHub:');
+    expect(mediumRendered).toContain('Web:');
+    expect(mediumRendered).toContain('Contact:');
     for (const line of dashboardLines(mediumRendered)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(78);
     }
 
     const narrow = await launch(48);
     const narrowRendered = narrow.rendered();
-    expect(narrowRendered).toMatch(/\bAIDEN\b/);
+    expect(narrowRendered).toContain('█████╗');
     expect(narrowRendered).toMatch(/Assistant\s+·\s+custom-default/i);
     expect(narrowRendered).toMatch(/built solo/i);
     expect(narrowRendered).not.toContain('Environment');
     expect(narrowRendered).not.toContain('Capabilities');
-    expect(dashboardLines(narrowRendered).join('\n')).not.toContain('╭');
+    expect(dashboardLines(narrowRendered).join('\n')).toContain('╭');
+    expect(narrowRendered).toContain('GitHub:');
+    expect(narrowRendered).toContain('Web:');
+    expect(narrowRendered).toContain('Contact:');
     for (const line of dashboardLines(narrowRendered)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(46);
     }

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -102,6 +102,14 @@ async function launch(columns: number, paused = false): Promise<{
     () => output.includes(COMPOSER_READY_TOKEN),
     () => stripAnsi(output),
   );
+  await waitFor(
+    () => {
+      const lines = screen.snapshot().split('\n');
+      return (lines.at(-4)?.includes('You') ?? false)
+        && (lines.at(-1)?.includes('custom-default') ?? false);
+    },
+    () => screen.snapshot(),
+  );
   return {
     child,
     raw: () => output,

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -129,7 +129,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     provider = await startMockProvider({ modelId: 'custom-default' });
 
     const wide = await launch(120, true);
-    const wideBeforeResize = wide.plain();
+    const wideBeforeResize = wide.rendered();
     expect(wideBeforeResize).toContain('Environment');
     expect(wideBeforeResize).toContain('Capabilities');
     expect(wideBeforeResize).toContain('Built solo');
@@ -148,18 +148,15 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     await new Promise((resolve) => setTimeout(resolve, 250));
     wide.child.resize(120, 50);
     await new Promise((resolve) => setTimeout(resolve, 250));
-    expect((wide.plain().match(/Autonomous AI Engine/g) ?? []).length).toBe(logoCount);
-    // ConPTY may replay visible bottom rows while reflowing its screen buffer;
-    // the typographic anchor is above that window and detects an actual second
-    // application startup render. The unit integration test separately proves
-    // the startup renderer owns no resize listener or repaint callback.
+    expect((wide.rendered().match(/Autonomous AI Engine/g) ?? []).length).toBe(logoCount);
 
     const medium = await launch(80);
-    expect(medium.plain()).toContain('Environment');
-    expect(medium.plain()).toContain('Capabilities');
-    expect(medium.plain()).toContain('github.com/taracodlabs/aiden');
-    expect(dashboardLines(medium.plain()).join('\n')).not.toContain('╭');
-    for (const line of dashboardLines(medium.plain())) {
+    const mediumRendered = medium.rendered();
+    expect(mediumRendered).toContain('Environment');
+    expect(mediumRendered).toContain('Capabilities');
+    expect(mediumRendered).toContain('github.com/taracodlabs/aiden');
+    expect(dashboardLines(mediumRendered).join('\n')).not.toContain('╭');
+    for (const line of dashboardLines(mediumRendered)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(78);
     }
 

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -186,10 +186,10 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     const narrow = await launch(48);
     const narrowRendered = narrow.rendered();
     expect(narrowRendered).toContain('█████╗');
-    expect(narrowRendered).toMatch(/Assistant\s+·\s+custom-default/i);
+    expect(narrowRendered).toMatch(/◇\s+Assistant\s+·\s+◆\s+custom-default/i);
     expect(narrowRendered).toMatch(/built solo/i);
-    expect(narrowRendered).not.toContain('Environment');
-    expect(narrowRendered).not.toContain('Capabilities');
+    expect(narrowRendered).toContain('Environment');
+    expect(narrowRendered).toContain('Capabilities');
     expect(dashboardLines(narrowRendered).join('\n')).toContain('╭');
     expect(narrowRendered).toContain('GitHub:');
     expect(narrowRendered).toContain('Web:');

--- a/tests/v4/cli/startupDashboard.test.ts
+++ b/tests/v4/cli/startupDashboard.test.ts
@@ -135,6 +135,18 @@ describe('responsive startup dashboard', () => {
   );
 
   it.each([160, 120, 100, 80, 60, 44])(
+    'keeps the Built solo card compact and indented at %i columns',
+    (columns) => {
+      const lines = render(columns);
+      const top = lines.find((line) => line.includes('╭')) ?? '';
+      const card = lines.filter((line) => /^[ ]{2}[╭│╰]/u.test(line));
+      expect(top.startsWith('  ╭')).toBe(true);
+      expect(card.length).toBeGreaterThanOrEqual(6);
+      expect(startupVisibleWidth(top)).toBeLessThanOrEqual(Math.min(columns, 74));
+    },
+  );
+
+  it.each([160, 120, 100, 80, 60, 44])(
     'keeps the complete logo on the Aiden orange accent at %i columns',
     (columns) => {
       const skin = new SkinEngine({ colorDepth: 'truecolor' });

--- a/tests/v4/cli/startupDashboard.test.ts
+++ b/tests/v4/cli/startupDashboard.test.ts
@@ -6,6 +6,7 @@ import {
   startupVisibleWidth,
   type StartupDashboardData,
 } from '../../../cli/v4/startupDashboard';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
 
 const base: StartupDashboardData = {
   trust: 'Partner',
@@ -40,6 +41,10 @@ const base: StartupDashboardData = {
 const banner = [
   '█████╗  ██╗██████╗ ███████╗███╗   ██╗',
   '██╔══██╗██║██╔══██╗██╔════╝████╗  ██║',
+  '███████║██║██║  ██║█████╗  ██╔██╗ ██║',
+  '██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║',
+  '██║  ██║██║██████╔╝███████╗██║ ╚████║',
+  '╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝',
 ].join('\n');
 
 function render(columns: number, data: StartupDashboardData = base): string[] {
@@ -80,7 +85,7 @@ describe('responsive startup dashboard', () => {
     assertBounded(lines, 120);
   });
 
-  it('renders a stacked medium dashboard without forcing the wide table or frame', () => {
+  it('renders a stacked medium dashboard while preserving the bordered project card', () => {
     const lines = render(80);
     const text = lines.join('\n');
     expect(text).toContain('Environment');
@@ -88,28 +93,109 @@ describe('responsive startup dashboard', () => {
     expect(text).toContain('77 tools');
     expect(text).toContain('76 skills');
     expect(text).toContain('github.com/taracodlabs/aiden');
-    expect(text).not.toContain('╭');
+    expect(text).toContain('╭');
+    expect(text).toContain('╯');
     assertBounded(lines, 80);
   });
 
-  it('keeps the compact narrow layout and omits detailed sections', () => {
+  it('keeps the compact narrow layout, full project details, and bounded card', () => {
     const lines = render(48);
     const text = lines.join('\n');
-    expect(text).toContain('AIDEN');
+    expect(text).toContain(banner.split('\n')[0]);
     expect(text).toContain('Partner');
     expect(text).toContain('gpt-5.6-sol');
-    expect(text).toContain('built solo');
+    expect(text).toContain('Built solo');
+    expect(text).toContain('github.com/taracodlabs/aiden');
+    expect(text).toContain('aiden.taracod.com');
+    expect(text).toContain('contact@taracod.com');
     expect(text).not.toContain('Environment');
     expect(text).not.toContain('Capabilities');
-    expect(text).not.toContain('╭');
+    expect(text).toContain('╭');
+    expect(text).toContain('╯');
     assertBounded(lines, 48);
   });
 
+  it.each([160, 120, 100, 80, 60, 44])(
+    'preserves the golden startup identity at %i columns',
+    (columns) => {
+      const lines = render(columns);
+      const text = lines.join('\n');
+      const logoFits = startupVisibleWidth(banner.split('\n')[0]) <= columns - 2;
+      expect(text).toContain(logoFits ? banner.split('\n')[0] : 'Aiden');
+      expect(text).toContain('Autonomous AI Engine');
+      expect(text).toContain('Built solo');
+      expect(text).toContain('GitHub:');
+      expect(text).toContain('Web:');
+      expect(text).toContain('Contact:');
+      expect(text).toContain('╭');
+      expect(text).toContain('╯');
+      expect(text).toContain('Ready when you are.');
+      assertBounded(lines, columns);
+    },
+  );
+
+  it.each([160, 120, 100, 80, 60, 44])(
+    'keeps the complete logo on the Aiden orange accent at %i columns',
+    (columns) => {
+      const skin = new SkinEngine({ colorDepth: 'truecolor' });
+      const coloredBanner = banner.split('\n').map((line) => skin.applyColors(line, 'brand')).join('\n');
+      const lines = renderStartupDashboard({
+        columns,
+        data: base,
+        banner: coloredBanner,
+        style: {
+          brand: (value) => skin.applyColors(value, 'brand'),
+          muted: (value) => skin.applyColors(value, 'muted'),
+          text: (value) => skin.applyColors(value, 'agent'),
+          success: (value) => skin.applyColors(value, 'success'),
+        },
+      }).lines;
+      const plainLines = lines.map((line) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/gu, ''));
+      for (const logoLine of banner.split('\n')) expect(plainLines).toContain(logoLine);
+      const logo = lines.slice(0, banner.split('\n').length).join('\n');
+      expect(logo).toContain('\x1b[38;2;255;107;53m');
+    },
+  );
+
+  it('wraps the welcome and helper instead of truncating either message', () => {
+    const lines = render(44, {
+      ...base,
+      greeting: 'Welcome back. What would you like to build with Aiden today?',
+      helper: 'Type your message · /help for commands · /skills to add more',
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('Welcome back. What would you like to build');
+    expect(text).toContain('with Aiden today?');
+    expect(text).toContain('/skills to add more');
+    assertBounded(lines, 44);
+  });
+
+  it.each([160, 120, 100, 80, 60, 44])(
+    'keeps startup geometry independent of theme color at %i columns',
+    (columns) => {
+      const plain = renderStartupDashboard({ columns, data: base, banner }).lines;
+      const styled = renderStartupDashboard({
+        columns,
+        data: base,
+        banner,
+        style: {
+          brand: (value) => `\x1b[38;2;255;107;53m${value}\x1b[39m`,
+          muted: (value) => `\x1b[38;2;184;168;154m${value}\x1b[39m`,
+          text: (value) => `\x1b[38;2;232;235;240m${value}\x1b[39m`,
+          success: (value) => `\x1b[38;2;127;194;139m${value}\x1b[39m`,
+        },
+      }).lines;
+      expect(styled).toHaveLength(plain.length);
+      expect(styled.map(startupVisibleWidth)).toEqual(plain.map(startupVisibleWidth));
+      expect(plain.some((line, index) => line === '' && plain[index + 1] === '')).toBe(false);
+    },
+  );
+
   it('is safe at minimal widths and never creates negative padding or broken borders', () => {
     const lines = render(20);
-    expect(lines.join('\n')).toContain('AIDEN');
+    expect(lines.join('\n')).toContain('Aiden');
     expect(lines.join('\n')).not.toMatch(/undefined|null|NaN/);
-    expect(lines.join('\n')).not.toContain('╭');
+    expect(lines.join('\n')).toContain('╭');
     assertBounded(lines, 20);
   });
 

--- a/tests/v4/cli/startupDashboard.test.ts
+++ b/tests/v4/cli/startupDashboard.test.ts
@@ -60,7 +60,8 @@ function assertBounded(lines: string[], columns: number): void {
 describe('responsive startup dashboard', () => {
   it.each([
     [120, 'wide'],
-    [80, 'medium'],
+    [80, 'wide'],
+    [60, 'medium'],
     [48, 'narrow'],
     [20, 'minimal'],
   ] as const)('selects the deterministic %s-column tier', (columns, tier) => {
@@ -79,19 +80,21 @@ describe('responsive startup dashboard', () => {
     expect(text).toContain('v4.14.9');
     expect(text).toContain('77 loaded');
     expect(text).toContain('76 loaded');
+    expect(text).toContain('│');
     expect(text).toContain('Built solo');
     expect(text).toContain('╭');
     expect(text).toContain('╯');
     assertBounded(lines, 120);
   });
 
-  it('renders a stacked medium dashboard while preserving the bordered project card', () => {
+  it('renders a side-by-side normal-width dashboard while preserving the bordered project card', () => {
     const lines = render(80);
     const text = lines.join('\n');
     expect(text).toContain('Environment');
     expect(text).toContain('Capabilities');
-    expect(text).toContain('77 tools');
-    expect(text).toContain('76 skills');
+    expect(text).toContain('77 loaded');
+    expect(text).toContain('76 loaded');
+    expect(text).toContain('│');
     expect(text).toContain('github.com/taracodlabs/aiden');
     expect(text).toContain('╭');
     expect(text).toContain('╯');
@@ -108,11 +111,49 @@ describe('responsive startup dashboard', () => {
     expect(text).toContain('github.com/taracodlabs/aiden');
     expect(text).toContain('aiden.taracod.com');
     expect(text).toContain('contact@taracod.com');
-    expect(text).not.toContain('Environment');
-    expect(text).not.toContain('Capabilities');
+    expect(text).toContain('Environment');
+    expect(text).toContain('Capabilities');
+    expect(text).toContain('Windows 11');
+    expect(text).toContain('PowerShell');
+    expect(text).toContain('web');
+    expect(text).toContain('browser');
     expect(text).toContain('╭');
     expect(text).toContain('╯');
     assertBounded(lines, 48);
+  });
+
+  it('uses distinct metadata glyphs and semantic colors for runtime state', () => {
+    const mark = (code: number) => (value: string): string => `\x1b[${code}m${value}\x1b[39m`;
+    const lines = renderStartupDashboard({
+      columns: 120,
+      data: base,
+      banner,
+      style: {
+        brand: mark(31),
+        muted: mark(90),
+        text: mark(37),
+        success: mark(32),
+        info: mark(36),
+      } as never,
+    }).lines;
+    const text = lines.join('\n');
+    expect(text).toContain('\x1b[32m●\x1b[39m');
+    expect(text).toContain('\x1b[36m◇\x1b[39m');
+    expect(text).toContain('\x1b[36m◆\x1b[39m');
+    expect(text).toContain('\x1b[32m77 loaded\x1b[39m');
+    expect(text).toContain('\x1b[32m76 loaded\x1b[39m');
+  });
+
+  it.each([60, 44])('retains labelled environment and capability rows at %i columns', (columns) => {
+    const lines = render(columns);
+    const text = lines.join('\n');
+    expect(text).toContain('Environment');
+    expect(text).toContain('Capabilities');
+    expect(text).toContain('OS');
+    expect(text).toContain('shell');
+    expect(text).toContain('web');
+    expect(text).toContain('files');
+    assertBounded(lines, columns);
   });
 
   it.each([160, 120, 100, 80, 60, 44])(

--- a/tests/v4/cli/startupNotices.test.ts
+++ b/tests/v4/cli/startupNotices.test.ts
@@ -200,6 +200,30 @@ describe('startup notices', () => {
     }
   });
 
+  it('renders one actionable notice in at most two semantically styled lines', () => {
+    const notices = prepareStartupNotices([
+      notice({
+        id: 'browser-permission',
+        source: 'plugin',
+        title: 'Browser control needs permission',
+        detail: 'Grant the installed browser capability before using it.',
+        command: '/plugins grant aiden-plugin-cdp-browser',
+      }),
+    ], registry());
+    const lines = renderStartupNoticeLines(notices, {
+      columns: 120,
+      style: {
+        warning: (value: string) => `\x1b[33m${value}\x1b[39m`,
+        text: (value: string) => `\x1b[37m${value}\x1b[39m`,
+        command: (value: string) => `\x1b[36m${value}\x1b[39m`,
+      },
+    } as never);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('\x1b[33m!\x1b[39m');
+    expect(lines[0]).toContain('\x1b[37mBrowser control needs permission\x1b[39m');
+    expect(lines[1]).toContain('\x1b[36m/plugins grant aiden-plugin-cdp-browser\x1b[39m');
+  });
+
   it('rejects displayed commands that are not registered or verified', () => {
     const reg = registry();
     expect(commandIsRegisteredOrVerified('/model', reg)).toBe(true);

--- a/tests/v4/cli/startupNotices.test.ts
+++ b/tests/v4/cli/startupNotices.test.ts
@@ -194,6 +194,9 @@ describe('startup notices', () => {
       for (const line of lines) {
         expect(startupNoticeVisibleWidth(line), line).toBeLessThanOrEqual(Math.max(1, columns - 2));
       }
+      if (columns === 48) {
+        expect(lines.some((line) => line.includes('/auth refresh provider-with-long-name'))).toBe(true);
+      }
     }
   });
 

--- a/tests/v4/cli/taskVerificationGate.test.ts
+++ b/tests/v4/cli/taskVerificationGate.test.ts
@@ -18,9 +18,9 @@
  * (via sweepOrphaned), and the v16 migration leaving pre-existing rows
  * untouched.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { Writable } from 'node:stream';
-import { promises as fs } from 'node:fs';
+import { promises as fs, mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import Database from 'better-sqlite3';
@@ -37,16 +37,40 @@ let tmp: string;
 let db: InstanceType<typeof Database>;
 let taskStore: TaskStore;
 
+// Build each schema fixture once while its database is closed, then copy it for
+// every isolated case. This keeps the real migration coverage without making
+// each test compete for a complete synchronous migration chain on Windows.
+const suiteTmp = mkdtempSync(path.join(os.tmpdir(), 'aiden-verify-gate-suite-'));
+const currentTemplate = path.join(suiteTmp, 'current.db');
+const currentTemplateDb = new Database(currentTemplate);
+runMigrations(currentTemplateDb);
+currentTemplateDb.close();
+
+const pre16Template = path.join(suiteTmp, 'pre16.db');
+const pre16TemplateDb = new Database(pre16Template);
+for (const migration of MIGRATIONS_FOR_TESTS) {
+  if (migration.version <= 15) pre16TemplateDb.exec(migration.sql);
+}
+pre16TemplateDb.prepare(
+  'INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, 15, ?)',
+).run(new Date().toISOString());
+pre16TemplateDb.close();
+
 beforeEach(async () => {
-  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-verify-gate-'));
-  db = new Database(path.join(tmp, 'daemon.db'));
-  runMigrations(db);
+  tmp = await fs.mkdtemp(path.join(suiteTmp, 'case-'));
+  const dbFile = path.join(tmp, 'daemon.db');
+  await fs.copyFile(currentTemplate, dbFile);
+  db = new Database(dbFile);
   taskStore = createTaskStore({ db });
 });
 
 afterEach(async () => {
   db.close();
   await fs.rm(tmp, { recursive: true, force: true }).catch(() => undefined);
+});
+
+afterAll(() => {
+  rmSync(suiteTmp, { recursive: true, force: true });
 });
 
 // ── ChatSession scaffolding (greeter integration-test pattern) ─────────
@@ -261,15 +285,10 @@ describe('pending_verification crash state + v16 migration', () => {
   });
 
   it('v16 migration: rows created on the v15 schema are untouched — status intact, evidence null', async () => {
-    const db2 = new Database(path.join(tmp, 'pre16.db'));
+    const pre16File = path.join(tmp, 'pre16.db');
+    await fs.copyFile(pre16Template, pre16File);
+    const db2 = new Database(pre16File);
     try {
-      // Apply everything below v16, marking the version like production.
-      for (const m of MIGRATIONS_FOR_TESTS) {
-        if (m.version <= 15) db2.exec(m.sql);
-      }
-      db2.prepare(
-        'INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, 15, ?)',
-      ).run(new Date().toISOString());
       db2.prepare(
         `INSERT INTO tasks (id, title, goal, status, created_at, updated_at,
            channel_id, session_id, parent_task_id, trace_ids, artifact_ids)

--- a/tests/v4/cli/taskVerificationGate.test.ts
+++ b/tests/v4/cli/taskVerificationGate.test.ts
@@ -166,8 +166,9 @@ describe('verify-before-done gate (real runAgentTurn seam)', () => {
     expect(task!.status).toBe('verification_failed');
     expect(task!.evidence!.verdict).toBe('verification_failed');
     expect(task!.evidence!.failures[0].tool).toBe('file_write');
-    expect(chunks.join('')).toMatch(/Could not verify required outcome/i);
-    expect(chunks.join('').match(/Could not verify required outcome/gi)).toHaveLength(1);
+    expect(chunks.join('')).toMatch(/\? Outcome unknown/i);
+    expect(chunks.join('').match(/Outcome unknown/gi)).toHaveLength(1);
+    expect(chunks.join('')).not.toMatch(/\u2713 Verified/i);
   });
 
   it('happy path: evidence-backed mutation (file present on disk) → completed with handles persisted on the row', async () => {

--- a/tests/v4/cli/themeCompatibility.test.ts
+++ b/tests/v4/cli/themeCompatibility.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { initializeEffectiveTheme } from '../../../cli/v4/themeCompatibility';
+import { getCurrentName, resetToDefault } from '../../../core/v4/theme/themeRegistry';
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  resetToDefault();
+  for (const directory of cleanup.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function root(): string {
+  const value = mkdtempSync(path.join(os.tmpdir(), 'aiden-effective-theme-'));
+  cleanup.push(value);
+  return value;
+}
+
+describe('effective theme startup compatibility', () => {
+  it('migrates a persisted legacy monochrome setting into theme authority', () => {
+    const directory = root();
+    const skin = new SkinEngine({ forceMono: false });
+    skin.setActive('light');
+
+    const result = initializeEffectiveTheme(directory, 'monochrome', skin);
+
+    expect(result).toMatchObject({ name: 'monochrome', source: 'legacy-migration' });
+    expect(getCurrentName()).toBe('monochrome');
+    expect(skin.getActive().name).toBe('default');
+    expect(readFileSync(path.join(directory, 'theme.yaml'), 'utf8')).toMatch(/name:\s*"?monochrome"?/);
+  });
+
+  it('gives an existing theme file precedence over a legacy skin setting', () => {
+    const directory = root();
+    writeFileSync(path.join(directory, 'theme.yaml'), [
+      'name: persisted-theme',
+      'colors:',
+      '  brand:',
+      '    primary: "#123456"',
+    ].join('\n'), 'utf8');
+    const skin = new SkinEngine({ forceMono: false });
+
+    const result = initializeEffectiveTheme(directory, 'light', skin);
+
+    expect(result).toMatchObject({ name: 'persisted-theme', source: 'theme-file' });
+    expect(getCurrentName()).toBe('persisted-theme');
+    expect(skin.getActive().name).toBe('default');
+  });
+
+  it('uses aiden-ember for an unmapped legacy name without creating conflicting state', () => {
+    const directory = root();
+    const skin = new SkinEngine({ forceMono: false });
+    const result = initializeEffectiveTheme(directory, 'old-custom-skin', skin);
+    expect(result).toMatchObject({ name: 'aiden-ember', source: 'bundled-default' });
+    expect(getCurrentName()).toBe('aiden-ember');
+    expect(skin.getActive().name).toBe('default');
+  });
+});

--- a/tests/v4/cli/turnInputListener.test.ts
+++ b/tests/v4/cli/turnInputListener.test.ts
@@ -106,6 +106,21 @@ describe('makeKeypressHandler — line buffer + key routing', () => {
     h(undefined, key('return'));
     expect(cb.onLine).toHaveBeenCalledWith('ab');
   });
+
+  it('routes transcript navigation without mutating the busy draft', () => {
+    const cb = { ...cbs(), onScroll: vi.fn(), onFollow: vi.fn(), onBufferChange: vi.fn() };
+    const h = makeKeypressHandler(cb);
+    h('a', key('a'));
+    cb.onBufferChange.mockClear();
+    h(undefined, key('pageup'));
+    h(undefined, key('pagedown'));
+    h(undefined, key('end', { ctrl: true }));
+    expect(cb.onScroll.mock.calls.map((call) => call[0])).toEqual([8, -8]);
+    expect(cb.onFollow).toHaveBeenCalledOnce();
+    expect(cb.onBufferChange).not.toHaveBeenCalled();
+    h(undefined, key('return'));
+    expect(cb.onLine).toHaveBeenCalledWith('a');
+  });
 });
 
 describe('makeKeypressHandler — onBufferChange fires per keystroke (Slice 2c)', () => {

--- a/tests/v4/cli/viewportEpoch.pty.test.ts
+++ b/tests/v4/cli/viewportEpoch.pty.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as pty from 'node-pty';
+
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+import { startMockProvider, type MockProvider } from '../harness/mockProvider';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+let child: RunningPty | null = null;
+let provider: MockProvider | null = null;
+const cleanup: string[] = [];
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function typeLine(terminal: RunningPty, value: string): void {
+  terminal.write(`${value}\r`);
+}
+
+function occurrence(lines: string[], value: string): number {
+  return lines.filter((line) => line.includes(value)).length;
+}
+
+function assertClearedFrame(screen: TerminalScreen, oldRows: readonly string[]): void {
+  const frame = screen.snapshot();
+  for (const old of oldRows) expect(frame, `stale row: ${old}\n${frame}`).not.toContain(old);
+  const lines = screen.lines();
+  const composerTop = lines.findIndex((line) => line.includes('▲ You'));
+  expect(composerTop, frame).toBeGreaterThanOrEqual(0);
+  expect(occurrence(lines, '▲ You'), frame).toBe(1);
+  expect(occurrence(lines, '◆'), frame).toBe(1);
+  expect(lines.at(-1), frame).toContain('◆');
+  expect(lines.slice(0, composerTop).every((line) => line === ''), frame).toBe(true);
+  expect(screen.cursorPosition().row, frame).toBe(composerTop + 1);
+}
+
+afterEach(async () => {
+  if (child) {
+    try { child.kill(); } catch { /* already exited */ }
+    child = null;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  if (provider) {
+    await provider.stop();
+    provider = null;
+  }
+  await Promise.all(cleanup.splice(0).map(
+    (directory) => fs.rm(directory, { recursive: true, force: true }).catch(() => undefined),
+  ));
+});
+
+describe.skipIf(process.platform !== 'win32')('built CLI physical viewport epoch', () => {
+  it.each([100, 44])('keeps pre-/cls rows hidden across resize and later repaint at %i columns', async (columns) => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-viewport-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-viewport-cwd-'));
+    cleanup.push(aidenHome, cwd);
+    provider = await startMockProvider({
+      modelId: 'custom-default',
+      responseText: 'VIEWPORT RESPONSE',
+      chunkDelayMs: 5,
+    });
+    await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'viewport\n', 'utf8');
+    await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+      'model:', '  provider: custom_openai', '  modelId: custom-default',
+      'providers:', '  custom_openai:', '    apiKey: viewport-key',
+      'display:', '  streaming: true', '  renderer: frame',
+    ].join('\n') + '\n', 'utf8');
+
+    const screen = new TerminalScreen(columns, 35);
+    const preloadPath = path.join(
+      repoRoot,
+      'tests/v4/harness',
+      process.env.AIDEN_TEST_INSTALLED_ROOT
+        ? 'installedProviderPreload.cjs'
+        : 'builtProviderPreload.cjs',
+    );
+    const cliPath = process.env.AIDEN_TEST_CLI_PATH
+      ? path.resolve(process.env.AIDEN_TEST_CLI_PATH)
+      : path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
+    const command = ['&', quotePowerShellLiteral(process.execPath), '-r',
+      quotePowerShellLiteral(preloadPath), quotePowerShellLiteral(cliPath)].join(' ');
+    child = pty.spawn('powershell.exe', [
+      '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command,
+    ], {
+      cwd, cols: columns, rows: 35,
+      env: {
+        ...process.env,
+        AIDEN_HOME: aidenHome,
+        AIDEN_TEST_REPO_ROOT: repoRoot,
+        AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl,
+        CUSTOM_OPENAI_API_KEY: 'viewport-key',
+        AIDEN_NO_UPDATE_CHECK: '1',
+        AIDEN_TEST_COMPOSER_READY: '1',
+        AIDEN_RENDERER: 'frame',
+        TELEGRAM_BOT_TOKEN: '',
+        FORCE_COLOR: '0',
+        NO_COLOR: '1',
+      },
+    });
+
+    const oldRows = ['FIRST VIEWPORT TURN', 'SECOND VIEWPORT TURN', 'Available themes:', 'AIDEN'];
+    let raw = '';
+    let state = 'boot';
+    let clearStart = 0;
+    await new Promise<void>((resolve, reject) => {
+      let watchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => reject(new Error(
+        `viewport PTY timeout (${state}, calls=${provider?.callCount() ?? -1})\n${screen.snapshot()}\nRAW:\n${raw.slice(-5000)}`,
+      )), 60_000);
+      const fail = (error: unknown): void => {
+        if (watchdog) clearTimeout(watchdog);
+        watchdog = null;
+        reject(error);
+      };
+      const later = (fn: () => void, ms: number): void => {
+        setTimeout(() => {
+          try { fn(); } catch (error) { fail(error); }
+        }, ms);
+      };
+      const dataSubscription = child!.onData((chunk) => {
+        raw += chunk;
+        screen.write(chunk);
+        const readyCount = raw.split(COMPOSER_READY_TOKEN).length - 1;
+        const frame = screen.snapshot();
+        if (state === 'boot' && readyCount >= 1) {
+          state = 'first';
+          later(() => typeLine(child!, 'FIRST VIEWPORT TURN'), 100);
+        } else if (state === 'first' && readyCount >= 2 && frame.includes('VIEWPORT RESPONSE')) {
+          state = 'second';
+          later(() => typeLine(child!, 'SECOND VIEWPORT TURN'), 100);
+        } else if (state === 'second' && readyCount >= 3 && frame.includes('SECOND VIEWPORT TURN')) {
+          state = 'theme';
+          later(() => typeLine(child!, '/theme list'), 100);
+        } else if (state === 'theme' && readyCount >= 4 && frame.includes('Available themes:')) {
+          state = 'clear';
+          clearStart = raw.length;
+          later(() => typeLine(child!, '/cls'), 100);
+        } else if (state === 'clear' && readyCount >= 5
+          && raw.slice(clearStart).includes('\x1b[3J')
+          && raw.slice(clearStart).includes('\x1b[2J')
+          && raw.slice(clearStart).includes('\x1b[H')) {
+          state = 'cleared';
+          later(() => {
+            assertClearedFrame(screen, oldRows);
+            const nextColumns = columns === 100 ? 44 : 100;
+            child!.resize(nextColumns, 24);
+            screen.resize(nextColumns, 24);
+            later(() => {
+              assertClearedFrame(screen, oldRows);
+              child!.resize(columns, 35);
+              screen.resize(columns, 35);
+              later(() => {
+                assertClearedFrame(screen, oldRows);
+                state = 'after';
+                typeLine(child!, 'AFTER VIEWPORT CLEAR');
+              }, 1_200);
+            }, 1_200);
+          }, 1_200);
+        } else if (state === 'after' && readyCount >= 6
+          && frame.includes('AFTER VIEWPORT CLEAR') && frame.includes('VIEWPORT RESPONSE')
+          && !frame.includes('queue mode')) {
+          try {
+            for (const old of oldRows) expect(frame).not.toContain(old);
+            expect(occurrence(screen.lines(), 'AFTER VIEWPORT CLEAR')).toBe(1);
+            expect(provider?.callCount()).toBe(3);
+            const thirdRequest = provider?.requests()[2] as {
+              messages?: Array<{ content?: unknown }>;
+            } | undefined;
+            const retainedContext = JSON.stringify(thirdRequest?.messages ?? []);
+            expect(retainedContext).toContain('FIRST VIEWPORT TURN');
+            expect(retainedContext).toContain('SECOND VIEWPORT TURN');
+            expect(retainedContext).toContain('AFTER VIEWPORT CLEAR');
+            state = 'exit';
+            later(() => typeLine(child!, '/quit'), 100);
+          } catch (error) { fail(error); }
+        }
+      });
+      const exitSubscription = child!.onExit(({ exitCode }) => {
+        dataSubscription.dispose();
+        exitSubscription.dispose();
+        if (watchdog) clearTimeout(watchdog);
+        watchdog = null;
+        child = null;
+        if (state === 'exit' && exitCode === 0) resolve();
+        else reject(new Error(
+          `viewport PTY exited ${exitCode} in ${state}\n${screen.snapshot()}\nRAW:\n${raw.slice(-5000)}`,
+        ));
+      });
+    });
+  }, 90_000);
+});

--- a/tests/v4/cli/viewportEpoch.test.ts
+++ b/tests/v4/cli/viewportEpoch.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+import { Writable } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { TerminalScreen } from '../harness/terminalScreen';
+
+class ViewportStream extends Writable {
+  isTTY = true;
+
+  constructor(
+    readonly screen: TerminalScreen,
+    public columns = 100,
+    public rows = 24,
+  ) {
+    super({
+      write: (chunk, _encoding, callback) => {
+        screen.write(chunk);
+        callback();
+      },
+    });
+  }
+
+  resize(columns: number, rows: number): void {
+    this.columns = columns;
+    this.rows = rows;
+    this.screen.resize(columns, rows);
+    this.emit('resize');
+  }
+}
+
+function harness(columns = 100, rows = 24): {
+  display: Display;
+  screen: TerminalScreen;
+  stream: ViewportStream;
+} {
+  const screen = new TerminalScreen(columns, rows);
+  const stream = new ViewportStream(screen, columns, rows);
+  const display = new Display({
+    stdout: stream as unknown as NodeJS.WriteStream,
+    skin: new SkinEngine({ forceMono: true }),
+  });
+  display.setStatusFooter('◆ provider · model │ ◉ context │ ready');
+  display.setIdleComposer('', 'Type your message · /help');
+  return { display, screen, stream };
+}
+
+function count(lines: string[], text: string): number {
+  return lines.filter((line) => line.includes(text)).length;
+}
+
+function expectCleanViewport(
+  screen: TerminalScreen,
+  opts: { draft?: string; active?: string } = {},
+): void {
+  const lines = screen.lines();
+  const composerTop = lines.findIndex((line) => line.startsWith('╭─ ▲ You'));
+  expect(composerTop).toBeGreaterThanOrEqual(0);
+  expect(count(lines, '╭─ ▲ You')).toBe(1);
+  expect(count(lines, '◆ provider')).toBe(1);
+  expect(lines.at(-1)).toContain('◆ provider');
+  expect(lines.at(-2)).toMatch(/^╰─/u);
+  if (opts.draft) expect(lines.slice(composerTop, -1).join('\n')).toContain(opts.draft);
+  if (opts.active) {
+    expect(count(lines, opts.active)).toBe(1);
+    expect(lines.slice(0, composerTop).join('\n')).toContain(opts.active);
+  } else {
+    expect(lines.slice(0, composerTop).every((line) => line === '')).toBe(true);
+  }
+  expect(screen.cursorPosition().row).toBe(composerTop + 1);
+}
+
+const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
+
+afterEach(() => {
+  if (previousLaneSetting === undefined) delete process.env.AIDEN_COMPOSER_LANE;
+  else process.env.AIDEN_COMPOSER_LANE = previousLaneSetting;
+});
+
+describe('physical viewport epochs', () => {
+  it.each([
+    ['startup', 'CANONICAL STARTUP\nEnvironment\nCapabilities\nBuilt solo\n'],
+    ['one chat turn', '▲ You  old question\n│ Aiden\nold answer\n'],
+    ['long multiline response', Array.from({ length: 80 }, (_, index) => `OLD LONG ROW ${index}`).join('\n') + '\n'],
+    ['settled tool activity', '⚙ PowerShell running\n✓ PowerShell completed\n'],
+    ['theme selector', 'Theme selection\naiden-ember\nmonochrome\n'],
+    ['idle command row', '▲ You  /cls\n'],
+  ])('clears pre-epoch %s rows without deleting footer ownership', (_name, transcript) => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.write(transcript);
+
+    display.clearScreen();
+
+    expect(screen.snapshot()).not.toContain(transcript.split('\n')[0]);
+    expect(screen.snapshot()).not.toContain('/cls');
+    expectCleanViewport(screen);
+  });
+
+  it.each([
+    [100, 16], [100, 24], [100, 35], [100, 45], [100, 60], [44, 24], [80, 35],
+  ])('keeps the new epoch clean through a %i x %i viewport', (columns, rows) => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen, stream } = harness(100, 24);
+    display.write('OLD BEFORE RESIZE\n'.repeat(40));
+    display.clearScreen();
+
+    stream.resize(columns, rows);
+
+    expect(screen.snapshot()).not.toContain('OLD BEFORE RESIZE');
+    expectCleanViewport(screen);
+  });
+
+  it('retains active provider and tool rows across clear and later ticks', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    display.write('OLD ACTIVE TURN\n');
+    const provider = display.liveActivityRow('calling provider');
+    const tool = display.toolRow('file_read', { path: 'C:\\workspace\\active.txt' }, undefined, {
+      activityId: 'viewport-active-tool', externalTicker: true,
+    });
+
+    display.clearScreen();
+    provider.refresh(1);
+    tool.refresh?.();
+
+    expect(screen.snapshot()).not.toContain('OLD ACTIVE TURN');
+    expectCleanViewport(screen, { active: 'calling provider' });
+    expect(count(screen.lines(), 'active.txt')).toBe(1);
+    tool.ok(25);
+    provider.stop();
+  });
+
+  it('preserves a queue draft while clearing all prior transcript rows', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness(44, 24);
+    display.write('OLD QUEUE TURN\n');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    display.setComposer('QUEUE TWO SURVIVES', 'queue');
+
+    display.clearScreen();
+
+    expect(screen.snapshot()).not.toContain('OLD QUEUE TURN');
+    expectCleanViewport(screen, { draft: 'QUEUE TWO SURVIVES' });
+    expect(screen.snapshot()).toContain('queue mode');
+  });
+
+  it('defers a clear requested during modal ownership and restores only the new epoch', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.write('OLD BEFORE APPROVAL\n');
+    display.pauseComposerSurface();
+    display.write('Approval required\nDecision: Once\n');
+
+    display.clearScreen();
+    display.resumeComposerSurface();
+
+    expect(screen.snapshot()).not.toContain('OLD BEFORE APPROVAL');
+    expect(screen.snapshot()).not.toContain('Approval required');
+    expectCleanViewport(screen);
+  });
+
+  it('does not resurrect rows on theme repaint, status tick, or activity animation', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.write('OLD BEFORE REPAINT\n');
+    const provider = display.liveActivityRow('calling provider');
+    display.clearScreen();
+
+    display.refreshTheme();
+    display.setStatusFooter('◆ provider · model │ ◉ context │ 2s');
+    provider.refresh(3);
+
+    expect(screen.snapshot()).not.toContain('OLD BEFORE REPAINT');
+    expectCleanViewport(screen, { active: 'calling provider' });
+    provider.stop();
+  });
+
+  it('shows only a new prompt while retaining the prior model conversation outside the viewport', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.write('OLD MODEL CONTEXT ROW\n');
+    display.clearScreen();
+
+    display.submitIdleComposer('NEW PROMPT', 'Type your message · /help');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const provider = display.liveActivityRow('calling provider');
+
+    expect(screen.snapshot()).not.toContain('OLD MODEL CONTEXT ROW');
+    expect(screen.snapshot()).toContain('NEW PROMPT');
+    expect(count(screen.lines(), 'NEW PROMPT')).toBe(1);
+    expect(count(screen.lines(), 'calling provider')).toBe(1);
+    provider.stop();
+  });
+
+  it('keeps the epoch boundary after bottom-region teardown and remount', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.write('OLD BEFORE REMOUNT\n');
+    display.clearScreen();
+    display.releaseBottomRegion();
+
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ready');
+    display.setIdleComposer('', 'Type your message · /help');
+
+    expect(screen.snapshot()).not.toContain('OLD BEFORE REMOUNT');
+    expectCleanViewport(screen);
+  });
+
+  it('hides ten thousand retained rows without replaying them on later repaint', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = harness();
+    display.write(Array.from({ length: 10_000 }, (_, index) => `OLD BULK ROW ${index}`).join('\n') + '\n');
+    display.clearScreen();
+
+    display.setStatusFooter('◆ provider · model │ ◉ context │ 3s');
+    display.refreshTheme();
+
+    expect(screen.snapshot()).not.toContain('OLD BULK ROW');
+    expectCleanViewport(screen);
+  });
+});

--- a/tests/v4/core/sideEffectLedger.test.ts
+++ b/tests/v4/core/sideEffectLedger.test.ts
@@ -16,8 +16,9 @@
  *     needs-confirmation (or verify), ambiguous ordinal → needs-confirmation;
  *   • the crash-then-resume simulation for both branches.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import Database from 'better-sqlite3';
@@ -35,6 +36,15 @@ let tmp: string;
 let dbFile: string;
 let db: Database.Database;
 
+// Run the real migration chain once, then copy the closed database for each
+// isolated case. Re-running every migration in every test made synchronous
+// SQLite setup vulnerable to Windows filesystem contention under full load.
+const suiteTmp = mkdtempSync(path.join(os.tmpdir(), 'aiden-sel-suite-'));
+const templateFile = path.join(suiteTmp, 'template.db');
+const templateDb = new Database(templateFile);
+runMigrations(templateDb);
+templateDb.close();
+
 function openLedger(): SideEffectLedger {
   db = new Database(dbFile);
   runMigrations(db);
@@ -42,13 +52,18 @@ function openLedger(): SideEffectLedger {
 }
 
 beforeEach(async () => {
-  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-sel-'));
+  tmp = await fs.mkdtemp(path.join(suiteTmp, 'case-'));
   dbFile = path.join(tmp, 'daemon.db');
+  await fs.copyFile(templateFile, dbFile);
 });
 
 afterEach(async () => {
   try { db?.close(); } catch { /* already closed */ }
   await fs.rm(tmp, { recursive: true, force: true }).catch(() => undefined);
+});
+
+afterAll(() => {
+  rmSync(suiteTmp, { recursive: true, force: true });
 });
 
 // ── Key derivation ──────────────────────────────────────────────────────────

--- a/tests/v4/daemon/kernelFailureInjection.test.ts
+++ b/tests/v4/daemon/kernelFailureInjection.test.ts
@@ -6,7 +6,7 @@
 import Database from 'better-sqlite3';
 import { createHash } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { createServer, type Server } from 'node:http';
+import { createServer, request, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -452,9 +452,19 @@ describe('kernel deterministic failure boundaries', () => {
     });
     engine.startToolCall({ toolCallId: 'tool-network', ...authority, producer: 'test', now: 102 });
 
-    await expect(fetch(target, { method: 'POST', body: 'received-before-disconnect' })).rejects.toThrow();
+    await expect(new Promise<void>((resolve, reject) => {
+      const client = request(target, { method: 'POST' }, (response) => {
+        response.resume();
+        response.once('end', resolve);
+      });
+      client.once('error', reject);
+      client.end('received-before-disconnect');
+    })).rejects.toThrow();
     expect(received).toBe(true);
-    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    await new Promise<void>((resolve, reject) => {
+      server!.close((error) => error ? reject(error) : resolve());
+      server!.closeAllConnections();
+    });
     server = null;
     engine.completeToolCall({
       toolCallId: 'tool-network', ...authority, state: 'unknown', sideEffectState: 'unknown',

--- a/tests/v4/sessionManager.test.ts
+++ b/tests/v4/sessionManager.test.ts
@@ -23,6 +23,14 @@ afterEach(async () => {
 });
 
 describe('SessionManager', () => {
+  it('deletes a stored conversation without affecting other sessions', () => {
+    const first = mgr.startSession({ providerId: 'test', modelId: 'first' });
+    const second = mgr.startSession({ providerId: 'test', modelId: 'second' });
+    expect(mgr.deleteSession(first.id)).toBe(true);
+    expect(mgr.resumeById(first.id)).toBeNull();
+    expect(mgr.resumeById(second.id)?.id).toBe(second.id);
+    expect(mgr.deleteSession(first.id)).toBe(false);
+  });
   it('1. startSession creates a new session when title is unique', () => {
     const s = mgr.startSession({
       title: 'first',

--- a/tests/v4/taskOutcomePresentation.test.ts
+++ b/tests/v4/taskOutcomePresentation.test.ts
@@ -76,6 +76,39 @@ describe('task outcome presentation mapper', () => {
     expect(mapTaskOutcomePresentation(input()).kind).toBe('completed');
   });
 
+  it('projects a zero-exit shell action as limited evidence rather than Verified', () => {
+    const trace = [{
+      name: 'shell_exec',
+      result: { success: true, exitCode: 0, stdout: 'ACTIVITY-DONE', durationMs: 5 },
+      handlerMutates: true,
+      verification: { ok: true, confidence: 1, code: 'ok' },
+    }];
+    const finalization = computeTaskFinalization({ finishReason: 'stop', toolCallTrace: trace as never });
+    const mapped = mapTaskOutcomePresentation(taskOutcomeInputFromFinalization({
+      finalization,
+      trace: trace as never,
+      finishReason: 'stop',
+    }));
+    expect(finalization.status).toBe('completed_unverified');
+    expect(mapped.kind).toBe('completed_limited');
+    expect(mapped.label).not.toBe('Verified');
+  });
+
+  it('never verifies a turn whose final response explicitly admits task failure', () => {
+    const trace = [{
+      name: 'shell_exec',
+      result: { success: true, exitCode: 0, stdout: 'unexpected', durationMs: 3 },
+      handlerMutates: true,
+      verification: { ok: true, confidence: 1, code: 'ok' },
+    }];
+    const finalization = computeTaskFinalization({
+      finishReason: 'stop',
+      assistantContent: 'I could not create the requested marker, and the task failed.',
+      toolCallTrace: trace as never,
+    });
+    expect(finalization.status).toBe('failed');
+  });
+
   it('treats successful completion-only empty output as Completed', () => {
     expect(mapTaskOutcomePresentation(input({
       status: 'completed_unverified',

--- a/tests/v4/taskVerification.test.ts
+++ b/tests/v4/taskVerification.test.ts
@@ -71,6 +71,18 @@ describe('decideTaskVerdict — policy', () => {
     expect(d.verdict).toBe('completed_unverified');
   });
 
+  it('does not treat a successful process exit and stdout as proof of the user goal', () => {
+    const d = decideTaskVerdict([
+      entry({
+        name: 'shell_exec',
+        result: { success: true, exitCode: 0, stdout: 'some output', durationMs: 2 },
+        handlerMutates: true,
+        verification: V_OK,
+      }),
+    ]);
+    expect(d.verdict).toBe('completed_unverified');
+  });
+
   it('mutation with NO verification verdict at all → completed_unverified (unverifiable is not verified)', () => {
     const d = decideTaskVerdict([
       entry({ name: 'custom_mutator', result: { success: true }, handlerMutates: true }),

--- a/tests/v4/tools/terminal.test.ts
+++ b/tests/v4/tools/terminal.test.ts
@@ -76,6 +76,17 @@ describe('localBackend', () => {
     expect(nested.stdout.trim()).toBe(process.env.TEMP);
   });
 
+  it.runIf(isWin)('executes one approved PowerShell command exactly once', async () => {
+    const marker = path.join(tmp, 'one-effect.txt').replace(/'/g, "''");
+    const result = await localBackendExecute({
+      command: `Add-Content -LiteralPath '${marker}' -Value 'effect'; Get-Content -LiteralPath '${marker}'`,
+      cwd: tmp,
+    });
+    expect(result.exitCode).toBe(0);
+    expect((await fs.readFile(path.join(tmp, 'one-effect.txt'), 'utf8')).trim().split(/\r?\n/u)).toEqual(['effect']);
+    expect(result.stdout.trim().split(/\r?\n/u)).toEqual(['effect']);
+  });
+
   it('2. executes a simple command', async () => {
     const r = await localBackendExecute({ command: echoCmd('hello-shell') });
     expect(r.exitCode).toBe(0);

--- a/tests/v4/tools/terminal.test.ts
+++ b/tests/v4/tools/terminal.test.ts
@@ -52,11 +52,38 @@ describe('localBackend', () => {
     for (const executable of ['powershell', 'powershell.exe', 'pwsh', 'pwsh.exe']) {
       const command = `${executable} -NoProfile -Command \"$env:TEMP; $env:LOCALAPPDATA\"`;
       expect(buildLocalShellInvocation(command, 'win32')).toEqual({
-        executable: 'cmd.exe',
-        args: ['/d', '/s', '/c', command],
+        executable,
+        args: ['-NoProfile', '-EncodedCommand', expect.any(String)],
         detached: false,
       });
+      const invocation = buildLocalShellInvocation(command, 'win32');
+      expect(Buffer.from(invocation.args.at(-1)!, 'base64').toString('utf16le'))
+        .toBe('$env:TEMP; $env:LOCALAPPDATA');
     }
+  });
+
+  it('preserves existing encoded commands and direct PowerShell argv', () => {
+    const encoded = Buffer.from("Write-Output 'encoded 世界'", 'utf16le').toString('base64');
+    expect(buildLocalShellInvocation(`powershell.exe -NoProfile -EncodedCommand ${encoded}`, 'win32')).toEqual({
+      executable: 'powershell.exe',
+      args: ['-NoProfile', '-EncodedCommand', encoded],
+      detached: false,
+    });
+    expect(buildLocalShellInvocation('pwsh.exe -NoProfile -File "C:\\space path\\script.ps1"', 'win32')).toEqual({
+      executable: 'pwsh.exe',
+      args: ['-NoProfile', '-File', 'C:\\space path\\script.ps1'],
+      detached: false,
+    });
+  });
+
+  it('removes a cmd host when its sole payload is PowerShell', () => {
+    const invocation = buildLocalShellInvocation(
+      'cmd.exe /d /s /c powershell.exe -NoProfile -Command "$marker = 1; Write-Output $marker"',
+      'win32',
+    );
+    expect(invocation.executable).toBe('powershell.exe');
+    expect(Buffer.from(invocation.args[invocation.args.length - 1]!, 'base64').toString('utf16le'))
+      .toBe('$marker = 1; Write-Output $marker');
   });
 
   it.runIf(isWin)('executes direct environment lookups and special characters on Windows', async () => {
@@ -74,6 +101,25 @@ describe('localBackend', () => {
     const nested = await localBackendExecute({ command: 'powershell -NoProfile -Command "$env:TEMP"' });
     expect(nested.exitCode).toBe(0);
     expect(nested.stdout.trim()).toBe(process.env.TEMP);
+  });
+
+  it.runIf(isWin)('executes cmd-hosted PowerShell without stripping local variables', async () => {
+    const nested = await localBackendExecute({
+      command: 'cmd.exe /d /s /c powershell.exe -NoProfile -Command "$marker = $env:TEMP; Write-Output $marker"',
+    });
+    expect(nested.exitCode).toBe(0);
+    expect(nested.stdout.trim()).toBe(process.env.TEMP);
+  });
+
+  it.runIf(isWin)('runs the exact delayed marker contract once with variables intact', async () => {
+    const marker = path.join(tmp, "activity marker '世界'.txt").replace(/'/g, "''");
+    const command = `powershell.exe -NoProfile -Command "$marker = '${marker}'; Start-Sleep -Milliseconds 250; $count = if (Test-Path -LiteralPath $marker) { [int](Get-Content -LiteralPath $marker) } else { 0 }; Set-Content -LiteralPath $marker -Value ($count + 1); Write-Output 'ACTIVITY-DONE'"`;
+    const started = Date.now();
+    const result = await localBackendExecute({ command, cwd: tmp });
+    expect(Date.now() - started).toBeGreaterThanOrEqual(200);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('ACTIVITY-DONE');
+    expect((await fs.readFile(path.join(tmp, "activity marker '世界'.txt"), 'utf8')).trim()).toBe('1');
   });
 
   it.runIf(isWin)('executes one approved PowerShell command exactly once', async () => {

--- a/themes/aiden-ember.yaml
+++ b/themes/aiden-ember.yaml
@@ -1,0 +1,25 @@
+name: "aiden-ember"
+description: "Aiden's warm orange identity on a restrained dark surface."
+colors:
+  brand:
+    primary: "#FF6B35"
+    muted: "#7A3119"
+  content:
+    primary: "#E8EBF0"
+    secondary: "#B8A89A"
+    tertiary: "#6A6A6A"
+  semantic:
+    success: "#7FC28B"
+    warn: "#E0A040"
+    error: "#E05A5A"
+    info: "#7DA7C7"
+  metrics:
+    model: "#9CDCFE"
+    tokens: "#E0A040"
+    turnCount: "#A48BE0"
+    timer: "#7FC28B"
+  surface:
+    bg: "#0D0E10"
+    elevated: "#16181B"
+    border: "#2A2A2A"
+    divider: "#3A3A3A"

--- a/themes/aurora.yaml
+++ b/themes/aurora.yaml
@@ -1,0 +1,25 @@
+name: "aurora"
+description: "Cool luminous accents with clear semantic contrast."
+colors:
+  brand:
+    primary: "#5EEAD4"
+    muted: "#245E5B"
+  content:
+    primary: "#ECFEFF"
+    secondary: "#B8D7DA"
+    tertiary: "#668A8F"
+  semantic:
+    success: "#86EFAC"
+    warn: "#FDE68A"
+    error: "#FDA4AF"
+    info: "#93C5FD"
+  metrics:
+    model: "#67E8F9"
+    tokens: "#FDE68A"
+    turnCount: "#C4B5FD"
+    timer: "#86EFAC"
+  surface:
+    bg: "#071416"
+    elevated: "#0D2023"
+    border: "#245258"
+    divider: "#36727A"

--- a/themes/high-contrast.yaml
+++ b/themes/high-contrast.yaml
@@ -1,0 +1,25 @@
+name: "high-contrast"
+description: "Accessibility-focused contrast and bright state boundaries."
+colors:
+  brand:
+    primary: "#FFB000"
+    muted: "#A66F00"
+  content:
+    primary: "#FFFFFF"
+    secondary: "#F2F2F2"
+    tertiary: "#C8C8C8"
+  semantic:
+    success: "#57FF57"
+    warn: "#FFFF00"
+    error: "#FF5C5C"
+    info: "#65C7FF"
+  metrics:
+    model: "#65C7FF"
+    tokens: "#FFFF00"
+    turnCount: "#FFB000"
+    timer: "#57FF57"
+  surface:
+    bg: "#000000"
+    elevated: "#111111"
+    border: "#FFFFFF"
+    divider: "#D9D9D9"

--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -1,0 +1,25 @@
+name: "midnight"
+description: "Restrained blue and gray accents for low-light terminals."
+colors:
+  brand:
+    primary: "#7AA2F7"
+    muted: "#334A78"
+  content:
+    primary: "#D8DEE9"
+    secondary: "#A7B0C0"
+    tertiary: "#667085"
+  semantic:
+    success: "#7DC4A4"
+    warn: "#D7BA7D"
+    error: "#E07178"
+    info: "#82AAFF"
+  metrics:
+    model: "#9CB8FF"
+    tokens: "#D7BA7D"
+    turnCount: "#B8A5FF"
+    timer: "#7DC4A4"
+  surface:
+    bg: "#10131A"
+    elevated: "#171C27"
+    border: "#354052"
+    divider: "#465268"

--- a/tools/v4/backends/local.ts
+++ b/tools/v4/backends/local.ts
@@ -48,7 +48,62 @@ export interface LocalShellInvocation {
   detached: boolean;
 }
 
-const WINDOWS_SHELL_COMMAND = /^\s*(?:powershell(?:\.exe)?|pwsh(?:\.exe)?)\b/iu;
+const WINDOWS_SHELL_COMMAND = /^\s*(powershell(?:\.exe)?|pwsh(?:\.exe)?)\b\s*(.*)$/isu;
+const WINDOWS_CMD_HOSTED_POWERSHELL = /^\s*cmd(?:\.exe)?\s+(?:\/d\s+)?(?:\/s\s+)?\/c\s+([\s\S]+)$/iu;
+
+function splitWindowsArguments(value: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+    if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (/\s/u.test(char)) {
+      if (current) {
+        args.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (current) args.push(current);
+  return args;
+}
+
+function stripMatchingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    if ((first === '"' || first === "'") && trimmed[trimmed.length - 1] === first) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function buildExplicitPowerShellInvocation(match: RegExpMatchArray): LocalShellInvocation {
+  const executable = match[1]!;
+  const rest = match[2] ?? '';
+  const commandToken = /(?:^|\s)-(?:command|c)\b/iu.exec(rest);
+  if (commandToken) {
+    const prefix = rest.slice(0, commandToken.index).trim();
+    const script = stripMatchingQuotes(rest.slice(commandToken.index + commandToken[0].length));
+    const encoded = Buffer.from(script, 'utf16le').toString('base64');
+    return {
+      executable,
+      args: [...splitWindowsArguments(prefix), '-EncodedCommand', encoded],
+      detached: false,
+    };
+  }
+  return { executable, args: splitWindowsArguments(rest), detached: false };
+}
 
 /** Build a host-shell invocation without interpolating into another shell. */
 export function buildLocalShellInvocation(
@@ -58,11 +113,16 @@ export function buildLocalShellInvocation(
   if (platform !== 'win32') {
     return { executable: 'bash', args: ['-lc', command], detached: true };
   }
+  const cmdHosted = command.match(WINDOWS_CMD_HOSTED_POWERSHELL);
+  if (cmdHosted) {
+    const nested = stripMatchingQuotes(cmdHosted[1] ?? '');
+    const nestedPowerShell = nested.match(WINDOWS_SHELL_COMMAND);
+    if (nestedPowerShell) return buildExplicitPowerShellInvocation(nestedPowerShell);
+  }
   // An explicit nested PowerShell command must not pass through an outer
   // PowerShell parser, which would expand `$env:*` before the child sees it.
-  if (WINDOWS_SHELL_COMMAND.test(command)) {
-    return { executable: 'cmd.exe', args: ['/d', '/s', '/c', command], detached: false };
-  }
+  const explicitPowerShell = command.match(WINDOWS_SHELL_COMMAND);
+  if (explicitPowerShell) return buildExplicitPowerShellInvocation(explicitPowerShell);
   // EncodedCommand preserves quotes, Unicode, backticks, semicolons, and
   // literal dollar signs across the native process boundary.
   const encoded = Buffer.from(command, 'utf16le').toString('base64');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,8 +11,13 @@ import { defineConfig } from 'vitest/config';
 //
 // Windows pseudo-terminal helpers also share console infrastructure outside the
 // worker process. Capping file workers prevents unrelated suites from starving
-// input delivery without serializing the entire repository.
-const windowsWorkerLimit = process.platform === 'win32' ? 2 : undefined;
+// input delivery. Node 22 serializes files because its hosted Windows runtime
+// still exhibits filesystem and SQLite starvation with two concurrent workers;
+// Node 20 retains bounded parallelism.
+const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+const windowsWorkerLimit = process.platform === 'win32'
+  ? (nodeMajor >= 22 ? 1 : 2)
+  : undefined;
 
 export default defineConfig({
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ import { defineConfig } from 'vitest/config';
 // Windows pseudo-terminal helpers also share console infrastructure outside the
 // worker process. Capping file workers prevents unrelated suites from starving
 // input delivery without serializing the entire repository.
-const windowsWorkerLimit = process.platform === 'win32' ? 4 : undefined;
+const windowsWorkerLimit = process.platform === 'win32' ? 2 : undefined;
 
 export default defineConfig({
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,12 +11,11 @@ import { defineConfig } from 'vitest/config';
 //
 // Windows pseudo-terminal helpers also share console infrastructure outside the
 // worker process. Capping file workers prevents unrelated suites from starving
-// input delivery. Node 22 serializes files because its hosted Windows runtime
-// still exhibits filesystem and SQLite starvation with two concurrent workers;
-// Node 20 retains bounded parallelism.
-const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
-const windowsWorkerLimit = process.platform === 'win32'
-  ? (nodeMajor >= 22 ? 1 : 2)
+// input delivery. Hosted Windows runners serialize files because synchronous
+// SQLite failure-injection and filesystem suites can starve each other's test
+// clocks even with two workers. Unix runners retain their default parallelism.
+const windowsWorkerLimit = process.platform === 'win32' && process.env.CI
+  ? 1
   : undefined;
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- restores the canonical six-line Aiden startup identity and responsive Environment/Capabilities presentation;
- preserves the bordered Built solo card, welcome guidance, boxed composer, and status strip;
- routes startup and onboarding output through the single display owner;
- keeps startup notices compact, actionable, responsive, and free of duplicate output;
- applies the active theme immediately to the composer frame and semantic runtime presentation;
- presents compact verified, limited-evidence, failed, unknown, and cancelled outcomes without changing durable proof authority;
- preserves compact prompt-to-provider spacing, approvals, queued input, `/usage`, `/clear`, `/cls`, and clean shutdown behavior.

## Durable viewport reset

- makes `/cls` advance a first-class viewport epoch without deleting session or transcript state;
- resets scroll, sticky-tail, selection, geometry, and measured viewport state;
- clears and repaints through the sole bottom-region owner;
- prevents resize, theme, timer, modal restoration, and remount paths from revealing pre-clear rows;
- retains active activity, the composer, status strip, and prior model context;
- keeps explicit persisted-session inspection available without replaying hidden rows during ordinary repaint.

## Validation

- Node 22.23.1 / ABI 127
- Typecheck passed
- Production build passed
- Deterministic non-PTY suite: 7,125 passed, 39 skipped, 0 failed
- Complete deterministic aggregate including serial PTY: 7,157 passed, 39 skipped, 0 failed
- Integration suite: 39 passed, 7 skipped, 0 failed
- Focused UI and lifecycle matrix: 511 passed, 1 skipped
- Proof and PowerShell neighbor matrix: 318 passed, 1 skipped
- Serial Windows PTY matrix: 32 passed, 0 failed
- Focused viewport tests: 55 passed, 0 failed
- Fresh installed-tarball `/cls` ConPTY acceptance passed at 100 and 44 columns
- Three provider turns completed with pre-clear model context retained after `/cls`
- Resize, theme/status repaint, post-clear input, and clean `/quit` passed
- Package version remained 4.16.1
- Diff, NUL, attribution, secret, version, temporary-data, and process-cleanup checks passed
## Physical Windows acceptance

Physical Windows acceptance completed successfully in Windows Terminal.

Validated:
- `/cls` hides the previous transcript;
- old rows do not reappear after later commands;
- conversation context remains available after clearing;
- `/activity` remains functional;
- `/quit` returns cleanly to PowerShell;
- session distillation and summary are written;
- no visible interactive Aiden process remains.

The remaining blank terminal region after `/cls` is classified as non-blocking P2 visual polish. It does not indicate data loss, state corruption, process leakage, or broken normal operation.