### PR TITLE
feat(codebase): add source-fenced change engine

### DIFF
--- a/core/v4/actionAuthority.ts
+++ b/core/v4/actionAuthority.ts
@@ -247,7 +247,7 @@ export function normalizeExecutionPlan(command: {
   const networkTargets = ['url', 'endpoint', 'host'].map((key) => command.args[key])
     .filter((value): value is string => typeof value === 'string' && /^[a-z][a-z0-9+.-]*:\/\//i.test(value))
     .sort();
-  const affectedResources = ['path', 'file', 'source', 'destination', 'cwd']
+  const affectedResources = ['path', 'file', 'from', 'to', 'source', 'destination', 'cwd']
     .map((key) => resolveResource(command.args[key], cwd))
     .filter((value): value is string => value !== null)
     .sort();

--- a/core/v4/codebase/repositorySnapshotAuthority.ts
+++ b/core/v4/codebase/repositorySnapshotAuthority.ts
@@ -102,6 +102,7 @@ export interface RepositorySnapshotAuthority {
   getSnapshot(snapshotId: string): RepositorySnapshotRecord | undefined;
   getWorkspace(workspaceId: string): WorkspaceDescriptor | undefined;
   getAttemptSnapshot(jobId: string, attemptId: string): RepositorySnapshotRecord | undefined;
+  getEntry(snapshotId: string, relativePath: string): RepositorySnapshotEntry | undefined;
   compareSnapshots(baseId: string, currentId: string): { baseId: string; currentId: string; added: string[]; removed: string[]; changed: string[] };
   inventory(snapshotId: string, options?: { cursor?: string; limit?: number }): Promise<{ snapshotId: string; stateDigest: string; entries: RepositorySnapshotEntry[]; nextCursor: string | null; truncated: boolean; stale: boolean }>;
   readFile(snapshotId: string, relativePath: string, options?: { offset?: number; limit?: number }): Promise<Record<string, unknown>>;
@@ -318,6 +319,10 @@ export function createRepositorySnapshotAuthority(deps: Deps): RepositorySnapsho
     getAttemptSnapshot(jobId, attemptId) {
       const row = db.prepare(`SELECT s.* FROM runs r JOIN repository_snapshots s ON s.snapshot_id=r.repository_snapshot_id WHERE r.task_id=? AND r.attempt_id=?`).get(jobId, attemptId) as Record<string, unknown> | undefined;
       return row ? rowToRecord(row) : undefined;
+    },
+    getEntry(snapshotId, relativePath) {
+      if (!getSnapshot(snapshotId)) return undefined;
+      return entriesFor(snapshotId).find((entry) => entry.path === normalizeRelative(relativePath));
     },
     compareSnapshots(baseId, currentId) {
       const base = getSnapshot(baseId); const current = getSnapshot(currentId);

--- a/core/v4/codebase/safeChangeAuthority.ts
+++ b/core/v4/codebase/safeChangeAuthority.ts
@@ -1,0 +1,821 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { Db } from '../daemon/db/connection';
+import type { AttemptRecord, JobRecord } from '../daemon/jobEngine';
+import type { JobProofAuthority } from '../daemon/jobProofAuthority';
+import { isPathAllowed, isWithin, realpathWithFallback } from '../sandboxFs';
+import { writeFileVerified } from '../writeFileVerified';
+import type {
+  RepositorySnapshotAuthority,
+  RepositorySnapshotEntry,
+  RepositorySnapshotRecord,
+} from './repositorySnapshotAuthority';
+
+export type FileChangeOperation = 'create' | 'modify' | 'patch' | 'delete' | 'move' | 'rename';
+
+export interface FileChangePlan {
+  operation: FileChangeOperation;
+  path: string;
+  destinationPath?: string;
+  content?: string;
+  find?: string;
+  replace?: string;
+  replaceAll?: boolean;
+}
+
+export interface FilePrecondition {
+  path: string;
+  canonicalPath: string;
+  exists: boolean;
+  size: number | null;
+  modifiedAt: number | null;
+  mode: number | null;
+  contentHash: string | null;
+  encoding: 'utf8' | 'binary' | 'absent';
+  byteOrderMark: boolean;
+  lineEnding: 'lf' | 'crlf' | 'mixed' | 'none';
+}
+
+export interface FilePostcondition extends FilePrecondition {}
+
+export interface ChangeIntentRecord {
+  intentId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  fenceToken: string;
+  toolCallId: string;
+  baseSnapshotId: string;
+  operation: FileChangeOperation;
+  canonicalTarget: string;
+  canonicalDestination: string | null;
+  expectedScope: string[];
+  originalHash: string | null;
+  originalMetadata: FilePrecondition;
+  destinationOriginalMetadata: FilePrecondition | null;
+  planDigest: string;
+  plannedResultHash: string | null;
+  plannedResultSize: number | null;
+  effectId: string | null;
+  approvalId: string | null;
+  actionDigest: string | null;
+  claimId: string;
+  state: 'planned' | 'executing' | 'committed' | 'failed' | 'unknown';
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ChangeRecord {
+  changeId: string;
+  intentId: string;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  fenceToken: string;
+  effectId: string;
+  baseSnapshotId: string;
+  state: 'committed' | 'failed' | 'unknown';
+  resultHash: string | null;
+  resultMetadata: FilePostcondition | null;
+  diffEvidenceId: string | null;
+  descendantSnapshotId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: number;
+  completedAt: number | null;
+}
+
+export interface SafeChangeIo {
+  readback?: (canonicalPath: string) => Promise<Buffer>;
+  afterMutation?: (intent: ChangeIntentRecord) => Promise<void>;
+}
+
+export class SafeChangeAuthorityError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = 'SafeChangeAuthorityError';
+  }
+}
+
+export interface SafeChangeAuthority {
+  prepare(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    toolCallId: string; baseSnapshotId: string; plan: FileChangePlan; producer: string;
+  }): Promise<ChangeIntentRecord>;
+  bindEffect(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    intentId: string; effectId: string;
+  }): ChangeIntentRecord;
+  bindApproval(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    intentId: string; effectId: string; approvalId: string; actionDigest: string;
+  }): ChangeIntentRecord;
+  execute(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    intentId: string; effectId: string; approvalId: string; actionDigest: string;
+    plan: FileChangePlan; producer: string; signal?: AbortSignal;
+  }): Promise<ChangeRecord>;
+  getIntent(intentId: string): ChangeIntentRecord | undefined;
+  getIntentForToolCall(attemptId: string, generation: number, toolCallId: string): ChangeIntentRecord | undefined;
+  getRecord(intentId: string): ChangeRecord | undefined;
+  listRecords(jobId: string): ChangeRecord[];
+}
+
+export async function fileChangePlanForTool(
+  toolName: string,
+  args: Readonly<Record<string, unknown>>,
+  rootPath: string,
+  priorOperation?: FileChangeOperation,
+): Promise<FileChangePlan | null> {
+  if (toolName === 'file_write') {
+    const requested = String(args.path ?? args.file ?? '').trim();
+    const content = typeof args.content === 'string' ? args.content : '';
+    if (priorOperation === 'create' || priorOperation === 'modify') {
+      return { operation: priorOperation, path: requested, content };
+    }
+    let exists = false;
+    try { exists = (await fs.stat(path.resolve(rootPath, requested))).isFile(); } catch { /* absent */ }
+    return { operation: exists ? 'modify' : 'create', path: requested, content };
+  }
+  if (toolName === 'file_patch') {
+    return {
+      operation: 'patch', path: String(args.path ?? args.file ?? '').trim(),
+      find: typeof args.find === 'string' ? args.find : '',
+      replace: typeof args.replace === 'string' ? args.replace : '',
+      replaceAll: args.replace_all === true,
+    };
+  }
+  if (toolName === 'file_delete') {
+    if (args.recursive === true) throw new SafeChangeAuthorityError('UNSUPPORTED_MULTI_FILE_CHANGE', 'Recursive deletion requires separately tracked file changes');
+    return { operation: 'delete', path: String(args.path ?? args.file ?? '').trim() };
+  }
+  if (toolName === 'file_move') {
+    const source = String(args.from ?? args.source ?? '').trim();
+    const destinationPath = String(args.to ?? args.dest ?? args.destination ?? '').trim();
+    const operation = priorOperation === 'move' || priorOperation === 'rename'
+      ? priorOperation
+      : path.dirname(path.resolve(rootPath, source)) === path.dirname(path.resolve(rootPath, destinationPath))
+        ? 'rename' : 'move';
+    return { operation, path: source, destinationPath };
+  }
+  return null;
+}
+
+export function projectSafeChangeResult(
+  record: ChangeRecord,
+  intent: ChangeIntentRecord,
+): Record<string, unknown> {
+  return {
+    success: record.state === 'committed',
+    changeId: record.changeId,
+    intentId: intent.intentId,
+    effectId: record.effectId,
+    operation: intent.operation,
+    path: intent.canonicalTarget,
+    ...(intent.canonicalDestination ? { destination: intent.canonicalDestination } : {}),
+    resultHash: record.resultHash,
+    descendantSnapshotId: record.descendantSnapshotId,
+    evidenceId: record.diffEvidenceId,
+    verified: record.state === 'committed' && record.diffEvidenceId !== null,
+  };
+}
+
+interface Deps {
+  db: Db;
+  repository: RepositorySnapshotAuthority;
+  proof: JobProofAuthority;
+  getJob(jobId: string): JobRecord | null;
+  getAttempt(attemptId: string): AttemptRecord | null;
+  appendJobEvent(command: {
+    jobId: string; attemptId: string; generation: number; type: string;
+    payload?: Record<string, unknown> | null; producer: string; idempotencyKey: string;
+  }): { applied: boolean; duplicate: boolean; conflict?: string };
+}
+
+const HASH = 'sha256';
+const id = (prefix: string): string => `${prefix}_${randomBytes(16).toString('hex')}`;
+const digest = (value: unknown): string => createHash(HASH).update(stableJson(value)).digest('hex');
+const normalizeRelative = (value: string): string => value.split(path.sep).join('/').replace(/^\.\//, '');
+const sameCanonicalPath = (left: string, right: string): boolean => (
+  process.platform === 'win32'
+    ? path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase()
+    : path.resolve(left) === path.resolve(right)
+);
+
+function stableJson(value: unknown): string {
+  const visit = (input: unknown): unknown => {
+    if (Array.isArray(input)) return input.map(visit);
+    if (input && typeof input === 'object') {
+      const record = input as Record<string, unknown>;
+      return Object.fromEntries(Object.keys(record).sort().map((key) => [key, visit(record[key])]));
+    }
+    return input;
+  };
+  return JSON.stringify(visit(value));
+}
+
+function isTerminal(status: string): boolean {
+  return ['succeeded', 'completed', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown', 'interrupted'].includes(status);
+}
+
+function lineEndingOf(text: string): FilePrecondition['lineEnding'] {
+  const crlf = (text.match(/\r\n/g) ?? []).length;
+  const lf = (text.match(/(?<!\r)\n/g) ?? []).length;
+  if (crlf > 0 && lf > 0) return 'mixed';
+  if (crlf > 0) return 'crlf';
+  if (lf > 0) return 'lf';
+  return 'none';
+}
+
+function decodeText(bytes: Buffer): { text: string; byteOrderMark: boolean; lineEnding: FilePrecondition['lineEnding'] } | null {
+  if (bytes.subarray(0, 8_192).includes(0)) return null;
+  try {
+    const byteOrderMark = bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf;
+    const body = byteOrderMark ? bytes.subarray(3) : bytes;
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(body);
+    return { text, byteOrderMark, lineEnding: lineEndingOf(text) };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeNewlines(text: string, lineEnding: FilePrecondition['lineEnding']): string {
+  if (lineEnding !== 'crlf') return text;
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
+}
+
+function formatContent(text: string, precondition: FilePrecondition): string {
+  const normalized = normalizeNewlines(text, precondition.lineEnding);
+  return precondition.byteOrderMark ? `\ufeff${normalized.replace(/^\ufeff/, '')}` : normalized.replace(/^\ufeff/, '');
+}
+
+async function inspectFile(canonicalPath: string): Promise<FilePrecondition> {
+  try {
+    const stat = await fs.stat(canonicalPath);
+    if (!stat.isFile()) throw new SafeChangeAuthorityError('UNSUPPORTED_PATH_KIND', 'Codebase changes require a regular file');
+    const bytes = await fs.readFile(canonicalPath);
+    const decoded = decodeText(bytes);
+    return {
+      path: canonicalPath,
+      canonicalPath,
+      exists: true,
+      size: stat.size,
+      modifiedAt: stat.mtimeMs,
+      mode: stat.mode,
+      contentHash: createHash(HASH).update(bytes).digest('hex'),
+      encoding: decoded ? 'utf8' : 'binary',
+      byteOrderMark: decoded?.byteOrderMark ?? false,
+      lineEnding: decoded?.lineEnding ?? 'none',
+    };
+  } catch (error) {
+    if (error instanceof SafeChangeAuthorityError) throw error;
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    return {
+      path: canonicalPath,
+      canonicalPath,
+      exists: false,
+      size: null,
+      modifiedAt: null,
+      mode: null,
+      contentHash: null,
+      encoding: 'absent',
+      byteOrderMark: false,
+      lineEnding: 'none',
+    };
+  }
+}
+
+function sameSource(expected: RepositorySnapshotEntry, current: FilePrecondition): boolean {
+  return current.exists
+    && expected.contentHash !== null
+    && current.contentHash === expected.contentHash
+    && current.size === expected.size
+    && current.modifiedAt === expected.modifiedAt
+    && current.mode === expected.mode;
+}
+
+function simpleDiff(before: string | null, after: string | null, relativePath: string): string {
+  const from = before === null ? [] : before.split(/\r?\n/);
+  const to = after === null ? [] : after.split(/\r?\n/);
+  const lines = [`--- a/${relativePath}`, `+++ b/${relativePath}`];
+  const max = Math.max(from.length, to.length);
+  for (let index = 0; index < max; index += 1) {
+    if (from[index] === to[index]) continue;
+    if (from[index] !== undefined) lines.push(`-${from[index]}`);
+    if (to[index] !== undefined) lines.push(`+${to[index]}`);
+    if (lines.join('\n').length > 128_000) { lines.push('... diff truncated ...'); break; }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function planHasRequiredFields(plan: FileChangePlan): void {
+  if (!plan.path || /[\0\r\n]/.test(plan.path)) throw new SafeChangeAuthorityError('INVALID_CHANGE_PLAN', 'Change target path is required');
+  if ((plan.operation === 'create' || plan.operation === 'modify') && typeof plan.content !== 'string') {
+    throw new SafeChangeAuthorityError('INVALID_CHANGE_PLAN', 'Text content is required');
+  }
+  if (plan.operation === 'patch' && (typeof plan.find !== 'string' || !plan.find || typeof plan.replace !== 'string')) {
+    throw new SafeChangeAuthorityError('INVALID_CHANGE_PLAN', 'Patch find and replace text are required');
+  }
+  if ((plan.operation === 'move' || plan.operation === 'rename') && !plan.destinationPath) {
+    throw new SafeChangeAuthorityError('INVALID_CHANGE_PLAN', 'Move destination is required');
+  }
+}
+
+export function createSafeChangeAuthority(deps: Deps, io: SafeChangeIo = {}): SafeChangeAuthority {
+  const { db } = deps;
+
+  const assertAuthority = (input: { jobId: string; attemptId: string; generation: number; fenceToken: string }): void => {
+    const job = deps.getJob(input.jobId);
+    const attempt = deps.getAttempt(input.attemptId);
+    if (!job || !attempt || attempt.jobId !== job.id || job.activeAttemptId !== attempt.id
+      || isTerminal(job.status) || attempt.generation !== input.generation
+      || attempt.fenceToken !== input.fenceToken || attempt.leaseExpiresAt === null
+      || attempt.leaseExpiresAt <= Date.now() || isTerminal(attempt.status)) {
+      throw new SafeChangeAuthorityError('STALE_CHANGE_AUTHORITY', 'Attempt generation or fence no longer owns this repository change');
+    }
+  };
+
+  const mapIntent = (row: Record<string, unknown>): ChangeIntentRecord => ({
+    intentId: String(row.intent_id), jobId: String(row.job_id), attemptId: String(row.attempt_id),
+    generation: Number(row.generation), fenceToken: String(row.fence_token), toolCallId: String(row.tool_call_id),
+    baseSnapshotId: String(row.base_snapshot_id), operation: row.operation as FileChangeOperation,
+    canonicalTarget: String(row.canonical_target),
+    canonicalDestination: row.canonical_destination === null ? null : String(row.canonical_destination),
+    expectedScope: JSON.parse(String(row.expected_scope_json)) as string[],
+    originalHash: row.original_hash === null ? null : String(row.original_hash),
+    originalMetadata: JSON.parse(String(row.original_metadata_json)) as FilePrecondition,
+    destinationOriginalMetadata: row.destination_original_metadata_json === null
+      ? null : JSON.parse(String(row.destination_original_metadata_json)) as FilePrecondition,
+    planDigest: String(row.plan_digest), effectId: row.effect_id === null ? null : String(row.effect_id),
+    plannedResultHash: row.planned_result_hash === null ? null : String(row.planned_result_hash),
+    plannedResultSize: row.planned_result_size === null ? null : Number(row.planned_result_size),
+    approvalId: row.approval_id === null ? null : String(row.approval_id),
+    actionDigest: row.action_digest === null ? null : String(row.action_digest),
+    claimId: String(row.claim_id), state: row.state as ChangeIntentRecord['state'],
+    createdAt: Number(row.created_at), updatedAt: Number(row.updated_at),
+  });
+  const getIntent = (intentId: string): ChangeIntentRecord | undefined => {
+    const row = db.prepare('SELECT * FROM repository_change_intents WHERE intent_id=?').get(intentId) as Record<string, unknown> | undefined;
+    return row ? mapIntent(row) : undefined;
+  };
+  const getIntentForToolCall = (attemptId: string, generation: number, toolCallId: string): ChangeIntentRecord | undefined => {
+    const row = db.prepare(
+      'SELECT * FROM repository_change_intents WHERE attempt_id=? AND generation=? AND tool_call_id=?',
+    ).get(attemptId, generation, toolCallId) as Record<string, unknown> | undefined;
+    return row ? mapIntent(row) : undefined;
+  };
+  const mapRecord = (row: Record<string, unknown>): ChangeRecord => ({
+    changeId: String(row.change_id), intentId: String(row.intent_id), jobId: String(row.job_id),
+    attemptId: String(row.attempt_id), generation: Number(row.generation), fenceToken: String(row.fence_token),
+    effectId: String(row.effect_id),
+    baseSnapshotId: String(row.base_snapshot_id), state: row.state as ChangeRecord['state'],
+    resultHash: row.result_hash === null ? null : String(row.result_hash),
+    resultMetadata: row.result_metadata_json === null ? null : JSON.parse(String(row.result_metadata_json)) as FilePostcondition,
+    diffEvidenceId: row.diff_evidence_id === null ? null : String(row.diff_evidence_id),
+    descendantSnapshotId: row.descendant_snapshot_id === null ? null : String(row.descendant_snapshot_id),
+    errorCode: row.error_code === null ? null : String(row.error_code),
+    errorMessage: row.error_message === null ? null : String(row.error_message),
+    createdAt: Number(row.created_at), completedAt: row.completed_at === null ? null : Number(row.completed_at),
+  });
+  const getRecord = (intentId: string): ChangeRecord | undefined => {
+    const row = db.prepare('SELECT * FROM repository_change_records WHERE intent_id=?').get(intentId) as Record<string, unknown> | undefined;
+    return row ? mapRecord(row) : undefined;
+  };
+  const listRecords = (jobId: string): ChangeRecord[] => (
+    db.prepare('SELECT * FROM repository_change_records WHERE job_id=? ORDER BY created_at,change_id').all(jobId) as Array<Record<string, unknown>>
+  ).map(mapRecord);
+
+  const rootFor = (snapshot: RepositorySnapshotRecord): string => {
+    const workspace = deps.repository.getWorkspace(snapshot.workspaceId);
+    if (!workspace) throw new SafeChangeAuthorityError('WORKSPACE_NOT_FOUND', 'Repository workspace is unavailable');
+    return realpathWithFallback(snapshot.repositoryRoot ?? workspace.canonicalPath);
+  };
+
+  const resolveTarget = (root: string, requested: string): { canonical: string; relative: string } => {
+    const lexical = path.resolve(root, requested);
+    if (!isWithin(lexical, root) || lexical === root) {
+      throw new SafeChangeAuthorityError('PATH_OUTSIDE_WORKSPACE', 'Change target is outside the repository workspace');
+    }
+    const canonical = realpathWithFallback(lexical);
+    if (!isWithin(canonical, root)) {
+      throw new SafeChangeAuthorityError('PATH_OUTSIDE_WORKSPACE', 'Change target resolves outside the repository workspace');
+    }
+    const sandbox = isPathAllowed(canonical, 'write', root);
+    if (!sandbox.allowed) throw new SafeChangeAuthorityError('PATH_NOT_ALLOWED', sandbox.violation?.message ?? 'Path is not allowed');
+    return { canonical, relative: normalizeRelative(path.relative(root, lexical)) };
+  };
+
+  const failRecord = (
+    intent: ChangeIntentRecord,
+    state: 'failed' | 'unknown',
+    code: string,
+    message: string,
+    extras: Partial<Pick<ChangeRecord, 'resultHash' | 'resultMetadata' | 'diffEvidenceId' | 'descendantSnapshotId'>> = {},
+  ): void => {
+    const now = Date.now();
+    db.prepare(
+      `UPDATE repository_change_records SET state=?,result_hash=?,result_metadata_json=?,diff_evidence_id=?,
+       descendant_snapshot_id=?,error_code=?,error_message=?,completed_at=? WHERE intent_id=?`,
+    ).run(state, extras.resultHash ?? null, extras.resultMetadata ? JSON.stringify(extras.resultMetadata) : null,
+      extras.diffEvidenceId ?? null, extras.descendantSnapshotId ?? null, code, message, now, intent.intentId);
+    db.prepare('UPDATE repository_change_intents SET state=?,updated_at=? WHERE intent_id=?').run(state, now, intent.intentId);
+  };
+
+  const recordUnknownEvidence = (input: {
+    intent: ChangeIntentRecord; fenceToken: string; producer: string; code: string; message: string;
+    resultMetadata?: FilePostcondition | null; resultHash?: string | null;
+  }): string => {
+    const observedAt = Date.now();
+    const evidence = deps.proof.recordEvidence({
+      jobId: input.intent.jobId, attemptId: input.intent.attemptId, generation: input.intent.generation,
+      fenceToken: input.fenceToken, effectId: input.intent.effectId, source: 'repository.change.readback',
+      producer: input.producer, observedAt, freshUntil: null, coverage: 'unknown',
+      verificationResult: 'unknown', payload: {
+        operation: input.intent.operation, target: input.intent.canonicalTarget,
+        resultHash: input.resultHash ?? null, errorCode: input.code,
+      },
+    });
+    deps.proof.checkClaim({
+      claimId: input.intent.claimId, attemptId: input.intent.attemptId,
+      generation: input.intent.generation, evidenceIds: [evidence.evidenceId], state: 'unknown',
+    });
+    return evidence.evidenceId;
+  };
+
+  return {
+    async prepare(input) {
+      assertAuthority(input);
+      planHasRequiredFields(input.plan);
+      const snapshot = deps.repository.getSnapshot(input.baseSnapshotId);
+      if (!snapshot || snapshot.jobId !== input.jobId || snapshot.attemptId !== input.attemptId
+        || snapshot.generation !== input.generation) {
+        throw new SafeChangeAuthorityError('INVALID_BASE_SNAPSHOT', 'Base repository snapshot is outside the active Attempt');
+      }
+      const root = rootFor(snapshot);
+      const target = resolveTarget(root, input.plan.path);
+      const destination = input.plan.destinationPath ? resolveTarget(root, input.plan.destinationPath) : null;
+      if (destination?.canonical === target.canonical) {
+        throw new SafeChangeAuthorityError('INVALID_CHANGE_PLAN', 'Source and destination must differ');
+      }
+      const planDigest = digest(input.plan);
+      const duplicate = db.prepare(
+        'SELECT * FROM repository_change_intents WHERE attempt_id=? AND generation=? AND tool_call_id=?',
+      ).get(input.attemptId, input.generation, input.toolCallId) as Record<string, unknown> | undefined;
+      if (duplicate) {
+        const existing = mapIntent(duplicate);
+        if (existing.planDigest !== planDigest || (existing.state !== 'committed' && existing.baseSnapshotId !== input.baseSnapshotId)) {
+          throw new SafeChangeAuthorityError('CHANGE_INTENT_CONFLICT', 'ToolCall identity is already bound to a different change');
+        }
+        return existing;
+      }
+      const baseEntry = deps.repository.getEntry(snapshot.id, target.relative);
+      const current = await inspectFile(target.canonical);
+      if (input.plan.operation === 'create') {
+        if (baseEntry || current.exists) throw new SafeChangeAuthorityError('STALE_SOURCE', 'Create target already exists');
+      } else {
+        if (!baseEntry || baseEntry.captureStatus !== 'captured' || baseEntry.contentHash === null) {
+          throw new SafeChangeAuthorityError(current.encoding === 'binary' ? 'BINARY_EDIT_UNSUPPORTED' : 'SOURCE_NOT_CAPTURED', 'Change source was not captured with a full content hash');
+        }
+        if (!sameSource(baseEntry, current)) throw new SafeChangeAuthorityError('STALE_SOURCE', 'Source metadata or content differs from the approved snapshot');
+        if (current.encoding === 'binary') throw new SafeChangeAuthorityError('BINARY_EDIT_UNSUPPORTED', 'Binary repository edits are not supported');
+      }
+      let destinationCurrent: FilePrecondition | null = null;
+      if (destination) {
+        const destinationEntry = deps.repository.getEntry(snapshot.id, destination.relative);
+        destinationCurrent = await inspectFile(destination.canonical);
+        if (destinationEntry || destinationCurrent.exists) {
+          throw new SafeChangeAuthorityError('STALE_DESTINATION', 'Move destination already exists');
+        }
+      }
+      let plannedResultHash: string | null = null;
+      let plannedResultSize: number | null = null;
+      if (input.plan.operation === 'create') {
+        plannedResultHash = createHash(HASH).update(input.plan.content!).digest('hex');
+        plannedResultSize = Buffer.byteLength(input.plan.content!);
+      } else if (input.plan.operation === 'modify') {
+        const planned = formatContent(input.plan.content!, current);
+        plannedResultHash = createHash(HASH).update(planned).digest('hex');
+        plannedResultSize = Buffer.byteLength(planned);
+      } else if (input.plan.operation === 'patch') {
+        const bytes = await fs.readFile(target.canonical);
+        const decoded = decodeText(bytes);
+        if (!decoded) throw new SafeChangeAuthorityError('BINARY_EDIT_UNSUPPORTED', 'Binary repository edits are not supported');
+        const count = decoded.text.split(input.plan.find!).length - 1;
+        if (count === 0) throw new SafeChangeAuthorityError('PATCH_NO_MATCH', 'Patch find text has no exact match');
+        if (count > 1 && input.plan.replaceAll !== true) throw new SafeChangeAuthorityError('PATCH_AMBIGUOUS', `Patch find text has ${count} matches`);
+        const replacement = normalizeNewlines(input.plan.replace!, current.lineEnding);
+        const next = input.plan.replaceAll === true
+          ? decoded.text.split(input.plan.find!).join(replacement)
+          : decoded.text.replace(input.plan.find!, replacement);
+        const planned = formatContent(next, current);
+        plannedResultHash = createHash(HASH).update(planned).digest('hex');
+        plannedResultSize = Buffer.byteLength(planned);
+      } else if (input.plan.operation === 'move' || input.plan.operation === 'rename') {
+        plannedResultHash = current.contentHash;
+        plannedResultSize = current.size;
+      }
+      const intentId = id('change_intent');
+      const claim = deps.proof.createClaim({
+        jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+        category: 'contract', statement: `repository ${input.plan.operation} matches approved source: ${target.relative}`,
+        required: true,
+      });
+      const now = Date.now();
+      const expectedScope = [target.relative, ...(destination ? [destination.relative] : [])].sort();
+      db.prepare(
+        `INSERT INTO repository_change_intents (
+          intent_id,job_id,attempt_id,generation,fence_token,tool_call_id,base_snapshot_id,operation,
+          canonical_target,canonical_destination,expected_scope_json,original_hash,original_metadata_json,
+          destination_original_metadata_json,plan_digest,planned_result_hash,planned_result_size,
+          effect_id,approval_id,action_digest,claim_id,state,created_at,updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'planned',?,?)`,
+      ).run(intentId,input.jobId,input.attemptId,input.generation,input.fenceToken,input.toolCallId,input.baseSnapshotId,input.plan.operation,
+        target.canonical,destination?.canonical??null,JSON.stringify(expectedScope),current.contentHash,JSON.stringify(current),
+        destinationCurrent ? JSON.stringify(destinationCurrent) : null,planDigest,plannedResultHash,plannedResultSize,
+        null,null,null,claim.claimId,now,now);
+      deps.appendJobEvent({
+        jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+        type: 'repository.change_intent_prepared', payload: { intentId, operation: input.plan.operation, baseSnapshotId: input.baseSnapshotId },
+        producer: input.producer, idempotencyKey: `repository-change-intent:${intentId}`,
+      });
+      return getIntent(intentId)!;
+    },
+
+    bindEffect(input) {
+      assertAuthority(input);
+      const intent = getIntent(input.intentId);
+      if (!intent || intent.jobId !== input.jobId || intent.attemptId !== input.attemptId || intent.generation !== input.generation) {
+        throw new SafeChangeAuthorityError('CHANGE_INTENT_NOT_FOUND', 'Change intent is outside the active Attempt');
+      }
+      const effect = db.prepare('SELECT job_id,attempt_id,generation,tool_call_id FROM side_effect_ledger WHERE key=?')
+        .get(input.effectId) as { job_id: string; attempt_id: string; generation: number; tool_call_id: string } | undefined;
+      if (!effect || effect.job_id !== input.jobId || effect.attempt_id !== input.attemptId
+        || effect.generation !== input.generation || effect.tool_call_id !== intent.toolCallId) {
+        throw new SafeChangeAuthorityError('EFFECT_BINDING_MISMATCH', 'Effect does not match the planned repository change');
+      }
+      if (intent.effectId && intent.effectId !== input.effectId) throw new SafeChangeAuthorityError('EFFECT_BINDING_MISMATCH', 'Change intent already has a different Effect');
+      db.prepare('UPDATE repository_change_intents SET effect_id=?,updated_at=? WHERE intent_id=?')
+        .run(input.effectId, Date.now(), input.intentId);
+      return getIntent(input.intentId)!;
+    },
+
+    bindApproval(input) {
+      assertAuthority(input);
+      const intent = getIntent(input.intentId);
+      if (!intent || intent.effectId !== input.effectId) throw new SafeChangeAuthorityError('EFFECT_BINDING_MISMATCH', 'Change intent is not bound to this Effect');
+      const approval = db.prepare(
+        'SELECT job_id,attempt_id,generation,tool_call_id,effect_id,action_digest FROM approvals WHERE approval_id=?',
+      ).get(input.approvalId) as {
+        job_id: string; attempt_id: string; generation: number; tool_call_id: string;
+        effect_id: string | null; action_digest: string;
+      } | undefined;
+      if (!approval || approval.job_id !== input.jobId || approval.attempt_id !== input.attemptId
+        || approval.generation !== input.generation || approval.tool_call_id !== intent.toolCallId
+        || approval.effect_id !== input.effectId || approval.action_digest !== input.actionDigest) {
+        throw new SafeChangeAuthorityError('APPROVAL_BINDING_MISMATCH', 'Approval does not match the exact planned change');
+      }
+      if ((intent.approvalId && intent.approvalId !== input.approvalId)
+        || (intent.actionDigest && intent.actionDigest !== input.actionDigest)) {
+        throw new SafeChangeAuthorityError('APPROVAL_BINDING_MISMATCH', 'Change intent already has a different approval');
+      }
+      db.prepare('UPDATE repository_change_intents SET approval_id=?,action_digest=?,updated_at=? WHERE intent_id=?')
+        .run(input.approvalId, input.actionDigest, Date.now(), input.intentId);
+      return getIntent(input.intentId)!;
+    },
+
+    async execute(input) {
+      const intent = getIntent(input.intentId);
+      if (!intent || intent.jobId !== input.jobId || intent.attemptId !== input.attemptId || intent.generation !== input.generation) {
+        throw new SafeChangeAuthorityError('CHANGE_INTENT_NOT_FOUND', 'Change intent is outside the active Attempt');
+      }
+      if (intent.planDigest !== digest(input.plan)) throw new SafeChangeAuthorityError('APPROVED_CHANGE_MISMATCH', 'Execution plan differs from the approved change intent');
+      if (intent.effectId !== input.effectId || intent.approvalId !== input.approvalId || intent.actionDigest !== input.actionDigest) {
+        throw new SafeChangeAuthorityError('APPROVAL_BINDING_MISMATCH', 'Execution does not match the bound Effect and approval');
+      }
+      const prior = getRecord(input.intentId);
+      if (prior?.state === 'committed') return prior;
+      if (prior) throw new SafeChangeAuthorityError('CHANGE_OUTCOME_UNRESOLVED', 'A prior change attempt did not reach a verified committed state');
+      assertAuthority(input);
+      const approval = db.prepare(
+        `SELECT state,job_id,attempt_id,generation,tool_call_id,effect_id,action_digest
+           FROM approvals WHERE approval_id=?`,
+      ).get(input.approvalId) as Record<string, unknown> | undefined;
+      if (!approval || approval.state !== 'executed' || approval.job_id !== input.jobId
+        || approval.attempt_id !== input.attemptId || Number(approval.generation) !== input.generation
+        || approval.tool_call_id !== intent.toolCallId || approval.effect_id !== input.effectId
+        || approval.action_digest !== input.actionDigest) {
+        throw new SafeChangeAuthorityError('APPROVAL_NOT_EXECUTABLE', 'Exact approval was not revalidated for execution');
+      }
+      const effect = db.prepare(
+        'SELECT job_id,attempt_id,generation,tool_call_id,effect_state FROM side_effect_ledger WHERE key=?',
+      ).get(input.effectId) as Record<string, unknown> | undefined;
+      if (!effect || effect.job_id !== input.jobId || effect.attempt_id !== input.attemptId
+        || Number(effect.generation) !== input.generation || effect.tool_call_id !== intent.toolCallId
+        || effect.effect_state !== 'started') {
+        throw new SafeChangeAuthorityError('EFFECT_NOT_EXECUTABLE', 'Producing Effect is not active for this change');
+      }
+      if (input.signal?.aborted) throw new SafeChangeAuthorityError('CHANGE_CANCELLED', 'Repository change was cancelled before mutation');
+
+      const baseSnapshot = deps.repository.getSnapshot(intent.baseSnapshotId);
+      if (!baseSnapshot) throw new SafeChangeAuthorityError('INVALID_BASE_SNAPSHOT', 'Base repository snapshot is unavailable');
+      const root = rootFor(baseSnapshot);
+      const refreshedTarget = realpathWithFallback(intent.canonicalTarget);
+      if (!isWithin(refreshedTarget, root) || !sameCanonicalPath(refreshedTarget, intent.canonicalTarget)) {
+        throw new SafeChangeAuthorityError('TARGET_IDENTITY_CHANGED', 'Canonical target identity changed after approval');
+      }
+      if (intent.canonicalDestination) {
+        const refreshedDestination = realpathWithFallback(intent.canonicalDestination);
+        if (!isWithin(refreshedDestination, root) || !sameCanonicalPath(refreshedDestination, intent.canonicalDestination)) {
+          throw new SafeChangeAuthorityError('TARGET_IDENTITY_CHANGED', 'Canonical destination identity changed after approval');
+        }
+      }
+
+      const current = await inspectFile(intent.canonicalTarget);
+      const expected = intent.originalMetadata;
+      if (expected.exists !== current.exists || expected.contentHash !== current.contentHash
+        || expected.size !== current.size || expected.modifiedAt !== current.modifiedAt || expected.mode !== current.mode) {
+        throw new SafeChangeAuthorityError('STALE_SOURCE', 'Source metadata or content changed after approval');
+      }
+      if (intent.canonicalDestination) {
+        const destination = await inspectFile(intent.canonicalDestination);
+        const expectedDestination = intent.destinationOriginalMetadata;
+        if (!expectedDestination || destination.exists !== expectedDestination.exists
+          || destination.contentHash !== expectedDestination.contentHash || destination.modifiedAt !== expectedDestination.modifiedAt) {
+          throw new SafeChangeAuthorityError('STALE_DESTINATION', 'Destination changed after approval');
+        }
+      }
+      const now = Date.now();
+      const changeId = id('change');
+      db.transaction(() => {
+        assertAuthority(input);
+        db.prepare('UPDATE repository_change_intents SET state=\'executing\',updated_at=? WHERE intent_id=? AND state=\'planned\'')
+          .run(now, intent.intentId);
+        db.prepare(
+          `INSERT INTO repository_change_records (
+            change_id,intent_id,job_id,attempt_id,generation,fence_token,effect_id,base_snapshot_id,state,
+            result_hash,result_metadata_json,diff_evidence_id,descendant_snapshot_id,error_code,error_message,created_at,completed_at
+          ) VALUES (?,?,?,?,?,?,?,?,'unknown',NULL,NULL,NULL,NULL,NULL,NULL,?,NULL)`,
+        ).run(changeId,intent.intentId,input.jobId,input.attemptId,input.generation,input.fenceToken,input.effectId,intent.baseSnapshotId,now);
+      }).immediate();
+
+      let beforeText: string | null = null;
+      let expectedText: string | null = null;
+      try {
+        if (current.exists) {
+          const bytes = await fs.readFile(intent.canonicalTarget);
+          const decoded = decodeText(bytes);
+          if (!decoded) throw new SafeChangeAuthorityError('BINARY_EDIT_UNSUPPORTED', 'Binary repository edits are not supported');
+          beforeText = `${decoded.byteOrderMark ? '\ufeff' : ''}${decoded.text}`;
+        }
+        if (input.plan.operation === 'create') {
+          expectedText = input.plan.content!;
+          await writeFileVerified(intent.canonicalTarget, expectedText);
+        } else if (input.plan.operation === 'modify') {
+          expectedText = formatContent(input.plan.content!, current);
+          await writeFileVerified(intent.canonicalTarget, expectedText);
+        } else if (input.plan.operation === 'patch') {
+          const body = beforeText!.replace(/^\ufeff/, '');
+          const count = body.split(input.plan.find!).length - 1;
+          if (count === 0) throw new SafeChangeAuthorityError('PATCH_NO_MATCH', 'Patch find text has no exact match');
+          if (count > 1 && input.plan.replaceAll !== true) throw new SafeChangeAuthorityError('PATCH_AMBIGUOUS', `Patch find text has ${count} matches`);
+          const replacement = normalizeNewlines(input.plan.replace!, current.lineEnding);
+          const next = input.plan.replaceAll === true
+            ? body.split(input.plan.find!).join(replacement)
+            : body.replace(input.plan.find!, replacement);
+          expectedText = formatContent(next, current);
+          await writeFileVerified(intent.canonicalTarget, expectedText);
+        } else if (input.plan.operation === 'delete') {
+          await fs.unlink(intent.canonicalTarget);
+        } else {
+          await fs.mkdir(path.dirname(intent.canonicalDestination!), { recursive: true });
+          try { await fs.rename(intent.canonicalTarget, intent.canonicalDestination!); }
+          catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'EXDEV') {
+              throw new SafeChangeAuthorityError('CROSS_DEVICE_MOVE_UNSUPPORTED', 'Cross-device repository moves require an explicit recoverable plan');
+            }
+            throw error;
+          }
+        }
+        await io.afterMutation?.(intent);
+      } catch (error) {
+        const safe = error instanceof SafeChangeAuthorityError
+          ? error : new SafeChangeAuthorityError('MUTATION_FAILED', error instanceof Error ? error.message : String(error));
+        failRecord(intent, 'unknown', safe.code, safe.message);
+        throw safe;
+      }
+
+      if (input.signal?.aborted) {
+        const code = 'CHANGE_CANCELLED_UNKNOWN';
+        const evidenceId = recordUnknownEvidence({ intent: { ...intent, effectId: input.effectId }, fenceToken: input.fenceToken, producer: input.producer, code, message: 'Cancellation raced with mutation' });
+        failRecord(intent, 'unknown', code, 'Cancellation raced with mutation', { diffEvidenceId: evidenceId });
+        throw new SafeChangeAuthorityError(code, 'Repository change outcome requires reconciliation after cancellation');
+      }
+
+      let resultMetadata: FilePostcondition;
+      let afterText: string | null = null;
+      try {
+        if (input.plan.operation === 'delete') {
+          resultMetadata = await inspectFile(intent.canonicalTarget);
+          if (resultMetadata.exists) throw new Error('deleted target still exists');
+        } else if (input.plan.operation === 'move' || input.plan.operation === 'rename') {
+          const source = await inspectFile(intent.canonicalTarget);
+          resultMetadata = await inspectFile(intent.canonicalDestination!);
+          if (source.exists || !resultMetadata.exists || resultMetadata.contentHash !== current.contentHash) {
+            throw new Error('moved file did not reach the exact destination');
+          }
+          const bytes = io.readback ? await io.readback(intent.canonicalDestination!) : await fs.readFile(intent.canonicalDestination!);
+          const decoded = decodeText(bytes);
+          if (!decoded || createHash(HASH).update(bytes).digest('hex') !== resultMetadata.contentHash) throw new Error('move readback mismatch');
+          afterText = `${decoded.byteOrderMark ? '\ufeff' : ''}${decoded.text}`;
+        } else {
+          const bytes = io.readback ? await io.readback(intent.canonicalTarget) : await fs.readFile(intent.canonicalTarget);
+          const decoded = decodeText(bytes);
+          if (!decoded) throw new Error('readback is not supported UTF-8 text');
+          afterText = `${decoded.byteOrderMark ? '\ufeff' : ''}${decoded.text}`;
+          if (afterText !== expectedText) throw new Error('readback content differs from the planned result');
+          resultMetadata = await inspectFile(intent.canonicalTarget);
+          if (resultMetadata.contentHash !== createHash(HASH).update(bytes).digest('hex')) throw new Error('readback hash mismatch');
+        }
+      } catch (error) {
+        const code = 'READBACK_FAILED';
+        const evidenceId = recordUnknownEvidence({ intent: { ...intent, effectId: input.effectId }, fenceToken: input.fenceToken, producer: input.producer, code, message: error instanceof Error ? error.message : String(error) });
+        failRecord(intent, 'unknown', code, error instanceof Error ? error.message : String(error), { diffEvidenceId: evidenceId });
+        throw new SafeChangeAuthorityError(code, 'Repository mutation could not be verified by fresh readback');
+      }
+
+      let descendant: RepositorySnapshotRecord;
+      try {
+        descendant = await deps.repository.captureSnapshot({
+          jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+          fenceToken: input.fenceToken, requestedPath: rootFor(deps.repository.getSnapshot(intent.baseSnapshotId)!),
+          previousSnapshotId: intent.baseSnapshotId, producer: input.producer,
+        });
+      } catch (error) {
+        const code = 'DESCENDANT_SNAPSHOT_FAILED';
+        const evidenceId = recordUnknownEvidence({ intent: { ...intent, effectId: input.effectId }, fenceToken: input.fenceToken, producer: input.producer, code, message: error instanceof Error ? error.message : String(error), resultMetadata, resultHash: resultMetadata.contentHash });
+        failRecord(intent, 'unknown', code, error instanceof Error ? error.message : String(error), { resultHash: resultMetadata.contentHash, resultMetadata, diffEvidenceId: evidenceId });
+        throw new SafeChangeAuthorityError(code, 'Verified filesystem result could not be bound to a descendant snapshot');
+      }
+      const comparison = deps.repository.compareSnapshots(intent.baseSnapshotId, descendant.id);
+      const changedScope = [...new Set([...comparison.added, ...comparison.removed, ...comparison.changed])].sort();
+      const undeclared = changedScope.filter((item) => !intent.expectedScope.includes(item));
+      const observedAt = Date.now();
+      const evidence = deps.proof.recordEvidence({
+        jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+        fenceToken: input.fenceToken, effectId: input.effectId, source: 'repository.change.readback',
+        producer: input.producer, observedAt, freshUntil: observedAt + 60_000,
+        coverage: 'full', verificationResult: undeclared.length ? 'failed' : 'verified',
+        payload: {
+          operation: intent.operation, baseSnapshotId: intent.baseSnapshotId,
+          descendantSnapshotId: descendant.id, target: intent.canonicalTarget,
+          destination: intent.canonicalDestination, beforeHash: intent.originalHash,
+          resultHash: resultMetadata.contentHash, changedScope,
+          diff: simpleDiff(beforeText, afterText, intent.expectedScope[0]),
+        },
+      });
+      if (undeclared.length) {
+        deps.proof.checkClaim({
+          claimId: intent.claimId, attemptId: input.attemptId, generation: input.generation,
+          evidenceIds: [evidence.evidenceId], state: 'failed',
+        });
+        failRecord(intent, 'failed', 'UNDECLARED_WORKSPACE_CHANGE', `Mutation changed paths outside its approved scope: ${undeclared.join(', ')}`, {
+          resultHash: resultMetadata.contentHash, resultMetadata,
+          diffEvidenceId: evidence.evidenceId, descendantSnapshotId: descendant.id,
+        });
+        throw new SafeChangeAuthorityError('UNDECLARED_WORKSPACE_CHANGE', 'Repository changed outside the approved scope');
+      }
+      deps.proof.checkClaim({
+        claimId: intent.claimId, attemptId: input.attemptId, generation: input.generation,
+        evidenceIds: [evidence.evidenceId], state: 'verified',
+      });
+      const completedAt = Date.now();
+      db.transaction(() => {
+        assertAuthority(input);
+        db.prepare(
+          `UPDATE repository_change_records SET state='committed',result_hash=?,result_metadata_json=?,
+           diff_evidence_id=?,descendant_snapshot_id=?,completed_at=? WHERE intent_id=?`,
+        ).run(resultMetadata.contentHash,JSON.stringify(resultMetadata),evidence.evidenceId,descendant.id,completedAt,intent.intentId);
+        db.prepare("UPDATE repository_change_intents SET state='committed',updated_at=? WHERE intent_id=?")
+          .run(completedAt,intent.intentId);
+      }).immediate();
+      deps.appendJobEvent({
+        jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+        type: 'repository.change_committed', payload: { intentId: intent.intentId, changeId, descendantSnapshotId: descendant.id, evidenceId: evidence.evidenceId },
+        producer: input.producer, idempotencyKey: `repository-change-committed:${intent.intentId}`,
+      });
+      return getRecord(intent.intentId)!;
+    },
+
+    getIntent,
+    getIntentForToolCall,
+    getRecord,
+    listRecords,
+  };
+}

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1529,6 +1529,76 @@ function applyV32(db: Database.Database): void {
   `);
 }
 
+/** Source-fenced repository change intents and their verified outcomes. */
+function applyV33(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS repository_change_intents (
+      intent_id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      fence_token TEXT NOT NULL,
+      tool_call_id TEXT NOT NULL,
+      base_snapshot_id TEXT NOT NULL,
+      operation TEXT NOT NULL,
+      canonical_target TEXT NOT NULL,
+      canonical_destination TEXT,
+      expected_scope_json TEXT NOT NULL,
+      original_hash TEXT,
+      original_metadata_json TEXT NOT NULL,
+      destination_original_metadata_json TEXT,
+      plan_digest TEXT NOT NULL,
+      planned_result_hash TEXT,
+      planned_result_size INTEGER,
+      effect_id TEXT,
+      approval_id TEXT,
+      action_digest TEXT,
+      claim_id TEXT NOT NULL,
+      state TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE(attempt_id, generation, tool_call_id),
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (base_snapshot_id) REFERENCES repository_snapshots(snapshot_id),
+      FOREIGN KEY (effect_id) REFERENCES side_effect_ledger(key),
+      FOREIGN KEY (approval_id) REFERENCES approvals(approval_id),
+      FOREIGN KEY (claim_id) REFERENCES job_claims(claim_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_repository_change_intents_job
+      ON repository_change_intents(job_id, created_at, intent_id);
+    CREATE INDEX IF NOT EXISTS idx_repository_change_intents_snapshot
+      ON repository_change_intents(base_snapshot_id, created_at, intent_id);
+
+    CREATE TABLE IF NOT EXISTS repository_change_records (
+      change_id TEXT PRIMARY KEY,
+      intent_id TEXT NOT NULL UNIQUE,
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      fence_token TEXT NOT NULL,
+      effect_id TEXT NOT NULL,
+      base_snapshot_id TEXT NOT NULL,
+      state TEXT NOT NULL,
+      result_hash TEXT,
+      result_metadata_json TEXT,
+      diff_evidence_id TEXT,
+      descendant_snapshot_id TEXT,
+      error_code TEXT,
+      error_message TEXT,
+      created_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      FOREIGN KEY (intent_id) REFERENCES repository_change_intents(intent_id) ON DELETE CASCADE,
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (effect_id) REFERENCES side_effect_ledger(key),
+      FOREIGN KEY (base_snapshot_id) REFERENCES repository_snapshots(snapshot_id),
+      FOREIGN KEY (diff_evidence_id) REFERENCES job_evidence(evidence_id),
+      FOREIGN KEY (descendant_snapshot_id) REFERENCES repository_snapshots(snapshot_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_repository_change_records_job
+      ON repository_change_records(job_id, created_at, change_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1562,6 +1632,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 30, name: 'durable Job event cursors', apply: applyV30 },
   { version: 31, name: 'kernel projection query indexes', apply: applyV31 },
   { version: 32, name: 'immutable repository snapshots', apply: applyV32 },
+  { version: 33, name: 'source-fenced repository changes', apply: applyV33 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -1596,7 +1667,8 @@ function tableExists(db: Database.Database, name: string): boolean {
 
 function validateLatestSchema(db: Database.Database): void {
   const required = ['tasks', 'runs', 'run_events', 'side_effect_ledger', 'durable_inputs',
-    'workspace_descriptors', 'repository_snapshots', 'repository_snapshot_entries'];
+    'workspace_descriptors', 'repository_snapshots', 'repository_snapshot_entries',
+    'repository_change_intents', 'repository_change_records'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -23,6 +23,11 @@ import type { JobBudgetKind, JobCapabilities } from './jobResourceAuthority';
 import { createJobProofAuthority, type JobProofAuthority } from './jobProofAuthority';
 import { createJobEventProjectionAuthority, type JobEventProjectionAuthority } from './jobEventProjection';
 import { createRepositorySnapshotAuthority, type RepositorySnapshotAuthority } from '../codebase/repositorySnapshotAuthority';
+import {
+  createSafeChangeAuthority,
+  type SafeChangeAuthority,
+  type SafeChangeIo,
+} from '../codebase/safeChangeAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -186,6 +191,7 @@ export interface JobEngine {
   readonly proof: JobProofAuthority;
   readonly projection: JobEventProjectionAuthority;
   readonly repository: RepositorySnapshotAuthority;
+  readonly changes: SafeChangeAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -412,6 +418,7 @@ export interface JobEngine {
 
 export interface CreateJobEngineOptions {
   db: Db;
+  safeChangeIo?: SafeChangeIo;
 }
 
 export class IdempotencyConflictError extends Error {
@@ -2279,6 +2286,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
     appendJobEvent: appendJobEventTx,
   });
+  const changes = createSafeChangeAuthority({
+    db,
+    repository,
+    proof,
+    getJob(jobId) { const row = getJobRow(jobId); return row ? mapJob(row) : null; },
+    getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
+    appendJobEvent: appendJobEventTx,
+  }, opts.safeChangeIo);
 
   return {
     graph,
@@ -2286,6 +2301,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     proof,
     projection,
     repository,
+    changes,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -264,6 +264,7 @@ export async function executeWithDurableToolCall<T>(command: {
   prepared?: PreparedDurableToolCall | null;
   execute: () => Promise<T>;
   isSuccessful?: (result: T) => boolean;
+  captureFilesystemProof?: boolean;
 }): Promise<T> {
   const context = currentJobExecutionContext();
   if (!context) return command.execute();
@@ -292,7 +293,7 @@ export async function executeWithDurableToolCall<T>(command: {
       resultRef: opaqueReference('tool-result', result),
       producer: context.producer,
     }));
-    if (succeeded) captureDurableFileProof(context, prepared);
+    if (succeeded && command.captureFilesystemProof !== false) captureDurableFileProof(context, prepared);
     return result;
   } catch (error) {
     const completion = context.engine.completeToolCall({

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -78,6 +78,12 @@ import {
   type ActionAuthority,
   type PolicySnapshotInput,
 } from './actionAuthority';
+import {
+  fileChangePlanForTool,
+  projectSafeChangeResult,
+  type ChangeIntentRecord,
+  type FileChangePlan,
+} from './codebase/safeChangeAuthority';
 
 /**
  * Risk profile for a tool. Used by the Phase 9 approval engine to decide
@@ -117,6 +123,12 @@ export interface ToolContext {
     snapshotId: string;
     rootPath: string;
     authority: import('./codebase/repositorySnapshotAuthority').RepositorySnapshotAuthority;
+  };
+  /** Optional source-fenced mutation authority for Codebase Mode file tools. */
+  repositoryChange?: {
+    baseSnapshotId: string;
+    rootPath: string;
+    authority: import('./codebase/safeChangeAuthority').SafeChangeAuthority;
   };
   /** Aiden user-data paths. Sessions, memory, skills, logs all live here. */
   paths: AidenPaths;
@@ -476,6 +488,7 @@ export class ToolRegistry {
         riskTier: string;
       } | undefined;
       let preparedToolCall: PreparedDurableToolCall | null | undefined;
+      let preparedRepositoryChange: { intent: ChangeIntentRecord; plan: FileChangePlan } | undefined;
       let effectDescriptor: DurableEffectDescriptor | undefined;
       let approvalWaitId: string | null = null;
       const emit = (phase: ToolActivityUpdate['phase'], attempt?: number): void => {
@@ -638,6 +651,78 @@ export class ToolRegistry {
         context.approvalEngine !== undefined || (context.actionAuthority !== undefined && durableJobContext !== undefined)
       );
       effectDescriptor = preliminaryEffect;
+      if (effectiveMutates && durableJobContext && context.repositoryChange) {
+        try {
+          if (context.repositoryChange.authority !== durableJobContext.engine.changes) {
+            throw new Error('Repository change authority does not match the active Job');
+          }
+          const persistedToolCallId = currentDurableToolCallId(call.id) ?? call.id;
+          const priorIntent = context.repositoryChange.authority.getIntentForToolCall(
+            durableJobContext.attemptId,
+            durableJobContext.generation,
+            persistedToolCallId,
+          );
+          const plan = await fileChangePlanForTool(
+            call.name,
+            args,
+            context.repositoryChange.rootPath,
+            priorIntent?.operation,
+          );
+          if (plan) {
+            const intent = await context.repositoryChange.authority.prepare({
+              jobId: durableJobContext.jobId,
+              attemptId: durableJobContext.attemptId,
+              generation: durableJobContext.generation,
+              fenceToken: durableJobContext.fenceToken,
+              toolCallId: persistedToolCallId,
+              baseSnapshotId: priorIntent?.state === 'committed'
+                ? priorIntent.baseSnapshotId
+                : context.repositoryChange.baseSnapshotId,
+              plan,
+              producer: durableJobContext.producer,
+            });
+            const priorRecord = context.repositoryChange.authority.getRecord(intent.intentId);
+            if (priorRecord?.state === 'committed') {
+              if (priorRecord.descendantSnapshotId) context.repositoryChange.baseSnapshotId = priorRecord.descendantSnapshotId;
+              return finish({
+                id: call.id,
+                name: call.name,
+                result: projectSafeChangeResult(priorRecord, intent),
+              }, 'completed');
+            }
+            preparedRepositoryChange = { intent, plan };
+            effectDescriptor = {
+              ...effectDescriptor,
+              target: intent.canonicalDestination
+                ? `${intent.canonicalTarget} -> ${intent.canonicalDestination}`
+                : intent.canonicalTarget,
+              reconciliationData: {
+                ...effectDescriptor.reconciliationData,
+                path: intent.canonicalDestination ?? intent.canonicalTarget,
+                sourcePath: intent.canonicalTarget,
+                destinationPath: intent.canonicalDestination ?? undefined,
+                expectedContentSha256: intent.plannedResultHash ?? undefined,
+                expectedSize: intent.plannedResultSize ?? undefined,
+              },
+            };
+          }
+        } catch (error) {
+          return finish({
+            id: call.id,
+            name: call.name,
+            result: null,
+            error: error instanceof Error ? error.message : String(error),
+          }, 'blocked');
+        }
+      }
+      if (preparedRepositoryChange && (!context.actionAuthority || !context.approvalEngine)) {
+        return finish({
+          id: call.id,
+          name: call.name,
+          result: null,
+          error: 'Source-fenced repository changes require exact interactive approval',
+        }, 'blocked');
+      }
       if (effectiveMutates && durableJobContext) {
         try {
           preparedToolCall = prepareDurableToolCall({
@@ -649,6 +734,16 @@ export class ToolRegistry {
             effect: effectDescriptor,
             approvalState: approvalGated ? 'pending' : 'not_required',
           });
+          if (preparedRepositoryChange && preparedToolCall?.effectId) {
+            context.repositoryChange!.authority.bindEffect({
+              jobId: durableJobContext.jobId,
+              attemptId: durableJobContext.attemptId,
+              generation: durableJobContext.generation,
+              fenceToken: durableJobContext.fenceToken,
+              intentId: preparedRepositoryChange.intent.intentId,
+              effectId: preparedToolCall.effectId,
+            });
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return finish({ id: call.id, name: call.name, result: null, error: message }, 'blocked');
@@ -794,6 +889,18 @@ export class ToolRegistry {
             riskTier: effectiveTier ?? 'caution',
             effectId: preparedToolCall?.effectId ?? null,
           };
+          if (preparedRepositoryChange && durableApproval.effectId) {
+            context.repositoryChange!.authority.bindApproval({
+              jobId: jobContext.jobId,
+              attemptId: jobContext.attemptId,
+              generation: jobContext.generation,
+              fenceToken: jobContext.fenceToken,
+              intentId: preparedRepositoryChange.intent.intentId,
+              effectId: durableApproval.effectId,
+              approvalId: durableApproval.approvalId,
+              actionDigest: durableApproval.actionDigest,
+            });
+          }
         }
         if (!context.approvalEngine) {
           try {
@@ -1050,6 +1157,7 @@ export class ToolRegistry {
           mutates: effectiveMutates,
           effect: effectDescriptor,
           prepared: preparedToolCall,
+          captureFilesystemProof: preparedRepositoryChange === undefined,
           execute: async () => {
             const jobContext = currentJobExecutionContext();
             if (
@@ -1080,7 +1188,26 @@ export class ToolRegistry {
               }).record.waitId;
             }
             try {
-              const value = await handler.execute(a, signal ? { ...context, signal } : context);
+              let value: unknown;
+              if (preparedRepositoryChange && durableApproval?.effectId) {
+                const record = await context.repositoryChange!.authority.execute({
+                  jobId: jobContext!.jobId,
+                  attemptId: jobContext!.attemptId,
+                  generation: jobContext!.generation,
+                  fenceToken: jobContext!.fenceToken,
+                  intentId: preparedRepositoryChange.intent.intentId,
+                  effectId: durableApproval.effectId,
+                  approvalId: durableApproval.approvalId,
+                  actionDigest: durableApproval.actionDigest,
+                  plan: preparedRepositoryChange.plan,
+                  producer: jobContext!.producer,
+                  signal,
+                });
+                if (record.descendantSnapshotId) context.repositoryChange!.baseSnapshotId = record.descendantSnapshotId;
+                value = projectSafeChangeResult(record, preparedRepositoryChange.intent);
+              } else {
+                value = await handler.execute(a, signal ? { ...context, signal } : context);
+              }
               if (waitId && jobContext?.controlAuthority) {
                 const status = value && typeof value === 'object'
                   ? String((value as Record<string, unknown>).status ?? '') : '';

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -26,13 +26,21 @@ describe('repository snapshot migration v32', () => {
     db.prepare(`INSERT INTO tasks (id,title,goal,status,created_at,updated_at,session_id,trace_ids,artifact_ids,root_job_id,next_event_sequence) VALUES ('job','job','goal','queued',?,?, 'session','[]','[]','job',1)`).run(now,now);
     db.prepare(`INSERT INTO runs (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence) VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
 
-    expect(runMigrations(db)).toEqual({ from: 31, to: 32 });
-    expect(LATEST_SCHEMA_VERSION).toBe(32);
+    const migration = MIGRATIONS_FOR_TESTS.find((item) => item.version === 32)!;
+    db.transaction(() => {
+      migration.apply!(db!);
+      db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
+    }).immediate();
+    expect(LATEST_SCHEMA_VERSION).toBe(33);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 32 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: 33 });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
+      { name: 'repository_change_intents' }, { name: 'repository_change_records' },
+    ]);
+    expect(runMigrations(db)).toEqual({ from: 33, to: 33 });
   });
 });

--- a/tests/v4/codebase/safeChangeAuthority.test.ts
+++ b/tests/v4/codebase/safeChangeAuthority.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+import { chmod, lstat, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createActionAuthority,
+  normalizeExecutionPlan,
+  type ActionAuthority,
+  type PolicySnapshotInput,
+} from '../../../core/v4/actionAuthority';
+import type { FileChangePlan, SafeChangeIo } from '../../../core/v4/codebase/safeChangeAuthority';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type AdmissionResult, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { normalizedArgsDigest } from '../../../core/v4/daemon/jobExecutionContext';
+
+const sha256 = (value: Buffer | string): string => createHash('sha256').update(value).digest('hex');
+
+const policy = (root: string): PolicySnapshotInput => ({
+  trustLevel: 'Assistant',
+  autonomyPolicy: 'ask_for_mutations',
+  approvalMode: 'smart',
+  toolMetadataVersion: 'codebase-v1',
+  sandboxPolicy: { roots: [root], deny: [] },
+  networkPolicy: {},
+  pluginGrants: [],
+  mcpGrants: [],
+  workspaceOverrides: {},
+  jobOverrides: {},
+});
+
+function toolFor(plan: FileChangePlan): string {
+  if (plan.operation === 'patch') return 'file_patch';
+  if (plan.operation === 'delete') return 'file_delete';
+  if (plan.operation === 'move' || plan.operation === 'rename') return 'file_move';
+  return 'file_write';
+}
+
+function argsFor(plan: FileChangePlan): Record<string, unknown> {
+  if (plan.operation === 'patch') {
+    return { path: plan.path, find: plan.find, replace: plan.replace, replace_all: plan.replaceAll === true };
+  }
+  if (plan.operation === 'delete') return { path: plan.path };
+  if (plan.operation === 'move' || plan.operation === 'rename') {
+    return { from: plan.path, to: plan.destinationPath };
+  }
+  return { path: plan.path, content: plan.content };
+}
+
+describe('source-fenced safe change authority', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let actions: ActionAuthority;
+  let root: string;
+  let admission: AdmissionResult;
+  let generation: number;
+  let fenceToken: string;
+  let ordinal: number;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('change-test',1,'localhost',1,1,'4.17.0')`,
+    ).run();
+    engine = createJobEngine({ db });
+    actions = createActionAuthority({ db, jobEngine: engine });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-safe-change-'));
+    admission = engine.submitJob({
+      entryPoint: 'test', source: 'unit', sessionId: 'safe-change', workspaceId: root,
+      instanceId: 'change-test', idempotencyNamespace: 'safe-change',
+      idempotencyKey: path.basename(root), goal: 'change repository safely',
+    });
+    const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 60_000 });
+    generation = lease.generation!;
+    fenceToken = lease.fenceToken!;
+    engine.transitionAttempt({
+      attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!, generation,
+      fenceToken, to: 'running', eventIdempotencyKey: 'change-attempt-running', producer: 'test',
+    });
+    engine.transitionJob({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation, fenceToken,
+      expectedStateVersion: 0, to: 'running', eventIdempotencyKey: 'change-job-running', producer: 'test',
+    });
+    ordinal = 0;
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const binding = () => ({
+    jobId: admission.jobId,
+    attemptId: admission.attemptId,
+    generation,
+    fenceToken,
+  });
+
+  async function capture(previousSnapshotId?: string) {
+    return engine.repository.captureSnapshot({
+      ...binding(), requestedPath: root, producer: 'test', previousSnapshotId,
+    });
+  }
+
+  async function approve(baseSnapshotId: string, plan: FileChangePlan) {
+    ordinal += 1;
+    const toolName = toolFor(plan);
+    const args = argsFor(plan);
+    const toolCallId = `change-tool-${ordinal}`;
+    const intent = await engine.changes.prepare({
+      ...binding(), toolCallId, baseSnapshotId, plan, producer: 'test',
+    });
+    const prepared = engine.prepareToolCall({
+      toolCallId, ...binding(), toolName, normalizedArgsDigest: normalizedArgsDigest(args),
+      riskTier: plan.operation === 'delete' ? 'dangerous' : 'caution', mutates: true, producer: 'test',
+      effect: {
+        classification: 'reconcilable_mutation',
+        kind: plan.operation === 'delete' ? 'filesystem.delete'
+          : plan.operation === 'move' || plan.operation === 'rename' ? 'filesystem.move'
+            : 'filesystem.write',
+        target: path.join(root, plan.path), retrySafety: 'reconcile_before_retry',
+        idempotencySupported: true, idempotencyKey: `change:${intent.intentId}`,
+        reconciliationSupported: true, verificationSupported: true,
+        approvalRequirement: 'policy', approvalState: 'pending', sensitiveFields: ['content'],
+        redactionRules: ['digest_arguments', 'omit_sensitive_values'], trusted: true,
+      },
+    });
+    if (!prepared.effectId) throw new Error('Effect was not created');
+    engine.changes.bindEffect({ ...binding(), intentId: intent.intentId, effectId: prepared.effectId });
+    const normalized = normalizeExecutionPlan({
+      toolName, args, cwd: root, mutates: true,
+      riskTier: plan.operation === 'delete' ? 'dangerous' : 'caution', policy: policy(root),
+    });
+    const approval = actions.request({
+      ...binding(), toolCallId, effectId: prepared.effectId, toolName,
+      riskTier: plan.operation === 'delete' ? 'dangerous' : 'caution', riskReasons: [], normalized,
+    });
+    engine.changes.bindApproval({
+      ...binding(), intentId: intent.intentId, effectId: prepared.effectId,
+      approvalId: approval.approvalId, actionDigest: normalized.actionDigest,
+    });
+    actions.decide({
+      approvalId: approval.approvalId, ...binding(), actionDigest: normalized.actionDigest,
+      policySnapshotId: approval.policySnapshotId, decision: 'approved',
+      decidedBy: 'user', decisionChannel: 'test',
+    });
+    engine.resolveToolCallApproval({
+      toolCallId, ...binding(), state: 'approved', approvalId: approval.approvalId,
+      actionDigest: normalized.actionDigest, producer: 'test',
+    });
+    expect(actions.authorizeExecution({
+      approvalId: approval.approvalId, ...binding(), toolCallId, effectId: prepared.effectId,
+      actionDigest: normalized.actionDigest, policySnapshotId: approval.policySnapshotId,
+    }).authorized).toBe(true);
+    engine.startToolCall({ toolCallId, ...binding(), producer: 'test' });
+    return {
+      intent,
+      effectId: prepared.effectId,
+      approvalId: approval.approvalId,
+      actionDigest: normalized.actionDigest,
+      execute: (override = plan, signal?: AbortSignal) => engine.changes.execute({
+        ...binding(), intentId: intent.intentId, effectId: prepared.effectId!,
+        approvalId: approval.approvalId, actionDigest: normalized.actionDigest,
+        plan: override, producer: 'test', signal,
+      }),
+    };
+  }
+
+  function replaceEngine(io: SafeChangeIo): void {
+    engine = createJobEngine({ db, safeChangeIo: io });
+    actions = createActionAuthority({ db, jobEngine: engine });
+  }
+
+  it('rejects a write when the user changes the source after approval', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'const value = 1;\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'const value = 2;\n' });
+    await writeFile(path.join(root, 'source.ts'), 'const userValue = 3;\n');
+    await expect(change.execute()).rejects.toMatchObject({ code: 'STALE_SOURCE' });
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('const userValue = 3;\n');
+  });
+
+  it('rejects inactive Attempts and stale fence tokens before mutation', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'after\n' });
+    db.prepare('UPDATE tasks SET active_attempt_id=NULL WHERE id=?').run(admission.jobId);
+    await expect(change.execute()).rejects.toMatchObject({ code: 'STALE_CHANGE_AUTHORITY' });
+    db.prepare('UPDATE tasks SET active_attempt_id=? WHERE id=?').run(admission.attemptId, admission.jobId);
+    db.prepare('UPDATE runs SET fence_token=? WHERE attempt_id=?').run('replacement-fence', admission.attemptId);
+    await expect(change.execute()).rejects.toMatchObject({ code: 'STALE_CHANGE_AUTHORITY' });
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('before\n');
+  });
+
+  it('rejects an operation changed after exact approval', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'approved\n' });
+    await expect(change.execute({ operation: 'modify', path: 'source.ts', content: 'changed\n' }))
+      .rejects.toMatchObject({ code: 'APPROVED_CHANGE_MISMATCH' });
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('before\n');
+  });
+
+  it('rejects symlink traversal outside the workspace', async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), 'aiden-safe-change-outside-'));
+    await writeFile(path.join(outside, 'outside.ts'), 'outside\n');
+    await symlink(outside, path.join(root, 'escape'), process.platform === 'win32' ? 'junction' : 'dir');
+    try {
+      const snapshot = await capture();
+      await expect(engine.changes.prepare({
+        ...binding(), toolCallId: 'escape', baseSnapshotId: snapshot.id,
+        plan: { operation: 'modify', path: 'escape/outside.ts', content: 'changed\n' }, producer: 'test',
+      })).rejects.toMatchObject({ code: 'PATH_OUTSIDE_WORKSPACE' });
+      await expect(readFile(path.join(outside, 'outside.ts'), 'utf8')).resolves.toBe('outside\n');
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== 'win32')('rejects Windows junction traversal outside the workspace', async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), 'aiden-safe-change-junction-'));
+    await writeFile(path.join(outside, 'outside.ts'), 'outside\n');
+    await symlink(outside, path.join(root, 'junction'), 'junction');
+    try {
+      const snapshot = await capture();
+      await expect(engine.changes.prepare({
+        ...binding(), toolCallId: 'junction', baseSnapshotId: snapshot.id,
+        plan: { operation: 'delete', path: 'junction/outside.ts' }, producer: 'test',
+      })).rejects.toMatchObject({ code: 'PATH_OUTSIDE_WORKSPACE' });
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('never verifies a write when fresh readback fails', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'after\n' });
+    replaceEngine({ readback: async () => { throw new Error('readback unavailable'); } });
+    await expect(change.execute()).rejects.toMatchObject({ code: 'READBACK_FAILED' });
+    expect(engine.proof.listClaims(admission.jobId)).toContainEqual(expect.objectContaining({ state: 'unknown' }));
+    expect(engine.proof.listEvidence(admission.jobId)).toContainEqual(expect.objectContaining({
+      effectId: change.effectId, verificationResult: 'unknown', coverage: 'unknown',
+    }));
+  });
+
+  it('fails closed for ambiguous and zero-match patches', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'value\nvalue\n');
+    let snapshot = await capture();
+    await expect(approve(snapshot.id, {
+      operation: 'patch', path: 'source.ts', find: 'value', replace: 'next', replaceAll: false,
+    })).rejects.toMatchObject({ code: 'PATCH_AMBIGUOUS' });
+    await writeFile(path.join(root, 'source.ts'), 'value\n');
+    snapshot = await capture(snapshot.id);
+    await expect(approve(snapshot.id, {
+      operation: 'patch', path: 'source.ts', find: 'missing', replace: 'next', replaceAll: false,
+    })).rejects.toMatchObject({ code: 'PATCH_NO_MATCH' });
+  });
+
+  it('preserves CRLF, UTF-8 BOM, and executable mode', async () => {
+    const target = path.join(root, 'script.ts');
+    await writeFile(target, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('first\r\nsecond\r\n')]));
+    if (process.platform !== 'win32') await chmod(target, 0o755);
+    const beforeMode = (await lstat(target)).mode & 0o777;
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, {
+      operation: 'patch', path: 'script.ts', find: 'second', replace: 'changed\ncontinued', replaceAll: false,
+    });
+    const result = await change.execute();
+    const bytes = await readFile(target);
+    expect(bytes.subarray(0, 3)).toEqual(Buffer.from([0xef, 0xbb, 0xbf]));
+    expect(bytes.toString('utf8')).toBe('\ufefffirst\r\nchanged\r\ncontinued\r\n');
+    expect((await lstat(target)).mode & 0o777).toBe(beforeMode);
+    expect(result.resultHash).toBe(sha256(bytes));
+  });
+
+  it('rejects unsupported binary edits', async () => {
+    await writeFile(path.join(root, 'asset.bin'), Buffer.from([0, 1, 2, 3]));
+    const snapshot = await capture();
+    await expect(engine.changes.prepare({
+      ...binding(), toolCallId: 'binary', baseSnapshotId: snapshot.id,
+      plan: { operation: 'modify', path: 'asset.bin', content: 'text' }, producer: 'test',
+    })).rejects.toMatchObject({ code: 'BINARY_EDIT_UNSUPPORTED' });
+  });
+
+  it('records cancellation after mutation as unknown and never verifies it', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'after\n' });
+    const aborter = new AbortController();
+    replaceEngine({ afterMutation: async () => { aborter.abort(); } });
+    await expect(change.execute(undefined, aborter.signal)).rejects.toMatchObject({ code: 'CHANGE_CANCELLED_UNKNOWN' });
+    expect(engine.proof.listClaims(admission.jobId)).toContainEqual(expect.objectContaining({ state: 'unknown' }));
+  });
+
+  it('returns the same committed record for an exact duplicate retry', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'after\n' });
+    const first = await change.execute();
+    const second = await change.execute();
+    expect(second.changeId).toBe(first.changeId);
+    expect(engine.changes.listRecords(admission.jobId)).toHaveLength(1);
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('after\n');
+  });
+
+  it('detects undeclared formatter changes without claiming scoped success', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    await writeFile(path.join(root, 'other.ts'), 'owned by user\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'after\n' });
+    replaceEngine({ afterMutation: async () => { await writeFile(path.join(root, 'other.ts'), 'formatter changed this\n'); } });
+    await expect(change.execute()).rejects.toMatchObject({ code: 'UNDECLARED_WORKSPACE_CHANGE' });
+    expect(engine.changes.getRecord(change.intent.intentId)).toMatchObject({ state: 'failed' });
+  });
+
+  it('persists exact Effect-linked evidence and a descendant snapshot', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    await writeFile(path.join(root, 'dirty.txt'), 'unrelated dirty work\n');
+    const snapshot = await capture();
+    const change = await approve(snapshot.id, { operation: 'modify', path: 'source.ts', content: 'after\n' });
+    const result = await change.execute();
+    const evidence = engine.proof.listEvidence(admission.jobId);
+    expect(result).toMatchObject({
+      state: 'committed', fenceToken, effectId: change.effectId, baseSnapshotId: snapshot.id,
+      descendantSnapshotId: expect.any(String), diffEvidenceId: expect.any(String),
+      resultHash: sha256('after\n'),
+    });
+    expect(evidence).toContainEqual(expect.objectContaining({
+      evidenceId: result.diffEvidenceId, effectId: change.effectId,
+      source: 'repository.change.readback', coverage: 'full', verificationResult: 'verified',
+    }));
+    expect(engine.repository.compareSnapshots(snapshot.id, result.descendantSnapshotId!).changed).toEqual(['source.ts']);
+    await expect(readFile(path.join(root, 'dirty.txt'), 'utf8')).resolves.toBe('unrelated dirty work\n');
+    expect(engine.proof.listClaims(admission.jobId)).toContainEqual(expect.objectContaining({ state: 'verified' }));
+  });
+
+  it('supports create, modify, patch, rename, move, and delete as fenced single-file changes', async () => {
+    let snapshot = await capture();
+    const create = await approve(snapshot.id, { operation: 'create', path: 'one.txt', content: 'one\n' });
+    snapshot = engine.repository.getSnapshot((await create.execute()).descendantSnapshotId!)!;
+    const modify = await approve(snapshot.id, { operation: 'modify', path: 'one.txt', content: 'two\n' });
+    snapshot = engine.repository.getSnapshot((await modify.execute()).descendantSnapshotId!)!;
+    const patch = await approve(snapshot.id, { operation: 'patch', path: 'one.txt', find: 'two', replace: 'three' });
+    snapshot = engine.repository.getSnapshot((await patch.execute()).descendantSnapshotId!)!;
+    const rename = await approve(snapshot.id, { operation: 'rename', path: 'one.txt', destinationPath: 'renamed.txt' });
+    snapshot = engine.repository.getSnapshot((await rename.execute()).descendantSnapshotId!)!;
+    const move = await approve(snapshot.id, { operation: 'move', path: 'renamed.txt', destinationPath: 'nested/moved.txt' });
+    snapshot = engine.repository.getSnapshot((await move.execute()).descendantSnapshotId!)!;
+    const remove = await approve(snapshot.id, { operation: 'delete', path: 'nested/moved.txt' });
+    const final = await remove.execute();
+    await expect(readFile(path.join(root, 'nested/moved.txt'))).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(engine.repository.compareSnapshots(snapshot.id, final.descendantSnapshotId!).removed).toEqual(['nested/moved.txt']);
+  });
+});

--- a/tests/v4/codebase/safeChangeToolIntegration.test.ts
+++ b/tests/v4/codebase/safeChangeToolIntegration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createActionAuthority } from '../../../core/v4/actionAuthority';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { runWithJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ToolRegistry } from '../../../core/v4/toolRegistry';
+import { ApprovalEngine } from '../../../moat/approvalEngine';
+import { withBuiltInEffectContract } from '../../../tools/v4/effectContracts';
+import { fileWriteTool } from '../../../tools/v4/files/fileWrite';
+import { filePatchTool } from '../../../tools/v4/files/filePatch';
+import { fileMoveTool } from '../../../tools/v4/files/fileMove';
+import { fileDeleteTool } from '../../../tools/v4/files/fileDelete';
+
+describe('safe change file-tool integration', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let root: string;
+  let context: ReturnType<typeof setup> extends Promise<infer T> ? T : never;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('change-integration',1,'localhost',1,1,'4.17.0')`,
+    ).run();
+    engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-safe-tool-'));
+    context = await setup();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function setup() {
+    const admission = engine.submitJob({
+      entryPoint: 'test', source: 'unit', sessionId: 'safe-tool', workspaceId: root,
+      instanceId: 'change-integration', idempotencyNamespace: 'safe-tool',
+      idempotencyKey: path.basename(root), goal: 'write safely',
+    });
+    const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 60_000 });
+    engine.transitionAttempt({
+      attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, to: 'running', eventIdempotencyKey: 'attempt-running', producer: 'test',
+    });
+    engine.transitionJob({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'job-running', producer: 'test',
+    });
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, requestedPath: root, producer: 'test',
+    });
+    const registry = new ToolRegistry();
+    for (const handler of [fileWriteTool, filePatchTool, fileMoveTool, fileDeleteTool]) {
+      registry.register(withBuiltInEffectContract(handler));
+    }
+    const repositoryChange = {
+      baseSnapshotId: snapshot.id,
+      rootPath: root,
+      authority: engine.changes,
+    };
+    return {
+      admission,
+      lease,
+      repositoryChange,
+      registry,
+      executor(promptUser: () => Promise<'allow' | 'deny'>) {
+        const execute = registry.buildExecutor({
+          cwd: root,
+          paths: resolveAidenPaths({ rootOverride: path.join(root, '.aiden') }),
+          actionAuthority: createActionAuthority({ db, jobEngine: engine }),
+          approvalEngine: new ApprovalEngine('manual', { promptUser }),
+          policySnapshot: {
+            trustLevel: 'Assistant', autonomyPolicy: 'ask_for_mutations', approvalMode: 'manual',
+            toolMetadataVersion: 'codebase-v1', sandboxPolicy: { roots: [root], deny: [] },
+            networkPolicy: {}, pluginGrants: [], mcpGrants: [], workspaceOverrides: {}, jobOverrides: {},
+          },
+          repositoryChange,
+        });
+        return (call: { id: string; name: string; arguments: Record<string, unknown> }) => runWithJobExecutionContext({
+          engine, jobId: admission.jobId, attemptId: admission.attemptId,
+          generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+        }, () => execute(call));
+      },
+      run(promptUser: () => Promise<'allow' | 'deny'>) {
+        const execute = this.executor(promptUser);
+        return (content: string) => execute({
+          id: 'provider-file-write', name: 'file_write', arguments: { path: 'source.ts', content },
+        });
+      },
+    };
+  }
+
+  it('routes an approved file write through the source-fenced authority', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const fresh = await engine.repository.captureSnapshot({
+      jobId: context.admission.jobId, attemptId: context.admission.attemptId,
+      generation: context.lease.generation!, fenceToken: context.lease.fenceToken!,
+      requestedPath: root, previousSnapshotId: context.repositoryChange.baseSnapshotId, producer: 'test',
+    });
+    context.repositoryChange.baseSnapshotId = fresh.id;
+    const execute = context.run(async () => 'allow');
+    const result = await execute('after\n');
+    expect(result.error).toBeUndefined();
+    expect(result.result).toMatchObject({ success: true, changeId: expect.any(String), verified: true });
+    expect(engine.changes.listRecords(context.admission.jobId)).toHaveLength(1);
+    expect(context.repositoryChange.baseSnapshotId).not.toBe(fresh.id);
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('after\n');
+  });
+
+  it('blocks a user edit made while exact approval is pending', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const fresh = await engine.repository.captureSnapshot({
+      jobId: context.admission.jobId, attemptId: context.admission.attemptId,
+      generation: context.lease.generation!, fenceToken: context.lease.fenceToken!,
+      requestedPath: root, previousSnapshotId: context.repositoryChange.baseSnapshotId, producer: 'test',
+    });
+    context.repositoryChange.baseSnapshotId = fresh.id;
+    const execute = context.run(async () => {
+      await writeFile(path.join(root, 'source.ts'), 'user edit\n');
+      return 'allow';
+    });
+    const result = await execute('planned\n');
+    expect(result.error).toContain('Source metadata or content changed after approval');
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('user edit\n');
+  });
+
+  it('fails closed before registering an Effect when exact approval authority is unavailable', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const fresh = await engine.repository.captureSnapshot({
+      jobId: context.admission.jobId, attemptId: context.admission.attemptId,
+      generation: context.lease.generation!, fenceToken: context.lease.fenceToken!,
+      requestedPath: root, previousSnapshotId: context.repositoryChange.baseSnapshotId, producer: 'test',
+    });
+    context.repositoryChange.baseSnapshotId = fresh.id;
+    const execute = context.registry.buildExecutor({
+      cwd: root,
+      paths: resolveAidenPaths({ rootOverride: path.join(root, '.aiden') }),
+      repositoryChange: context.repositoryChange,
+    });
+    const result = await runWithJobExecutionContext({
+      engine, jobId: context.admission.jobId, attemptId: context.admission.attemptId,
+      generation: context.lease.generation!, fenceToken: context.lease.fenceToken!, producer: 'test',
+    }, () => execute({
+      id: 'provider-file-write-without-approval', name: 'file_write',
+      arguments: { path: 'source.ts', content: 'after\n' },
+    }));
+
+    expect(result.error).toContain('require exact interactive approval');
+    expect(db.prepare('SELECT COUNT(*) AS count FROM side_effect_ledger').get()).toEqual({ count: 0 });
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('before\n');
+  });
+
+  it('returns one committed result for an exact duplicate ToolCall retry', async () => {
+    const execute = context.run(async () => 'allow');
+    const first = await execute('created\n');
+    const second = await execute('created\n');
+    expect(first.result).toMatchObject({ success: true, changeId: expect.any(String) });
+    expect(second.result).toEqual(first.result);
+    expect(engine.changes.listRecords(context.admission.jobId)).toHaveLength(1);
+  });
+
+  it('repairs patch proof by linking one fresh readback to the patch Effect', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before value\n');
+    const fresh = await engine.repository.captureSnapshot({
+      jobId: context.admission.jobId, attemptId: context.admission.attemptId,
+      generation: context.lease.generation!, fenceToken: context.lease.fenceToken!,
+      requestedPath: root, previousSnapshotId: context.repositoryChange.baseSnapshotId, producer: 'test',
+    });
+    context.repositoryChange.baseSnapshotId = fresh.id;
+    const execute = context.executor(async () => 'allow');
+    const result = await execute({
+      id: 'provider-file-patch', name: 'file_patch',
+      arguments: { path: 'source.ts', find: 'value', replace: 'result' },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.result).toMatchObject({ success: true, operation: 'patch', verified: true });
+    expect(engine.proof.listEvidence(context.admission.jobId)).toEqual([
+      expect.objectContaining({
+        effectId: (result.result as Record<string, unknown>).effectId,
+        source: 'repository.change.readback', verificationResult: 'verified', coverage: 'full',
+      }),
+    ]);
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('before result\n');
+  });
+});

--- a/tests/v4/core/effectContract.test.ts
+++ b/tests/v4/core/effectContract.test.ts
@@ -5,6 +5,9 @@
 
 import { describe, expect, it } from 'vitest';
 import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { win32 } from 'node:path';
 
 import {
@@ -85,5 +88,29 @@ describe('durable tool effect contracts', () => {
       expectedSize: Buffer.byteLength(content),
     });
     expect(JSON.stringify(descriptor.reconciliationData)).not.toContain(content);
+  });
+
+  it('derives patch verification from the exact pre-execution content', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'aiden-patch-effect-'));
+    try {
+      const target = path.join(root, 'source.ts');
+      writeFileSync(target, 'const value = 1;\n');
+      const registry = new ToolRegistry();
+      registerAllTools(registry);
+      const expected = 'const value = 2;\n';
+      const descriptor = describeToolEffect(
+        registry.get('file_patch')!,
+        { path: 'source.ts', find: 'value = 1', replace: 'value = 2' },
+        root,
+      );
+      expect(descriptor.reconciliationData).toEqual({
+        path: target,
+        expectedContentSha256: createHash('sha256').update(expected).digest('hex'),
+        expectedSize: Buffer.byteLength(expected),
+      });
+      expect(JSON.stringify(descriptor.reconciliationData)).not.toContain('value = 2');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -55,6 +55,8 @@ describe('runMigrations', () => {
     expect(names).toContain('job_verdicts');
     expect(names).toContain('proof_reviews');
     expect(names).toContain('job_event_cursors');
+    expect(names).toContain('repository_change_intents');
+    expect(names).toContain('repository_change_records');
   });
 
   it('enforces trigger_events UNIQUE(source, idempotency_key) when key present', () => {

--- a/tools/v4/effectContracts.ts
+++ b/tools/v4/effectContracts.ts
@@ -4,6 +4,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 
 import type { ToolEffectContract } from '../../core/v4/effectContract';
 import { resolvePortablePath } from '../../core/v4/portablePath';
@@ -46,12 +47,47 @@ const FILE_WRITE = contract({
     };
   },
 });
+const FILE_PATCH = contract({
+  classification: 'reconcilable_mutation', kind: 'filesystem.write',
+  retrySafety: 'reconcile_before_retry', idempotencySupported: true,
+  reconciliationSupported: true, verificationSupported: true,
+  approvalRequirement: 'policy', sensitiveFields: ['find', 'replace'],
+  redactionRules: ['digest_arguments', 'omit_sensitive_values'], targetFields: ['path'],
+  reconciliationData(args, cwd) {
+    const target = typeof args.path === 'string' ? resolvePortablePath(cwd, args.path) : null;
+    const find = typeof args.find === 'string' ? args.find : null;
+    const replace = typeof args.replace === 'string' ? args.replace : null;
+    if (!target || !find || replace === null) return null;
+    try {
+      const original = readFileSync(target, 'utf8');
+      const count = original.split(find).length - 1;
+      if (count === 0 || (count > 1 && args.replace_all !== true)) return null;
+      const content = args.replace_all === true
+        ? original.split(find).join(replace)
+        : original.replace(find, replace);
+      return {
+        path: target,
+        expectedContentSha256: createHash('sha256').update(content).digest('hex'),
+        expectedSize: Buffer.byteLength(content),
+      };
+    } catch {
+      return null;
+    }
+  },
+});
 const FILE_MOVE = contract({
   classification: 'reconcilable_mutation', kind: 'filesystem.move',
   retrySafety: 'reconcile_before_retry', idempotencySupported: true,
   reconciliationSupported: true, verificationSupported: true,
   approvalRequirement: 'policy', sensitiveFields: [], redactionRules: ['digest_arguments'],
-  targetFields: ['source', 'destination'],
+  targetFields: ['from', 'to', 'source', 'destination'],
+  reconciliationData(args, cwd) {
+    const source = typeof (args.from ?? args.source) === 'string'
+      ? resolvePortablePath(cwd, String(args.from ?? args.source)) : null;
+    const destination = typeof (args.to ?? args.destination) === 'string'
+      ? resolvePortablePath(cwd, String(args.to ?? args.destination)) : null;
+    return source && destination ? { sourcePath: source, destinationPath: destination } : null;
+  },
 });
 const FILE_DELETE = contract({
   classification: 'reconcilable_mutation', kind: 'filesystem.delete',
@@ -112,7 +148,7 @@ const PACKAGE_INSTALL = contract({
 
 const CONTRACTS: Readonly<Record<string, ToolEffectContract>> = Object.freeze({
   file_write: FILE_WRITE,
-  file_patch: FILE_WRITE,
+  file_patch: FILE_PATCH,
   file_delete: FILE_DELETE,
   file_move: FILE_MOVE,
   file_copy: { ...FILE_MOVE, kind: 'filesystem.copy' },


### PR DESCRIPTION
## Summary

- adds source-fenced repository change intents and verified change records;
- binds create, modify, patch, delete, move and rename operations to the active Job, Attempt, generation, fence, Effect and exact approval;
- rejects stale sources, ambiguous patches, workspace escapes, unsupported binary edits and undeclared scope changes;
- records fresh readback evidence and a descendant repository snapshot for every committed change;
- preserves existing file-tool behavior outside snapshot-bound Codebase Mode.

## Validation

- 179 focused codebase, authority, Effect, proof, JobEngine and migration tests passed
- 26 final safe-change and migration tests passed
- Windows junction traversal regression passed
- Typecheck passed on Node 22.23.1
- Production build passed
- Package dry-run passed for aiden-runtime@4.17.0
- Diff, NUL, attribution, secret and protected-scope scans passed