### PR TITLE
fix(codebase): preserve conflict evidence and runtime plans

### DIFF
--- a/core/v4/codebase/runtimePlanProjection.ts
+++ b/core/v4/codebase/runtimePlanProjection.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { JobExecutionContext } from '../daemon/jobExecutionContext';
+import type { CodingPlanReference, CodingPlanStepDefinition } from '../daemon/executionGraph';
+import type { ChangeIntentRecord, ChangeRecord } from './safeChangeAuthority';
+import type { StructuredValidationRun } from './structuredValidationAuthority';
+
+const PLAN_PREFIX = 'runtime-codebase-plan:';
+
+const digest = (value: string): string => createHash('sha256').update(value).digest('hex');
+
+function authority(context: JobExecutionContext) {
+  return {
+    jobId: context.jobId,
+    attemptId: context.attemptId,
+    generation: context.generation,
+    fenceToken: context.fenceToken,
+    producer: context.producer,
+  };
+}
+
+function planDigest(context: JobExecutionContext): string {
+  return `${PLAN_PREFIX}${digest(context.jobId)}`;
+}
+
+function requireTransition(operation: string, result: { applied: boolean; duplicate?: boolean; conflict?: string }): void {
+  if (!result.applied && !result.duplicate) {
+    throw new Error(`Coding plan ${operation} was rejected: ${result.conflict ?? 'unknown conflict'}`);
+  }
+}
+
+function completeStep(input: {
+  context: JobExecutionContext;
+  step: CodingPlanStepDefinition;
+  references: readonly CodingPlanReference[];
+  outputRef: string;
+  verificationRef?: string | null;
+}): void {
+  const { context, step } = input;
+  const existing = context.engine.graph.getCodingPlan(context.jobId);
+  if (!existing) {
+    context.engine.graph.createCodingPlan({
+      jobId: context.jobId,
+      planDigest: planDigest(context),
+      steps: [step],
+      producer: context.producer,
+      idempotencyKey: `runtime-codebase-plan:${context.jobId}`,
+    });
+  } else {
+    if (existing.planDigest !== planDigest(context)) return;
+    const prior = existing.steps.find((candidate) => candidate.stepId === step.stepId);
+    if (prior?.state === 'completed') return;
+    if (!prior) {
+      context.engine.graph.edit({
+        jobId: context.jobId,
+        expectedVersion: existing.version,
+        nodes: [{
+          nodeId: step.stepId,
+          kind: 'coding_step',
+          label: step.label,
+          inputRef: `repository_snapshot:${step.repositorySnapshotId}`,
+          dependsOn: step.dependsOn,
+          requiresVerification: step.requiresVerification,
+        }],
+        producer: context.producer,
+        idempotencyKey: `runtime-codebase-step:${step.stepId}`,
+      });
+    }
+  }
+
+  const binding = authority(context);
+  context.engine.graph.schedule({
+    ...binding,
+    idempotencyKey: `runtime-codebase-schedule:${step.stepId}`,
+  });
+  requireTransition('claim', context.engine.graph.claim({
+    ...binding,
+    nodeId: step.stepId,
+    idempotencyKey: `runtime-codebase-claim:${step.stepId}`,
+  }));
+  if (input.references.length > 0) {
+    requireTransition('reference update', context.engine.graph.addNodeReferences({
+      ...binding,
+      nodeId: step.stepId,
+      references: input.references,
+      idempotencyKey: `runtime-codebase-references:${step.stepId}`,
+    }));
+  }
+  requireTransition('completion', context.engine.graph.complete({
+    ...binding,
+    nodeId: step.stepId,
+    state: 'succeeded',
+    outputRef: input.outputRef,
+    verificationRef: input.verificationRef,
+    idempotencyKey: `runtime-codebase-complete:${step.stepId}`,
+  }));
+}
+
+/** Project a verified source-fenced change into the existing durable execution graph. */
+export function projectCommittedRepositoryChange(input: {
+  context: JobExecutionContext;
+  intent: ChangeIntentRecord;
+  record: ChangeRecord;
+}): void {
+  if (input.record.state !== 'committed' || !input.record.descendantSnapshotId) return;
+  const existing = input.context.engine.graph.getCodingPlan(input.context.jobId);
+  if (existing && existing.planDigest !== planDigest(input.context)) return;
+
+  if (!existing) {
+    const inspectedPath = input.intent.expectedScope[0];
+    completeStep({
+      context: input.context,
+      step: {
+        stepId: 'inspect-source',
+        label: 'Capture source state',
+        repositorySnapshotId: input.intent.baseSnapshotId,
+      },
+      references: inspectedPath ? [{
+        kind: 'inspected_file',
+        snapshotId: input.intent.baseSnapshotId,
+        path: inspectedPath,
+      }] : [],
+      outputRef: `repository_snapshot:${input.intent.baseSnapshotId}`,
+    });
+  }
+
+  const plan = input.context.engine.graph.getCodingPlan(input.context.jobId)!;
+  const previous = plan.steps[plan.steps.length - 1]?.stepId;
+  const stepId = `change-${input.intent.intentId}`;
+  completeStep({
+    context: input.context,
+    step: {
+      stepId,
+      label: `Apply ${input.intent.operation}`,
+      repositorySnapshotId: input.record.descendantSnapshotId,
+      dependsOn: previous ? [previous] : undefined,
+    },
+    references: [{
+      kind: 'change_record',
+      id: input.record.changeId,
+      snapshotId: input.record.descendantSnapshotId,
+    }],
+    outputRef: `change:${input.record.changeId}`,
+    verificationRef: input.record.diffEvidenceId,
+  });
+}
+
+/** Project a completed structured validation run into the active runtime coding plan. */
+export function projectCompletedRepositoryValidation(input: {
+  context: JobExecutionContext;
+  run: StructuredValidationRun;
+}): void {
+  if (input.run.state !== 'succeeded' || !input.run.rawLogEvidenceId) return;
+  const existing = input.context.engine.graph.getCodingPlan(input.context.jobId);
+  if (existing && existing.planDigest !== planDigest(input.context)) return;
+  const previous = existing?.steps[(existing?.steps.length ?? 0) - 1]?.stepId;
+  const stepId = `validate-${input.run.runId}`;
+  completeStep({
+    context: input.context,
+    step: {
+      stepId,
+      label: input.run.kind === 'test' ? 'Run tests' : 'Run build',
+      repositorySnapshotId: input.run.repositorySnapshotId,
+      dependsOn: previous ? [previous] : undefined,
+      requiresVerification: true,
+    },
+    references: [{
+      kind: input.run.kind === 'test' ? 'test_run' : 'build_run',
+      id: input.run.runId,
+      snapshotId: input.run.repositorySnapshotId,
+    }],
+    outputRef: `${input.run.kind}:${input.run.runId}`,
+    verificationRef: input.run.rawLogEvidenceId,
+  });
+}

--- a/core/v4/codebase/safeChangeAuthority.ts
+++ b/core/v4/codebase/safeChangeAuthority.ts
@@ -449,6 +449,50 @@ export function createSafeChangeAuthority(deps: Deps, io: SafeChangeIo = {}): Sa
     return evidence.evidenceId;
   };
 
+  const recordConflictEvidence = (input: {
+    intent: ChangeIntentRecord; fenceToken: string; producer: string;
+    code: 'STALE_SOURCE' | 'STALE_DESTINATION'; message: string;
+    expected: FilePrecondition; observed: FilePrecondition;
+  }): string => {
+    const existing = deps.proof.listEvidence(input.intent.jobId).find((evidence) => (
+      evidence.source === 'repository.change.conflict'
+      && evidence.effectId === input.intent.effectId
+      && (evidence.payload as { intentId?: unknown }).intentId === input.intent.intentId
+      && (evidence.payload as { errorCode?: unknown }).errorCode === input.code
+    ));
+    const observedAt = Date.now();
+    const evidence = existing ?? deps.proof.recordEvidence({
+      jobId: input.intent.jobId, attemptId: input.intent.attemptId, generation: input.intent.generation,
+      fenceToken: input.fenceToken, effectId: input.intent.effectId,
+      repositorySnapshotId: input.intent.baseSnapshotId,
+      source: 'repository.change.conflict', producer: input.producer,
+      observedAt, freshUntil: null, coverage: 'full', verificationResult: 'unknown',
+      payload: {
+        intentId: input.intent.intentId, operation: input.intent.operation,
+        baseSnapshotId: input.intent.baseSnapshotId, target: input.intent.canonicalTarget,
+        errorCode: input.code, message: input.message, expectedHash: input.expected.contentHash,
+        observedHash: input.observed.contentHash, expectedMetadata: input.expected,
+        observedMetadata: input.observed,
+      },
+    });
+    deps.proof.checkClaim({
+      claimId: input.intent.claimId, attemptId: input.intent.attemptId,
+      generation: input.intent.generation, evidenceIds: [evidence.evidenceId], state: 'unknown',
+    });
+    db.prepare("UPDATE repository_change_intents SET state='failed',updated_at=? WHERE intent_id=? AND state='planned'")
+      .run(observedAt, input.intent.intentId);
+    deps.appendJobEvent({
+      jobId: input.intent.jobId, attemptId: input.intent.attemptId, generation: input.intent.generation,
+      type: 'repository.change_conflict', payload: {
+        intentId: input.intent.intentId, errorCode: input.code,
+        baseSnapshotId: input.intent.baseSnapshotId, evidenceId: evidence.evidenceId,
+      },
+      producer: input.producer,
+      idempotencyKey: `repository-change-conflict:${input.intent.intentId}:${input.code}`,
+    });
+    return evidence.evidenceId;
+  };
+
   return {
     async prepare(input) {
       assertAuthority(input);
@@ -641,6 +685,11 @@ export function createSafeChangeAuthority(deps: Deps, io: SafeChangeIo = {}): Sa
       const expected = intent.originalMetadata;
       if (expected.exists !== current.exists || expected.contentHash !== current.contentHash
         || expected.size !== current.size || expected.modifiedAt !== current.modifiedAt || expected.mode !== current.mode) {
+        recordConflictEvidence({
+          intent: { ...intent, effectId: input.effectId }, fenceToken: input.fenceToken,
+          producer: input.producer, code: 'STALE_SOURCE',
+          message: 'Source metadata or content changed after approval', expected, observed: current,
+        });
         throw new SafeChangeAuthorityError('STALE_SOURCE', 'Source metadata or content changed after approval');
       }
       if (intent.canonicalDestination) {
@@ -648,6 +697,17 @@ export function createSafeChangeAuthority(deps: Deps, io: SafeChangeIo = {}): Sa
         const expectedDestination = intent.destinationOriginalMetadata;
         if (!expectedDestination || destination.exists !== expectedDestination.exists
           || destination.contentHash !== expectedDestination.contentHash || destination.modifiedAt !== expectedDestination.modifiedAt) {
+          recordConflictEvidence({
+            intent: { ...intent, effectId: input.effectId }, fenceToken: input.fenceToken,
+            producer: input.producer, code: 'STALE_DESTINATION',
+            message: 'Destination changed after approval',
+            expected: expectedDestination ?? {
+              path: intent.canonicalDestination, canonicalPath: intent.canonicalDestination,
+              exists: false, size: null, modifiedAt: null, mode: null, contentHash: null,
+              encoding: 'absent', byteOrderMark: false, lineEnding: 'none',
+            },
+            observed: destination,
+          });
           throw new SafeChangeAuthorityError('STALE_DESTINATION', 'Destination changed after approval');
         }
       }

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -83,13 +83,19 @@ import {
   fileChangePlanForTool,
   projectSafeChangeResult,
   type ChangeIntentRecord,
+  type ChangeRecord,
   type FileChangePlan,
 } from './codebase/safeChangeAuthority';
 import {
   structuredValidationPlanForShell,
+  type StructuredValidationRun,
   type ValidationEnvironment,
 } from './codebase/structuredValidationAuthority';
 import { getRawValidationOutput } from './codebase/validationOutput';
+import {
+  projectCommittedRepositoryChange,
+  projectCompletedRepositoryValidation,
+} from './codebase/runtimePlanProjection';
 import { isWithin } from './sandboxFs';
 
 /**
@@ -503,6 +509,8 @@ export class ToolRegistry {
       } | undefined;
       let preparedToolCall: PreparedDurableToolCall | null | undefined;
       let preparedRepositoryChange: { intent: ChangeIntentRecord; plan: FileChangePlan } | undefined;
+      let committedRepositoryChange: { intent: ChangeIntentRecord; record: ChangeRecord } | undefined;
+      let completedRepositoryValidation: StructuredValidationRun | undefined;
       let effectDescriptor: DurableEffectDescriptor | undefined;
       let approvalWaitId: string | null = null;
       const emit = (phase: ToolActivityUpdate['phase'], attempt?: number): void => {
@@ -1266,6 +1274,7 @@ export class ToolRegistry {
                   context.repositoryChange!.baseSnapshotId = record.descendantSnapshotId;
                   jobContext!.repository?.advance(record.descendantSnapshotId);
                 }
+                committedRepositoryChange = { intent: preparedRepositoryChange.intent, record };
                 value = projectSafeChangeResult(record, preparedRepositoryChange.intent);
               } else {
                 const validationContext = context.repositoryValidation;
@@ -1321,6 +1330,7 @@ export class ToolRegistry {
                     ...(rawOutput ? { rawOutput } : {}),
                     producer: jobContext.producer,
                   });
+                  completedRepositoryValidation = completion.run;
                   if (completion.run.resultingSnapshotId) {
                     validationContext!.baseSnapshotId = completion.run.resultingSnapshotId;
                     jobContext.repository?.advance(completion.run.resultingSnapshotId);
@@ -1465,6 +1475,34 @@ export class ToolRegistry {
           );
         } else {
           result = await dispatch(args);
+        }
+        const projectionContext = currentJobExecutionContext();
+        if (projectionContext && (committedRepositoryChange || completedRepositoryValidation)) {
+          try {
+            if (committedRepositoryChange) {
+              projectCommittedRepositoryChange({
+                context: projectionContext,
+                intent: committedRepositoryChange.intent,
+                record: committedRepositoryChange.record,
+              });
+            }
+            if (completedRepositoryValidation) {
+              projectCompletedRepositoryValidation({
+                context: projectionContext,
+                run: completedRepositoryValidation,
+              });
+            }
+          } catch (error) {
+            projectionContext.engine.appendJobEvent({
+              jobId: projectionContext.jobId,
+              attemptId: projectionContext.attemptId,
+              generation: projectionContext.generation,
+              type: 'repository.plan_projection_failed',
+              payload: { message: error instanceof Error ? error.message : String(error) },
+              producer: projectionContext.producer,
+              idempotencyKey: `repository-plan-projection-failed:${call.id}`,
+            });
+          }
         }
         executionAttempt.endedAt = Date.now();
         executionAttempt.terminalResult = 'completed';

--- a/tests/v4/codebase/codebaseModeAcceptance.test.ts
+++ b/tests/v4/codebase/codebaseModeAcceptance.test.ts
@@ -128,6 +128,16 @@ describe('Codebase Mode production lifecycle acceptance', () => {
     await expect(readFile(path.join(root, 'source.ts'), 'utf8'))
       .resolves.toBe('export const value = 2;\n');
     expect(engine.changes.listRecords(result.jobId)).toHaveLength(1);
+    expect(engine.graph.getCodingPlan(result.jobId)).toMatchObject({
+      state: 'completed',
+      remainingStepIds: [],
+      steps: [
+        expect.objectContaining({ state: 'completed', filesInspected: ['source.ts'] }),
+        expect.objectContaining({ state: 'completed', references: [
+          expect.objectContaining({ kind: 'change_record' }),
+        ] }),
+      ],
+    });
     expect(engine.proof.listEvidence(result.jobId)).toEqual([
       expect.objectContaining({ source: 'repository.change.readback', verificationResult: 'verified' }),
     ]);
@@ -162,6 +172,49 @@ describe('Codebase Mode production lifecycle acceptance', () => {
     } finally {
       await rm(outside, { recursive: true, force: true });
     }
+  });
+
+  it('persists automatically projected change and validation steps across restart', async () => {
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+    const validationShell: ToolHandler = {
+      ...shellExecTool,
+      execute: async () => attachRawValidationOutput({
+        success: true, exitCode: 0, stdout: 'Tests  1 passed (1)\n', stderr: '', timedOut: false,
+      }, { stdout: 'Tests  1 passed (1)\n', stderr: '' }),
+    };
+    const execute = buildExecutor([fileReadTool, fileWriteTool, validationShell]);
+
+    const result = await runJob({
+      execute: async () => {
+        const inspected = await execute({ id: 'auto-read', name: 'file_read', arguments: { path: 'source.ts' } });
+        const changed = await execute({
+          id: 'auto-write', name: 'file_write',
+          arguments: { path: 'source.ts', content: 'export const value = 2;\n' },
+        });
+        const validated = await execute({
+          id: 'auto-test', name: 'shell_exec',
+          arguments: { command: 'npm test -- --run source.test.ts', cwd: root },
+        });
+        return { inspected, changed, validated };
+      },
+    });
+
+    expect(result.value.changed.error).toBeUndefined();
+    expect(result.value.validated.error).toBeUndefined();
+    const reopened = createJobEngine({ db });
+    expect(reopened.graph.getCodingPlan(result.jobId)).toMatchObject({
+      state: 'completed',
+      remainingStepIds: [],
+      steps: [
+        expect.objectContaining({ state: 'completed', filesInspected: ['source.ts'] }),
+        expect.objectContaining({ state: 'completed', references: [
+          expect.objectContaining({ kind: 'change_record' }),
+        ] }),
+        expect.objectContaining({ state: 'completed', references: [
+          expect.objectContaining({ kind: 'test_run' }),
+        ], verificationRef: expect.stringMatching(/^evidence_/) }),
+      ],
+    });
   });
 
   it('completes a durable inspect-change-validate plan with source-bound Proof', async () => {
@@ -332,6 +385,16 @@ describe('Codebase Mode production lifecycle acceptance', () => {
       status: 'unknown', terminalOutcome: 'unknown', finishReason: 'verification_incomplete',
     });
     expect(engine.proof.getVerdict(result.jobId)?.verdict).toBe('unknown');
+    expect(engine.proof.listEvidence(result.jobId)).toContainEqual(expect.objectContaining({
+      source: 'repository.change.conflict',
+      repositorySnapshotId: expect.stringMatching(/^repository_snapshot_/),
+      coverage: 'full',
+      verificationResult: 'unknown',
+      payload: expect.objectContaining({
+        errorCode: 'STALE_SOURCE',
+        observedHash: expect.any(String),
+      }),
+    }));
   });
 
   it('records terminal-created mutations and refuses to reuse their validation as current proof', async () => {

--- a/tests/v4/codebase/safeChangeAuthority.test.ts
+++ b/tests/v4/codebase/safeChangeAuthority.test.ts
@@ -189,6 +189,19 @@ describe('source-fenced safe change authority', () => {
     await writeFile(path.join(root, 'source.ts'), 'const userValue = 3;\n');
     await expect(change.execute()).rejects.toMatchObject({ code: 'STALE_SOURCE' });
     await expect(readFile(path.join(root, 'source.ts'), 'utf8')).resolves.toBe('const userValue = 3;\n');
+    expect(engine.proof.listEvidence(admission.jobId)).toContainEqual(expect.objectContaining({
+      effectId: change.effectId,
+      repositorySnapshotId: snapshot.id,
+      source: 'repository.change.conflict',
+      coverage: 'full',
+      verificationResult: 'unknown',
+      payload: expect.objectContaining({
+        intentId: change.intent.intentId,
+        errorCode: 'STALE_SOURCE',
+        expectedHash: sha256('const value = 1;\n'),
+        observedHash: sha256('const userValue = 3;\n'),
+      }),
+    }));
   });
 
   it('rejects inactive Attempts and stale fence tokens before mutation', async () => {


### PR DESCRIPTION
## Summary

- records source and destination drift as durable conflict Evidence without overwriting newer user content;
- projects verified repository changes and structured validation into the existing durable execution graph;
- preserves explicit coding plans while making ordinary Codebase Mode jobs restart-aware.

## Root cause

The packaged runtime rejected stale writes correctly, but did not persist conflict Evidence. Ordinary production tool execution also persisted snapshots, changes, and validation independently without linking them through the existing coding-plan graph, so completed steps were unavailable after restart.

## Validation

- focused Codebase Mode and ToolRegistry matrix: 150 passed;
- TypeScript typecheck passed;
- production build passed;
- exact packed artifact installed into an isolated prefix;
- repository capture, safe mutation, structured test result, concurrent-edit rejection, restart persistence, `/usage`, `/queue`, `/cls`, and `/quit` passed;
- unrelated dirty content and concurrent user content remained byte-for-byte unchanged;
- package version remains 4.17.0.