### PR TITLE
feat(codebase): add repository snapshot authority

### DIFF
--- a/core/v4/codebase/repositorySnapshotAuthority.ts
+++ b/core/v4/codebase/repositorySnapshotAuthority.ts
@@ -1,0 +1,361 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { execFile } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { Db } from '../daemon/db/connection';
+import type { AttemptRecord, JobRecord } from '../daemon/jobEngine';
+import { isPathAllowed, isWithin, realpathWithFallback } from '../sandboxFs';
+import { resolveWorkspace, type WorkspaceDescriptor } from './workspaceResolver';
+
+const execFileAsync = promisify(execFile);
+const HASH = 'sha256';
+const DEFAULT_MAX_ENTRIES = 5_000;
+const DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git', 'node_modules', 'vendor', '.cache', '.next', '.nuxt', 'dist', 'build', 'coverage', 'target', '__pycache__',
+]);
+const SECRET_NAME = /^(?:\.env(?:\..*)?|credentials?(?:\..*)?|secrets?(?:\..*)?|.*\.(?:pem|key|p12|pfx))$/i;
+const INSTRUCTION_NAME = /^(?:AGENTS\.md|AIDEN\.md|PROJECT\.md|INSTRUCTIONS\.md|CONTRIBUTING\.md)$/i;
+const MANIFEST_NAME = /^(?:package\.json|pnpm-workspace\.yaml|Cargo\.toml|pyproject\.toml|go\.mod|pom\.xml|build\.gradle(?:\.kts)?)$/i;
+const LOCKFILE_NAME = /^(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?|Cargo\.lock|poetry\.lock|uv\.lock|go\.sum)$/i;
+const CONFIG_NAME = /^(?:tsconfig(?:\..+)?\.json|vitest\.config\..+|jest\.config\..+|vite\.config\..+|Makefile|Taskfile\.ya?ml|turbo\.json|nx\.json)$/i;
+
+export interface RepositoryCapturePolicy {
+  maxEntries: number;
+  maxFileBytes: number;
+  excludedDirectories: readonly string[];
+  explicitlyInspectedPaths: readonly string[];
+}
+
+export interface RepositorySnapshotEntry {
+  path: string;
+  canonicalIdentity: string;
+  classification: string;
+  gitState: string | null;
+  size: number | null;
+  modifiedAt: number | null;
+  mode: number | null;
+  contentHash: string | null;
+  captureStatus: 'captured' | 'metadata_only' | 'excluded' | 'unavailable';
+  reason: string | null;
+}
+
+export interface RepositorySnapshotRecord {
+  id: string;
+  workspaceId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  repositoryRoot: string | null;
+  vcsKind: 'git' | 'none';
+  branch: string | null;
+  headCommit: string | null;
+  upstream: string | null;
+  indexDigest: string;
+  workingTreeDigest: string;
+  capturePolicyDigest: string;
+  incomplete: boolean;
+  incompleteReasons: string[];
+  previousSnapshotId: string | null;
+  stateDigest: string;
+  capturedAt: number;
+  dirtyPaths: string[];
+  stagedPaths: string[];
+  untrackedPaths: string[];
+}
+
+export class RepositorySnapshotAuthorityError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) { super(message); this.name = 'RepositorySnapshotAuthorityError'; this.code = code; }
+}
+
+interface CaptureState {
+  descriptor: WorkspaceDescriptor;
+  policy: RepositoryCapturePolicy;
+  capturePolicyDigest: string;
+  branch: string | null;
+  headCommit: string | null;
+  upstream: string | null;
+  stagedPaths: string[];
+  dirtyPaths: string[];
+  untrackedPaths: string[];
+  entries: RepositorySnapshotEntry[];
+  incompleteReasons: string[];
+  indexDigest: string;
+  workingTreeDigest: string;
+  stateDigest: string;
+}
+
+export interface RepositorySnapshotAuthority {
+  captureSnapshot(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    requestedPath: string; producer: string; previousSnapshotId?: string | null;
+    policy?: Partial<RepositoryCapturePolicy>;
+  }): Promise<RepositorySnapshotRecord>;
+  getSnapshot(snapshotId: string): RepositorySnapshotRecord | undefined;
+  getWorkspace(workspaceId: string): WorkspaceDescriptor | undefined;
+  getAttemptSnapshot(jobId: string, attemptId: string): RepositorySnapshotRecord | undefined;
+  compareSnapshots(baseId: string, currentId: string): { baseId: string; currentId: string; added: string[]; removed: string[]; changed: string[] };
+  inventory(snapshotId: string, options?: { cursor?: string; limit?: number }): Promise<{ snapshotId: string; stateDigest: string; entries: RepositorySnapshotEntry[]; nextCursor: string | null; truncated: boolean; stale: boolean }>;
+  readFile(snapshotId: string, relativePath: string, options?: { offset?: number; limit?: number }): Promise<Record<string, unknown>>;
+  search(snapshotId: string, query: string, options?: { limit?: number; include?: RegExp; exclude?: RegExp }): Promise<{ snapshotId: string; stateDigest: string; matches: Array<{ path: string; line: number; column: number; text: string }>; truncated: boolean; stale: boolean }>;
+  discoverInstructions(snapshotId: string): Array<{ path: string; contentHash: string | null; scope: string; precedence: number; trust: 'repository'; snapshotId: string }>;
+}
+
+function digest(value: unknown): string { return createHash(HASH).update(JSON.stringify(value)).digest('hex'); }
+function normalizeRelative(value: string): string { return value.split(path.sep).join('/').replace(/^\.\//, ''); }
+function uniqueSorted(values: readonly string[]): string[] { return [...new Set(values.map(normalizeRelative))].sort(); }
+function parseNul(value: string): string[] { return value.split('\0').filter(Boolean).map(normalizeRelative); }
+
+async function git(root: string, args: readonly string[]): Promise<string | null> {
+  try {
+    const result = await execFileAsync('git', ['-c', 'color.ui=false', '-C', root, ...args], {
+      windowsHide: true, encoding: 'utf8', maxBuffer: 8 * 1024 * 1024,
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0', GIT_PAGER: 'cat', LC_ALL: 'C' },
+    });
+    return result.stdout.trimEnd();
+  } catch { return null; }
+}
+
+function classify(relativePath: string): string {
+  const name = path.posix.basename(relativePath);
+  if (INSTRUCTION_NAME.test(name)) return 'instruction';
+  if (MANIFEST_NAME.test(name)) return 'manifest';
+  if (LOCKFILE_NAME.test(name)) return 'lockfile';
+  if (relativePath.startsWith('.github/workflows/')) return 'ci';
+  if (CONFIG_NAME.test(name)) return 'configuration';
+  return 'source';
+}
+
+function policyOf(input?: Partial<RepositoryCapturePolicy>): RepositoryCapturePolicy {
+  return {
+    maxEntries: Math.max(1, Math.min(50_000, input?.maxEntries ?? DEFAULT_MAX_ENTRIES)),
+    maxFileBytes: Math.max(1, Math.min(16 * 1024 * 1024, input?.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES)),
+    excludedDirectories: uniqueSorted(input?.excludedDirectories ?? [...EXCLUDED_DIRECTORIES]),
+    explicitlyInspectedPaths: uniqueSorted(input?.explicitlyInspectedPaths ?? []),
+  };
+}
+
+function excludedByPolicy(relativePath: string, policy: RepositoryCapturePolicy): boolean {
+  const first = normalizeRelative(relativePath).split('/')[0].toLowerCase();
+  return policy.excludedDirectories.some((item) => item.toLowerCase() === first);
+}
+
+async function gatherState(requestedPath: string, policyInput?: Partial<RepositoryCapturePolicy>, resolved?: WorkspaceDescriptor): Promise<CaptureState> {
+  const descriptor = resolved ?? await resolveWorkspace(requestedPath);
+  if (!descriptor.exists) throw new RepositorySnapshotAuthorityError('WORKSPACE_NOT_FOUND', 'Repository snapshot root does not exist');
+  const root = descriptor.repositoryRoot ?? descriptor.canonicalPath;
+  const policy = policyOf(policyInput);
+  const capturePolicyDigest = digest({ version: 1, ...policy });
+  const branch = descriptor.vcsKind === 'git' ? (await git(root, ['symbolic-ref', '--quiet', '--short', 'HEAD'])) : null;
+  const headCommit = descriptor.vcsKind === 'git' ? (await git(root, ['rev-parse', '--verify', 'HEAD'])) : null;
+  const upstream = descriptor.vcsKind === 'git' ? (await git(root, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])) : null;
+  const stagedPaths = descriptor.vcsKind === 'git' ? uniqueSorted(parseNul(await git(root, ['diff', '--cached', '--name-only', '-z', '--']) ?? '')).filter((item) => !excludedByPolicy(item, policy)) : [];
+  const dirtyPaths = descriptor.vcsKind === 'git' ? uniqueSorted(parseNul(await git(root, ['diff', '--name-only', '-z', '--']) ?? '')).filter((item) => !excludedByPolicy(item, policy)) : [];
+  const untrackedPaths = descriptor.vcsKind === 'git' ? uniqueSorted(parseNul(await git(root, ['ls-files', '--others', '--exclude-standard', '-z', '--']) ?? '')).filter((item) => !excludedByPolicy(item, policy)) : [];
+  const gitStates = new Map<string, string>();
+  for (const item of stagedPaths) gitStates.set(item, 'staged');
+  for (const item of dirtyPaths) gitStates.set(item, gitStates.has(item) ? 'staged,dirty' : 'dirty');
+  for (const item of untrackedPaths) gitStates.set(item, 'untracked');
+  const entries: RepositorySnapshotEntry[] = [];
+  const incompleteReasons: string[] = [];
+  const excluded = new Set(policy.excludedDirectories.map((item) => item.toLowerCase()));
+
+  async function walk(directory: string, relative = ''): Promise<void> {
+    if (entries.length >= policy.maxEntries) return;
+    let children;
+    try { children = await fs.readdir(directory, { withFileTypes: true }); }
+    catch { incompleteReasons.push(`unreadable:${relative || '.'}`); return; }
+    children.sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of children) {
+      const rel = normalizeRelative(path.join(relative, child.name));
+      if (entries.length >= policy.maxEntries) { incompleteReasons.push(`entry_limit:${policy.maxEntries}`); break; }
+      if (child.isDirectory()) {
+        if (excluded.has(child.name.toLowerCase())) {
+          entries.push({ path: `${rel}/`, canonicalIdentity: normalizeRelative(path.join(root, rel)), classification: 'excluded_directory', gitState: null, size: null, modifiedAt: null, mode: null, contentHash: null, captureStatus: 'excluded', reason: 'policy_excluded_directory' });
+        } else await walk(path.join(directory, child.name), rel);
+        continue;
+      }
+      if (!child.isFile()) continue;
+      const absolute = path.join(directory, child.name);
+      try {
+        const stat = await fs.stat(absolute);
+        let contentHash: string | null = null;
+        let captureStatus: RepositorySnapshotEntry['captureStatus'] = 'captured';
+        let reason: string | null = null;
+        if (SECRET_NAME.test(child.name)) { captureStatus = 'metadata_only'; reason = 'secret_content'; }
+        else if (stat.size > policy.maxFileBytes) { captureStatus = 'metadata_only'; reason = 'file_size_limit'; }
+        else {
+          const bytes = await fs.readFile(absolute);
+          if (bytes.subarray(0, 8_192).includes(0)) { captureStatus = 'metadata_only'; reason = 'binary_content'; }
+          else contentHash = createHash(HASH).update(bytes).digest('hex');
+        }
+        entries.push({ path: rel, canonicalIdentity: normalizeRelative(realpathWithFallback(absolute)), classification: classify(rel), gitState: gitStates.get(rel) ?? null, size: stat.size, modifiedAt: stat.mtimeMs, mode: stat.mode, contentHash, captureStatus, reason });
+      } catch { entries.push({ path: rel, canonicalIdentity: normalizeRelative(absolute), classification: classify(rel), gitState: gitStates.get(rel) ?? null, size: null, modifiedAt: null, mode: null, contentHash: null, captureStatus: 'unavailable', reason: 'read_error' }); incompleteReasons.push(`unreadable:${rel}`); }
+    }
+  }
+  await walk(root);
+  const capturedPaths = new Set(entries.map((entry) => entry.path.replace(/\/$/, '')));
+  for (const [gitPath, gitState] of gitStates) {
+    if (capturedPaths.has(gitPath)) continue;
+    if (entries.length >= policy.maxEntries) { incompleteReasons.push(`entry_limit:${policy.maxEntries}`); break; }
+    entries.push({ path: gitPath, canonicalIdentity: normalizeRelative(path.join(root, gitPath)), classification: classify(gitPath), gitState, size: null, modifiedAt: null, mode: null, contentHash: null, captureStatus: 'unavailable', reason: 'path_missing_at_capture' });
+  }
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  const stableEntries = entries.map(({ modifiedAt: _modifiedAt, ...entry }) => entry);
+  const indexDigest = digest(stagedPaths);
+  const workingTreeDigest = digest({ dirtyPaths, untrackedPaths, entries: stableEntries });
+  const stateDigest = digest({ workspaceId: descriptor.id, repositoryRoot: descriptor.repositoryRoot ?? null, vcsKind: descriptor.vcsKind, branch, headCommit, upstream, indexDigest, workingTreeDigest, capturePolicyDigest, incompleteReasons: uniqueSorted(incompleteReasons) });
+  return { descriptor, policy, capturePolicyDigest, branch, headCommit, upstream, stagedPaths, dirtyPaths, untrackedPaths, entries, incompleteReasons: uniqueSorted(incompleteReasons), indexDigest, workingTreeDigest, stateDigest };
+}
+
+interface Deps {
+  db: Db;
+  getJob(jobId: string): JobRecord | null;
+  getAttempt(attemptId: string): AttemptRecord | null;
+  appendJobEvent(command: { jobId: string; attemptId: string; generation: number; type: string; payload?: Record<string, unknown> | null; producer: string; idempotencyKey: string }): { applied: boolean; duplicate: boolean; conflict?: string };
+}
+
+export function createRepositorySnapshotAuthority(deps: Deps): RepositorySnapshotAuthority {
+  const { db } = deps;
+  const rowToRecord = (row: Record<string, unknown>): RepositorySnapshotRecord => {
+    const list = (sql: string) => (db.prepare(sql).all(row.snapshot_id) as Array<{ relative_path: string }>).map((item) => item.relative_path);
+    return {
+      id: String(row.snapshot_id), workspaceId: String(row.workspace_id), jobId: String(row.job_id), attemptId: String(row.attempt_id), generation: Number(row.generation),
+      repositoryRoot: row.repository_root === null ? null : String(row.repository_root), vcsKind: row.vcs_kind as 'git' | 'none', branch: row.branch === null ? null : String(row.branch), headCommit: row.head_commit === null ? null : String(row.head_commit), upstream: row.upstream === null ? null : String(row.upstream),
+      indexDigest: String(row.index_digest), workingTreeDigest: String(row.working_tree_digest), capturePolicyDigest: String(row.capture_policy_digest), incomplete: Number(row.incomplete) === 1,
+      incompleteReasons: JSON.parse(String(row.incomplete_reasons_json)) as string[], previousSnapshotId: row.previous_snapshot_id === null ? null : String(row.previous_snapshot_id), stateDigest: String(row.state_digest), capturedAt: Number(row.captured_at),
+      stagedPaths: list("SELECT relative_path FROM repository_snapshot_entries WHERE snapshot_id=? AND instr(COALESCE(git_state,''),'staged')>0 ORDER BY relative_path"),
+      dirtyPaths: list("SELECT relative_path FROM repository_snapshot_entries WHERE snapshot_id=? AND instr(COALESCE(git_state,''),'dirty')>0 ORDER BY relative_path"),
+      untrackedPaths: list("SELECT relative_path FROM repository_snapshot_entries WHERE snapshot_id=? AND git_state='untracked' ORDER BY relative_path"),
+    };
+  };
+  const getSnapshot = (snapshotId: string) => {
+    const row = db.prepare('SELECT * FROM repository_snapshots WHERE snapshot_id=?').get(snapshotId) as Record<string, unknown> | undefined;
+    return row ? rowToRecord(row) : undefined;
+  };
+  const entriesFor = (snapshotId: string): RepositorySnapshotEntry[] => (db.prepare('SELECT * FROM repository_snapshot_entries WHERE snapshot_id=? ORDER BY relative_path').all(snapshotId) as Array<Record<string, unknown>>).map((row) => ({
+    path: String(row.relative_path), canonicalIdentity: String(row.canonical_identity), classification: String(row.classification), gitState: row.git_state === null ? null : String(row.git_state), size: row.size === null ? null : Number(row.size), modifiedAt: row.modified_at === null ? null : Number(row.modified_at), mode: row.mode === null ? null : Number(row.mode), contentHash: row.content_hash === null ? null : String(row.content_hash), captureStatus: row.capture_status as RepositorySnapshotEntry['captureStatus'], reason: row.reason === null ? null : String(row.reason),
+  }));
+  const descriptorFor = (workspaceId: string) => db.prepare('SELECT * FROM workspace_descriptors WHERE workspace_id=?').get(workspaceId) as Record<string, unknown> | undefined;
+  const mapDescriptor = (row: Record<string, unknown>): WorkspaceDescriptor => ({
+    id: String(row.workspace_id), requestedPath: String(row.requested_path), canonicalPath: String(row.canonical_path), portablePath: String(row.portable_path),
+    pathKind: row.path_kind as WorkspaceDescriptor['pathKind'], platform: row.platform as NodeJS.Platform, exists: Number(row.exists_flag) === 1,
+    ...(row.repository_root === null ? {} : { repositoryRoot: String(row.repository_root) }),
+    ...(row.git_directory === null ? {} : { gitDirectory: String(row.git_directory) }),
+    ...(row.git_common_directory === null ? {} : { gitCommonDirectory: String(row.git_common_directory) }),
+    ...(row.outer_repository_root === null ? {} : { outerRepositoryRoot: String(row.outer_repository_root) }),
+    vcsKind: row.vcs_kind as 'git' | 'none', trustPolicyDigest: String(row.trust_policy_digest),
+  });
+  const rootFor = (snapshot: RepositorySnapshotRecord): string => {
+    const descriptor = descriptorFor(snapshot.workspaceId);
+    if (!descriptor) throw new RepositorySnapshotAuthorityError('WORKSPACE_NOT_FOUND', 'Snapshot workspace descriptor is missing');
+    return String(snapshot.repositoryRoot ?? descriptor.canonical_path);
+  };
+  const stale = async (snapshot: RepositorySnapshotRecord) => {
+    const descriptor = descriptorFor(snapshot.workspaceId);
+    if (!descriptor) return true;
+    const row = db.prepare('SELECT capture_policy_json FROM repository_snapshots WHERE snapshot_id=?').get(snapshot.id) as { capture_policy_json: string };
+    return (await gatherState(String(descriptor.canonical_path), JSON.parse(row.capture_policy_json) as RepositoryCapturePolicy)).stateDigest !== snapshot.stateDigest;
+  };
+  const assertActiveAuthority = (input: { jobId: string; attemptId: string; generation: number; fenceToken: string }): void => {
+    const job = deps.getJob(input.jobId);
+    const attempt = deps.getAttempt(input.attemptId);
+    const now = Date.now();
+    if (!job || !attempt || attempt.jobId !== job.id || attempt.generation !== input.generation || attempt.fenceToken !== input.fenceToken || attempt.leaseExpiresAt === null || attempt.leaseExpiresAt <= now || ['succeeded','failed','cancelled','timed_out','crashed','unknown'].includes(attempt.status)) {
+      throw new RepositorySnapshotAuthorityError('STALE_REPOSITORY_SNAPSHOT_AUTHORITY', 'Attempt generation or fence no longer owns repository capture');
+    }
+  };
+
+  return {
+    async captureSnapshot(input) {
+      const eventKey = digest({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, requestedPath: input.requestedPath, previous: input.previousSnapshotId ?? null });
+      try { assertActiveAuthority(input); }
+      catch (error) {
+        if (error instanceof RepositorySnapshotAuthorityError) deps.appendJobEvent({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, type: 'repository.snapshot_rejected_stale', payload: null, producer: input.producer, idempotencyKey: `repository-capture-stale:${eventKey}` });
+        throw error;
+      }
+      const descriptor = await resolveWorkspace(input.requestedPath);
+      deps.appendJobEvent({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, type: 'repository.workspace_resolved', payload: { workspaceId: descriptor.id, vcsKind: descriptor.vcsKind }, producer: input.producer, idempotencyKey: `repository-workspace:${input.attemptId}:${input.generation}:${descriptor.id}` });
+      deps.appendJobEvent({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, type: 'repository.snapshot_capture_started', payload: null, producer: input.producer, idempotencyKey: `repository-capture-started:${eventKey}` });
+      const state = await gatherState(input.requestedPath, input.policy, descriptor);
+      const snapshotId = `repository_snapshot_${randomBytes(16).toString('hex')}`;
+      const capturedAt = Date.now();
+      const persist = db.transaction(() => {
+        assertActiveAuthority(input);
+        if (input.previousSnapshotId) {
+          const previous = getSnapshot(input.previousSnapshotId);
+          if (!previous || previous.jobId !== input.jobId || previous.attemptId !== input.attemptId || previous.generation !== input.generation) throw new RepositorySnapshotAuthorityError('INVALID_REPOSITORY_SNAPSHOT_ANCESTRY', 'Previous snapshot is outside the active Attempt lineage');
+          const latest = db.prepare('SELECT snapshot_id FROM repository_snapshots WHERE attempt_id=? AND generation=? ORDER BY captured_at DESC, rowid DESC LIMIT 1').get(input.attemptId, input.generation) as { snapshot_id: string } | undefined;
+          if (latest && latest.snapshot_id !== input.previousSnapshotId) throw new RepositorySnapshotAuthorityError('INVALID_REPOSITORY_SNAPSHOT_ANCESTRY', 'Previous snapshot is not the current lineage head');
+        }
+        const d = state.descriptor;
+        db.prepare(`INSERT OR IGNORE INTO workspace_descriptors (workspace_id,requested_path,canonical_path,portable_path,path_kind,platform,exists_flag,repository_root,git_directory,git_common_directory,outer_repository_root,vcs_kind,trust_policy_digest,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`).run(d.id,d.requestedPath,d.canonicalPath,d.portablePath,d.pathKind,d.platform,d.exists?1:0,d.repositoryRoot??null,d.gitDirectory??null,d.gitCommonDirectory??null,d.outerRepositoryRoot??null,d.vcsKind,d.trustPolicyDigest,capturedAt);
+        db.prepare(`INSERT INTO repository_snapshots (snapshot_id,workspace_id,job_id,attempt_id,generation,repository_root,vcs_kind,branch,head_commit,upstream,index_digest,working_tree_digest,capture_policy_digest,capture_policy_json,incomplete,incomplete_reasons_json,previous_snapshot_id,state_digest,captured_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`).run(snapshotId,d.id,input.jobId,input.attemptId,input.generation,d.repositoryRoot??null,d.vcsKind,state.branch,state.headCommit,state.upstream,state.indexDigest,state.workingTreeDigest,state.capturePolicyDigest,JSON.stringify(state.policy),state.incompleteReasons.length?1:0,JSON.stringify(state.incompleteReasons),input.previousSnapshotId??null,state.stateDigest,capturedAt);
+        const insert = db.prepare(`INSERT INTO repository_snapshot_entries (snapshot_id,relative_path,canonical_identity,classification,git_state,size,modified_at,mode,content_hash,capture_status,reason) VALUES (?,?,?,?,?,?,?,?,?,?,?)`);
+        for (const entry of state.entries) insert.run(snapshotId,entry.path,entry.canonicalIdentity,entry.classification,entry.gitState,entry.size,entry.modifiedAt,entry.mode,entry.contentHash,entry.captureStatus,entry.reason);
+        db.prepare('UPDATE tasks SET repository_snapshot_id=COALESCE(repository_snapshot_id,?) WHERE id=?').run(snapshotId,input.jobId);
+        db.prepare('UPDATE runs SET repository_snapshot_id=COALESCE(repository_snapshot_id,?) WHERE attempt_id=? AND generation=?').run(snapshotId,input.attemptId,input.generation);
+      }).immediate;
+      try { persist(); }
+      catch (error) {
+        if (error instanceof RepositorySnapshotAuthorityError && error.code === 'STALE_REPOSITORY_SNAPSHOT_AUTHORITY') deps.appendJobEvent({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, type: 'repository.snapshot_rejected_stale', payload: null, producer: input.producer, idempotencyKey: `repository-capture-stale:${eventKey}` });
+        throw error;
+      }
+      deps.appendJobEvent({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, type: 'repository.snapshot_captured', payload: { snapshotId, stateDigest: state.stateDigest, workspaceId: state.descriptor.id }, producer: input.producer, idempotencyKey: `repository-captured:${snapshotId}` });
+      if (state.incompleteReasons.length) deps.appendJobEvent({ jobId: input.jobId, attemptId: input.attemptId, generation: input.generation, type: 'repository.snapshot_incomplete', payload: { snapshotId, reasons: state.incompleteReasons }, producer: input.producer, idempotencyKey: `repository-incomplete:${snapshotId}` });
+      return getSnapshot(snapshotId)!;
+    },
+    getSnapshot,
+    getWorkspace(workspaceId) { const row = descriptorFor(workspaceId); return row ? mapDescriptor(row) : undefined; },
+    getAttemptSnapshot(jobId, attemptId) {
+      const row = db.prepare(`SELECT s.* FROM runs r JOIN repository_snapshots s ON s.snapshot_id=r.repository_snapshot_id WHERE r.task_id=? AND r.attempt_id=?`).get(jobId, attemptId) as Record<string, unknown> | undefined;
+      return row ? rowToRecord(row) : undefined;
+    },
+    compareSnapshots(baseId, currentId) {
+      const base = getSnapshot(baseId); const current = getSnapshot(currentId);
+      if (!base || !current || base.workspaceId !== current.workspaceId) throw new RepositorySnapshotAuthorityError('SNAPSHOT_NOT_COMPARABLE', 'Snapshots must exist in the same workspace');
+      const a = new Map(entriesFor(baseId).map((entry) => [entry.path, entry])); const b = new Map(entriesFor(currentId).map((entry) => [entry.path, entry]));
+      const added = [...b.keys()].filter((key) => !a.has(key)); const removed = [...a.keys()].filter((key) => !b.has(key));
+      const changed = [...a.keys()].filter((key) => b.has(key) && digest(a.get(key)) !== digest(b.get(key)));
+      deps.appendJobEvent({ jobId: current.jobId, attemptId: current.attemptId, generation: current.generation, type: 'repository.snapshot_compared', payload: { baseId, currentId, added: added.length, removed: removed.length, changed: changed.length }, producer: 'repository-snapshot', idempotencyKey: `repository-compared:${baseId}:${currentId}` });
+      return { baseId, currentId, added, removed, changed };
+    },
+    async inventory(snapshotId, options = {}) {
+      const snapshot = getSnapshot(snapshotId); if (!snapshot) throw new RepositorySnapshotAuthorityError('SNAPSHOT_NOT_FOUND', 'Repository snapshot not found');
+      const all = entriesFor(snapshotId); const start = options.cursor ? Math.max(0, all.findIndex((entry) => entry.path === options.cursor) + 1) : 0; const limit = Math.max(1, Math.min(5_000, options.limit ?? 200)); const entries = all.slice(start, start + limit); const truncated = start + entries.length < all.length;
+      return { snapshotId, stateDigest: snapshot.stateDigest, entries, nextCursor: truncated ? entries[entries.length - 1]?.path ?? null : null, truncated, stale: await stale(snapshot) };
+    },
+    async readFile(snapshotId, relativePath, options = {}) {
+      const snapshot = getSnapshot(snapshotId); if (!snapshot) throw new RepositorySnapshotAuthorityError('SNAPSHOT_NOT_FOUND', 'Repository snapshot not found');
+      const entry = entriesFor(snapshotId).find((candidate) => candidate.path === normalizeRelative(relativePath)); if (!entry || entry.captureStatus !== 'captured') throw new RepositorySnapshotAuthorityError('SNAPSHOT_PATH_NOT_READABLE', 'Path content is not captured by this snapshot policy');
+      const root = rootFor(snapshot); const absolute = realpathWithFallback(path.join(root, relativePath)); if (!isWithin(absolute, root)) throw new RepositorySnapshotAuthorityError('PATH_OUTSIDE_WORKSPACE', 'Path resolves outside the snapshot workspace');
+      const policy = isPathAllowed(absolute, 'read', root); if (!policy.allowed) throw new RepositorySnapshotAuthorityError('PATH_NOT_ALLOWED', policy.violation?.message ?? 'Path is not allowed');
+      const bytes = await fs.readFile(absolute); const text = bytes.toString('utf8'); const offset = Math.max(0, options.offset ?? 0); const limit = Math.max(1, Math.min(1_000_000, options.limit ?? (text.length || 1))); const page = text.slice(offset, offset + limit);
+      return { snapshotId, stateDigest: snapshot.stateDigest, path: entry.path, canonicalIdentity: entry.canonicalIdentity, size: bytes.length, modifiedAt: (await fs.stat(absolute)).mtimeMs, fullContentHash: createHash(HASH).update(bytes).digest('hex'), pageContentHash: createHash(HASH).update(page).digest('hex'), fullFileHash: true, offset, limit, content: page, truncated: offset + page.length < text.length, capturedAt: snapshot.capturedAt, encoding: bytes.subarray(0,8192).includes(0) ? 'binary' : 'utf8', stale: await stale(snapshot) };
+    },
+    async search(snapshotId, query, options = {}) {
+      const snapshot = getSnapshot(snapshotId); if (!snapshot) throw new RepositorySnapshotAuthorityError('SNAPSHOT_NOT_FOUND', 'Repository snapshot not found');
+      if (!query) throw new RepositorySnapshotAuthorityError('INVALID_SEARCH_QUERY', 'Lexical search query must not be empty');
+      const limit = Math.max(1, Math.min(1_000, options.limit ?? 100)); const matches: Array<{path:string;line:number;column:number;text:string}> = []; let truncated = false; const root = rootFor(snapshot);
+      outer: for (const entry of entriesFor(snapshotId)) {
+        if (entry.captureStatus !== 'captured' || !entry.contentHash || options.include && !options.include.test(entry.path) || options.exclude?.test(entry.path)) continue;
+        const absolute = realpathWithFallback(path.join(root, entry.path)); if (!isWithin(absolute, root)) continue;
+        const lines = (await fs.readFile(absolute, 'utf8')).split(/\r?\n/);
+        for (let line = 0; line < lines.length; line++) { const column = lines[line].indexOf(query); if (column < 0) continue; if (matches.length >= limit) { truncated = true; break outer; } matches.push({ path: entry.path, line: line + 1, column: column + 1, text: lines[line].slice(0, 500) }); }
+      }
+      return { snapshotId, stateDigest: snapshot.stateDigest, matches, truncated, stale: await stale(snapshot) };
+    },
+    discoverInstructions(snapshotId) {
+      if (!getSnapshot(snapshotId)) throw new RepositorySnapshotAuthorityError('SNAPSHOT_NOT_FOUND', 'Repository snapshot not found');
+      return entriesFor(snapshotId).filter((entry) => entry.classification === 'instruction').map((entry, index) => ({ path: entry.path, contentHash: entry.contentHash, scope: path.posix.dirname(entry.path), precedence: index, trust: 'repository' as const, snapshotId }));
+    },
+  };
+}

--- a/core/v4/codebase/workspaceResolver.ts
+++ b/core/v4/codebase/workspaceResolver.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { realpathWithFallback } from '../sandboxFs';
+
+const execFileAsync = promisify(execFile);
+
+export type WorkspacePathKind = 'windows' | 'posix' | 'unc' | 'wsl';
+
+export interface WorkspaceDescriptor {
+  id: string;
+  requestedPath: string;
+  canonicalPath: string;
+  portablePath: string;
+  pathKind: WorkspacePathKind;
+  platform: NodeJS.Platform;
+  exists: boolean;
+  repositoryRoot?: string;
+  gitDirectory?: string;
+  gitCommonDirectory?: string;
+  outerRepositoryRoot?: string;
+  vcsKind: 'git' | 'none';
+  trustPolicyDigest: string;
+}
+
+function portable(value: string): string {
+  const normalized = path.normalize(value).replace(/\\/g, '/');
+  if (/^[a-z]:\//i.test(normalized)) return normalized[0].toUpperCase() + normalized.slice(1);
+  return normalized;
+}
+
+function identityPath(value: string, platform: NodeJS.Platform): string {
+  const normalized = portable(value);
+  return platform === 'win32' ? normalized.toLocaleLowerCase('en-US') : normalized;
+}
+
+function kindOf(value: string, platform: NodeJS.Platform): WorkspacePathKind {
+  if (/^(?:\\\\|\/\/)/.test(value)) return 'unc';
+  if (/^\/mnt\/[a-z](?:\/|$)/i.test(value)) return 'wsl';
+  if (platform === 'win32' || /^[a-z]:[\\/]/i.test(value)) return 'windows';
+  return 'posix';
+}
+
+async function gitText(cwd: string, args: readonly string[]): Promise<string | undefined> {
+  try {
+    const result = await execFileAsync('git', ['-c', 'color.ui=false', '-C', cwd, ...args], {
+      windowsHide: true,
+      maxBuffer: 2 * 1024 * 1024,
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0', GIT_PAGER: 'cat', LC_ALL: 'C' },
+    });
+    return result.stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+async function discoverGit(canonicalPath: string): Promise<Pick<WorkspaceDescriptor,
+  'repositoryRoot' | 'gitDirectory' | 'gitCommonDirectory' | 'outerRepositoryRoot' | 'vcsKind'>> {
+  const root = await gitText(canonicalPath, ['rev-parse', '--show-toplevel']);
+  if (!root) return { vcsKind: 'none' };
+  const repositoryRoot = realpathWithFallback(root);
+  const gitDirectoryRaw = await gitText(canonicalPath, ['rev-parse', '--path-format=absolute', '--git-dir']);
+  const gitCommonRaw = await gitText(canonicalPath, ['rev-parse', '--path-format=absolute', '--git-common-dir']);
+  const gitDirectory = gitDirectoryRaw ? realpathWithFallback(gitDirectoryRaw) : undefined;
+  const gitCommonDirectory = gitCommonRaw
+    ? realpathWithFallback(path.isAbsolute(gitCommonRaw) ? gitCommonRaw : path.join(repositoryRoot, gitCommonRaw))
+    : undefined;
+  const parent = path.dirname(repositoryRoot);
+  const outer = parent !== repositoryRoot ? await gitText(parent, ['rev-parse', '--show-toplevel']) : undefined;
+  const outerRepositoryRoot = outer && identityPath(outer, process.platform) !== identityPath(repositoryRoot, process.platform)
+    ? realpathWithFallback(outer)
+    : undefined;
+  return { repositoryRoot, gitDirectory, gitCommonDirectory, outerRepositoryRoot, vcsKind: 'git' };
+}
+
+/** Resolve a caller-supplied root into the one durable workspace identity. */
+export async function resolveWorkspace(requestedPath: string): Promise<WorkspaceDescriptor> {
+  if (typeof requestedPath !== 'string' || requestedPath.includes('\0') || requestedPath.trim().length === 0) {
+    throw new Error('Workspace path must be a non-empty filesystem path');
+  }
+  const requested = path.resolve(requestedPath);
+  const canonicalPath = realpathWithFallback(requested);
+  const exists = canonicalPath === realpathWithFallback(canonicalPath)
+    && await import('node:fs').then(({ existsSync }) => existsSync(canonicalPath));
+  const pathKind = kindOf(requestedPath, process.platform);
+  let discoveryRoot = canonicalPath;
+  while (!await import('node:fs').then(({ existsSync }) => existsSync(discoveryRoot))) {
+    const parent = path.dirname(discoveryRoot);
+    if (parent === discoveryRoot) break;
+    discoveryRoot = parent;
+  }
+  const git = await discoverGit(discoveryRoot);
+  const portablePath = portable(canonicalPath);
+  const identity = identityPath(canonicalPath, process.platform);
+  const trustPolicyDigest = createHash('sha256').update(JSON.stringify({
+    version: 1,
+    identity,
+    repositoryRoot: git.repositoryRoot ? identityPath(git.repositoryRoot, process.platform) : null,
+    vcsKind: git.vcsKind,
+  })).digest('hex');
+  return {
+    id: `workspace_${createHash('sha256').update(`${process.platform}\0${identity}`).digest('hex')}`,
+    requestedPath: requested,
+    canonicalPath,
+    portablePath,
+    pathKind,
+    platform: process.platform,
+    exists,
+    ...git,
+    trustPolicyDigest,
+  };
+}
+
+export function isSameWorkspacePath(left: string, right: string, platform = process.platform): boolean {
+  return identityPath(realpathWithFallback(left), platform) === identityPath(realpathWithFallback(right), platform);
+}

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1452,6 +1452,83 @@ function applyV31(db: Database.Database): void {
   `);
 }
 
+/** Immutable repository identity and source-state captures bound to durable Attempts. */
+function applyV32(db: Database.Database): void {
+  addMissingColumns(db, 'tasks', [['repository_snapshot_id', 'TEXT']]);
+  addMissingColumns(db, 'runs', [['repository_snapshot_id', 'TEXT']]);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workspace_descriptors (
+      workspace_id TEXT PRIMARY KEY,
+      requested_path TEXT NOT NULL,
+      canonical_path TEXT NOT NULL,
+      portable_path TEXT NOT NULL,
+      path_kind TEXT NOT NULL,
+      platform TEXT NOT NULL,
+      exists_flag INTEGER NOT NULL,
+      repository_root TEXT,
+      git_directory TEXT,
+      git_common_directory TEXT,
+      outer_repository_root TEXT,
+      vcs_kind TEXT NOT NULL,
+      trust_policy_digest TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_descriptors_identity
+      ON workspace_descriptors(platform, portable_path);
+
+    CREATE TABLE IF NOT EXISTS repository_snapshots (
+      snapshot_id TEXT PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      repository_root TEXT,
+      vcs_kind TEXT NOT NULL,
+      branch TEXT,
+      head_commit TEXT,
+      upstream TEXT,
+      index_digest TEXT NOT NULL,
+      working_tree_digest TEXT NOT NULL,
+      capture_policy_digest TEXT NOT NULL,
+      capture_policy_json TEXT NOT NULL,
+      incomplete INTEGER NOT NULL DEFAULT 0,
+      incomplete_reasons_json TEXT NOT NULL DEFAULT '[]',
+      previous_snapshot_id TEXT,
+      state_digest TEXT NOT NULL,
+      captured_at INTEGER NOT NULL,
+      FOREIGN KEY (workspace_id) REFERENCES workspace_descriptors(workspace_id),
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (previous_snapshot_id) REFERENCES repository_snapshots(snapshot_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_repository_snapshots_job
+      ON repository_snapshots(job_id, captured_at, snapshot_id);
+    CREATE INDEX IF NOT EXISTS idx_repository_snapshots_attempt
+      ON repository_snapshots(attempt_id, generation, captured_at, snapshot_id);
+    CREATE INDEX IF NOT EXISTS idx_repository_snapshots_workspace
+      ON repository_snapshots(workspace_id, captured_at, snapshot_id);
+    CREATE INDEX IF NOT EXISTS idx_repository_snapshots_ancestry
+      ON repository_snapshots(previous_snapshot_id);
+
+    CREATE TABLE IF NOT EXISTS repository_snapshot_entries (
+      snapshot_id TEXT NOT NULL,
+      relative_path TEXT NOT NULL,
+      canonical_identity TEXT NOT NULL,
+      classification TEXT NOT NULL,
+      git_state TEXT,
+      size INTEGER,
+      modified_at REAL,
+      mode INTEGER,
+      content_hash TEXT,
+      capture_status TEXT NOT NULL,
+      reason TEXT,
+      PRIMARY KEY (snapshot_id, relative_path),
+      FOREIGN KEY (snapshot_id) REFERENCES repository_snapshots(snapshot_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_repository_snapshot_entries_path
+      ON repository_snapshot_entries(relative_path, snapshot_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1484,6 +1561,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 29, name: 'durable claims evidence and verdicts', apply: applyV29 },
   { version: 30, name: 'durable Job event cursors', apply: applyV30 },
   { version: 31, name: 'kernel projection query indexes', apply: applyV31 },
+  { version: 32, name: 'immutable repository snapshots', apply: applyV32 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -1517,7 +1595,8 @@ function tableExists(db: Database.Database, name: string): boolean {
 }
 
 function validateLatestSchema(db: Database.Database): void {
-  const required = ['tasks', 'runs', 'run_events', 'side_effect_ledger', 'durable_inputs'];
+  const required = ['tasks', 'runs', 'run_events', 'side_effect_ledger', 'durable_inputs',
+    'workspace_descriptors', 'repository_snapshots', 'repository_snapshot_entries'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -22,6 +22,7 @@ import { createJobResourceAuthority, type JobResourceAuthority } from './jobReso
 import type { JobBudgetKind, JobCapabilities } from './jobResourceAuthority';
 import { createJobProofAuthority, type JobProofAuthority } from './jobProofAuthority';
 import { createJobEventProjectionAuthority, type JobEventProjectionAuthority } from './jobEventProjection';
+import { createRepositorySnapshotAuthority, type RepositorySnapshotAuthority } from '../codebase/repositorySnapshotAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -47,10 +48,12 @@ export interface JobRecord {
   goal: string;
   entryPoint: string | null;
   source: string | null;
+  workspaceId?: string | null;
   terminalAt: number | null;
   terminalOutcome: string | null;
   finishReason: string | null;
   nextEventSequence: number;
+  repositorySnapshotId?: string | null;
 }
 
 export interface AttemptRecord {
@@ -67,6 +70,7 @@ export interface AttemptRecord {
   leaseHeartbeatAt: number | null;
   fenceToken: string | null;
   recoveryOfAttemptId: string | null;
+  repositorySnapshotId?: string | null;
 }
 
 export interface JobEventRecord {
@@ -181,6 +185,7 @@ export interface JobEngine {
   readonly resources: JobResourceAuthority;
   readonly proof: JobProofAuthority;
   readonly projection: JobEventProjectionAuthority;
+  readonly repository: RepositorySnapshotAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -428,10 +433,12 @@ interface JobSqlRow {
   goal: string;
   entry_point: string | null;
   source: string | null;
+  workspace_id: string | null;
   terminal_at: number | null;
   terminal_outcome: string | null;
   finish_reason: string | null;
   next_event_sequence: number;
+  repository_snapshot_id: string | null;
 }
 
 interface AttemptSqlRow {
@@ -449,6 +456,7 @@ interface AttemptSqlRow {
   fence_token: string | null;
   recovery_of_attempt_id: string | null;
   session_id: string;
+  repository_snapshot_id: string | null;
 }
 
 interface ToolCallSqlRow {
@@ -548,10 +556,12 @@ function mapJob(row: JobSqlRow): JobRecord {
     goal: row.goal,
     entryPoint: row.entry_point,
     source: row.source,
+    workspaceId: row.workspace_id,
     terminalAt: row.terminal_at,
     terminalOutcome: row.terminal_outcome,
     finishReason: row.finish_reason,
     nextEventSequence: row.next_event_sequence,
+    repositorySnapshotId: row.repository_snapshot_id,
   };
 }
 
@@ -570,6 +580,7 @@ function mapAttempt(row: AttemptSqlRow): AttemptRecord {
     leaseHeartbeatAt: row.lease_heartbeat_at,
     fenceToken: row.fence_token,
     recoveryOfAttemptId: row.recovery_of_attempt_id,
+    repositorySnapshotId: row.repository_snapshot_id,
   };
 }
 
@@ -628,15 +639,17 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
 
   const getJobRow = (jobId: string): JobSqlRow | undefined => db.prepare(
     `SELECT id, status, state_version, active_attempt_id, root_job_id,
-            parent_task_id, session_id, goal, entry_point, source,
-            terminal_at, terminal_outcome, finish_reason, next_event_sequence
+            parent_task_id, session_id, goal, entry_point, source, workspace_id,
+            terminal_at, terminal_outcome, finish_reason, next_event_sequence,
+            repository_snapshot_id
        FROM tasks WHERE id = ?`,
   ).get(jobId) as JobSqlRow | undefined;
 
   const getAttemptRow = (attemptId: string): AttemptSqlRow | undefined => db.prepare(
     `SELECT id, attempt_id, task_id, status, attempt_number, generation,
             state_version, lease_id, lease_owner, lease_expires_at,
-            lease_heartbeat_at, fence_token, recovery_of_attempt_id, session_id
+            lease_heartbeat_at, fence_token, recovery_of_attempt_id, session_id,
+            repository_snapshot_id
        FROM runs WHERE attempt_id = ?`,
   ).get(attemptId) as AttemptSqlRow | undefined;
 
@@ -2260,11 +2273,19 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     return { jobId: job.id, expiredAttemptId: attempt.attempt_id, recoveryAttemptId, decision };
   }).immediate;
 
+  const repository = createRepositorySnapshotAuthority({
+    db,
+    getJob(jobId) { const row = getJobRow(jobId); return row ? mapJob(row) : null; },
+    getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
+    appendJobEvent: appendJobEventTx,
+  });
+
   return {
     graph,
     resources,
     proof,
     projection,
+    repository,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);
@@ -2279,8 +2300,9 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       const limit = Math.max(1, Math.min(1_000, filters.limit ?? 100));
       const rows = db.prepare(
         `SELECT id, status, state_version, active_attempt_id, root_job_id,
-                parent_task_id, session_id, goal, entry_point, source,
-                terminal_at, terminal_outcome, finish_reason, next_event_sequence
+                parent_task_id, session_id, goal, entry_point, source, workspace_id,
+                terminal_at, terminal_outcome, finish_reason, next_event_sequence,
+                repository_snapshot_id
            FROM tasks
           ${clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''}
           ORDER BY created_at ASC, id ASC
@@ -2307,7 +2329,8 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       const rows = db.prepare(
         `SELECT id, attempt_id, task_id, status, attempt_number, generation,
                 state_version, lease_id, lease_owner, lease_expires_at,
-                lease_heartbeat_at, fence_token, recovery_of_attempt_id, session_id
+                lease_heartbeat_at, fence_token, recovery_of_attempt_id, session_id,
+                repository_snapshot_id
            FROM runs WHERE task_id = ? ORDER BY attempt_number`,
       ).all(jobId) as AttemptSqlRow[];
       return rows.map(mapAttempt);

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -112,6 +112,12 @@ export type ExecutionContext = 'repl' | 'daemon';
 export interface ToolContext {
   /** Current working directory (for relative paths in file tools). */
   cwd: string;
+  /** Optional immutable repository view for snapshot-aware read-only file tools. */
+  repositoryInspection?: {
+    snapshotId: string;
+    rootPath: string;
+    authority: import('./codebase/repositorySnapshotAuthority').RepositorySnapshotAuthority;
+  };
   /** Aiden user-data paths. Sessions, memory, skills, logs all live here. */
   paths: AidenPaths;
   /**

--- a/tests/v4/codebase/repositorySnapshotAuthority.test.ts
+++ b/tests/v4/codebase/repositorySnapshotAuthority.test.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { fileReadTool } from '../../../tools/v4/files/fileRead';
+import { fileListTool } from '../../../tools/v4/files/fileList';
+
+let db: Database.Database;
+let engine: JobEngine;
+let root: string;
+
+beforeEach(async () => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  db.prepare('INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)')
+    .run('instance', 1, 'localhost', Date.now(), Date.now(), '4.17.0');
+  engine = createJobEngine({ db });
+  root = await mkdtemp(path.join(os.tmpdir(), 'aiden-snapshot-'));
+});
+
+afterEach(async () => { db.close(); await rm(root, { recursive: true, force: true }); });
+
+function authority() {
+  const admitted = engine.submitJob({
+    entryPoint: 'test', source: 'unit', sessionId: 'session', workspaceId: root,
+    instanceId: 'instance', idempotencyNamespace: 'snapshot', idempotencyKey: 'one', goal: 'inspect',
+  });
+  const lease = engine.claimAttempt({ attemptId: admitted.attemptId, ownerId: 'worker', ttlMs: 60_000 });
+  if (!lease.acquired || !lease.fenceToken || lease.generation === undefined) throw new Error('lease');
+  return { ...admitted, generation: lease.generation, fenceToken: lease.fenceToken };
+}
+
+describe('RepositorySnapshot authority', () => {
+  it('captures immutable dirty Git state with a deterministic state digest', async () => {
+    execFileSync('git', ['init', '-q', root]);
+    execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.invalid']);
+    await writeFile(path.join(root, 'package.json'), '{"name":"fixture"}\n');
+    execFileSync('git', ['-C', root, 'add', 'package.json']);
+    execFileSync('git', ['-C', root, 'commit', '-qm', 'initial']);
+    await writeFile(path.join(root, 'package.json'), '{"name":"changed"}\n');
+    await writeFile(path.join(root, 'new.txt'), 'untracked\n');
+    const binding = authority();
+    const first = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    const second = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', previousSnapshotId: first.id });
+    expect(first.stateDigest).toBe(second.stateDigest);
+    expect(first.id).not.toBe(second.id);
+    expect(first.dirtyPaths).toContain('package.json');
+    expect(first.untrackedPaths).toContain('new.txt');
+    expect(engine.repository.getWorkspace(first.workspaceId)?.canonicalPath).toBe(await (await import('node:fs/promises')).realpath(root));
+    expect(await (await import('node:fs/promises')).readFile(path.join(root, 'package.json'), 'utf8')).toContain('changed');
+    expect(engine.repository.getAttemptSnapshot(binding.jobId, binding.attemptId)?.id).toBe(first.id);
+  });
+
+  it('rejects stale generations and expired fences', async () => {
+    await writeFile(path.join(root, 'package.json'), '{}');
+    const binding = authority();
+    await expect(engine.repository.captureSnapshot({ ...binding, generation: binding.generation + 1, requestedPath: root, producer: 'test' }))
+      .rejects.toMatchObject({ code: 'STALE_REPOSITORY_SNAPSHOT_AUTHORITY' });
+    db.prepare('UPDATE runs SET lease_expires_at=? WHERE attempt_id=?').run(Date.now() - 1, binding.attemptId);
+    await expect(engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' }))
+      .rejects.toMatchObject({ code: 'STALE_REPOSITORY_SNAPSHOT_AUTHORITY' });
+  });
+
+  it('changes the state digest without mutating prior records', async () => {
+    await writeFile(path.join(root, 'package.json'), '{"name":"before"}');
+    const binding = authority();
+    const first = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    await writeFile(path.join(root, 'package.json'), '{"name":"after"}');
+    const second = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', previousSnapshotId: first.id });
+    expect(second.stateDigest).not.toBe(first.stateDigest);
+    expect(engine.repository.getSnapshot(first.id)?.stateDigest).toBe(first.stateDigest);
+    expect(engine.repository.compareSnapshots(first.id, second.id).changed).toContain('package.json');
+    engine.repository.compareSnapshots(first.id, second.id);
+    expect(engine.listEvents(binding.jobId).filter((event) => event.type === 'repository.snapshot_compared')).toHaveLength(1);
+    await expect(engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', previousSnapshotId: first.id }))
+      .rejects.toMatchObject({ code: 'INVALID_REPOSITORY_SNAPSHOT_ANCESTRY' });
+  });
+
+  it('records bounded incomplete captures explicitly', async () => {
+    await writeFile(path.join(root, 'a.ts'), 'a');
+    await writeFile(path.join(root, 'b.ts'), 'b');
+    const binding = authority();
+    const snapshot = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', policy: { maxEntries: 1 } });
+    expect(snapshot.incomplete).toBe(true);
+    expect(snapshot.incompleteReasons).toContain('entry_limit:1');
+    expect(engine.listEvents(binding.jobId).map((event) => event.type)).toContain('repository.snapshot_incomplete');
+  });
+
+  it('changes digest for staged state and HEAD identity', async () => {
+    execFileSync('git', ['init', '-q', root]);
+    execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.invalid']);
+    await writeFile(path.join(root, 'source.ts'), 'one');
+    execFileSync('git', ['-C', root, 'add', 'source.ts']);
+    execFileSync('git', ['-C', root, 'commit', '-qm', 'one']);
+    const binding = authority();
+    const committed = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    await writeFile(path.join(root, 'source.ts'), 'two');
+    execFileSync('git', ['-C', root, 'add', 'source.ts']);
+    const staged = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', previousSnapshotId: committed.id });
+    expect(staged.stateDigest).not.toBe(committed.stateDigest);
+    execFileSync('git', ['-C', root, 'commit', '-qm', 'two']);
+    const nextHead = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', previousSnapshotId: staged.id });
+    expect(nextHead.headCommit).not.toBe(committed.headCommit);
+    expect(nextHead.stateDigest).not.toBe(staged.stateDigest);
+  });
+
+  it('persists snapshot binding and ordered events across engine reconstruction', async () => {
+    await writeFile(path.join(root, 'AGENTS.md'), 'Repository instructions');
+    const binding = authority();
+    const snapshot = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    const restored = createJobEngine({ db });
+    expect(restored.repository.getAttemptSnapshot(binding.jobId, binding.attemptId)?.id).toBe(snapshot.id);
+    expect(restored.repository.discoverInstructions(snapshot.id)).toEqual([
+      expect.objectContaining({ path: 'AGENTS.md', snapshotId: snapshot.id, trust: 'repository' }),
+    ]);
+    expect(restored.listEvents(binding.jobId).map((event) => event.type)).toEqual([
+      'job.submitted', 'attempt.created', 'attempt.leased',
+      'repository.workspace_resolved', 'repository.snapshot_capture_started', 'repository.snapshot_captured',
+    ]);
+  });
+
+  it('provides bounded snapshot inventory, read and lexical search', async () => {
+    await writeFile(path.join(root, 'package.json'), '{"name":"fixture"}\n');
+    await writeFile(path.join(root, 'source.ts'), 'export const value = "needle";\n');
+    const binding = authority();
+    const snapshot = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    const inventory = await engine.repository.inventory(snapshot.id, { limit: 1 });
+    expect(inventory.snapshotId).toBe(snapshot.id);
+    expect(inventory.truncated).toBe(true);
+    const read = await engine.repository.readFile(snapshot.id, 'source.ts', { offset: 0, limit: 6 });
+    expect(read.fullContentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(read.pageContentHash).not.toBe(read.fullContentHash);
+    expect(read.fullFileHash).toBe(true);
+    const search = await engine.repository.search(snapshot.id, 'needle', { limit: 10 });
+    expect(search.matches[0]).toMatchObject({ path: 'source.ts', line: 1 });
+    await writeFile(path.join(root, 'source.ts'), 'changed after capture\n');
+    expect((await engine.repository.readFile(snapshot.id, 'source.ts')).stale).toBe(true);
+  });
+
+  it('extends canonical file tools with an optional immutable inspection view', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'snapshot content');
+    const binding = authority();
+    const snapshot = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    const context = {
+      cwd: root,
+      paths: {} as never,
+      repositoryInspection: { snapshotId: snapshot.id, rootPath: root, authority: engine.repository },
+    };
+    const read = await fileReadTool.execute({ path: 'source.ts' }, context) as Record<string, unknown>;
+    expect(read).toMatchObject({ success: true, snapshotId: snapshot.id, stateDigest: snapshot.stateDigest, content: 'snapshot content' });
+    const list = await fileListTool.execute({}, context) as Record<string, unknown>;
+    expect(list).toMatchObject({ success: true, snapshotId: snapshot.id, entries: [{ name: 'source.ts', type: 'file' }] });
+  });
+
+  it('records policy exclusions without hashing excluded directory changes', async () => {
+    await (await import('node:fs/promises')).mkdir(path.join(root, 'node_modules'));
+    await writeFile(path.join(root, 'node_modules', 'dependency.js'), 'one');
+    await writeFile(path.join(root, 'package.json'), '{}');
+    const binding = authority();
+    const first = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    await writeFile(path.join(root, 'node_modules', 'dependency.js'), 'two');
+    const second = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test', previousSnapshotId: first.id });
+    expect(second.stateDigest).toBe(first.stateDigest);
+    const inventory = await engine.repository.inventory(first.id);
+    expect(inventory.entries).toContainEqual(expect.objectContaining({ path: 'node_modules/', captureStatus: 'excluded' }));
+  });
+
+  it('records secret metadata without reading secret content through inspection', async () => {
+    await writeFile(path.join(root, '.env'), 'SETTING=fixture');
+    const binding = authority();
+    const snapshot = await engine.repository.captureSnapshot({ ...binding, requestedPath: root, producer: 'test' });
+    const inventory = await engine.repository.inventory(snapshot.id);
+    expect(inventory.entries).toContainEqual(expect.objectContaining({ path: '.env', captureStatus: 'metadata_only', contentHash: null, reason: 'secret_content' }));
+    await expect(engine.repository.readFile(snapshot.id, '.env')).rejects.toMatchObject({ code: 'SNAPSHOT_PATH_NOT_READABLE' });
+  });
+});

--- a/tests/v4/codebase/repositorySnapshotAuthority.test.ts
+++ b/tests/v4/codebase/repositorySnapshotAuthority.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
@@ -158,6 +158,32 @@ describe('RepositorySnapshot authority', () => {
     expect(read).toMatchObject({ success: true, snapshotId: snapshot.id, stateDigest: snapshot.stateDigest, content: 'snapshot content' });
     const list = await fileListTool.execute({}, context) as Record<string, unknown>;
     expect(list).toMatchObject({ success: true, snapshotId: snapshot.id, entries: [{ name: 'source.ts', type: 'file' }] });
+  });
+
+  it('keeps snapshot inspection metadata when the workspace root is a filesystem alias', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'snapshot content');
+    const alias = `${root}-alias`;
+    await symlink(root, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    try {
+      const binding = authority();
+      const snapshot = await engine.repository.captureSnapshot({ ...binding, requestedPath: alias, producer: 'test' });
+      const context = {
+        cwd: alias,
+        paths: {} as never,
+        repositoryInspection: { snapshotId: snapshot.id, rootPath: alias, authority: engine.repository },
+      };
+      const read = await fileReadTool.execute({ path: 'source.ts' }, context) as Record<string, unknown>;
+      expect(read).toMatchObject({
+        success: true,
+        snapshotId: snapshot.id,
+        stateDigest: snapshot.stateDigest,
+        content: 'snapshot content',
+      });
+      const list = await fileListTool.execute({}, context) as Record<string, unknown>;
+      expect(list).toMatchObject({ success: true, snapshotId: snapshot.id });
+    } finally {
+      await rm(alias, { recursive: true, force: true });
+    }
   });
 
   it('records policy exclusions without hashing excluded directory changes', async () => {

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -1,0 +1,38 @@
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { LATEST_SCHEMA_VERSION, MIGRATIONS_FOR_TESTS, runMigrations } from '../../../core/v4/daemon/db/migrations';
+
+let db: Database.Database | undefined;
+afterEach(() => { db?.close(); db = undefined; });
+
+function migrateThrough31(database: Database.Database): void {
+  for (const migration of MIGRATIONS_FOR_TESTS.filter((item) => item.version <= 31)) {
+    database.transaction(() => {
+      if (migration.apply) migration.apply(database);
+      else database.exec(migration.sql ?? '');
+      database.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)').run(migration.version, Date.now());
+    }).immediate();
+  }
+}
+
+describe('repository snapshot migration v32', () => {
+  it('migrates v31 additively while preserving existing Job and Attempt rows', () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    migrateThrough31(db);
+    const now = Date.now();
+    db.prepare('INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)').run('instance',1,'host',now,now,'4.17.0');
+    db.prepare(`INSERT INTO tasks (id,title,goal,status,created_at,updated_at,session_id,trace_ids,artifact_ids,root_job_id,next_event_sequence) VALUES ('job','job','goal','queued',?,?, 'session','[]','[]','job',1)`).run(now,now);
+    db.prepare(`INSERT INTO runs (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence) VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
+
+    expect(runMigrations(db)).toEqual({ from: 31, to: 32 });
+    expect(LATEST_SCHEMA_VERSION).toBe(32);
+    expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
+    expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
+      { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
+    ]);
+    expect(runMigrations(db)).toEqual({ from: 32, to: 32 });
+  });
+});

--- a/tests/v4/codebase/workspaceResolver.test.ts
+++ b/tests/v4/codebase/workspaceResolver.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isSameWorkspacePath, resolveWorkspace } from '../../../core/v4/codebase/workspaceResolver';
+
+const roots: string[] = [];
+async function temp(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'aiden-workspace-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => { await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))); });
+
+describe('canonical workspace resolution', () => {
+  it('realpaths existing aliases and safely appends a non-existing child', async () => {
+    const root = await temp();
+    const actual = path.join(root, 'actual');
+    const alias = path.join(root, 'alias');
+    await mkdir(actual);
+    await symlink(actual, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    const existing = await resolveWorkspace(alias);
+    const missing = await resolveWorkspace(path.join(alias, 'future', 'file.ts'));
+    expect(existing.canonicalPath).toBe(await (await import('node:fs/promises')).realpath(actual));
+    expect(missing.canonicalPath).toBe(path.join(existing.canonicalPath, 'future', 'file.ts'));
+    expect(existing.id).toBe((await resolveWorkspace(actual)).id);
+    expect(isSameWorkspacePath(alias, actual)).toBe(true);
+    expect(existing.id).not.toBe(missing.id);
+  });
+
+  it('identifies nested repositories and linked worktree metadata', async () => {
+    const root = await temp();
+    execFileSync('git', ['init', '-q', root]);
+    execFileSync('git', ['-C', root, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', root, 'config', 'user.email', 'test@example.invalid']);
+    await writeFile(path.join(root, 'README.md'), 'root');
+    execFileSync('git', ['-C', root, 'add', 'README.md']);
+    execFileSync('git', ['-C', root, 'commit', '-qm', 'initial']);
+    const nested = path.join(root, 'nested');
+    await mkdir(nested);
+    execFileSync('git', ['init', '-q', nested]);
+    expect((await resolveWorkspace(nested)).outerRepositoryRoot).toBe(await (await import('node:fs/promises')).realpath(root));
+
+    const linked = path.join(await temp(), 'linked');
+    execFileSync('git', ['-C', root, 'worktree', 'add', '-q', '-b', 'linked-test', linked]);
+    const descriptor = await resolveWorkspace(linked);
+    expect(descriptor.repositoryRoot).toBe(await (await import('node:fs/promises')).realpath(linked));
+    expect(descriptor.gitDirectory).not.toBe(descriptor.gitCommonDirectory);
+  });
+
+  it.runIf(process.platform === 'win32')('normalizes Windows case and separator aliases', async () => {
+    const root = await temp();
+    const alternate = root.replace(/\\/g, '/').replace(/^([A-Z]):/, (_, drive: string) => `${drive.toLowerCase()}:`);
+    expect((await resolveWorkspace(root)).id).toBe((await resolveWorkspace(alternate)).id);
+  });
+
+  it('distinguishes requested subdirectory from the nearest Git root', async () => {
+    const root = await temp();
+    execFileSync('git', ['init', '-q', root]);
+    const child = path.join(root, 'src');
+    await mkdir(child);
+    const descriptor = await resolveWorkspace(child);
+    expect(descriptor.vcsKind).toBe('git');
+    expect(descriptor.repositoryRoot).toBe(await (await import('node:fs/promises')).realpath(root));
+    expect(descriptor.canonicalPath).toBe(await (await import('node:fs/promises')).realpath(child));
+  });
+
+  it('supports deterministic non-Git folders', async () => {
+    const root = await temp();
+    await writeFile(path.join(root, 'package.json'), '{}');
+    const first = await resolveWorkspace(root);
+    const second = await resolveWorkspace(root);
+    expect(first).toEqual(second);
+    expect(first.vcsKind).toBe('none');
+  });
+});

--- a/tests/v4/daemon/taskStore.test.ts
+++ b/tests/v4/daemon/taskStore.test.ts
@@ -275,6 +275,7 @@ describe('v14 migration — Slice 10.8 tasks table', () => {
       'next_event_sequence', 'next_input_sequence', 'next_wait_sequence', 'parent_task_id',
       // v4.13 Gap 3 (v17 migration) — job-card columns.
       'permissions', 'policy_snapshot_id', 'principal_id', 'recovery_state',
+      'repository_snapshot_id',
       'request_fingerprint',
       // v4.13 Gap 4 (v18 migration) — wake-loop cap.
       'resume_count', 'root_job_id', 'session_id',

--- a/tools/v4/files/fileList.ts
+++ b/tools/v4/files/fileList.ts
@@ -76,8 +76,12 @@ export const fileListTool: ToolHandler = {
     }
     const resolved = policy.resolvedPath;
     try {
-      if (ctx.repositoryInspection && isWithin(resolved, ctx.repositoryInspection.rootPath)) {
-        const relativeDirectory = path.relative(ctx.repositoryInspection.rootPath, resolved).replace(/\\/g, '/');
+      const canonicalDirectory = await fs.realpath(resolved);
+      const inspectionRoot = ctx.repositoryInspection
+        ? await fs.realpath(ctx.repositoryInspection.rootPath)
+        : undefined;
+      if (ctx.repositoryInspection && inspectionRoot && isWithin(canonicalDirectory, inspectionRoot)) {
+        const relativeDirectory = path.relative(inspectionRoot, canonicalDirectory).replace(/\\/g, '/');
         const inventory = await ctx.repositoryInspection.authority.inventory(
           ctx.repositoryInspection.snapshotId,
           { limit: 5_000 },
@@ -104,7 +108,7 @@ export const fileListTool: ToolHandler = {
         const entries = [...immediate.values()].sort((a, b) => String(a.name).localeCompare(String(b.name)));
         return {
           success: true,
-          path: resolved,
+          path: canonicalDirectory,
           count: entries.length,
           entries,
           snapshotId: inventory.snapshotId,

--- a/tools/v4/files/fileList.ts
+++ b/tools/v4/files/fileList.ts
@@ -20,7 +20,7 @@ import os from 'node:os';
 import crypto from 'node:crypto';
 
 import type { ToolHandler } from '../../../core/v4/toolRegistry';
-import { isPathAllowed, violationEnvelope } from '../../../core/v4/sandboxFs';
+import { isPathAllowed, isWithin, violationEnvelope } from '../../../core/v4/sandboxFs';
 
 function expandPath(input: string, cwd: string): string {
   const home = os.homedir();
@@ -76,6 +76,43 @@ export const fileListTool: ToolHandler = {
     }
     const resolved = policy.resolvedPath;
     try {
+      if (ctx.repositoryInspection && isWithin(resolved, ctx.repositoryInspection.rootPath)) {
+        const relativeDirectory = path.relative(ctx.repositoryInspection.rootPath, resolved).replace(/\\/g, '/');
+        const inventory = await ctx.repositoryInspection.authority.inventory(
+          ctx.repositoryInspection.snapshotId,
+          { limit: 5_000 },
+        );
+        const prefix = relativeDirectory ? `${relativeDirectory}/` : '';
+        const immediate = new Map<string, Record<string, unknown>>();
+        for (const entry of inventory.entries) {
+          if (!entry.path.startsWith(prefix)) continue;
+          const remainder = entry.path.slice(prefix.length);
+          if (!remainder) continue;
+          const slash = remainder.indexOf('/');
+          if (slash >= 0) {
+            const name = remainder.slice(0, slash);
+            immediate.set(name, { name, type: 'dir' });
+          } else {
+            immediate.set(remainder, {
+              name: remainder,
+              type: 'file',
+              ...(args.stat === true || args.hash === true ? { size: entry.size, mtimeMs: entry.modifiedAt } : {}),
+              ...(args.hash === true && entry.contentHash ? { sha256: entry.contentHash } : {}),
+            });
+          }
+        }
+        const entries = [...immediate.values()].sort((a, b) => String(a.name).localeCompare(String(b.name)));
+        return {
+          success: true,
+          path: resolved,
+          count: entries.length,
+          entries,
+          snapshotId: inventory.snapshotId,
+          stateDigest: inventory.stateDigest,
+          stale: inventory.stale,
+          truncated: inventory.truncated,
+        };
+      }
       const entries = await fs.readdir(resolved, { withFileTypes: true });
       // v4.13 Phase D — optional stat + content hash. `hash` implies
       // `stat`; sha256 is size-guarded (files over the cap get

--- a/tools/v4/files/fileRead.ts
+++ b/tools/v4/files/fileRead.ts
@@ -22,7 +22,7 @@ import os from 'node:os';
 import crypto from 'node:crypto';
 
 import type { ToolHandler } from '../../../core/v4/toolRegistry';
-import { isPathAllowed, violationEnvelope } from '../../../core/v4/sandboxFs';
+import { isPathAllowed, isWithin, violationEnvelope } from '../../../core/v4/sandboxFs';
 import { fileReadHandle } from '../../../core/v4/toolOutputCap';
 import { protectedPathMessage } from '../utils/paths';
 
@@ -117,6 +117,15 @@ export const fileReadTool: ToolHandler = {
     const limit = Math.max(1, Math.min(MAX_OUTPUT, typeof args.limit === 'number' ? Math.floor(args.limit) : MAX_OUTPUT));
     try {
       const canonicalPath = await fs.realpath(resolved);
+      if (ctx.repositoryInspection && isWithin(canonicalPath, ctx.repositoryInspection.rootPath)) {
+        const relativePath = path.relative(ctx.repositoryInspection.rootPath, canonicalPath);
+        const result = await ctx.repositoryInspection.authority.readFile(
+          ctx.repositoryInspection.snapshotId,
+          relativePath,
+          { offset, limit },
+        );
+        return { success: true, ...result };
+      }
       const [content, fileStat] = await Promise.all([
         fs.readFile(canonicalPath, 'utf-8'),
         fs.stat(canonicalPath),

--- a/tools/v4/files/fileRead.ts
+++ b/tools/v4/files/fileRead.ts
@@ -117,8 +117,11 @@ export const fileReadTool: ToolHandler = {
     const limit = Math.max(1, Math.min(MAX_OUTPUT, typeof args.limit === 'number' ? Math.floor(args.limit) : MAX_OUTPUT));
     try {
       const canonicalPath = await fs.realpath(resolved);
-      if (ctx.repositoryInspection && isWithin(canonicalPath, ctx.repositoryInspection.rootPath)) {
-        const relativePath = path.relative(ctx.repositoryInspection.rootPath, canonicalPath);
+      const inspectionRoot = ctx.repositoryInspection
+        ? await fs.realpath(ctx.repositoryInspection.rootPath)
+        : undefined;
+      if (ctx.repositoryInspection && inspectionRoot && isWithin(canonicalPath, inspectionRoot)) {
+        const relativePath = path.relative(inspectionRoot, canonicalPath);
         const result = await ctx.repositoryInspection.authority.readFile(
           ctx.repositoryInspection.snapshotId,
           relativePath,


### PR DESCRIPTION
## Summary

- adds one canonical workspace/path resolver with native realpath identity, non-existing-child handling, Git root discovery, nested repositories, and linked worktrees;
- adds immutable repository snapshots bound to exact Job, Attempt, generation, and fence authority;
- captures Git and non-Git identity, dirty/staged/untracked state, bounded source metadata, exclusions, incomplete reasons, and deterministic state digests;
- extends the canonical read-only file tools with an optional snapshot-bound inspection view;
- persists snapshot ancestry and bindings through additive schema migration v32.

## Reused kernel owners

- JobEngine and existing Job/Attempt records;
- Attempt generations, fences, leases, and terminal protection;
- ordered Job events and idempotency;
- the existing migration and recovery infrastructure;
- the existing filesystem realpath and sandbox enforcement.

## Invariants

- persisted snapshots and Attempt bindings are immutable;
- stale generations, expired leases, and stale fence tokens cannot capture authoritative state;
- unchanged state under the same policy has a stable digest;
- changed HEAD, index, working tree, or captured content changes the digest;
- dirty user files and the Git index are never mutated;
- exclusions and incomplete captures remain explicit;
- secret and binary contents are not captured by default;
- old records remain readable with a null snapshot and are not source-verified.

## Out of scope

- source mutation and patch fencing;
- test/build records;
- Git mutation or reconciliation;
- LSP or semantic indexing;
- undo;
- Workbench changes;
- version changes.

## Validation

- Node 22.23.1 typecheck: passed;
- Node 22.23.1 production build: passed;
- focused codebase, JobEngine, lifecycle, recovery, migration, sandbox, and file-tool matrix: 147 passed, 2 skipped;
- daemon, MCP, API, and CLI compatibility matrix: 203 passed, 1 skipped;
- integration suite: 37 passed, 9 skipped;
- package dry run: passed (1,054 entries, 2,289,011-byte archive);
- built CLI version/help smoke: passed;
- diff, NUL, secret, attribution, and scope scans: passed.

The broad local run completed 7,160 passing tests and 39 skips after the schema assertion update. Windows PTY files could not complete in this host because the console helper returned `AttachConsole failed`; required CI remains the authoritative Windows/macOS/Linux terminal gate.