### PR TITLE
chore(release): prepare v4.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,52 @@
+## v4.17.0 — 2026-07-29
+
+### Overview
+
+**Aiden v4.17.0 — Durable Autonomy Kernel + Operator TUI**
+
+Aiden now runs production entry points through a unified durable lifecycle authority and presents that state through a responsive operator interface.
+
+### Durable execution
+
+- A canonical lifecycle authority coordinates Job admission, Attempts, leases, heartbeats, cancellation, verification, and finalization across production entry points.
+- Job and Attempt generations, fence tokens, terminal-state protection, and ordered durable events reject stale or late execution.
+- Cancellation remains persist-first, unknown side effects remain reconcilable, and execution graphs retain durable recovery state.
+- Child supervision and budgets preserve parent authority while keeping worker results subject to parent-side verification.
+
+### Evidence and verification
+
+- Proof and Verdict projection uses authoritative execution evidence rather than model prose.
+- File mutations require fresh exact readback before verified completion is presented.
+- Replayable projections, migration coverage, and failure-injection tests protect recovery and reconciliation behavior.
+
+### Operator experience
+
+- The startup screen retains Aiden's visual identity while adapting to wide and narrow terminals.
+- A boxed composer and separate provider, model, context, and timer strip remain stable during provider and tool activity.
+- Theme-aware rendering, compact outcomes, durable queued input, and durable `/cls` and `/clear` improve terminal operation.
+- Settled activity cannot resurrect, and shutdown returns terminal ownership cleanly.
+
+### Platform reliability
+
+- Windows shell and process cleanup behavior is preserved through packaged and ConPTY validation.
+- Windows, Ubuntu, and macOS CI cover Node 20 and Node 22, with Windows suites isolated from shared runner resource starvation.
+
+### Known non-blocking polish
+
+- `/cls` may leave a visually empty terminal region.
+- `/quit` output remains more verbose than desired.
+- First-run name extraction and onboarding transitions can be polished later.
+
+### Upgrade instructions
+
+```bash
+npm install -g aiden-runtime@4.17.0
+```
+
+Restart Aiden after upgrading. Existing configuration and durable state continue through the normal migration path.
+
+---
+
 ## v4.16.1 — 2026-07-24
 
 ### Windows self-update correctness

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Give Aiden a goal. It can work across your files, terminal, browser, supported a
 ![Built solo](https://img.shields.io/badge/Built-solo-B8A893?style=flat-square)
 ![By Taracod](https://img.shields.io/badge/By-Taracod-FF6B35?style=flat-square)
 ![White Lotus](https://img.shields.io/badge/Brand-White_Lotus-FFB088?style=flat-square)
-![v4.16.1](https://img.shields.io/badge/Latest-v4.16.1-4ADE80?style=flat-square)
+![v4.17.0](https://img.shields.io/badge/Latest-v4.17.0-4ADE80?style=flat-square)
 
 </details>
 
@@ -204,20 +204,17 @@ https://github.com/user-attachments/assets/7a66bc19-8b17-4b01-be85-3aa5945a1b3b
 
 <br>
 
-## What's new in v4.16.1
+## What's new in v4.17.0
 
-**Aiden v4.16.1 hardens Windows self-update correctness while preserving the durable autonomy foundation introduced in v4.16.0.**
+**Aiden v4.17.0 unifies durable runtime authority with a responsive operator terminal.**
 
-This patch release makes in-app updates target the exact npm installation that launched Aiden, even when Node and npm are installed under a different prefix.
+- **One durable lifecycle.** Interactive, one-shot, API, Workbench, daemon, channel, child, and MCP execution share authoritative Job and Attempt transitions.
+- **Stale-result protection.** Generations, leases, fence tokens, terminal-state guards, and persist-first cancellation prevent old work from rewriting current truth.
+- **Evidence-based completion.** Proof, Verdict, exact file readback, effect reconciliation, and failure-injection coverage strengthen completion claims and recovery.
+- **Operator TUI.** The original Aiden startup identity, responsive metadata, boxed composer, status strip, themes, compact outcomes, and durable queue controls form one terminal surface.
+- **Platform reliability.** Windows process cleanup, ConPTY coverage, and cross-platform CI preserve clean startup, activity rendering, and shutdown.
 
-- **Windows self-update correctness.** The updater now resolves the running package root and installs into that exact npm prefix instead of trusting an unrelated npm configured prefix.
-- **Safer update verification.** The installer passes an explicit `--prefix`, checks the installed package version at that target, and fails honestly on mismatches.
-- **Truthful update progress.** Update output uses phase-based progress and failure categories without fabricated percentages or permission misclassification.
-- **Physical cancellation.** Active runtimes and descendant process trees are stopped so cancelled work cannot later become successful.
-- **Safe admission across surfaces.** Interactive, one-shot, API, Workbench, daemon, channel, schedule, child, and MCP work enters the same durable authority before execution.
-- **Fixed terminal composer.** A boxed composer stays usable while tools run, places the hardware cursor correctly, and keeps provider, model, context, and elapsed status separate.
-
-See the full [v4.16.1 release notes](https://github.com/taracodlabs/aiden/releases/tag/v4.16.1).
+See the full [v4.17.0 release notes](https://github.com/taracodlabs/aiden/releases/tag/v4.17.0).
 
 <details>
 <summary><strong>Earlier v4 release highlights — v4.13 through v4.5</strong></summary>
@@ -729,7 +726,7 @@ The future `skills.taracod.com` marketplace will ship community skills under the
 | 📦 **npm** | [aiden-runtime](https://www.npmjs.com/package/aiden-runtime) |
 | 🐙 **Source** | [github.com/taracodlabs/aiden](https://github.com/taracodlabs/aiden) |
 | 📁 **Standalone releases** | [github.com/taracodlabs/aiden-releases](https://github.com/taracodlabs/aiden-releases) |
-| 🧾 **Release notes** | [v4.16.1](https://github.com/taracodlabs/aiden/releases/tag/v4.16.1) · [v4.16.0](https://github.com/taracodlabs/aiden/releases/tag/v4.16.0) · [v4.15.1](https://github.com/taracodlabs/aiden/releases/tag/v4.15.1) · [v4.15.0](https://github.com/taracodlabs/aiden/releases/tag/v4.15.0) · [v4.13.0](https://github.com/taracodlabs/aiden/releases/tag/v4.13.0) · [v4.12.0](https://github.com/taracodlabs/aiden/releases/tag/v4.12.0) |
+| 🧾 **Release notes** | [v4.17.0](https://github.com/taracodlabs/aiden/releases/tag/v4.17.0) · [v4.16.1](https://github.com/taracodlabs/aiden/releases/tag/v4.16.1) · [v4.16.0](https://github.com/taracodlabs/aiden/releases/tag/v4.16.0) · [v4.15.1](https://github.com/taracodlabs/aiden/releases/tag/v4.15.1) · [v4.15.0](https://github.com/taracodlabs/aiden/releases/tag/v4.15.0) · [v4.13.0](https://github.com/taracodlabs/aiden/releases/tag/v4.13.0) · [v4.12.0](https://github.com/taracodlabs/aiden/releases/tag/v4.12.0) |
 | 📖 **Book — Omega** | [Amazon](https://amzn.to/49ceO8l) |
 | 📚 **Docs** | [`docs/v4.5/`](docs/v4.5/) (in this repo) |
 | 💖 **Sponsor (Razorpay)** | [razorpay.me/@whitelotus9625](https://razorpay.me/@whitelotus9625) |

--- a/RELEASE-NOTES-v4.17.0.md
+++ b/RELEASE-NOTES-v4.17.0.md
@@ -1,0 +1,34 @@
+# Aiden v4.17.0
+
+## Durable Autonomy Kernel + Operator TUI
+
+Aiden v4.17.0 strengthens durable execution and unifies the terminal operator experience.
+
+### Durable execution
+
+- Production entry points share one authoritative Job and Attempt lifecycle.
+- Generations, leases, fence tokens, terminal-state guards, and persist-first cancellation reject stale execution.
+- Durable input, execution graphs, effect reconciliation, child supervision, and budgets retain recovery-safe state.
+
+### Evidence and verification
+
+- Completion is projected from authoritative evidence rather than response prose.
+- File mutations require fresh exact readback before verified completion.
+- Replay, migration, recovery, and failure-injection coverage protect durable state transitions.
+
+### Operator experience
+
+- The canonical Aiden startup identity adapts across terminal widths.
+- The boxed composer and separate provider, model, context, and timer strip remain stable while work runs.
+- Theme-aware rendering, compact outcomes, durable queued input, `/cls`, `/clear`, and clean shutdown improve daily operation.
+
+### Platform reliability
+
+- Windows terminal ownership, process cleanup, and ConPTY behavior are covered alongside Ubuntu and macOS CI.
+- Node 20 and Node 22 remain covered by the release matrix.
+
+### Known non-blocking polish
+
+- `/cls` may leave a visually empty terminal region.
+- `/quit` output remains more verbose than desired.
+- First-run name extraction and onboarding transitions can be polished later.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-runtime",
-  "version": "4.16.1",
+  "version": "4.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-runtime",
-      "version": "4.16.1",
+      "version": "4.17.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-runtime",
-  "version": "4.16.1",
+  "version": "4.17.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- sets the established runtime package version to 4.17.0;
- documents the Durable Autonomy Kernel and Operator TUI release;
- updates the focused README release highlights;
- adds reviewed GitHub release notes.

## Dependency scope

No dependency versions are changed. The focused audit found no clearly intended low-risk security update for this release; unrelated major dependency changes remain out of scope.

## Validation

- Operator implementation CI passed on Windows, Ubuntu, and macOS with Node 20 and Node 22.
- Security, CodeQL, CLA, build, typecheck, packaged smoke, and Windows PTY checks passed.
- Release JSON, version consistency, diff, NUL, attribution, secret, and scope checks passed.
- Release PR CI is the authoritative cross-platform release validation.
- Exact tarball inspection and isolated packaged smoke will run from the merged release commit.

## Known non-blocking polish

- `/cls` may leave a visually empty terminal region.
- `/quit` output remains more verbose than desired.
- First-run name extraction and onboarding transitions can be polished later.

## Out of scope

- Codebase Mode
- broad dependency upgrades
- unrelated refactoring