### PR TITLE
feat(codebase): add snapshot-bound validation records

### DIFF
--- a/core/v4/codebase/structuredValidationAuthority.ts
+++ b/core/v4/codebase/structuredValidationAuthority.ts
@@ -1,0 +1,760 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { gunzipSync, gzipSync } from 'node:zlib';
+
+import type { Db } from '../daemon/db/connection';
+import type { AttemptRecord, JobRecord } from '../daemon/jobEngine';
+import type { JobProofAuthority } from '../daemon/jobProofAuthority';
+import { scrubString } from '../logger/redact';
+import { McpCredentialFilter } from '../mcp/credentialFilter';
+import { isWithin, realpathWithFallback } from '../sandboxFs';
+import type { RepositorySnapshotAuthority, RepositorySnapshotRecord } from './repositorySnapshotAuthority';
+
+export type ValidationKind = 'test' | 'build';
+export type ValidationScope = 'focused' | 'full';
+export type ValidationRunState =
+  | 'running' | 'succeeded' | 'failed' | 'timed_out' | 'cancelled'
+  | 'environment_failed' | 'unknown';
+
+export interface StructuredValidationPlan {
+  kind: ValidationKind;
+  command: string;
+  workingDirectory: string;
+  scope: ValidationScope;
+  outputPaths?: string[];
+}
+
+export interface ValidationEnvironment {
+  platform: string;
+  architecture: string;
+  nodeVersion: string;
+  npmVersion: string;
+  toolVersions?: Record<string, string>;
+  variables?: Record<string, string>;
+}
+
+export interface ValidationExecutionResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  cancelled: boolean;
+}
+
+export interface ValidationOutputArtifact {
+  path: string;
+  sha256: string;
+  byteCount: number;
+}
+
+export interface StructuredValidationRun {
+  runId: string;
+  kind: ValidationKind;
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  fenceToken: string;
+  toolCallId: string;
+  effectId: string;
+  executionNodeId: string | null;
+  repositorySnapshotId: string;
+  sourceStateDigest: string;
+  command: string;
+  workingDirectory: string;
+  environmentFingerprint: string;
+  environment: ValidationEnvironment;
+  scope: ValidationScope;
+  state: ValidationRunState;
+  startedAt: number;
+  completedAt: number | null;
+  exitCode: number | null;
+  timedOut: boolean;
+  cancelled: boolean;
+  parseState: 'pending' | 'parsed' | 'unparsed';
+  resultingSnapshotId: string | null;
+  sourceMutations: string[];
+  rawLogEvidenceId: string | null;
+  claimIds: string[];
+  artifactIds: string[];
+  passedCount?: number | null;
+  failedCount?: number | null;
+  skippedCount?: number | null;
+  failedTestIds?: string[];
+  outputArtifacts?: ValidationOutputArtifact[];
+  outputHashes?: Record<string, string>;
+  packageIdentity?: Record<string, unknown> | null;
+  warnings?: string[];
+  reproducibility?: Record<string, unknown>;
+}
+
+export interface ValidationArtifactRecord {
+  artifactId: string;
+  runId: string;
+  kind: 'log' | 'build_output';
+  relativePath: string | null;
+  sha256: string;
+  byteCount: number;
+  mediaType: string;
+  compression: 'gzip' | null;
+  metadata: Record<string, unknown>;
+  createdAt: number;
+}
+
+export interface ValidationDiagnosticRecord {
+  diagnosticId: string;
+  runId: string;
+  repositorySnapshotId: string;
+  tool: string;
+  severity: 'error' | 'warning' | 'info';
+  message: string;
+  path: string | null;
+  line: number | null;
+  column: number | null;
+  endLine: number | null;
+  endColumn: number | null;
+  code: string | null;
+  createdAt: number;
+}
+
+export interface ValidationDiscovery {
+  snapshotId: string;
+  sources: Array<{ kind: 'manifest' | 'lockfile' | 'workflow' | 'instruction'; path: string }>;
+  commands: Array<{ command: string; kind: ValidationKind; source: string }>;
+}
+
+export interface StructuredValidationAuthority {
+  start(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    repositorySnapshotId: string; toolCallId: string; effectId: string;
+    plan: StructuredValidationPlan; environment: ValidationEnvironment; producer: string;
+    now?: number;
+  }): StructuredValidationRun;
+  complete(input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+    runId: string; execution: ValidationExecutionResult;
+    rawOutput?: { stdout: string; stderr: string };
+    producer: string; now?: number;
+  }): Promise<{ run: StructuredValidationRun; diagnostics: ValidationDiagnosticRecord[] }>;
+  getRun(runId: string): StructuredValidationRun | undefined;
+  getArtifact(artifactId: string): ValidationArtifactRecord | undefined;
+  readLogArtifact(artifactId: string): string;
+  listDiagnostics(runId: string): ValidationDiagnosticRecord[];
+  assess(runId: string, input: {
+    repositorySnapshotId: string; requiredScope?: ValidationScope;
+  }): Promise<{ usable: boolean; reasons: string[] }>;
+  discover(snapshotId: string, explicitCommands?: Array<{ command: string; kind: ValidationKind }>): Promise<ValidationDiscovery>;
+}
+
+export class StructuredValidationAuthorityError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = 'StructuredValidationAuthorityError';
+  }
+}
+
+export function structuredValidationPlanForShell(
+  command: string,
+  workingDirectory: string,
+): StructuredValidationPlan | null {
+  const normalized = command.trim();
+  const testCommand = /(?:^|\s)(?:npm\s+(?:run\s+)?test(?::[^\s]+)?|pnpm\s+(?:run\s+)?test|yarn\s+(?:run\s+)?test|vitest|jest|pytest|cargo\s+test|go\s+test)(?:\s|$)/i;
+  if (testCommand.test(normalized)) {
+    const focused = /(?:--run\s+\S+|\.(?:test|spec)\.[cm]?[jt]sx?\b|pytest\s+\S+)/i.test(normalized);
+    return { kind: 'test', command: normalized, workingDirectory, scope: focused ? 'focused' : 'full' };
+  }
+  const buildCommand = /(?:^|\s)(?:npm\s+run\s+(?:build|typecheck|lint)|pnpm\s+(?:run\s+)?(?:build|typecheck|lint)|yarn\s+(?:run\s+)?(?:build|typecheck|lint)|tsc|cargo\s+build|go\s+build)(?:\s|$)/i;
+  if (!buildCommand.test(normalized)) return null;
+  const producesBuildOutput = /(?:^|\s)(?:npm\s+run\s+build|pnpm\s+(?:run\s+)?build|yarn\s+(?:run\s+)?build|cargo\s+build|go\s+build)(?:\s|$)/i.test(normalized);
+  return {
+    kind: 'build', command: normalized, workingDirectory, scope: 'full',
+    ...(producesBuildOutput ? { outputPaths: ['dist', 'build', 'target'] } : {}),
+  };
+}
+
+interface Deps {
+  db: Db;
+  repository: RepositorySnapshotAuthority;
+  proof: JobProofAuthority;
+  getJob(jobId: string): JobRecord | null;
+  getAttempt(attemptId: string): AttemptRecord | null;
+  appendJobEvent(command: {
+    jobId: string; attemptId: string; generation: number; type: string;
+    payload?: Record<string, unknown> | null; producer: string; idempotencyKey: string;
+  }): { applied: boolean; duplicate: boolean; conflict?: string };
+}
+
+const HASH = 'sha256';
+const credentialFilter = new McpCredentialFilter();
+const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b[@-Z\\-_]/g; // eslint-disable-line no-control-regex
+const id = (prefix: string): string => `${prefix}_${randomBytes(16).toString('hex')}`;
+const sha256 = (value: string | Buffer): string => createHash(HASH).update(value).digest('hex');
+const normalizeRelative = (value: string): string => value.split(path.sep).join('/').replace(/^\.\//, '');
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(record).sort().map((key) => [key, stableValue(record[key])]));
+  }
+  return value;
+}
+
+function fingerprint(value: unknown): string {
+  return sha256(JSON.stringify(stableValue(value)));
+}
+
+function sanitizeLog(value: string): string {
+  const withoutAnsi = value.replace(ANSI_RE, '');
+  const labelled = withoutAnsi.replace(
+    /\b(credential|api[_-]?key|token|password|secret)(\s*[=:]\s*)([^\s,;]{6,})/gi,
+    '$1$2[REDACTED]',
+  );
+  return credentialFilter.redact(scrubString(labelled));
+}
+
+function terminal(status: string): boolean {
+  return ['completed', 'succeeded', 'failed', 'cancelled', 'timed_out', 'crashed', 'unknown', 'dead_letter'].includes(status);
+}
+
+function executionState(result: ValidationExecutionResult): ValidationRunState {
+  if (result.cancelled) return 'cancelled';
+  if (result.timedOut) return 'timed_out';
+  if (/\b(?:ENOENT|EACCES|EPERM|command not found|not recognized as an internal|unable to load native|MODULE_NOT_FOUND)\b/i.test(result.stderr)) {
+    return 'environment_failed';
+  }
+  return result.exitCode === 0 ? 'succeeded' : 'failed';
+}
+
+function parseTestResult(output: string): {
+  parsed: boolean; passed: number | null; failed: number | null; skipped: number | null; failedIds: string[];
+} {
+  const count = (label: string): number | null => {
+    const match = output.match(new RegExp(`(?:^|\\s)(\\d+)\\s+${label}\\b`, 'im'));
+    return match ? Number(match[1]) : null;
+  };
+  const passed = count('passed');
+  const failed = count('failed');
+  const skipped = count('skipped');
+  const failedIds = [...output.matchAll(/^\s*(?:FAIL|×|✗)\s+(.+)$/gim)].map((match) => match[1].trim()).slice(0, 500);
+  const parsed = passed !== null || failed !== null || skipped !== null;
+  return {
+    parsed,
+    passed: parsed ? passed ?? 0 : null,
+    failed: parsed ? failed ?? 0 : null,
+    skipped: parsed ? skipped ?? 0 : null,
+    failedIds,
+  };
+}
+
+function diagnosticTool(command: string): string {
+  const first = command.trim().split(/\s+/)[0];
+  return first || 'validation';
+}
+
+function parseDiagnostics(
+  runId: string,
+  snapshotId: string,
+  command: string,
+  output: string,
+  now: number,
+): ValidationDiagnosticRecord[] {
+  const records: ValidationDiagnosticRecord[] = [];
+  const pattern = /^(.*?):(\d+):(\d+)\s+(?:(error|warning|info)\s+)?([A-Z]+\d+):\s*(.+)$/gim;
+  for (const match of output.matchAll(pattern)) {
+    records.push({
+      diagnosticId: id('diagnostic'), runId, repositorySnapshotId: snapshotId,
+      tool: diagnosticTool(command), severity: (match[4]?.toLowerCase() ?? 'error') as ValidationDiagnosticRecord['severity'],
+      message: sanitizeLog(match[6]), path: normalizeRelative(match[1]), line: Number(match[2]),
+      column: Number(match[3]), endLine: null, endColumn: null, code: match[5], createdAt: now,
+    });
+  }
+  return records;
+}
+
+function rowToArtifact(row: Record<string, unknown>): ValidationArtifactRecord {
+  return {
+    artifactId: String(row.artifact_id), runId: String(row.run_id),
+    kind: row.kind as ValidationArtifactRecord['kind'],
+    relativePath: row.relative_path === null ? null : String(row.relative_path),
+    sha256: String(row.sha256), byteCount: Number(row.byte_count), mediaType: String(row.media_type),
+    compression: row.compression === null ? null : row.compression as 'gzip',
+    metadata: JSON.parse(String(row.metadata_json)) as Record<string, unknown>, createdAt: Number(row.created_at),
+  };
+}
+
+function rowToDiagnostic(row: Record<string, unknown>): ValidationDiagnosticRecord {
+  return {
+    diagnosticId: String(row.diagnostic_id), runId: String(row.run_id),
+    repositorySnapshotId: String(row.repository_snapshot_id), tool: String(row.tool),
+    severity: row.severity as ValidationDiagnosticRecord['severity'], message: String(row.message),
+    path: row.relative_path === null ? null : String(row.relative_path),
+    line: row.start_line === null ? null : Number(row.start_line),
+    column: row.start_column === null ? null : Number(row.start_column),
+    endLine: row.end_line === null ? null : Number(row.end_line),
+    endColumn: row.end_column === null ? null : Number(row.end_column),
+    code: row.code === null ? null : String(row.code), createdAt: Number(row.created_at),
+  };
+}
+
+export function createStructuredValidationAuthority(deps: Deps): StructuredValidationAuthority {
+  const { db } = deps;
+
+  const assertAuthority = (input: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string;
+  }): void => {
+    const job = deps.getJob(input.jobId);
+    const attempt = deps.getAttempt(input.attemptId);
+    if (!job || !attempt || attempt.jobId !== job.id || job.activeAttemptId !== attempt.id
+      || terminal(job.status) || terminal(attempt.status) || attempt.generation !== input.generation
+      || attempt.fenceToken !== input.fenceToken || attempt.leaseExpiresAt === null
+      || attempt.leaseExpiresAt <= Date.now()) {
+      throw new StructuredValidationAuthorityError(
+        'STALE_VALIDATION_AUTHORITY',
+        'Attempt generation or fence no longer owns this validation record',
+      );
+    }
+  };
+
+  const rootFor = (snapshot: RepositorySnapshotRecord): string => {
+    const workspace = deps.repository.getWorkspace(snapshot.workspaceId);
+    if (!workspace) throw new StructuredValidationAuthorityError('WORKSPACE_NOT_FOUND', 'Validation workspace is unavailable');
+    return realpathWithFallback(snapshot.repositoryRoot ?? workspace.canonicalPath);
+  };
+
+  const getRun = (runId: string): StructuredValidationRun | undefined => {
+    const row = db.prepare('SELECT * FROM validation_runs WHERE run_id=?').get(runId) as Record<string, unknown> | undefined;
+    if (!row) return undefined;
+    const common: StructuredValidationRun = {
+      runId: String(row.run_id), kind: row.kind as ValidationKind, jobId: String(row.job_id),
+      attemptId: String(row.attempt_id), generation: Number(row.generation), fenceToken: String(row.fence_token),
+      toolCallId: String(row.tool_call_id), effectId: String(row.effect_id),
+      executionNodeId: row.execution_node_id === null ? null : String(row.execution_node_id),
+      repositorySnapshotId: String(row.repository_snapshot_id), sourceStateDigest: String(row.source_state_digest),
+      command: String(row.command), workingDirectory: String(row.working_directory),
+      environmentFingerprint: String(row.environment_fingerprint),
+      environment: JSON.parse(String(row.environment_json)) as ValidationEnvironment,
+      scope: row.scope as ValidationScope, state: row.state as ValidationRunState,
+      startedAt: Number(row.started_at), completedAt: row.completed_at === null ? null : Number(row.completed_at),
+      exitCode: row.exit_code === null ? null : Number(row.exit_code), timedOut: Number(row.timed_out) === 1,
+      cancelled: Number(row.cancelled) === 1, parseState: row.parse_state as StructuredValidationRun['parseState'],
+      resultingSnapshotId: row.resulting_snapshot_id === null ? null : String(row.resulting_snapshot_id),
+      sourceMutations: JSON.parse(String(row.source_mutations_json)) as string[],
+      rawLogEvidenceId: row.raw_log_evidence_id === null ? null : String(row.raw_log_evidence_id),
+      claimIds: JSON.parse(String(row.claim_ids_json)) as string[],
+      artifactIds: JSON.parse(String(row.artifact_ids_json)) as string[],
+    };
+    if (common.kind === 'test') {
+      const detail = db.prepare('SELECT * FROM test_run_details WHERE run_id=?').get(runId) as Record<string, unknown>;
+      common.passedCount = detail.passed_count === null ? null : Number(detail.passed_count);
+      common.failedCount = detail.failed_count === null ? null : Number(detail.failed_count);
+      common.skippedCount = detail.skipped_count === null ? null : Number(detail.skipped_count);
+      common.failedTestIds = JSON.parse(String(detail.failed_test_ids_json)) as string[];
+    } else {
+      const detail = db.prepare('SELECT * FROM build_run_details WHERE run_id=?').get(runId) as Record<string, unknown>;
+      common.outputArtifacts = JSON.parse(String(detail.output_artifacts_json)) as ValidationOutputArtifact[];
+      common.outputHashes = JSON.parse(String(detail.output_hashes_json)) as Record<string, string>;
+      common.packageIdentity = detail.package_identity_json === null
+        ? null : JSON.parse(String(detail.package_identity_json)) as Record<string, unknown>;
+      common.warnings = JSON.parse(String(detail.warnings_json)) as string[];
+      common.reproducibility = JSON.parse(String(detail.reproducibility_json)) as Record<string, unknown>;
+    }
+    return common;
+  };
+
+  const getArtifact = (artifactId: string): ValidationArtifactRecord | undefined => {
+    const row = db.prepare('SELECT * FROM validation_artifacts WHERE artifact_id=?').get(artifactId) as Record<string, unknown> | undefined;
+    return row ? rowToArtifact(row) : undefined;
+  };
+
+  const listDiagnostics = (runId: string): ValidationDiagnosticRecord[] => (
+    db.prepare('SELECT * FROM validation_diagnostics WHERE run_id=? ORDER BY created_at,diagnostic_id').all(runId) as Array<Record<string, unknown>>
+  ).map(rowToDiagnostic);
+
+  const outputFiles = async (
+    root: string,
+    requested: readonly string[],
+  ): Promise<Array<{ relative: string; absolute: string; bytes: Buffer }>> => {
+    const files: Array<{ relative: string; absolute: string; bytes: Buffer }> = [];
+    const visit = async (absolute: string): Promise<void> => {
+      const resolved = realpathWithFallback(absolute);
+      if (!isWithin(resolved, root) || resolved === root) {
+        throw new StructuredValidationAuthorityError('OUTPUT_OUTSIDE_WORKSPACE', 'Build output resolves outside the repository workspace');
+      }
+      let stat;
+      try { stat = await fs.stat(resolved); } catch { return; }
+      if (stat.isDirectory()) {
+        for (const entry of (await fs.readdir(resolved, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
+          if (files.length >= 5_000) throw new StructuredValidationAuthorityError('OUTPUT_LIMIT', 'Build output file limit exceeded');
+          await visit(path.join(resolved, entry.name));
+        }
+      } else if (stat.isFile()) {
+        const relative = normalizeRelative(path.relative(root, resolved));
+        files.push({ relative, absolute: resolved, bytes: await fs.readFile(resolved) });
+      }
+    };
+    for (const requestedPath of requested) {
+      const absolute = path.resolve(root, requestedPath);
+      if (!isWithin(absolute, root) || absolute === root) {
+        throw new StructuredValidationAuthorityError('OUTPUT_OUTSIDE_WORKSPACE', 'Build output path is outside the repository workspace');
+      }
+      await visit(absolute);
+    }
+    return files.sort((a, b) => a.relative.localeCompare(b.relative));
+  };
+
+  const authority: StructuredValidationAuthority = {
+    start(input) {
+      assertAuthority(input);
+      const snapshot = deps.repository.getSnapshot(input.repositorySnapshotId);
+      if (!snapshot || snapshot.jobId !== input.jobId || snapshot.attemptId !== input.attemptId
+        || snapshot.generation !== input.generation) {
+        throw new StructuredValidationAuthorityError('SNAPSHOT_BINDING_MISMATCH', 'Validation source snapshot does not match the active Attempt');
+      }
+      const tool = db.prepare(
+        'SELECT state,side_effect_id FROM tool_calls WHERE tool_call_id=? AND attempt_id=? AND generation=?',
+      ).get(input.toolCallId, input.attemptId, input.generation) as { state: string; side_effect_id: string | null } | undefined;
+      if (!tool || tool.state !== 'started' || tool.side_effect_id !== input.effectId) {
+        throw new StructuredValidationAuthorityError('TOOL_CALL_BINDING_MISMATCH', 'Validation must bind the active shell ToolCall and Effect');
+      }
+      const existing = db.prepare(
+        'SELECT run_id FROM validation_runs WHERE attempt_id=? AND generation=? AND tool_call_id=? AND kind=?',
+      ).get(input.attemptId, input.generation, input.toolCallId, input.plan.kind) as { run_id: string } | undefined;
+      if (existing) {
+        const record = getRun(existing.run_id)!;
+        if (record.repositorySnapshotId !== input.repositorySnapshotId
+          || record.command !== input.plan.command || record.workingDirectory !== input.plan.workingDirectory) {
+          throw new StructuredValidationAuthorityError('VALIDATION_IDEMPOTENCY_CONFLICT', 'Validation ToolCall was already bound to different inputs');
+        }
+        return record;
+      }
+      const root = rootFor(snapshot);
+      const workingDirectory = realpathWithFallback(path.resolve(input.plan.workingDirectory));
+      if (!isWithin(workingDirectory, root) && workingDirectory !== root) {
+        throw new StructuredValidationAuthorityError('WORKING_DIRECTORY_OUTSIDE_WORKSPACE', 'Validation working directory is outside the repository workspace');
+      }
+      const runId = id(input.plan.kind === 'test' ? 'test_run' : 'build_run');
+      const now = input.now ?? Date.now();
+      const executionNode = db.prepare(
+        `SELECT n.node_id
+           FROM execution_graph_nodes n
+           JOIN execution_node_attempts x ON x.node_id=n.node_id
+          WHERE n.job_id=? AND x.attempt_id=? AND x.generation=? AND x.state='running'
+          ORDER BY x.started_at DESC,x.node_execution_id DESC LIMIT 1`,
+      ).get(input.jobId, input.attemptId, input.generation) as { node_id: string } | undefined;
+      const claim = deps.proof.createClaim({
+        jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+        category: 'observed', statement: `${input.plan.kind} validation completed for snapshot ${snapshot.id}`,
+        required: false, now,
+      });
+      const environmentFingerprint = fingerprint(input.environment);
+      db.transaction(() => {
+        db.prepare(
+          `INSERT INTO validation_runs (
+             run_id,kind,job_id,attempt_id,generation,fence_token,tool_call_id,effect_id,execution_node_id,
+             repository_snapshot_id,source_state_digest,command,working_directory,
+             environment_fingerprint,environment_json,scope,state,started_at,claim_ids_json
+           ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'running',?,?)`,
+        ).run(
+          runId, input.plan.kind, input.jobId, input.attemptId, input.generation, input.fenceToken,
+          input.toolCallId, input.effectId, executionNode?.node_id ?? null, snapshot.id, snapshot.stateDigest, input.plan.command,
+          workingDirectory, environmentFingerprint, JSON.stringify(stableValue(input.environment)),
+          input.plan.scope, now, JSON.stringify([claim.claimId]),
+        );
+        if (input.plan.kind === 'test') {
+          db.prepare('INSERT INTO test_run_details (run_id) VALUES (?)').run(runId);
+        } else {
+          db.prepare('INSERT INTO build_run_details (run_id,declared_output_paths_json) VALUES (?,?)')
+            .run(runId, JSON.stringify(input.plan.outputPaths ?? []));
+        }
+      }).immediate();
+      deps.appendJobEvent({
+        jobId: input.jobId, attemptId: input.attemptId, generation: input.generation,
+        type: `validation.${input.plan.kind}.started`,
+        payload: { runId, snapshotId: snapshot.id, scope: input.plan.scope, environmentFingerprint },
+        producer: input.producer, idempotencyKey: `validation-started:${runId}`,
+      });
+      return getRun(runId)!;
+    },
+
+    async complete(input) {
+      assertAuthority(input);
+      const current = getRun(input.runId);
+      if (!current) throw new StructuredValidationAuthorityError('VALIDATION_NOT_FOUND', 'Validation record was not found');
+      if (current.jobId !== input.jobId || current.attemptId !== input.attemptId
+        || current.generation !== input.generation || current.fenceToken !== input.fenceToken) {
+        throw new StructuredValidationAuthorityError('VALIDATION_BINDING_MISMATCH', 'Validation completion does not match its producing Attempt');
+      }
+      if (current.state !== 'running') return { run: current, diagnostics: listDiagnostics(current.runId) };
+
+      const now = input.now ?? Date.now();
+      const snapshot = deps.repository.getSnapshot(current.repositorySnapshotId)!;
+      const root = rootFor(snapshot);
+      const state = executionState(input.execution);
+      const combined = `${input.execution.stdout}${input.execution.stderr ? `\n${input.execution.stderr}` : ''}`;
+      const rawCombined = input.rawOutput
+        ? `${input.rawOutput.stdout}${input.rawOutput.stderr ? `\n${input.rawOutput.stderr}` : ''}`
+        : combined;
+      const sanitized = sanitizeLog(rawCombined);
+      const compressed = gzipSync(Buffer.from(sanitized, 'utf8'));
+      const logArtifactId = id('validation_artifact');
+      const artifactIds = [logArtifactId];
+      const parsedTest = current.kind === 'test' ? parseTestResult(combined) : null;
+      const outputArtifacts: ValidationOutputArtifact[] = [];
+      const outputHashes: Record<string, string> = {};
+      let packageIdentity: Record<string, unknown> | null = null;
+      const warnings = [...combined.matchAll(/^\s*(?:warning|warn)[:\s]+(.+)$/gim)]
+        .map((match) => sanitizeLog(match[1])).slice(0, 500);
+
+      if (current.kind === 'build' && state === 'succeeded') {
+        const detail = db.prepare('SELECT declared_output_paths_json FROM build_run_details WHERE run_id=?')
+          .get(current.runId) as { declared_output_paths_json: string };
+        const requested = JSON.parse(detail.declared_output_paths_json) as string[];
+        for (const output of await outputFiles(root, requested)) {
+          const hash = sha256(output.bytes);
+          const artifactId = id('validation_artifact');
+          outputArtifacts.push({ path: output.relative, sha256: hash, byteCount: output.bytes.length });
+          outputHashes[output.relative] = hash;
+          artifactIds.push(artifactId);
+          db.prepare(
+            `INSERT INTO validation_artifacts
+               (artifact_id,run_id,kind,relative_path,sha256,byte_count,media_type,compression,content_blob,metadata_json,created_at)
+             VALUES (?,?,'build_output',?,?,?,?,NULL,NULL,?,?)`,
+          ).run(artifactId, current.runId, output.relative, hash, output.bytes.length,
+            'application/octet-stream', JSON.stringify({ capturedFrom: output.relative }), now);
+        }
+        try {
+          const manifest = JSON.parse(await fs.readFile(path.join(root, 'package.json'), 'utf8')) as Record<string, unknown>;
+          packageIdentity = { name: manifest.name ?? null, version: manifest.version ?? null };
+        } catch { /* package identity is optional */ }
+      }
+
+      db.prepare(
+        `INSERT INTO validation_artifacts
+           (artifact_id,run_id,kind,relative_path,sha256,byte_count,media_type,compression,content_blob,metadata_json,created_at)
+         VALUES (?,?,'log',NULL,?,?,'text/plain; charset=utf-8','gzip',?,'{}',?)`,
+      ).run(logArtifactId, current.runId, sha256(sanitized), Buffer.byteLength(sanitized), compressed, now);
+
+      let resultingSnapshotId: string | null = null;
+      let sourceMutations: string[] = [];
+      const inventory = await deps.repository.inventory(snapshot.id, { limit: 1 });
+      if (inventory.stale) {
+        const descendant = await deps.repository.captureSnapshot({
+          jobId: current.jobId, attemptId: current.attemptId, generation: current.generation,
+          fenceToken: current.fenceToken, requestedPath: root, previousSnapshotId: snapshot.id,
+          producer: input.producer,
+        });
+        resultingSnapshotId = descendant.id;
+        const comparison = deps.repository.compareSnapshots(snapshot.id, descendant.id);
+        const allChanges = [...comparison.added, ...comparison.removed, ...comparison.changed];
+        const declaredOutputs = current.kind === 'build'
+          ? (db.prepare('SELECT declared_output_paths_json FROM build_run_details WHERE run_id=?')
+            .get(current.runId) as { declared_output_paths_json: string })
+          : null;
+        const outputPrefixes = declaredOutputs
+          ? (JSON.parse(declaredOutputs.declared_output_paths_json) as string[]).map((item) => normalizeRelative(item).replace(/\/$/, ''))
+          : [];
+        sourceMutations = [...new Set(allChanges.filter((changed) => !outputPrefixes.some(
+          (prefix) => changed === prefix || changed === `${prefix}/` || changed.startsWith(`${prefix}/`),
+        )))].sort();
+      }
+
+      let parseState: StructuredValidationRun['parseState'] = 'unparsed';
+      let semanticallyVerified = false;
+      if (current.kind === 'test') {
+        parseState = parsedTest!.parsed ? 'parsed' : 'unparsed';
+        semanticallyVerified = state === 'succeeded' && parsedTest!.parsed
+          && (parsedTest!.failed ?? 0) === 0 && sourceMutations.length === 0;
+      } else {
+        parseState = outputArtifacts.length > 0 ? 'parsed' : 'unparsed';
+        semanticallyVerified = state === 'succeeded' && outputArtifacts.length > 0 && sourceMutations.length === 0;
+      }
+
+      const evidence = deps.proof.recordEvidence({
+        jobId: current.jobId, attemptId: current.attemptId, generation: current.generation,
+        fenceToken: current.fenceToken, effectId: current.effectId,
+        source: `validation.${current.kind}`, producer: input.producer, observedAt: now,
+        coverage: semanticallyVerified ? 'full' : parseState === 'parsed' ? 'partial' : 'unknown',
+        verificationResult: semanticallyVerified ? 'verified' : state === 'failed' ? 'failed' : 'unknown',
+        payload: {
+          runId: current.runId, repositorySnapshotId: snapshot.id, sourceStateDigest: snapshot.stateDigest,
+          environmentFingerprint: current.environmentFingerprint, executionNodeId: current.executionNodeId,
+          scope: current.scope, state,
+          exitCode: input.execution.exitCode, parseState, logArtifactId, artifactIds,
+          resultingSnapshotId, sourceMutations,
+        }, now,
+      });
+      const claimState = semanticallyVerified ? 'verified' : state === 'failed' ? 'failed' : 'unknown';
+      for (const claimId of current.claimIds) {
+        deps.proof.checkClaim({
+          claimId, attemptId: current.attemptId, generation: current.generation,
+          evidenceIds: [evidence.evidenceId], state: claimState, now,
+        });
+      }
+
+      const diagnostics = parseDiagnostics(current.runId, snapshot.id, current.command, combined, now);
+      if (sourceMutations.length > 0) {
+        diagnostics.push({
+          diagnosticId: id('diagnostic'), runId: current.runId, repositorySnapshotId: snapshot.id,
+          tool: diagnosticTool(current.command), severity: 'warning',
+          message: 'Validation changed repository source; the result cannot verify the input snapshot',
+          path: sourceMutations[0] ?? null, line: null, column: null, endLine: null, endColumn: null,
+          code: 'VALIDATION_SOURCE_MUTATION', createdAt: now,
+        });
+      }
+      for (const diagnostic of diagnostics) {
+        db.prepare(
+          `INSERT INTO validation_diagnostics (
+             diagnostic_id,run_id,repository_snapshot_id,tool,severity,message,relative_path,
+             start_line,start_column,end_line,end_column,code,created_at
+           ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        ).run(
+          diagnostic.diagnosticId, diagnostic.runId, diagnostic.repositorySnapshotId,
+          diagnostic.tool, diagnostic.severity, diagnostic.message, diagnostic.path,
+          diagnostic.line, diagnostic.column, diagnostic.endLine, diagnostic.endColumn,
+          diagnostic.code, diagnostic.createdAt,
+        );
+      }
+
+      db.prepare(
+        `UPDATE validation_runs SET state=?,completed_at=?,exit_code=?,timed_out=?,cancelled=?,
+           parse_state=?,resulting_snapshot_id=?,source_mutations_json=?,raw_log_evidence_id=?,artifact_ids_json=?
+         WHERE run_id=? AND state='running'`,
+      ).run(
+        state, now, input.execution.exitCode, input.execution.timedOut ? 1 : 0,
+        input.execution.cancelled ? 1 : 0, parseState, resultingSnapshotId,
+        JSON.stringify(sourceMutations), evidence.evidenceId, JSON.stringify(artifactIds), current.runId,
+      );
+      if (current.kind === 'test') {
+        db.prepare(
+          `UPDATE test_run_details SET passed_count=?,failed_count=?,skipped_count=?,failed_test_ids_json=? WHERE run_id=?`,
+        ).run(parsedTest!.passed, parsedTest!.failed, parsedTest!.skipped, JSON.stringify(parsedTest!.failedIds), current.runId);
+      } else {
+        db.prepare(
+          `UPDATE build_run_details SET output_artifacts_json=?,output_hashes_json=?,package_identity_json=?,
+             warnings_json=?,reproducibility_json=? WHERE run_id=?`,
+        ).run(
+          JSON.stringify(outputArtifacts), JSON.stringify(outputHashes), packageIdentity ? JSON.stringify(packageIdentity) : null,
+          JSON.stringify(warnings), JSON.stringify({ environmentFingerprint: current.environmentFingerprint, sourceStateDigest: current.sourceStateDigest }),
+          current.runId,
+        );
+      }
+      deps.appendJobEvent({
+        jobId: current.jobId, attemptId: current.attemptId, generation: current.generation,
+        type: `validation.${current.kind}.completed`,
+        payload: { runId: current.runId, state, snapshotId: snapshot.id, evidenceId: evidence.evidenceId, parseState },
+        producer: input.producer, idempotencyKey: `validation-completed:${current.runId}`,
+      });
+      return { run: getRun(current.runId)!, diagnostics: listDiagnostics(current.runId) };
+    },
+
+    getRun,
+    getArtifact,
+    readLogArtifact(artifactId) {
+      const row = db.prepare('SELECT kind,compression,content_blob FROM validation_artifacts WHERE artifact_id=?')
+        .get(artifactId) as { kind: string; compression: string | null; content_blob: Buffer | null } | undefined;
+      if (!row || row.kind !== 'log' || !row.content_blob) {
+        throw new StructuredValidationAuthorityError('LOG_ARTIFACT_NOT_FOUND', 'Validation log artifact was not found');
+      }
+      const bytes = row.compression === 'gzip' ? gunzipSync(row.content_blob) : row.content_blob;
+      return bytes.toString('utf8');
+    },
+    listDiagnostics,
+
+    async assess(runId, input) {
+      const run = getRun(runId);
+      if (!run) return { usable: false, reasons: ['run_not_found'] };
+      const reasons: string[] = [];
+      if (run.repositorySnapshotId !== input.repositorySnapshotId) reasons.push('snapshot_mismatch');
+      if (run.state !== 'succeeded') reasons.push('run_not_succeeded');
+      if (run.parseState !== 'parsed') reasons.push('unparsed_result');
+      if (run.sourceMutations.length > 0) reasons.push('source_mutated');
+      if (input.requiredScope === 'full' && run.scope !== 'full') reasons.push('scope_too_narrow');
+      const referenceSnapshotId = run.resultingSnapshotId ?? run.repositorySnapshotId;
+      const reference = deps.repository.getSnapshot(referenceSnapshotId);
+      if (!reference) reasons.push('snapshot_unavailable');
+      else if ((await deps.repository.inventory(reference.id, { limit: 1 })).stale) reasons.push('source_changed');
+      if (run.kind === 'build') {
+        const snapshot = deps.repository.getSnapshot(run.repositorySnapshotId);
+        if (!snapshot) reasons.push('snapshot_unavailable');
+        else {
+          const root = rootFor(snapshot);
+          for (const artifact of run.outputArtifacts ?? []) {
+            try {
+              const absolute = realpathWithFallback(path.resolve(root, artifact.path));
+              if (!isWithin(absolute, root) || sha256(await fs.readFile(absolute)) !== artifact.sha256) {
+                reasons.push('artifact_changed');
+                break;
+              }
+            } catch {
+              reasons.push('artifact_changed');
+              break;
+            }
+          }
+          if ((run.outputArtifacts ?? []).length === 0) reasons.push('build_artifact_missing');
+        }
+      }
+      const claimStates = deps.proof.listClaims(run.jobId)
+        .filter((claim) => run.claimIds.includes(claim.claimId)).map((claim) => claim.state);
+      if (claimStates.length === 0 || claimStates.some((state) => state !== 'verified')) reasons.push('claim_not_verified');
+      return { usable: reasons.length === 0, reasons: [...new Set(reasons)] };
+    },
+
+    async discover(snapshotId, explicitCommands = []) {
+      const snapshot = deps.repository.getSnapshot(snapshotId);
+      if (!snapshot) throw new StructuredValidationAuthorityError('SNAPSHOT_NOT_FOUND', 'Repository snapshot was not found');
+      const inventory = await deps.repository.inventory(snapshotId, { limit: 10_000 });
+      const sources: ValidationDiscovery['sources'] = [];
+      const commands: ValidationDiscovery['commands'] = [];
+      const addCommand = (command: string, kind: ValidationKind, source: string): void => {
+        const normalized = command.trim();
+        if (!normalized || commands.some((item) => item.command === normalized && item.kind === kind)) return;
+        commands.push({ command: normalized, kind, source });
+      };
+      for (const entry of inventory.entries) {
+        const lower = entry.path.toLowerCase();
+        let sourceKind: ValidationDiscovery['sources'][number]['kind'] | null = null;
+        if (entry.path === 'package.json') sourceKind = 'manifest';
+        else if (/^(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?)$/i.test(entry.path)) sourceKind = 'lockfile';
+        else if (lower.startsWith('.github/workflows/') && /\.ya?ml$/i.test(entry.path)) sourceKind = 'workflow';
+        else if (/^(?:AGENTS|AIDEN|PROJECT|INSTRUCTIONS|CONTRIBUTING)\.md$/i.test(path.posix.basename(entry.path))) sourceKind = 'instruction';
+        if (!sourceKind) continue;
+        sources.push({ kind: sourceKind, path: entry.path });
+        if (entry.captureStatus !== 'captured') continue;
+        const read = await deps.repository.readFile(snapshotId, entry.path, { limit: 512_000 });
+        const content = typeof read.content === 'string' ? read.content : '';
+        if (sourceKind === 'manifest' && entry.path === 'package.json') {
+          try {
+            const manifest = JSON.parse(content) as { scripts?: Record<string, string> };
+            for (const script of Object.keys(manifest.scripts ?? {}).sort()) {
+              const kind: ValidationKind = script === 'test' || script.startsWith('test:') ? 'test' : 'build';
+              addCommand(script === 'test' ? 'npm test' : `npm run ${script}`, kind, entry.path);
+            }
+          } catch { /* invalid manifests remain discoverable sources */ }
+        } else if (sourceKind === 'workflow') {
+          for (const match of content.matchAll(/^\s*-?\s*run:\s*(.+?)\s*$/gim)) {
+            const command = match[1].replace(/^['"]|['"]$/g, '');
+            addCommand(command, /(?:^|\s)(?:test|vitest|jest)(?:\s|$)/i.test(command) ? 'test' : 'build', entry.path);
+          }
+        } else if (sourceKind === 'instruction') {
+          for (const match of content.matchAll(/`((?:npm|pnpm|yarn|bun)\s+(?:run\s+)?[^`\r\n]+)`/gi)) {
+            const command = match[1].trim();
+            addCommand(command, /(?:^|\s)(?:test|vitest|jest)(?:\s|$)/i.test(command) ? 'test' : 'build', entry.path);
+          }
+        }
+      }
+      for (const explicit of explicitCommands) addCommand(explicit.command, explicit.kind, 'explicit');
+      return {
+        snapshotId,
+        sources: sources.sort((a, b) => a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind)),
+        commands,
+      };
+    },
+  };
+  return authority;
+}

--- a/core/v4/codebase/structuredValidationAuthority.ts
+++ b/core/v4/codebase/structuredValidationAuthority.ts
@@ -422,21 +422,30 @@ export function createStructuredValidationAuthority(deps: Deps): StructuredValid
       if (!tool || tool.state !== 'started' || tool.side_effect_id !== input.effectId) {
         throw new StructuredValidationAuthorityError('TOOL_CALL_BINDING_MISMATCH', 'Validation must bind the active shell ToolCall and Effect');
       }
+      const root = rootFor(snapshot);
+      const workingDirectory = realpathWithFallback(path.resolve(input.plan.workingDirectory));
+      if (!isWithin(workingDirectory, root) && workingDirectory !== root) {
+        throw new StructuredValidationAuthorityError('WORKING_DIRECTORY_OUTSIDE_WORKSPACE', 'Validation working directory is outside the repository workspace');
+      }
+      const environmentFingerprint = fingerprint(input.environment);
       const existing = db.prepare(
         'SELECT run_id FROM validation_runs WHERE attempt_id=? AND generation=? AND tool_call_id=? AND kind=?',
       ).get(input.attemptId, input.generation, input.toolCallId, input.plan.kind) as { run_id: string } | undefined;
       if (existing) {
         const record = getRun(existing.run_id)!;
         if (record.repositorySnapshotId !== input.repositorySnapshotId
-          || record.command !== input.plan.command || record.workingDirectory !== input.plan.workingDirectory) {
+          || record.command !== input.plan.command || record.workingDirectory !== workingDirectory
+          || record.environmentFingerprint !== environmentFingerprint || record.scope !== input.plan.scope) {
           throw new StructuredValidationAuthorityError('VALIDATION_IDEMPOTENCY_CONFLICT', 'Validation ToolCall was already bound to different inputs');
         }
+        if (record.kind === 'build') {
+          const outputPaths = db.prepare('SELECT declared_output_paths_json FROM build_run_details WHERE run_id=?')
+            .get(record.runId) as { declared_output_paths_json: string };
+          if (fingerprint(JSON.parse(outputPaths.declared_output_paths_json)) !== fingerprint(input.plan.outputPaths ?? [])) {
+            throw new StructuredValidationAuthorityError('VALIDATION_IDEMPOTENCY_CONFLICT', 'Validation ToolCall was already bound to different inputs');
+          }
+        }
         return record;
-      }
-      const root = rootFor(snapshot);
-      const workingDirectory = realpathWithFallback(path.resolve(input.plan.workingDirectory));
-      if (!isWithin(workingDirectory, root) && workingDirectory !== root) {
-        throw new StructuredValidationAuthorityError('WORKING_DIRECTORY_OUTSIDE_WORKSPACE', 'Validation working directory is outside the repository workspace');
       }
       const runId = id(input.plan.kind === 'test' ? 'test_run' : 'build_run');
       const now = input.now ?? Date.now();
@@ -452,7 +461,6 @@ export function createStructuredValidationAuthority(deps: Deps): StructuredValid
         category: 'observed', statement: `${input.plan.kind} validation completed for snapshot ${snapshot.id}`,
         required: false, now,
       });
-      const environmentFingerprint = fingerprint(input.environment);
       db.transaction(() => {
         db.prepare(
           `INSERT INTO validation_runs (

--- a/core/v4/codebase/structuredValidationAuthority.ts
+++ b/core/v4/codebase/structuredValidationAuthority.ts
@@ -572,16 +572,13 @@ export function createStructuredValidationAuthority(deps: Deps): StructuredValid
         )))].sort();
       }
 
-      let parseState: StructuredValidationRun['parseState'] = 'unparsed';
-      let semanticallyVerified = false;
-      if (current.kind === 'test') {
-        parseState = parsedTest!.parsed ? 'parsed' : 'unparsed';
-        semanticallyVerified = state === 'succeeded' && parsedTest!.parsed
-          && (parsedTest!.failed ?? 0) === 0 && sourceMutations.length === 0;
-      } else {
-        parseState = outputArtifacts.length > 0 ? 'parsed' : 'unparsed';
-        semanticallyVerified = state === 'succeeded' && outputArtifacts.length > 0 && sourceMutations.length === 0;
-      }
+      const parseState: StructuredValidationRun['parseState'] = current.kind === 'test'
+        ? parsedTest!.parsed ? 'parsed' : 'unparsed'
+        : outputArtifacts.length > 0 ? 'parsed' : 'unparsed';
+      const semanticallyVerified = current.kind === 'test'
+        ? state === 'succeeded' && parsedTest!.parsed
+          && (parsedTest!.failed ?? 0) === 0 && sourceMutations.length === 0
+        : state === 'succeeded' && outputArtifacts.length > 0 && sourceMutations.length === 0;
 
       const evidence = deps.proof.recordEvidence({
         jobId: current.jobId, attemptId: current.attemptId, generation: current.generation,

--- a/core/v4/codebase/validationOutput.ts
+++ b/core/v4/codebase/validationOutput.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+export interface RawValidationOutput {
+  stdout: string;
+  stderr: string;
+}
+
+const rawValidationOutput = Symbol('aiden.rawValidationOutput');
+
+export function attachRawValidationOutput<T extends object>(value: T, output: RawValidationOutput): T {
+  Object.defineProperty(value, rawValidationOutput, {
+    value: output,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return value;
+}
+
+export function getRawValidationOutput(value: unknown): RawValidationOutput | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  return (value as Record<symbol, unknown>)[rawValidationOutput] as RawValidationOutput | undefined;
+}

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1599,6 +1599,110 @@ function applyV33(db: Database.Database): void {
   `);
 }
 
+/** Snapshot-bound test, build, diagnostic, and validation artifact records. */
+function applyV34(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS validation_runs (
+      run_id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL CHECK (kind IN ('test','build')),
+      job_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      fence_token TEXT NOT NULL,
+      tool_call_id TEXT NOT NULL,
+      effect_id TEXT NOT NULL,
+      execution_node_id TEXT,
+      repository_snapshot_id TEXT NOT NULL,
+      source_state_digest TEXT NOT NULL,
+      command TEXT NOT NULL,
+      working_directory TEXT NOT NULL,
+      environment_fingerprint TEXT NOT NULL,
+      environment_json TEXT NOT NULL,
+      scope TEXT NOT NULL CHECK (scope IN ('focused','full')),
+      state TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      exit_code INTEGER,
+      timed_out INTEGER NOT NULL DEFAULT 0,
+      cancelled INTEGER NOT NULL DEFAULT 0,
+      parse_state TEXT NOT NULL DEFAULT 'pending',
+      resulting_snapshot_id TEXT,
+      source_mutations_json TEXT NOT NULL DEFAULT '[]',
+      raw_log_evidence_id TEXT,
+      claim_ids_json TEXT NOT NULL DEFAULT '[]',
+      artifact_ids_json TEXT NOT NULL DEFAULT '[]',
+      UNIQUE(attempt_id, generation, tool_call_id, kind),
+      FOREIGN KEY (job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (repository_snapshot_id) REFERENCES repository_snapshots(snapshot_id),
+      FOREIGN KEY (resulting_snapshot_id) REFERENCES repository_snapshots(snapshot_id),
+      FOREIGN KEY (effect_id) REFERENCES side_effect_ledger(key),
+      FOREIGN KEY (execution_node_id) REFERENCES execution_graph_nodes(node_id),
+      FOREIGN KEY (raw_log_evidence_id) REFERENCES job_evidence(evidence_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_validation_runs_job
+      ON validation_runs(job_id, started_at, run_id);
+    CREATE INDEX IF NOT EXISTS idx_validation_runs_snapshot
+      ON validation_runs(repository_snapshot_id, kind, completed_at, run_id);
+
+    CREATE TABLE IF NOT EXISTS test_run_details (
+      run_id TEXT PRIMARY KEY,
+      passed_count INTEGER,
+      failed_count INTEGER,
+      skipped_count INTEGER,
+      failed_test_ids_json TEXT NOT NULL DEFAULT '[]',
+      FOREIGN KEY (run_id) REFERENCES validation_runs(run_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS build_run_details (
+      run_id TEXT PRIMARY KEY,
+      declared_output_paths_json TEXT NOT NULL DEFAULT '[]',
+      output_artifacts_json TEXT NOT NULL DEFAULT '[]',
+      output_hashes_json TEXT NOT NULL DEFAULT '{}',
+      package_identity_json TEXT,
+      warnings_json TEXT NOT NULL DEFAULT '[]',
+      reproducibility_json TEXT NOT NULL DEFAULT '{}',
+      FOREIGN KEY (run_id) REFERENCES validation_runs(run_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS validation_artifacts (
+      artifact_id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      relative_path TEXT,
+      sha256 TEXT NOT NULL,
+      byte_count INTEGER NOT NULL,
+      media_type TEXT NOT NULL,
+      compression TEXT,
+      content_blob BLOB,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (run_id) REFERENCES validation_runs(run_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_validation_artifacts_run
+      ON validation_artifacts(run_id, created_at, artifact_id);
+
+    CREATE TABLE IF NOT EXISTS validation_diagnostics (
+      diagnostic_id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      repository_snapshot_id TEXT NOT NULL,
+      tool TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      message TEXT NOT NULL,
+      relative_path TEXT,
+      start_line INTEGER,
+      start_column INTEGER,
+      end_line INTEGER,
+      end_column INTEGER,
+      code TEXT,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (run_id) REFERENCES validation_runs(run_id) ON DELETE CASCADE,
+      FOREIGN KEY (repository_snapshot_id) REFERENCES repository_snapshots(snapshot_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_validation_diagnostics_run
+      ON validation_diagnostics(run_id, created_at, diagnostic_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1633,6 +1737,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 31, name: 'kernel projection query indexes', apply: applyV31 },
   { version: 32, name: 'immutable repository snapshots', apply: applyV32 },
   { version: 33, name: 'source-fenced repository changes', apply: applyV33 },
+  { version: 34, name: 'snapshot-bound structured validation', apply: applyV34 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -1668,7 +1773,8 @@ function tableExists(db: Database.Database, name: string): boolean {
 function validateLatestSchema(db: Database.Database): void {
   const required = ['tasks', 'runs', 'run_events', 'side_effect_ledger', 'durable_inputs',
     'workspace_descriptors', 'repository_snapshots', 'repository_snapshot_entries',
-    'repository_change_intents', 'repository_change_records'];
+    'repository_change_intents', 'repository_change_records', 'validation_runs',
+    'test_run_details', 'build_run_details', 'validation_artifacts', 'validation_diagnostics'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -28,6 +28,10 @@ import {
   type SafeChangeAuthority,
   type SafeChangeIo,
 } from '../codebase/safeChangeAuthority';
+import {
+  createStructuredValidationAuthority,
+  type StructuredValidationAuthority,
+} from '../codebase/structuredValidationAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -192,6 +196,7 @@ export interface JobEngine {
   readonly projection: JobEventProjectionAuthority;
   readonly repository: RepositorySnapshotAuthority;
   readonly changes: SafeChangeAuthority;
+  readonly validation: StructuredValidationAuthority;
   submitJob(command: SubmitJobCommand): AdmissionResult;
   getJob(jobId: string): JobRecord | null;
   listJobs(filters?: {
@@ -2294,6 +2299,14 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
     appendJobEvent: appendJobEventTx,
   }, opts.safeChangeIo);
+  const validation = createStructuredValidationAuthority({
+    db,
+    repository,
+    proof,
+    getJob(jobId) { const row = getJobRow(jobId); return row ? mapJob(row) : null; },
+    getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
+    appendJobEvent: appendJobEventTx,
+  });
 
   return {
     graph,
@@ -2302,6 +2315,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     projection,
     repository,
     changes,
+    validation,
     submitJob: submitTx,
     getJob(jobId) {
       const row = getJobRow(jobId);

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -84,6 +84,11 @@ import {
   type ChangeIntentRecord,
   type FileChangePlan,
 } from './codebase/safeChangeAuthority';
+import {
+  structuredValidationPlanForShell,
+  type ValidationEnvironment,
+} from './codebase/structuredValidationAuthority';
+import { getRawValidationOutput } from './codebase/validationOutput';
 
 /**
  * Risk profile for a tool. Used by the Phase 9 approval engine to decide
@@ -129,6 +134,13 @@ export interface ToolContext {
     baseSnapshotId: string;
     rootPath: string;
     authority: import('./codebase/safeChangeAuthority').SafeChangeAuthority;
+  };
+  /** Optional snapshot-bound test/build recording over the existing shell authority. */
+  repositoryValidation?: {
+    baseSnapshotId: string;
+    rootPath: string;
+    authority: import('./codebase/structuredValidationAuthority').StructuredValidationAuthority;
+    environment?: ValidationEnvironment;
   };
   /** Aiden user-data paths. Sessions, memory, skills, logs all live here. */
   paths: AidenPaths;
@@ -1206,7 +1218,65 @@ export class ToolRegistry {
                 if (record.descendantSnapshotId) context.repositoryChange!.baseSnapshotId = record.descendantSnapshotId;
                 value = projectSafeChangeResult(record, preparedRepositoryChange.intent);
               } else {
-                value = await handler.execute(a, signal ? { ...context, signal } : context);
+                const validationContext = context.repositoryValidation;
+                const validationPlan = call.name === 'shell_exec' && validationContext
+                  ? structuredValidationPlanForShell(
+                    String(a.command ?? ''),
+                    resolvePath(context.cwd ?? process.cwd(), String(a.cwd ?? '.')),
+                  )
+                  : null;
+                if (validationPlan && jobContext && preparedToolCall?.effectId) {
+                  if (validationContext!.authority !== jobContext.engine.validation) {
+                    throw new Error('Repository validation authority does not match the active Job');
+                  }
+                  const environment = validationContext!.environment ?? {
+                    platform: process.platform,
+                    architecture: process.arch,
+                    nodeVersion: process.version,
+                    npmVersion: process.env.npm_config_user_agent?.match(/\bnpm\/([^\s]+)/)?.[1] ?? 'unknown',
+                    variables: {
+                      CI: process.env.CI ?? '',
+                      NODE_ENV: process.env.NODE_ENV ?? '',
+                    },
+                  };
+                  const validationRun = validationContext!.authority.start({
+                    jobId: jobContext.jobId,
+                    attemptId: jobContext.attemptId,
+                    generation: jobContext.generation,
+                    fenceToken: jobContext.fenceToken,
+                    repositorySnapshotId: validationContext!.baseSnapshotId,
+                    toolCallId: preparedToolCall.toolCallId,
+                    effectId: preparedToolCall.effectId,
+                    plan: validationPlan,
+                    environment,
+                    producer: jobContext.producer,
+                  });
+                  value = await handler.execute(a, signal ? { ...context, signal } : context);
+                  const result = value && typeof value === 'object'
+                    ? value as Record<string, unknown> : {};
+                  const rawOutput = getRawValidationOutput(value);
+                  const completion = await validationContext!.authority.complete({
+                    jobId: jobContext.jobId,
+                    attemptId: jobContext.attemptId,
+                    generation: jobContext.generation,
+                    fenceToken: jobContext.fenceToken,
+                    runId: validationRun.runId,
+                    execution: {
+                      exitCode: typeof result.exitCode === 'number' ? result.exitCode : result.success === true ? 0 : 1,
+                      stdout: typeof result.stdout === 'string' ? result.stdout : '',
+                      stderr: typeof result.stderr === 'string' ? result.stderr : '',
+                      timedOut: result.timedOut === true,
+                      cancelled: signal?.aborted === true,
+                    },
+                    ...(rawOutput ? { rawOutput } : {}),
+                    producer: jobContext.producer,
+                  });
+                  if (completion.run.resultingSnapshotId) {
+                    validationContext!.baseSnapshotId = completion.run.resultingSnapshotId;
+                  }
+                } else {
+                  value = await handler.execute(a, signal ? { ...context, signal } : context);
+                }
               }
               if (waitId && jobContext?.controlAuthority) {
                 const status = value && typeof value === 'object'

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,16 +31,51 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(33);
+    expect(LATEST_SCHEMA_VERSION).toBe(34);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 33 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: 34 });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
       { name: 'repository_change_intents' }, { name: 'repository_change_records' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 33, to: 33 });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'validation_%' ORDER BY name").all()).toEqual([
+      { name: 'validation_artifacts' }, { name: 'validation_diagnostics' }, { name: 'validation_runs' },
+    ]);
+    expect(runMigrations(db)).toEqual({ from: 34, to: 34 });
+  });
+
+  it('adds validation records to a v33 database without changing repository history', () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((item) => item.version <= 33)) {
+      db.transaction(() => {
+        if (migration.apply) migration.apply(db!);
+        else db!.exec(migration.sql ?? '');
+        db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)')
+          .run(migration.version, Date.now());
+      }).immediate();
+    }
+    const now = Date.now();
+    db.prepare('INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)')
+      .run('instance', 1, 'host', now, now, '4.17.0');
+    db.prepare(`INSERT INTO tasks
+      (id,title,goal,status,created_at,updated_at,session_id,trace_ids,artifact_ids,root_job_id,next_event_sequence)
+      VALUES ('job','job','goal','queued',?,?,'session','[]','[]','job',1)`).run(now, now);
+    db.prepare(`INSERT INTO runs
+      (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence)
+      VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
+
+    expect(runMigrations(db)).toEqual({ from: 33, to: 34 });
+    expect(db.prepare('SELECT id,status FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued' });
+    expect(db.prepare('SELECT attempt_id,status FROM runs WHERE attempt_id=?').get('attempt'))
+      .toEqual({ attempt_id: 'attempt', status: 'queued' });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('validation_runs','test_run_details','build_run_details','validation_artifacts','validation_diagnostics') ORDER BY name").all())
+      .toEqual([
+        { name: 'build_run_details' }, { name: 'test_run_details' }, { name: 'validation_artifacts' },
+        { name: 'validation_diagnostics' }, { name: 'validation_runs' },
+      ]);
   });
 });

--- a/tests/v4/codebase/structuredValidationAuthority.test.ts
+++ b/tests/v4/codebase/structuredValidationAuthority.test.ts
@@ -307,7 +307,9 @@ describe('snapshot-bound structured validation authority', () => {
     const first = await start(plan, source.id);
     const replay = engine.validation.start({
       ...binding(), repositorySnapshotId: source.id, toolCallId: first.toolCallId,
-      effectId: first.effectId, plan, environment: ENVIRONMENT, producer: 'test',
+      effectId: first.effectId,
+      plan: { ...plan, workingDirectory: `${root}${path.sep}alias${path.sep}..` },
+      environment: ENVIRONMENT, producer: 'test',
     });
 
     expect(replay.runId).toBe(first.run.runId);

--- a/tests/v4/codebase/structuredValidationAuthority.test.ts
+++ b/tests/v4/codebase/structuredValidationAuthority.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type {
+  StructuredValidationPlan,
+  ValidationEnvironment,
+  ValidationExecutionResult,
+} from '../../../core/v4/codebase/structuredValidationAuthority';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type AdmissionResult, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { normalizedArgsDigest } from '../../../core/v4/daemon/jobExecutionContext';
+
+const ENVIRONMENT: ValidationEnvironment = {
+  platform: 'win32',
+  architecture: 'x64',
+  nodeVersion: 'v22.23.1',
+  npmVersion: '11.8.0',
+  toolVersions: { vitest: '4.1.7', typescript: '5.9.3' },
+};
+
+describe('snapshot-bound structured validation authority', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let root: string;
+  let admission: AdmissionResult;
+  let generation: number;
+  let fenceToken: string;
+  let ordinal: number;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('validation-test',1,'localhost',1,1,'4.17.0')`,
+    ).run();
+    engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-validation-'));
+    admission = engine.submitJob({
+      entryPoint: 'test', source: 'unit', sessionId: 'validation', workspaceId: root,
+      instanceId: 'validation-test', idempotencyNamespace: 'validation',
+      idempotencyKey: path.basename(root), goal: 'validate exact source',
+    });
+    const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 60_000 });
+    generation = lease.generation!;
+    fenceToken = lease.fenceToken!;
+    engine.transitionAttempt({
+      attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!, generation,
+      fenceToken, to: 'running', eventIdempotencyKey: 'validation-attempt-running', producer: 'test',
+    });
+    engine.transitionJob({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation, fenceToken,
+      expectedStateVersion: 0, to: 'running', eventIdempotencyKey: 'validation-job-running', producer: 'test',
+    });
+    ordinal = 0;
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const binding = () => ({
+    jobId: admission.jobId,
+    attemptId: admission.attemptId,
+    generation,
+    fenceToken,
+  });
+
+  async function capture(previousSnapshotId?: string) {
+    return engine.repository.captureSnapshot({
+      ...binding(), requestedPath: root, previousSnapshotId, producer: 'test',
+    });
+  }
+
+  async function start(plan: StructuredValidationPlan, snapshotId: string, environment = ENVIRONMENT) {
+    ordinal += 1;
+    const toolCallId = `validation-tool-${ordinal}`;
+    const prepared = engine.prepareToolCall({
+      ...binding(), toolCallId, toolName: 'shell_exec',
+      normalizedArgsDigest: normalizedArgsDigest({ command: plan.command, cwd: plan.workingDirectory }),
+      riskTier: 'dangerous', mutates: true, producer: 'test',
+      effect: {
+        classification: 'non_reconcilable_mutation', kind: 'process.execute', target: plan.command,
+        retrySafety: 'never_retry', idempotencySupported: false, idempotencyKey: null,
+        reconciliationSupported: false, verificationSupported: true,
+        approvalRequirement: 'policy', approvalState: 'not_required', sensitiveFields: ['command'],
+        redactionRules: ['digest_arguments'], trusted: true,
+      },
+    });
+    if (!prepared.effectId) throw new Error('validation Effect was not created');
+    engine.startToolCall({ toolCallId, ...binding(), producer: 'test' });
+    const run = engine.validation.start({
+      ...binding(), repositorySnapshotId: snapshotId, toolCallId, effectId: prepared.effectId,
+      plan, environment, producer: 'test',
+    });
+    return { run, toolCallId, effectId: prepared.effectId };
+  }
+
+  async function complete(
+    runId: string,
+    execution: Partial<ValidationExecutionResult> = {},
+    rawOutput?: { stdout: string; stderr: string },
+  ) {
+    return engine.validation.complete({
+      ...binding(), runId, producer: 'test',
+      execution: {
+        exitCode: 0,
+        stdout: 'Tests  1 passed (1)\n',
+        stderr: '',
+        timedOut: false,
+        cancelled: false,
+        ...execution,
+      },
+      rawOutput,
+    });
+  }
+
+  it('binds a passing TestRun to one source snapshot and invalidates it for newer source', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+    const source = await capture();
+    const { run } = await start({
+      kind: 'test', command: 'npm test -- --run source.test.ts', workingDirectory: root, scope: 'focused',
+    }, source.id);
+    const completed = await complete(run.runId);
+    expect(completed.run).toMatchObject({
+      kind: 'test', state: 'succeeded', repositorySnapshotId: source.id,
+      sourceStateDigest: source.stateDigest, passedCount: 1, failedCount: 0, skippedCount: 0,
+      scope: 'focused', rawLogEvidenceId: expect.any(String), claimIds: [expect.any(String)],
+    });
+    expect((await engine.validation.assess(run.runId, { repositorySnapshotId: source.id })).usable).toBe(true);
+
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 2;\n');
+    const newer = await capture(source.id);
+    await expect(engine.validation.assess(run.runId, { repositorySnapshotId: newer.id }))
+      .resolves.toMatchObject({ usable: false, reasons: expect.arrayContaining(['snapshot_mismatch']) });
+  });
+
+  it('detects a BuildRun artifact changed after successful execution', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+    const source = await capture();
+    const { run } = await start({
+      kind: 'build', command: 'npm run build', workingDirectory: root, scope: 'full', outputPaths: ['dist'],
+    }, source.id);
+    await mkdir(path.join(root, 'dist'));
+    await writeFile(path.join(root, 'dist', 'bundle.js'), 'bundle-v1\n');
+    const completed = await complete(run.runId, { stdout: 'build completed\n' });
+    expect(completed.run).toMatchObject({
+      kind: 'build', state: 'succeeded', outputArtifacts: [expect.objectContaining({ path: 'dist/bundle.js' })],
+      outputHashes: { 'dist/bundle.js': expect.stringMatching(/^[a-f0-9]{64}$/) },
+    });
+    await writeFile(path.join(root, 'dist', 'bundle.js'), 'bundle-v2\n');
+    await expect(engine.validation.assess(run.runId, { repositorySnapshotId: source.id }))
+      .resolves.toMatchObject({ usable: false, reasons: expect.arrayContaining(['artifact_changed']) });
+  });
+
+  it('does not verify a Claim from exit code zero when test parsing fails', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'value\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    const completed = await complete(run.runId, { stdout: 'command completed without structured test totals\n' });
+    expect(completed.run).toMatchObject({ state: 'succeeded', parseState: 'unparsed' });
+    expect(engine.proof.listClaims(admission.jobId)).toContainEqual(expect.objectContaining({ state: 'unknown' }));
+    expect((await engine.validation.assess(run.runId, { repositorySnapshotId: source.id })).usable).toBe(false);
+  });
+
+  it('keeps timed-out, cancelled, environment and product failures distinct', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'value\n');
+    const source = await capture();
+    const timed = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    expect((await complete(timed.run.runId, { exitCode: -1, timedOut: true, stderr: 'timed out' })).run.state).toBe('timed_out');
+    const cancelled = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    expect((await complete(cancelled.run.runId, { exitCode: -1, cancelled: true, stderr: 'interrupted' })).run.state).toBe('cancelled');
+    const environment = await start({ kind: 'build', command: 'npm run build', workingDirectory: root, scope: 'full' }, source.id);
+    expect((await complete(environment.run.runId, { exitCode: -1, stderr: 'spawn npm ENOENT' })).run.state).toBe('environment_failed');
+    const product = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    expect((await complete(product.run.runId, { exitCode: 1, stdout: 'Tests  1 failed (1)\nFAIL source.test.ts > rejects invalid input' })).run.state).toBe('failed');
+  });
+
+  it('creates a descendant snapshot and withholds verification when validation mutates source', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'snapshot: old\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test -u', workingDirectory: root, scope: 'full' }, source.id);
+    await writeFile(path.join(root, 'source.test.ts'), 'snapshot: updated\n');
+    const completed = await complete(run.runId);
+    expect(completed.run).toMatchObject({
+      state: 'succeeded', resultingSnapshotId: expect.any(String), sourceMutations: ['source.test.ts'],
+    });
+    expect(engine.proof.listClaims(admission.jobId)).toContainEqual(expect.objectContaining({ state: 'unknown' }));
+    expect(completed.diagnostics).toContainEqual(expect.objectContaining({ code: 'VALIDATION_SOURCE_MUTATION' }));
+  });
+
+  it('detects undeclared files created by a test command', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    await writeFile(path.join(root, 'unexpected.tmp'), 'undeclared\n');
+    const completed = await complete(run.runId);
+    expect(completed.run.sourceMutations).toContain('unexpected.tmp');
+    expect((await engine.validation.assess(run.runId, { repositorySnapshotId: source.id })).usable).toBe(false);
+  });
+
+  it('preserves the full sanitized raw log artifact when provider-facing output is truncated', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    const full = `${'line\n'.repeat(20_000)}Tests  1 passed (1)\ncredential=must_not_survive_validation_log`;
+    const completed = await complete(run.runId, { stdout: 'Tests  1 passed (1)\n' }, { stdout: full, stderr: '' });
+    const artifact = engine.validation.getArtifact(completed.run.artifactIds[0]!);
+    expect(artifact).toMatchObject({ kind: 'log', byteCount: expect.any(Number), sha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
+    const stored = engine.validation.readLogArtifact(artifact!.artifactId);
+    expect(stored.length).toBeGreaterThan(50_000);
+    expect(stored).toContain('Tests  1 passed (1)');
+    expect(stored).not.toContain('must_not_survive_validation_log');
+  });
+
+  it('preserves raw Evidence and diagnostics when result parsing fails', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    const completed = await complete(run.runId, { stdout: 'unrecognized runner output\nsource.ts:7:3 error TS9999: invalid result\n' });
+    expect(completed.run).toMatchObject({ parseState: 'unparsed', rawLogEvidenceId: expect.any(String) });
+    expect(completed.diagnostics).toContainEqual(expect.objectContaining({
+      severity: 'error', path: 'source.ts', line: 7, column: 3, code: 'TS9999',
+    }));
+  });
+
+  it('fingerprints Node and npm versions and keeps focused validation scoped', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const first = await start({
+      kind: 'test', command: 'npm test -- --run source.test.ts', workingDirectory: root, scope: 'focused',
+    }, source.id, ENVIRONMENT);
+    const second = await start({
+      kind: 'test', command: 'npm test -- --run source.test.ts', workingDirectory: root, scope: 'focused',
+    }, source.id, { ...ENVIRONMENT, nodeVersion: 'v20.19.5', npmVersion: '10.8.2' });
+    expect(first.run.environmentFingerprint).not.toBe(second.run.environmentFingerprint);
+    await complete(first.run.runId);
+    await expect(engine.validation.assess(first.run.runId, { repositorySnapshotId: source.id, requiredScope: 'full' }))
+      .resolves.toMatchObject({ usable: false, reasons: expect.arrayContaining(['scope_too_narrow']) });
+  });
+
+  it('reloads a completed run after restart without rebinding it to a newer snapshot', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    await complete(run.runId);
+    engine = createJobEngine({ db });
+    expect(engine.validation.getRun(run.runId)).toMatchObject({ repositorySnapshotId: source.id, state: 'succeeded' });
+    await writeFile(path.join(root, 'source.test.ts'), 'changed\n');
+    const newer = await capture(source.id);
+    await expect(engine.validation.assess(run.runId, { repositorySnapshotId: newer.id }))
+      .resolves.toMatchObject({ usable: false, reasons: expect.arrayContaining(['snapshot_mismatch']) });
+  });
+
+  it('discovers common package, workflow, instruction and explicit validation commands', async () => {
+    await mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
+    await writeFile(path.join(root, 'package.json'), JSON.stringify({
+      scripts: { test: 'vitest run', build: 'tsc -p tsconfig.json', lint: 'eslint .' },
+    }));
+    await writeFile(path.join(root, 'package-lock.json'), '{}\n');
+    await writeFile(path.join(root, 'AGENTS.md'), 'Validate with `npm run lint`.\n');
+    await writeFile(path.join(root, '.github', 'workflows', 'ci.yml'), 'steps:\n  - run: npm test\n');
+    const source = await capture();
+    const discovery = await engine.validation.discover(source.id, [{ command: 'npm run build', kind: 'build' }]);
+    expect(discovery.sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'manifest', path: 'package.json' }),
+      expect.objectContaining({ kind: 'lockfile', path: 'package-lock.json' }),
+      expect.objectContaining({ kind: 'workflow', path: '.github/workflows/ci.yml' }),
+      expect.objectContaining({ kind: 'instruction', path: 'AGENTS.md' }),
+    ]));
+    expect(discovery.commands).toEqual(expect.arrayContaining([
+      expect.objectContaining({ command: 'npm test', kind: 'test' }),
+      expect.objectContaining({ command: 'npm run build', kind: 'build' }),
+      expect.objectContaining({ command: 'npm run lint', kind: 'build' }),
+    ]));
+    await expect(readFile(path.join(root, 'package.json'), 'utf8')).resolves.toContain('vitest run');
+  });
+
+  it('rejects completion after the producing lease loses authority', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const { run } = await start({ kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full' }, source.id);
+    db.prepare('UPDATE runs SET lease_expires_at=0 WHERE attempt_id=?').run(admission.attemptId);
+
+    await expect(complete(run.runId)).rejects.toMatchObject({ code: 'STALE_VALIDATION_AUTHORITY' });
+    expect(engine.validation.getRun(run.runId)).toMatchObject({ state: 'running', rawLogEvidenceId: null });
+    expect(engine.proof.listClaims(admission.jobId)).toContainEqual(expect.objectContaining({ state: 'unverified' }));
+  });
+
+  it('replays an identical start idempotently without duplicating its Claim', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test\n');
+    const source = await capture();
+    const plan: StructuredValidationPlan = {
+      kind: 'test', command: 'npm test', workingDirectory: root, scope: 'full',
+    };
+    const first = await start(plan, source.id);
+    const replay = engine.validation.start({
+      ...binding(), repositorySnapshotId: source.id, toolCallId: first.toolCallId,
+      effectId: first.effectId, plan, environment: ENVIRONMENT, producer: 'test',
+    });
+
+    expect(replay.runId).toBe(first.run.runId);
+    expect(engine.proof.listClaims(admission.jobId)).toHaveLength(1);
+  });
+});

--- a/tests/v4/codebase/structuredValidationToolIntegration.test.ts
+++ b/tests/v4/codebase/structuredValidationToolIntegration.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { attachRawValidationOutput } from '../../../core/v4/codebase/validationOutput';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { runWithJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ToolRegistry } from '../../../core/v4/toolRegistry';
+import { withBuiltInEffectContract } from '../../../tools/v4/effectContracts';
+import { shellExecTool } from '../../../tools/v4/terminal/shellExec';
+
+describe('structured validation shell integration', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let root: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('validation-integration',1,'localhost',1,1,'4.17.0')`,
+    ).run();
+    engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-validation-tool-'));
+    await writeFile(path.join(root, 'source.test.ts'), 'test source\n');
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('records one shell execution without changing its provider-facing result', async () => {
+    const admission = engine.submitJob({
+      entryPoint: 'test', source: 'unit', sessionId: 'validation-tool', workspaceId: root,
+      instanceId: 'validation-integration', idempotencyNamespace: 'validation-tool',
+      idempotencyKey: path.basename(root), goal: 'run validation',
+    });
+    const lease = engine.claimAttempt({ attemptId: admission.attemptId, ownerId: 'worker', ttlMs: 60_000 });
+    engine.transitionAttempt({
+      attemptId: admission.attemptId, expectedStateVersion: lease.stateVersion!, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, to: 'running', eventIdempotencyKey: 'attempt-running', producer: 'test',
+    });
+    engine.transitionJob({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, expectedStateVersion: 0, to: 'running',
+      eventIdempotencyKey: 'job-running', producer: 'test',
+    });
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: admission.jobId, attemptId: admission.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, requestedPath: root, producer: 'test',
+    });
+    const executeProcess = vi.fn(async () => attachRawValidationOutput({
+      success: true, exitCode: 0, stdout: 'Tests  2 passed (2)\n', stderr: '', timedOut: false,
+    }, {
+      stdout: `${'complete output\n'.repeat(5_000)}Tests  2 passed (2)\n`, stderr: '',
+    }));
+    const registry = new ToolRegistry();
+    registry.register(withBuiltInEffectContract({ ...shellExecTool, execute: executeProcess }));
+    const repositoryValidation = {
+      baseSnapshotId: snapshot.id,
+      rootPath: root,
+      authority: engine.validation,
+      environment: {
+        platform: 'win32', architecture: 'x64', nodeVersion: 'v22.23.1', npmVersion: '11.8.0',
+      },
+    };
+    const execute = registry.buildExecutor({
+      cwd: root,
+      paths: resolveAidenPaths({ rootOverride: path.join(root, '.aiden') }),
+      repositoryValidation,
+    });
+    const result = await runWithJobExecutionContext({
+      engine, jobId: admission.jobId, attemptId: admission.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!, producer: 'test',
+    }, () => execute({ id: 'provider-validation', name: 'shell_exec', arguments: { command: 'npm test', cwd: root } }));
+
+    expect(result).toMatchObject({
+      id: 'provider-validation', name: 'shell_exec',
+      result: { success: true, exitCode: 0, stdout: 'Tests  2 passed (2)\n', stderr: '' },
+    });
+    expect(executeProcess).toHaveBeenCalledTimes(1);
+    const run = db.prepare('SELECT run_id FROM validation_runs').get() as { run_id: string };
+    expect(engine.validation.getRun(run.run_id)).toMatchObject({
+      state: 'succeeded', passedCount: 2, failedCount: 0, repositorySnapshotId: snapshot.id,
+    });
+    expect(await engine.validation.assess(run.run_id, { repositorySnapshotId: snapshot.id }))
+      .toEqual({ usable: true, reasons: [] });
+    expect(engine.validation.readLogArtifact(engine.validation.getRun(run.run_id)!.artifactIds[0]!))
+      .toContain('complete output');
+  });
+});

--- a/tools/v4/terminal/shellExec.ts
+++ b/tools/v4/terminal/shellExec.ts
@@ -32,6 +32,7 @@
 
 import type { ToolHandler } from '../../../core/v4/toolRegistry';
 import { capToolOutput, shellOutputHandle } from '../../../core/v4/toolOutputCap';
+import { attachRawValidationOutput } from '../../../core/v4/codebase/validationOutput';
 import { localBackendExecute } from '../backends/local';
 import { dockerBackendExecute } from '../backends/docker';
 import {
@@ -158,7 +159,7 @@ export const shellExecTool: ToolHandler = {
     const outCap = capToolOutput(result.stdout ?? '');
     const errCap = capToolOutput(result.stderr ?? '');
     const omitted = outCap.omittedChars + errCap.omittedChars;
-    return {
+    return attachRawValidationOutput({
       success: result.exitCode === 0 || isGrepNoMatchExit(command, result.exitCode),
       exitCode: result.exitCode,
       stdout: outCap.text,
@@ -167,6 +168,6 @@ export const shellExecTool: ToolHandler = {
       timedOut: result.timedOut,
       backend: result.backend,
       ...(outCap.truncated || errCap.truncated ? shellOutputHandle(omitted) : {}),
-    };
+    }, { stdout: result.stdout ?? '', stderr: result.stderr ?? '' });
   },
 };


### PR DESCRIPTION
## Summary

- adds durable snapshot-bound test and build validation records;
- preserves full sanitized command logs while keeping provider-facing output bounded;
- records parsed test results, build artifacts, diagnostics, environment fingerprints and proof links;
- invalidates validation after source or output drift;
- reuses the existing shell ToolCall and Effect execution authority.

## Validation

- 164 focused and neighboring tests passed
- Typecheck passed on Node 22
- Production build passed
- Package dry-run passed
- Migration, NUL, secret, attribution and scope scans passed