### PR TITLE
test(codebase): complete Codebase Mode acceptance

### DIFF
--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -668,6 +668,7 @@ async function invokeDurableDaemon(
         entryPoint: 'daemon',
         source: input.triggerContext.source,
         sessionId: input.sessionId,
+        workspaceId: process.cwd(),
         instanceId: input.instanceId,
         idempotencyNamespace: `trigger:${input.triggerContext.source}:${input.triggerContext.triggerId}`,
         idempotencyKey: String(input.triggerEventId),

--- a/core/v4/daemon/httpJobIngress.ts
+++ b/core/v4/daemon/httpJobIngress.ts
@@ -133,6 +133,7 @@ export function createHttpJobCoordinator(options: HttpJobCoordinatorOptions): Ht
         entryPoint: route.entryPoint,
         source: route.source,
         sessionId: sessionIdFor(req),
+        workspaceId: process.cwd(),
         instanceId: options.instanceId,
         idempotencyNamespace: `http:${route.entryPoint}`,
         idempotencyKey: suppliedKey || undefined,

--- a/core/v4/daemon/jobExecutionContext.ts
+++ b/core/v4/daemon/jobExecutionContext.ts
@@ -10,6 +10,33 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import type { JobEngine, TransitionResult } from './jobEngine';
 import type { JobControlAuthority } from './jobControlAuthority';
 import type { DurableEffectDescriptor } from '../effectContract';
+import type { RepositorySnapshotAuthority } from '../codebase/repositorySnapshotAuthority';
+import type { SafeChangeAuthority } from '../codebase/safeChangeAuthority';
+import type {
+  StructuredValidationAuthority,
+  ValidationEnvironment,
+} from '../codebase/structuredValidationAuthority';
+
+export interface RepositoryExecutionBinding {
+  rootPath: string;
+  inspection: {
+    snapshotId: string;
+    rootPath: string;
+    authority: RepositorySnapshotAuthority;
+  };
+  change: {
+    baseSnapshotId: string;
+    rootPath: string;
+    authority: SafeChangeAuthority;
+  };
+  validation: {
+    baseSnapshotId: string;
+    rootPath: string;
+    authority: StructuredValidationAuthority;
+    environment: ValidationEnvironment;
+  };
+  advance(snapshotId: string): void;
+}
 
 export interface JobExecutionContext {
   engine: JobEngine;
@@ -19,6 +46,9 @@ export interface JobExecutionContext {
   fenceToken: string;
   producer: string;
   controlAuthority?: JobControlAuthority;
+  workspacePath?: string;
+  repository?: RepositoryExecutionBinding;
+  repositoryPromise?: Promise<RepositoryExecutionBinding>;
 }
 
 const storage = new AsyncLocalStorage<JobExecutionContext>();
@@ -29,6 +59,74 @@ export function runWithJobExecutionContext<T>(context: JobExecutionContext, oper
 
 export function currentJobExecutionContext(): JobExecutionContext | undefined {
   return storage.getStore();
+}
+
+/** Lazily bind repository tools to the exact active Attempt and source snapshot. */
+export async function ensureRepositoryExecutionBinding(
+  context: JobExecutionContext,
+): Promise<RepositoryExecutionBinding | undefined> {
+  if (context.repository) return context.repository;
+  if (!context.workspacePath) return undefined;
+  if (!context.repositoryPromise) {
+    context.repositoryPromise = (async () => {
+      const existing = context.engine.repository.getAttemptSnapshot(context.jobId, context.attemptId);
+      const snapshot = existing ?? await context.engine.repository.captureSnapshot({
+        jobId: context.jobId,
+        attemptId: context.attemptId,
+        generation: context.generation,
+        fenceToken: context.fenceToken,
+        requestedPath: context.workspacePath!,
+        producer: context.producer,
+      });
+      const workspace = context.engine.repository.getWorkspace(snapshot.workspaceId);
+      if (!workspace) throw new Error('Repository workspace binding is unavailable');
+      const rootPath = snapshot.repositoryRoot ?? workspace.canonicalPath;
+      const inspection = {
+        snapshotId: snapshot.id,
+        rootPath,
+        authority: context.engine.repository,
+      };
+      const change = {
+        baseSnapshotId: snapshot.id,
+        rootPath,
+        authority: context.engine.changes,
+      };
+      const validation = {
+        baseSnapshotId: snapshot.id,
+        rootPath,
+        authority: context.engine.validation,
+        environment: {
+          platform: process.platform,
+          architecture: process.arch,
+          nodeVersion: process.version,
+          npmVersion: process.env.npm_config_user_agent?.match(/\bnpm\/([^\s]+)/)?.[1] ?? 'unknown',
+          variables: {
+            CI: process.env.CI ?? '',
+            NODE_ENV: process.env.NODE_ENV ?? '',
+          },
+        },
+      };
+      const binding: RepositoryExecutionBinding = {
+        rootPath,
+        inspection,
+        change,
+        validation,
+        advance(snapshotId) {
+          inspection.snapshotId = snapshotId;
+          change.baseSnapshotId = snapshotId;
+          validation.baseSnapshotId = snapshotId;
+        },
+      };
+      context.repository = binding;
+      return binding;
+    })();
+  }
+  try {
+    return await context.repositoryPromise;
+  } catch (error) {
+    context.repositoryPromise = undefined;
+    throw error;
+  }
 }
 
 function canonicalize(value: unknown): unknown {

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -177,6 +177,48 @@ function isJobTerminal(job: JobRecord | null): boolean {
   return job !== null && /^(cancelled|completed|failed|dead_letter|completed_unverified|verification_failed|abandoned)$/.test(job.status);
 }
 
+function applyRequiredProof(
+  engine: JobEngine,
+  handle: DurableJobHandle,
+  finalization: DurableJobDisposition,
+): DurableJobDisposition {
+  if (!engine.proof.hasRequiredClaims(handle.jobId)) return finalization;
+  const proof = engine.proof.getVerdict(handle.jobId) ?? engine.proof.finalize({
+    jobId: handle.jobId,
+    attemptId: handle.attemptId,
+    generation: handle.generation,
+    fenceToken: handle.fenceToken,
+    cancelled: finalization.status === 'cancelled',
+  });
+  if (finalization.status !== 'completed' || proof.verdict === 'verified') return finalization;
+  const evidence = engine.proof.exportJson(handle.jobId);
+  if (proof.verdict === 'failed') {
+    return {
+      status: 'failed',
+      attemptStatus: 'failed',
+      outcome: 'failed',
+      finishReason: 'verification_failed',
+      evidence,
+      ...('jobCard' in finalization && finalization.jobCard ? { jobCard: finalization.jobCard } : {}),
+    };
+  }
+  if (proof.verdict === 'cancelled') {
+    return {
+      status: 'cancelled',
+      attemptStatus: 'cancelled',
+      outcome: 'cancelled',
+      finishReason: 'interrupted',
+      evidence,
+    };
+  }
+  return {
+    status: 'unknown',
+    outcome: proof.verdict,
+    finishReason: 'verification_incomplete',
+    evidence,
+  };
+}
+
 function assertAuthority(engine: JobEngine, handle: DurableJobHandle): { attempt: AttemptRecord; job: JobRecord } {
   const attempt = engine.getAttempt(handle.attemptId);
   const job = engine.getJob(handle.jobId);
@@ -280,6 +322,9 @@ export async function executeDurableJob<T>(
     fenceToken: handle.fenceToken,
     producer,
     controlAuthority: options.controlAuthority,
+    ...(options.engine.getJob(handle.jobId)?.workspaceId
+      ? { workspacePath: options.engine.getJob(handle.jobId)!.workspaceId! }
+      : {}),
   };
   let attemptStateVersion = lease.stateVersion;
   let jobStateVersion = options.engine.getJob(handle.jobId)?.stateVersion ?? 0;
@@ -434,6 +479,8 @@ export async function executeDurableJob<T>(
         executionContext.attemptId = handle.attemptId;
         executionContext.generation = handle.generation;
         executionContext.fenceToken = handle.fenceToken;
+        executionContext.repository = undefined;
+        executionContext.repositoryPromise = undefined;
         attemptStateVersion = attemptStarted.stateVersion;
         jobStateVersion = jobStarted.stateVersion;
         leaseLost = null;
@@ -532,9 +579,10 @@ export async function executeDurableJob<T>(
     assertAuthority(options.engine, handle);
 
     notifyPhase(options.onPhase, 'verifying', handle, handle.generation);
-    const finalization = await options.finalize(value, handle);
+    const requestedFinalization = await options.finalize(value, handle);
     if (leaseLost) throw leaseLost;
     const authority = assertAuthority(options.engine, handle);
+    const finalization = applyRequiredProof(options.engine, handle, requestedFinalization);
     attemptStateVersion = authority.attempt.stateVersion;
     jobStateVersion = authority.job.stateVersion;
     settle(options.engine, handle, finalization, attemptStateVersion, jobStateVersion, producer);

--- a/core/v4/mcp/server/toolBridge.ts
+++ b/core/v4/mcp/server/toolBridge.ts
@@ -200,6 +200,7 @@ export function buildToolCallHandler(
               entryPoint: 'mcp',
               source: 'mcp-stdio',
               sessionId: `mcp:${jobAuthority.instanceId}`,
+              workspaceId: executionContext.cwd,
               instanceId: jobAuthority.instanceId,
               idempotencyNamespace: `mcp:${jobAuthority.instanceId}`,
               idempotencyKey: id,

--- a/core/v4/subagent/spawnSubAgent.ts
+++ b/core/v4/subagent/spawnSubAgent.ts
@@ -258,6 +258,7 @@ export async function spawnSubAgent(
           entryPoint: 'subagent',
           source: 'subagent',
           sessionId: childSessionId,
+          workspaceId: parentJob.workspaceId ?? deps.parentToolContext.cwd,
           instanceId: deps.instanceId,
           idempotencyNamespace: `child:${parentJobContext.jobId}`,
           idempotencyKey: childSessionId,

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -67,6 +67,7 @@ import type { BundledManifest } from './skillBundledManifest';
 import {
   currentDurableToolCallId,
   currentJobExecutionContext,
+  ensureRepositoryExecutionBinding,
   executeWithDurableToolCall,
   prepareDurableToolCall,
   recordDurableToolApproval,
@@ -475,7 +476,7 @@ export class ToolRegistry {
    *   - Handler threw         → that error's message verbatim.
    */
   buildExecutor(
-    context: ToolContext,
+    baseContext: ToolContext,
   ): (
     call: ToolCallRequest,
     signal?: AbortSignal,
@@ -547,6 +548,37 @@ export class ToolRegistry {
         }, 'failed');
       }
 
+      const durableJobContext = currentJobExecutionContext();
+      let context = baseContext;
+      const needsRepositoryBinding =
+        ((call.name === 'file_read' || call.name === 'file_list') && !baseContext.repositoryInspection)
+        || (['file_write', 'file_patch', 'file_move', 'file_delete'].includes(call.name)
+          && !baseContext.repositoryChange)
+        || (call.name === 'shell_exec' && !baseContext.repositoryValidation);
+      if (
+        durableJobContext
+        && needsRepositoryBinding
+      ) {
+        try {
+          const repository = await ensureRepositoryExecutionBinding(durableJobContext);
+          if (repository) {
+            context = {
+              ...baseContext,
+              repositoryInspection: baseContext.repositoryInspection ?? repository.inspection,
+              repositoryChange: baseContext.repositoryChange ?? repository.change,
+              repositoryValidation: baseContext.repositoryValidation ?? repository.validation,
+            };
+          }
+        } catch (error) {
+          return finish({
+            id: call.id,
+            name: call.name,
+            result: null,
+            error: `Repository state could not be captured: ${error instanceof Error ? error.message : String(error)}`,
+          }, 'blocked');
+        }
+      }
+
       let args = call.arguments ?? {};
 
       // ── Argument-shape guard — JSON that PARSES can still be garbage ───
@@ -612,7 +644,6 @@ export class ToolRegistry {
       // registered tool that never set it) is ASSUMED to mutate and is gated —
       // a forgotten declaration must not become a silent bypass.
       const assumeMutates = handler.mutates ?? true;
-      const durableJobContext = currentJobExecutionContext();
       const effectiveMutates = assumeMutates && !readOnlyShell;
       const preliminaryEffect = describeToolEffect(
         effectiveMutates ? handler : { ...handler, mutates: false },
@@ -695,7 +726,10 @@ export class ToolRegistry {
             });
             const priorRecord = context.repositoryChange.authority.getRecord(intent.intentId);
             if (priorRecord?.state === 'committed') {
-              if (priorRecord.descendantSnapshotId) context.repositoryChange.baseSnapshotId = priorRecord.descendantSnapshotId;
+              if (priorRecord.descendantSnapshotId) {
+                context.repositoryChange.baseSnapshotId = priorRecord.descendantSnapshotId;
+                durableJobContext.repository?.advance(priorRecord.descendantSnapshotId);
+              }
               return finish({
                 id: call.id,
                 name: call.name,
@@ -1215,7 +1249,10 @@ export class ToolRegistry {
                   producer: jobContext!.producer,
                   signal,
                 });
-                if (record.descendantSnapshotId) context.repositoryChange!.baseSnapshotId = record.descendantSnapshotId;
+                if (record.descendantSnapshotId) {
+                  context.repositoryChange!.baseSnapshotId = record.descendantSnapshotId;
+                  jobContext!.repository?.advance(record.descendantSnapshotId);
+                }
                 value = projectSafeChangeResult(record, preparedRepositoryChange.intent);
               } else {
                 const validationContext = context.repositoryValidation;
@@ -1273,6 +1310,7 @@ export class ToolRegistry {
                   });
                   if (completion.run.resultingSnapshotId) {
                     validationContext!.baseSnapshotId = completion.run.resultingSnapshotId;
+                    jobContext.repository?.advance(completion.run.resultingSnapshotId);
                   }
                 } else {
                   value = await handler.execute(a, signal ? { ...context, signal } : context);

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -90,6 +90,7 @@ import {
   type ValidationEnvironment,
 } from './codebase/structuredValidationAuthority';
 import { getRawValidationOutput } from './codebase/validationOutput';
+import { isWithin } from './sandboxFs';
 
 /**
  * Risk profile for a tool. Used by the Phase 9 approval engine to decide
@@ -550,6 +551,7 @@ export class ToolRegistry {
 
       const durableJobContext = currentJobExecutionContext();
       let context = baseContext;
+      let repositoryChangeAutoBound = false;
       const needsRepositoryBinding =
         ((call.name === 'file_read' || call.name === 'file_list') && !baseContext.repositoryInspection)
         || (['file_write', 'file_patch', 'file_move', 'file_delete'].includes(call.name)
@@ -562,6 +564,7 @@ export class ToolRegistry {
         try {
           const repository = await ensureRepositoryExecutionBinding(durableJobContext);
           if (repository) {
+            repositoryChangeAutoBound = baseContext.repositoryChange === undefined;
             context = {
               ...baseContext,
               repositoryInspection: baseContext.repositoryInspection ?? repository.inspection,
@@ -711,7 +714,17 @@ export class ToolRegistry {
             context.repositoryChange.rootPath,
             priorIntent?.operation,
           );
-          if (plan) {
+          const planBelongsToRepository = !plan || (
+            isWithin(resolvePath(context.repositoryChange.rootPath, plan.path), context.repositoryChange.rootPath)
+            && (!plan.destinationPath || isWithin(
+              resolvePath(context.repositoryChange.rootPath, plan.destinationPath),
+              context.repositoryChange.rootPath,
+            ))
+          );
+          if (repositoryChangeAutoBound && !planBelongsToRepository) {
+            context = { ...context, repositoryChange: undefined };
+          }
+          if (plan && context.repositoryChange) {
             const intent = await context.repositoryChange.authority.prepare({
               jobId: durableJobContext.jobId,
               attemptId: durableJobContext.attemptId,

--- a/tests/v4/cli/oneShotJobIdentity.test.ts
+++ b/tests/v4/cli/oneShotJobIdentity.test.ts
@@ -5,16 +5,23 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import { executeOneShotTurn } from '../../../cli/v4/aidenCLI';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ToolRegistry } from '../../../core/v4/toolRegistry';
+import { fileReadTool } from '../../../tools/v4/files/fileRead';
 
 describe('headless durable Job admission', () => {
   let db: Database.Database;
   let engine: JobEngine;
+  let root: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     db = new Database(':memory:');
     runMigrations(db);
     const now = Date.now();
@@ -24,9 +31,13 @@ describe('headless durable Job admission', () => {
        VALUES ('instance_oneshot', 1, 'localhost', ?, ?, '4.15.1')`,
     ).run(now, now);
     engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-oneshot-codebase-'));
   });
 
-  afterEach(() => db.close());
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
 
   it('creates identity before the first provider-facing agent call', async () => {
     const agent = {
@@ -51,5 +62,50 @@ describe('headless durable Job admission', () => {
 
     expect(agent.runConversation).toHaveBeenCalledOnce();
     expect(engine.listJobs({ sessionId: 'session_oneshot' })[0]).toMatchObject({ status: 'completed' });
+  });
+
+  it('binds repository inspection to the one-shot durable workspace', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+    const registry = new ToolRegistry();
+    registry.register(fileReadTool);
+    const execute = registry.buildExecutor({
+      cwd: root,
+      paths: resolveAidenPaths({ rootOverride: path.join(root, '.aiden') }),
+    });
+    let readResult: unknown;
+    const agent = {
+      runConversation: vi.fn(async () => {
+        readResult = await execute({
+          id: 'oneshot-read',
+          name: 'file_read',
+          arguments: { path: 'source.ts' },
+        });
+        return { finalContent: 'ok', finishReason: 'stop', toolCallTrace: [] };
+      }),
+    };
+
+    expect(await executeOneShotTurn({
+      agent,
+      prompt: 'inspect source.ts',
+      writeOut: () => {},
+      writeErr: () => {},
+      jobEngine: engine,
+      instanceId: 'instance_oneshot',
+      sessionId: 'session_codebase_oneshot',
+      cwd: root,
+    })).toBe(0);
+
+    expect(readResult).toMatchObject({
+      result: {
+        success: true,
+        content: 'export const value = 1;\n',
+        snapshotId: expect.stringMatching(/^repository_snapshot_/),
+      },
+    });
+    const job = engine.listJobs({ sessionId: 'session_codebase_oneshot' })[0]!;
+    expect(job).toMatchObject({ status: 'completed', workspaceId: root });
+    const snapshot = engine.repository.getAttemptSnapshot(job.id, engine.listAttempts(job.id)[0]!.id)!;
+    expect(snapshot.repositoryRoot).toBeNull();
+    expect(engine.repository.getWorkspace(snapshot.workspaceId)?.canonicalPath).toBe(root);
   });
 });

--- a/tests/v4/cli/oneShotJobIdentity.test.ts
+++ b/tests/v4/cli/oneShotJobIdentity.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -106,6 +106,6 @@ describe('headless durable Job admission', () => {
     expect(job).toMatchObject({ status: 'completed', workspaceId: root });
     const snapshot = engine.repository.getAttemptSnapshot(job.id, engine.listAttempts(job.id)[0]!.id)!;
     expect(snapshot.repositoryRoot).toBeNull();
-    expect(engine.repository.getWorkspace(snapshot.workspaceId)?.canonicalPath).toBe(root);
+    expect(engine.repository.getWorkspace(snapshot.workspaceId)?.canonicalPath).toBe(await realpath(root));
   });
 });

--- a/tests/v4/codebase/codebaseModeAcceptance.test.ts
+++ b/tests/v4/codebase/codebaseModeAcceptance.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createActionAuthority } from '../../../core/v4/actionAuthority';
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { executeDurableJob, type DurableJobHandle } from '../../../core/v4/daemon/jobLifecycle';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ToolRegistry, type ToolHandler, type ToolCallResult } from '../../../core/v4/toolRegistry';
+import { attachRawValidationOutput } from '../../../core/v4/codebase/validationOutput';
+import { ApprovalEngine } from '../../../moat/approvalEngine';
+import { withBuiltInEffectContract } from '../../../tools/v4/effectContracts';
+import { __resetFileReadCache, fileReadTool } from '../../../tools/v4/files/fileRead';
+import { fileWriteTool } from '../../../tools/v4/files/fileWrite';
+import { shellExecTool } from '../../../tools/v4/terminal/shellExec';
+
+describe('Codebase Mode production lifecycle acceptance', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let root: string;
+  let ordinal: number;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('codebase-acceptance',1,'localhost',1,1,'4.17.0')`,
+    ).run();
+    engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-codebase-acceptance-'));
+    __resetFileReadCache();
+    ordinal = 0;
+  });
+
+  function buildExecutor(
+    handlers: ToolHandler[],
+    promptUser: () => Promise<'allow' | 'deny'> = async () => 'allow',
+  ) {
+    const registry = new ToolRegistry();
+    for (const handler of handlers) {
+      registry.register(handler.schema.name === 'delegated_mutation'
+        ? handler
+        : withBuiltInEffectContract(handler));
+    }
+    return registry.buildExecutor({
+      cwd: root,
+      paths: resolveAidenPaths({ rootOverride: path.join(root, '.aiden') }),
+      approvalEngine: new ApprovalEngine('manual', { promptUser }),
+      actionAuthority: createActionAuthority({ db, jobEngine: engine }),
+      policySnapshot: {
+        trustLevel: 'Assistant', autonomyPolicy: 'ask_for_mutations', approvalMode: 'manual',
+        toolMetadataVersion: 'codebase-v1', sandboxPolicy: { roots: [root], deny: [] },
+        networkPolicy: {}, pluginGrants: [], mcpGrants: [], workspaceOverrides: {}, jobOverrides: {},
+      },
+    });
+  }
+
+  async function runJob<T>(input: {
+    execute: (handle: DurableJobHandle) => Promise<T>;
+    finalStatus?: 'completed' | 'failed';
+    outcome?: string;
+    capabilities?: { tools?: string[]; paths?: string[]; effectKinds?: string[] };
+  }) {
+    ordinal += 1;
+    return executeDurableJob({
+      engine,
+      ownerId: 'codebase-acceptance',
+      admission: {
+        entryPoint: 'interactive', source: 'test', sessionId: `codebase-acceptance-${ordinal}`,
+        workspaceId: root, instanceId: 'codebase-acceptance',
+        idempotencyNamespace: 'codebase-acceptance', idempotencyKey: `${path.basename(root)}-${ordinal}`,
+        goal: 'complete a source-bound repository task',
+        ...(input.capabilities ? { resourcePolicy: { capabilities: input.capabilities } } : {}),
+      },
+      execute: input.execute,
+      finalize: () => ({
+        status: input.finalStatus ?? 'completed',
+        outcome: input.outcome ?? (input.finalStatus === 'failed' ? 'failed' : 'verified'),
+        finishReason: input.finalStatus === 'failed' ? 'blocked' : 'stop',
+        evidence: { accepted: true },
+      }),
+    });
+  }
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('automatically binds repository inspection and safe changes to a durable workspace', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+    const execute = buildExecutor([fileReadTool, fileWriteTool]);
+
+    const result = await runJob({
+      execute: async () => ({
+        read: await execute({ id: 'read-source', name: 'file_read', arguments: { path: 'source.ts' } }),
+        write: await execute({
+          id: 'write-source', name: 'file_write',
+          arguments: { path: 'source.ts', content: 'export const value = 2;\n' },
+        }),
+      }),
+    });
+
+    expect(result.value.read.error).toBeUndefined();
+    expect(result.value.read.result).toMatchObject({
+      success: true,
+      snapshotId: expect.stringMatching(/^repository_snapshot_/),
+      content: 'export const value = 1;\n',
+    });
+    expect(result.value.write.error).toBeUndefined();
+    expect(result.value.write.result).toMatchObject({
+      success: true,
+      changeId: expect.stringMatching(/^change_/),
+      verified: true,
+      descendantSnapshotId: expect.stringMatching(/^repository_snapshot_/),
+    });
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8'))
+      .resolves.toBe('export const value = 2;\n');
+    expect(engine.changes.listRecords(result.jobId)).toHaveLength(1);
+    expect(engine.proof.listEvidence(result.jobId)).toEqual([
+      expect.objectContaining({ source: 'repository.change.readback', verificationResult: 'verified' }),
+    ]);
+    expect(engine.proof.getVerdict(result.jobId)?.verdict).toBe('verified');
+    expect(engine.proof.exportJson(result.jobId)).toMatchObject({
+      job: { id: result.jobId },
+      verdict: { verdict: 'verified' },
+    });
+  });
+
+  it('completes a durable inspect-change-validate plan with source-bound Proof', async () => {
+    await writeFile(path.join(root, 'calculator.ts'), 'export const add = (a: number, b: number) => a - b;\n');
+    await writeFile(path.join(root, 'calculator.test.ts'), 'expect(add(2, 1)).toBe(3);\n');
+    const validationShell: ToolHandler = {
+      ...shellExecTool,
+      execute: async () => attachRawValidationOutput({
+        success: true, exitCode: 0, stdout: 'Tests  1 passed (1)\n', stderr: '', timedOut: false,
+      }, { stdout: 'Tests  1 passed (1)\n', stderr: '' }),
+    };
+    const execute = buildExecutor([fileReadTool, fileWriteTool, validationShell]);
+
+    const result = await runJob({
+      execute: async (handle) => {
+        const authority = {
+          jobId: handle.jobId, attemptId: handle.attemptId, generation: handle.generation,
+          fenceToken: handle.fenceToken, producer: 'test',
+        };
+        const read = await execute({ id: 'bug-read', name: 'file_read', arguments: { path: 'calculator.ts' } });
+        const sourceSnapshotId = String((read.result as Record<string, unknown>).snapshotId);
+        const understanding = await engine.understanding.indexSnapshot({
+          ...authority, repositorySnapshotId: sourceSnapshotId,
+        });
+        const located = await engine.understanding.search(sourceSnapshotId, 'a - b');
+        engine.graph.createCodingPlan({
+          jobId: handle.jobId, planDigest: 'calculator-repair-v1', producer: 'test', idempotencyKey: 'plan',
+          steps: [
+            {
+              stepId: 'inspect', label: 'Locate defect', repositorySnapshotId: sourceSnapshotId,
+              references: [{ kind: 'inspected_file', snapshotId: sourceSnapshotId, path: 'calculator.ts' }],
+            },
+            { stepId: 'change', label: 'Repair implementation', repositorySnapshotId: sourceSnapshotId, dependsOn: ['inspect'] },
+            {
+              stepId: 'validate', label: 'Run regression', repositorySnapshotId: sourceSnapshotId,
+              dependsOn: ['change'], requiresVerification: true,
+            },
+          ],
+        });
+        engine.graph.schedule({ ...authority, idempotencyKey: 'schedule-inspect' });
+        engine.graph.claim({ ...authority, nodeId: 'inspect', idempotencyKey: 'claim-inspect' });
+        engine.graph.complete({
+          ...authority, nodeId: 'inspect', state: 'succeeded', outputRef: `search:${sourceSnapshotId}`,
+          idempotencyKey: 'complete-inspect',
+        });
+
+        engine.graph.schedule({ ...authority, idempotencyKey: 'schedule-change' });
+        engine.graph.claim({ ...authority, nodeId: 'change', idempotencyKey: 'claim-change' });
+        const changed = await execute({
+          id: 'bug-write', name: 'file_write',
+          arguments: { path: 'calculator.ts', content: 'export const add = (a: number, b: number) => a + b;\n' },
+        });
+        const change = engine.changes.listRecords(handle.jobId)[0]!;
+        engine.graph.addNodeReferences({
+          ...authority, nodeId: 'change', idempotencyKey: 'reference-change',
+          references: [{ kind: 'change_record', id: change.changeId, snapshotId: change.descendantSnapshotId }],
+        });
+        engine.graph.complete({
+          ...authority, nodeId: 'change', state: 'succeeded', outputRef: `change:${change.changeId}`,
+          idempotencyKey: 'complete-change',
+        });
+
+        engine.graph.schedule({ ...authority, idempotencyKey: 'schedule-validation' });
+        engine.graph.claim({ ...authority, nodeId: 'validate', idempotencyKey: 'claim-validation' });
+        const validation = await execute({
+          id: 'bug-test', name: 'shell_exec',
+          arguments: { command: 'npm test -- --run calculator.test.ts', cwd: root },
+        });
+        const testRun = (db.prepare('SELECT run_id FROM validation_runs WHERE job_id = ?').get(handle.jobId) as { run_id: string }).run_id;
+        const run = engine.validation.getRun(testRun)!;
+        engine.graph.addNodeReferences({
+          ...authority, nodeId: 'validate', idempotencyKey: 'reference-validation',
+          references: [{ kind: 'test_run', id: testRun, snapshotId: run.repositorySnapshotId }],
+        });
+        engine.graph.complete({
+          ...authority, nodeId: 'validate', state: 'succeeded', outputRef: `test:${testRun}`,
+          verificationRef: run.rawLogEvidenceId, idempotencyKey: 'complete-validation',
+        });
+        return { read, changed, validation, understanding, located, testRun };
+      },
+    });
+
+    expect(result.value.located.lexicalMatches).toEqual([
+      expect.objectContaining({ path: 'calculator.ts', line: 1 }),
+    ]);
+    expect(result.value.understanding.stale).toBe(false);
+    expect(result.value.changed.result).toMatchObject({ verified: true });
+    expect(result.value.validation.error).toBeUndefined();
+    expect(engine.validation.getRun(result.value.testRun)).toMatchObject({
+      state: 'succeeded', passedCount: 1, sourceMutations: [],
+    });
+    expect(engine.graph.getCodingPlan(result.jobId)).toMatchObject({
+      state: 'completed', remainingStepIds: [],
+      steps: [
+        expect.objectContaining({ stepId: 'inspect', state: 'completed' }),
+        expect.objectContaining({ stepId: 'change', state: 'completed' }),
+        expect.objectContaining({ stepId: 'validate', state: 'completed' }),
+      ],
+    });
+    expect(engine.proof.getVerdict(result.jobId)?.verdict).toBe('verified');
+    expect(engine.proof.exportMarkdown(result.jobId)).toContain('Verdict: verified');
+  });
+
+  it('updates connected files while preserving unrelated dirty work and restart identity', async () => {
+    await mkdir(path.join(root, 'src'));
+    await writeFile(path.join(root, 'src', 'service.ts'), 'export const service = 1;\n');
+    await writeFile(path.join(root, 'src', 'service.test.ts'), 'expect(service).toBe(1);\n');
+    await writeFile(path.join(root, 'user-notes.txt'), 'private draft\n');
+    const execute = buildExecutor([fileReadTool, fileWriteTool]);
+
+    const result = await runJob({
+      execute: async (handle) => {
+        const inspected = await execute({ id: 'read-service', name: 'file_read', arguments: { path: 'src/service.ts' } });
+        const implementation = await execute({
+          id: 'write-service', name: 'file_write',
+          arguments: { path: 'src/service.ts', content: 'export const service = 2;\n' },
+        });
+        const regression = await execute({
+          id: 'write-test', name: 'file_write',
+          arguments: { path: 'src/service.test.ts', content: 'expect(service).toBe(2);\n' },
+        });
+        const duplicate = await execute({
+          id: 'write-test', name: 'file_write',
+          arguments: { path: 'src/service.test.ts', content: 'expect(service).toBe(2);\n' },
+        });
+        const reopened = createJobEngine({ db });
+        return {
+          inspected, implementation, regression, duplicate,
+          restoredChanges: reopened.changes.listRecords(handle.jobId),
+        };
+      },
+    });
+
+    expect(result.value.inspected.result).toMatchObject({ snapshotId: expect.any(String) });
+    expect(result.value.implementation.result).toMatchObject({ verified: true, changeId: expect.any(String) });
+    expect(result.value.regression.result).toMatchObject({ verified: true, changeId: expect.any(String) });
+    expect(result.value.duplicate).toMatchObject({
+      id: result.value.regression.id,
+      name: result.value.regression.name,
+      result: result.value.regression.result,
+    });
+    expect(result.value.restoredChanges).toHaveLength(2);
+    await expect(readFile(path.join(root, 'user-notes.txt'), 'utf8')).resolves.toBe('private draft\n');
+    expect(engine.proof.getVerdict(result.jobId)?.verdict).toBe('verified');
+  });
+
+  it('blocks a stale write after a user edit and leaves the Job recoverably unknown', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'before\n');
+    const execute = buildExecutor([fileReadTool, fileWriteTool], async () => {
+      await writeFile(path.join(root, 'source.ts'), 'user edit\n');
+      return 'allow';
+    });
+
+    const result = await runJob({
+      execute: async () => {
+        const inspected = await execute({ id: 'read-stale', name: 'file_read', arguments: { path: 'source.ts' } });
+        const blocked = await execute({
+          id: 'write-stale', name: 'file_write', arguments: { path: 'source.ts', content: 'planned\n' },
+        });
+        return { inspected, blocked };
+      },
+    });
+
+    expect(result.value.inspected.error).toBeUndefined();
+    expect(result.value.blocked.error).toContain('Source metadata or content changed after approval');
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('user edit\n');
+    expect(engine.getJob(result.jobId)).toMatchObject({
+      status: 'unknown', terminalOutcome: 'unknown', finishReason: 'verification_incomplete',
+    });
+    expect(engine.proof.getVerdict(result.jobId)?.verdict).toBe('unknown');
+  });
+
+  it('records terminal-created mutations and refuses to reuse their validation as current proof', async () => {
+    await writeFile(path.join(root, 'source.test.ts'), 'test source\n');
+    const mutatingShell: ToolHandler = {
+      ...shellExecTool,
+      execute: async () => {
+        await writeFile(path.join(root, 'terminal-output.txt'), 'created by validation\n');
+        return attachRawValidationOutput({
+          success: true, exitCode: 0, stdout: 'Tests  1 passed (1)\n', stderr: '', timedOut: false,
+        }, { stdout: 'Tests  1 passed (1)\n', stderr: '' });
+      },
+    };
+    const execute = buildExecutor([mutatingShell]);
+
+    const result = await runJob({
+      execute: async () => execute({
+        id: 'focused-validation', name: 'shell_exec',
+        arguments: { command: 'npm test -- --run source.test.ts', cwd: root },
+      }),
+    });
+    const runId = (db.prepare('SELECT run_id FROM validation_runs WHERE job_id = ?').get(result.jobId) as { run_id: string }).run_id;
+    const run = engine.validation.getRun(runId)!;
+    expect(run).toMatchObject({
+      state: 'succeeded', passedCount: 1,
+      sourceMutations: expect.arrayContaining(['terminal-output.txt']),
+      resultingSnapshotId: expect.stringMatching(/^repository_snapshot_/),
+    });
+    await expect(engine.validation.assess(runId, { repositorySnapshotId: run.repositorySnapshotId }))
+      .resolves.toMatchObject({ usable: false, reasons: expect.arrayContaining(['source_mutated']) });
+  });
+
+  it('enforces inspect-only capability boundaries for direct, shell, and delegated mutations', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'unchanged\n');
+    let delegatedExecutionCount = 0;
+    const delegatedMutation: ToolHandler = {
+      schema: { name: 'delegated_mutation', description: 'delegated mutation', inputSchema: { type: 'object' } },
+      category: 'write', mutates: true, riskTier: 'caution', toolset: 'misc',
+      execute: async () => { delegatedExecutionCount += 1; return { success: true }; },
+    };
+    const execute = buildExecutor([fileReadTool, fileWriteTool, shellExecTool, delegatedMutation]);
+
+    const result = await runJob({
+      capabilities: { tools: ['file_read'], paths: [root], effectKinds: [] },
+      execute: async () => ({
+        read: await execute({ id: 'inspect-read', name: 'file_read', arguments: { path: 'source.ts' } }),
+        write: await execute({
+          id: 'inspect-write', name: 'file_write', arguments: { path: 'source.ts', content: 'changed\n' },
+        }),
+        shell: await execute({
+          id: 'inspect-shell', name: 'shell_exec', arguments: { command: 'echo changed > source.ts', cwd: root },
+        }),
+        delegated: await execute({ id: 'inspect-delegated', name: 'delegated_mutation', arguments: {} }),
+      }),
+    });
+
+    expect(result.value.read.error).toBeUndefined();
+    for (const blocked of [result.value.write, result.value.shell, result.value.delegated] as ToolCallResult[]) {
+      expect(blocked.error).toBe('Tool is outside this Job capability boundary');
+    }
+    expect(delegatedExecutionCount).toBe(0);
+    await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('unchanged\n');
+  });
+});

--- a/tests/v4/codebase/codebaseModeAcceptance.test.ts
+++ b/tests/v4/codebase/codebaseModeAcceptance.test.ts
@@ -138,6 +138,32 @@ describe('Codebase Mode production lifecycle acceptance', () => {
     });
   });
 
+  it('keeps an external file change on the ordinary approval path', async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), 'aiden-codebase-external-'));
+    const target = path.join(outside, 'denied.txt');
+    let prompts = 0;
+    try {
+      const execute = buildExecutor([fileWriteTool], async () => {
+        prompts += 1;
+        return 'deny';
+      });
+      const result = await runJob({
+        execute: async () => execute({
+          id: 'external-write', name: 'file_write',
+          arguments: { path: target, content: 'must not be written' },
+        }),
+        finalStatus: 'failed',
+      });
+
+      expect(prompts).toBe(1);
+      expect(result.value.error).toMatch(/denied/i);
+      expect(engine.changes.listRecords(result.jobId)).toHaveLength(0);
+      await expect(readFile(target, 'utf8')).rejects.toThrow();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it('completes a durable inspect-change-validate plan with source-bound Proof', async () => {
     await writeFile(path.join(root, 'calculator.ts'), 'export const add = (a: number, b: number) => a - b;\n');
     await writeFile(path.join(root, 'calculator.test.ts'), 'expect(add(2, 1)).toBe(3);\n');

--- a/tests/v4/daemon/dispatcher/realAgentRunner.test.ts
+++ b/tests/v4/daemon/dispatcher/realAgentRunner.test.ts
@@ -95,7 +95,7 @@ describe('createRealAgentRunner durable identity', () => {
     agent.runConversation = async (...args: Parameters<AidenAgent['runConversation']>) => {
       const jobs = jobEngine.listJobs({ sessionId: 'trigger:file:t1:abc' });
       expect(jobs).toHaveLength(1);
-      expect(jobs[0]).toMatchObject({ status: 'running' });
+      expect(jobs[0]).toMatchObject({ status: 'running', workspaceId: process.cwd() });
       expect(jobEngine.listAttempts(jobs[0]!.id)[0]).toMatchObject({ status: 'running' });
       return original(...args);
     };

--- a/tests/v4/daemon/httpJobIngress.test.ts
+++ b/tests/v4/daemon/httpJobIngress.test.ts
@@ -89,6 +89,8 @@ describe('HTTP durable Job ingress', () => {
       status: 'completed',
       active_attempt_id: null,
     });
+    expect(db.prepare('SELECT workspace_id FROM tasks WHERE id = ?').get(body.job_id))
+      .toEqual({ workspace_id: process.cwd() });
     expect(db.prepare('SELECT status FROM runs WHERE id = ?').get(body.run_id)).toEqual({ status: 'succeeded' });
     expect(db.prepare('SELECT job_id, attempt_id, state FROM tool_calls').get()).toEqual({
       job_id: body.job_id,

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -81,6 +81,93 @@ describe('executeDurableJob', () => {
     expect(engine.getAttempt(job.activeAttemptId!)?.status ?? engine.listAttempts(job.id)[0]?.status).toBe('failed');
   });
 
+  it('does not finalize completed while a required claim remains unknown', async () => {
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_unknown_proof',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_unknown_proof', goal: 'verify required work',
+      },
+      execute: async (handle) => {
+        engine.proof.createClaim({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          category: 'contract',
+          statement: 'required artifact exists',
+          required: true,
+        });
+        return 'done';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    });
+
+    expect(engine.proof.getVerdict(execution.jobId)?.verdict).toBe('unknown');
+    expect(engine.getJob(execution.jobId)).toMatchObject({
+      status: 'unknown',
+      terminalOutcome: 'unknown',
+      finishReason: 'verification_incomplete',
+    });
+    expect(engine.getAttempt(execution.attemptId)?.status).toBe('unknown');
+  });
+
+  it('projects failed required Proof into authoritative Job failure', async () => {
+    const execution = await executeDurableJob({
+      engine,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_failed_proof',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_failed_proof', goal: 'verify required work',
+      },
+      execute: async (handle) => {
+        const claim = engine.proof.createClaim({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          category: 'contract',
+          statement: 'required result is correct',
+          required: true,
+        });
+        const evidence = engine.proof.recordEvidence({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          fenceToken: handle.fenceToken,
+          source: 'test',
+          producer: 'test',
+          observedAt: Date.now(),
+          coverage: 'full',
+          verificationResult: 'failed',
+          payload: { actual: 'wrong' },
+        });
+        engine.proof.checkClaim({
+          claimId: claim.claimId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          evidenceIds: [evidence.evidenceId],
+          state: 'failed',
+        });
+        return 'done';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    });
+
+    expect(engine.proof.getVerdict(execution.jobId)?.verdict).toBe('failed');
+    expect(engine.getJob(execution.jobId)).toMatchObject({
+      status: 'failed',
+      terminalOutcome: 'failed',
+      finishReason: 'verification_failed',
+    });
+    expect(engine.getAttempt(execution.attemptId)?.status).toBe('failed');
+  });
+
   it('aborts active work when lease renewal loses authority', async () => {
     let sawAbort = false;
     const authorityLosingEngine: JobEngine = {

--- a/tests/v4/mcp/server/toolBridgeJobIdentity.test.ts
+++ b/tests/v4/mcp/server/toolBridgeJobIdentity.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -118,6 +118,6 @@ describe('MCP direct durable identity', () => {
     expect(job).toMatchObject({ status: 'completed', workspaceId: root });
     const snapshot = engine.repository.getAttemptSnapshot(job.id, engine.listAttempts(job.id)[0]!.id)!;
     expect(snapshot.repositoryRoot).toBeNull();
-    expect(engine.repository.getWorkspace(snapshot.workspaceId)?.canonicalPath).toBe(root);
+    expect(engine.repository.getWorkspace(snapshot.workspaceId)?.canonicalPath).toBe(await realpath(root));
   });
 });

--- a/tests/v4/mcp/server/toolBridgeJobIdentity.test.ts
+++ b/tests/v4/mcp/server/toolBridgeJobIdentity.test.ts
@@ -5,18 +5,23 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import { runMigrations } from '../../../../core/v4/daemon/db/migrations';
 import { createJobEngine, type JobEngine } from '../../../../core/v4/daemon/jobEngine';
 import { buildToolCallHandler } from '../../../../core/v4/mcp/server/toolBridge';
 import { resolveAidenPaths } from '../../../../core/v4/paths';
 import { ToolRegistry } from '../../../../core/v4/toolRegistry';
+import { fileReadTool } from '../../../../tools/v4/files/fileRead';
 
 describe('MCP direct durable identity', () => {
   let db: Database.Database;
   let engine: JobEngine;
+  let root: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     db = new Database(':memory:');
     runMigrations(db);
     const now = Date.now();
@@ -26,9 +31,13 @@ describe('MCP direct durable identity', () => {
        VALUES ('mcp_instance', 1, 'localhost', ?, ?, '4.15.1')`,
     ).run(now, now);
     engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-mcp-codebase-'));
   });
 
-  afterEach(() => db.close());
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
 
   it('creates a resolvable Job and Attempt before executing the tool', async () => {
     const registry = new ToolRegistry();
@@ -52,7 +61,7 @@ describe('MCP direct durable identity', () => {
 
     expect(await call('mcp_read', {})).toMatchObject({ isError: false });
     const job = engine.listJobs({ sessionId: 'mcp:mcp_instance' })[0]!;
-    expect(job.status).toBe('completed');
+    expect(job).toMatchObject({ status: 'completed', workspaceId: process.cwd() });
     expect(engine.listAttempts(job.id)[0]!.status).toBe('succeeded');
   });
 
@@ -83,5 +92,32 @@ describe('MCP direct durable identity', () => {
     const job = engine.listJobs({ sessionId: 'mcp:mcp_instance' })[0]!;
     expect(job).toMatchObject({ status: 'failed', terminalOutcome: 'failed', finishReason: 'tool_error' });
     expect(engine.listAttempts(job.id)[0]).toMatchObject({ status: 'failed' });
+  });
+
+  it('binds repository inspection to the MCP durable workspace', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+    const registry = new ToolRegistry();
+    registry.register(fileReadTool);
+    const call = buildToolCallHandler(
+      registry,
+      { cwd: root, paths: resolveAidenPaths({ rootOverride: path.join(root, '.aiden') }) },
+      { allowDestructive: false, allowlist: null },
+      undefined,
+      { engine, instanceId: 'mcp_instance' },
+    );
+
+    const result = await call('file_read', { path: 'source.ts' });
+
+    expect(result).toMatchObject({ isError: false });
+    expect(JSON.parse(result.content[0]!.text)).toMatchObject({
+      success: true,
+      content: 'export const value = 1;\n',
+      snapshotId: expect.stringMatching(/^repository_snapshot_/),
+    });
+    const job = engine.listJobs({ sessionId: 'mcp:mcp_instance' })[0]!;
+    expect(job).toMatchObject({ status: 'completed', workspaceId: root });
+    const snapshot = engine.repository.getAttemptSnapshot(job.id, engine.listAttempts(job.id)[0]!.id)!;
+    expect(snapshot.repositoryRoot).toBeNull();
+    expect(engine.repository.getWorkspace(snapshot.workspaceId)?.canonicalPath).toBe(root);
   });
 });

--- a/tests/v4/subagent/spawnSubAgent.test.ts
+++ b/tests/v4/subagent/spawnSubAgent.test.ts
@@ -139,6 +139,7 @@ describe('spawnSubAgent — v4.6 Phase 1 contract', () => {
     const jobEngine = createJobEngine({ db });
     const parent = jobEngine.submitJob({
       entryPoint: 'test', source: 'test', sessionId: 'parent_session',
+      workspaceId: process.cwd(),
       instanceId: INST, idempotencyNamespace: 'parent', idempotencyKey: 'parent_1',
       requestFingerprint: 'parent_fingerprint', goal: 'parent goal',
     });
@@ -164,7 +165,12 @@ describe('spawnSubAgent — v4.6 Phase 1 contract', () => {
     expect(started.applied).toBe(true);
     expect(result.status).toBe('completed');
     expect(children).toHaveLength(1);
-    expect(children[0]).toMatchObject({ parentJobId: parent.jobId, rootJobId: parent.jobId, status: 'completed' });
+    expect(children[0]).toMatchObject({
+      parentJobId: parent.jobId,
+      rootJobId: parent.jobId,
+      workspaceId: process.cwd(),
+      status: 'completed',
+    });
     expect(jobEngine.listAttempts(children[0]!.id)[0]).toMatchObject({ status: 'succeeded' });
     expect(jobEngine.getChildContract(children[0]!.id)).toMatchObject({
       parentJobId: parent.jobId,


### PR DESCRIPTION
## Summary

- binds repository inspection, source-fenced changes and structured validation to the active durable Job and Attempt;
- advances one shared repository snapshot after mutations and validation-created changes;
- propagates workspace identity through one-shot CLI, daemon, HTTP, MCP and child Job entry points;
- makes required Proof authoritative when a caller requests successful completion;
- adds end-to-end Codebase Mode acceptance for safe changes, durable plans, validation, restart identity, stale-source protection, terminal mutations and inspect-only boundaries.

## Validation

- Codebase Mode and lifecycle matrix: 214 passed
- Node 22 typecheck passed
- Production build passed
- Package dry-run passed
- Isolated global, local package-runner and fresh-cache package-runner smoke passed
- Controlled package smoke completed 19 expected provider calls
- Diff, NUL, secret and attribution checks passed

Package version remains 4.17.0.