### PR TITLE
fix(tui): enforce transcript and activity ownership

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -46,6 +46,7 @@ import { pwClose } from '../core/playwrightBridge'
 // runtime lock, crash recovery, health endpoints, signal handlers.
 import { bootstrapDaemon } from '../core/v4/daemon'
 import { resolveAidenPaths } from '../core/v4/paths'
+import { resolveRuntimeStorageRoot } from '../core/v4/runtimeStorage'
 import { daemonDbPath } from '../core/v4/daemon/daemonConfig'
 import { openDaemonDb } from '../core/v4/daemon/db/connection'
 import { createJobEngine } from '../core/v4/daemon/jobEngine'
@@ -360,8 +361,9 @@ function handleChatError(
 }
 
 
-// Workspace root — AIDEN_USER_DATA in packaged Electron, cwd in dev
-const WORKSPACE_ROOT = process.env.AIDEN_USER_DATA || process.cwd()
+// Runtime-owned state belongs under the canonical Aiden data root, never the
+// caller's active repository. Packaged shells may provide AIDEN_USER_DATA.
+const WORKSPACE_ROOT = resolveRuntimeStorageRoot()
 
 // Package root — where workspace-templates/ ships inside the npm tarball.
 // In esbuild bundle (dist-bundle/index.js): __dirname = <pkg>/dist-bundle/ → parent is <pkg>
@@ -373,7 +375,7 @@ const PACKAGE_ROOT = fs.existsSync(path.join(_pkgCandidate1, 'workspace-template
   ? _pkgCandidate1
   : fs.existsSync(path.join(_pkgCandidate2, 'workspace-templates'))
     ? _pkgCandidate2
-    : WORKSPACE_ROOT  // dev mode: cwd has workspace-templates
+    : process.cwd()  // dev mode: cwd has workspace-templates
 
 // Per-session soul hash for Option-B protected-context injection.
 // First turn: undefined → full SOUL inject. Subsequent turns: compare → emit

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -534,6 +534,12 @@ export class CliCallbacks {
     if (!settled) return;
 
     try { this.renderBlockerCardIfPresent(result); } catch { /* defensive */ }
+    try {
+      const payload = result?.result && typeof result.result === 'object'
+        ? { ...(result.result as Record<string, unknown>), ...(result.error ? { error: result.error } : {}) }
+        : result?.result;
+      this.display.toolEffect(call.name, payload);
+    } catch { /* presentation must never affect execution */ }
     if (err) {
       if (result?.capabilityCard) {
         this.display.capabilityCard(result.capabilityCard);
@@ -590,7 +596,7 @@ export class CliCallbacks {
     // Yellow distinguishes the awaiting-attention state from the
     // brand-orange (informational) frames used by setup-complete and
     // /doctor.
-    this.display.write(renderApprovalBox(req, this.display) + '\n');
+    this.display.writeTransient(renderApprovalBox(req, this.display) + '\n');
 
     const prompts = await this.promptsPromise;
     let choice: string;

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -645,6 +645,7 @@ export class ChatSession implements ChatSessionLike {
    * silently fix for the user.
    */
   private streamingDisabledWarned = false;
+  private startupRendered = false;
 
   /**
    * Phase v4.1.2-memory-D:
@@ -3488,6 +3489,8 @@ export class ChatSession implements ChatSessionLike {
     // Tier-3.1a: skip entirely on non-TTY so piped/scripted callers
     // don't get scrollback chatter on stdout.
     if (!process.stdout.isTTY) return;
+    if (this.startupRendered) return;
+    this.startupRendered = true;
 
     // Channel summary — observable, not banner-essential, but kept so
     // status pills aren't the only place a user sees telegram health.

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -25,6 +25,8 @@ import {
   type OperatorActivityState,
   type OperatorProjectionState,
 } from './operatorProjection';
+import { wrap as wrapAnsiText } from './display/frame';
+import { terminalSupportsUnicode } from './terminalSymbols';
 
 const ESC = '\x1b';
 const SAVE = `${ESC}7`;
@@ -83,6 +85,7 @@ type StatusSource = string | (() => string);
 export interface BottomRegionStyle {
   brand(value: string): string;
   muted(value: string): string;
+  unicode?: boolean;
 }
 
 const PLAIN_BOTTOM_STYLE: BottomRegionStyle = {
@@ -127,15 +130,34 @@ function wrapTranscriptText(text: string, width: number): string[] {
   const rows: string[] = [];
   for (const logical of plain.split('\n')) {
     let row = '';
-    for (const character of Array.from(logical)) {
-      if (row && terminalWidth(row + character) > width) {
-        rows.push(row);
-        row = character;
-      } else {
+    let pendingWhitespace = '';
+    const pushRow = (): void => {
+      rows.push(row.replace(/\s+$/u, ''));
+      row = '';
+      pendingWhitespace = '';
+    };
+    const appendLongToken = (token: string): void => {
+      for (const character of Array.from(token)) {
+        if (row && terminalWidth(row + character) > width) pushRow();
         row += character;
       }
+    };
+
+    for (const token of logical.match(/\s+|\S+/gu) ?? []) {
+      if (/^\s+$/u.test(token)) {
+        pendingWhitespace += token;
+        continue;
+      }
+      const separator = row ? pendingWhitespace : '';
+      if (row && terminalWidth(row + separator + token) > width) pushRow();
+      if (terminalWidth(token) > width) {
+        appendLongToken(token);
+      } else {
+        row += (row ? separator : '') + token;
+      }
+      pendingWhitespace = '';
     }
-    rows.push(row);
+    rows.push(row.replace(/\s+$/u, ''));
   }
   if (plain.endsWith('\n')) rows.pop();
   return rows;
@@ -236,11 +258,12 @@ function normalizeComposer(source: ComposerSource): BottomComposerSurface {
     : source;
 }
 
-function modeTitle(mode: BottomComposerMode): string {
-  if (mode === 'idle') return '▲ You';
-  if (mode === 'queue') return '▲ You · queue mode';
-  if (mode === 'interrupt') return '▲ You · interrupt mode';
-  return '▲ You · steer mode';
+function modeTitle(mode: BottomComposerMode, unicode = terminalSupportsUnicode()): string {
+  const user = unicode ? '▲ You' : '> You';
+  if (mode === 'idle') return user;
+  if (mode === 'queue') return `${user} · queue mode`;
+  if (mode === 'interrupt') return `${user} · interrupt mode`;
+  return `${user} · steer mode`;
 }
 
 export function renderBottomSurface(
@@ -251,6 +274,10 @@ export function renderBottomSurface(
   style: BottomRegionStyle = PLAIN_BOTTOM_STYLE,
 ): RenderedSurface {
   const composer = normalizeComposer(composerSource);
+  const unicode = style.unicode ?? terminalSupportsUnicode();
+  const chrome = unicode
+    ? { topLeft: '╭', topRight: '╮', bottomLeft: '╰', bottomRight: '╯', horizontal: '─', vertical: '│' }
+    : { topLeft: '+', topRight: '+', bottomLeft: '+', bottomRight: '+', horizontal: '-', vertical: '|' };
   // Leave the final physical cell unused so Windows ConPTY never enters its
   // pending-wrap state after painting a border or status row.
   const outerWidth = Math.max(8, cols - 1);
@@ -264,14 +291,14 @@ export function renderBottomSurface(
   );
   const content = wrapped.lines;
   const laneRows = Math.min(rows - 1, content.length + 3);
-  const title = modeTitle(composer.mode);
+  const title = modeTitle(composer.mode, unicode);
   const titleRoom = Math.max(1, outerWidth - 5);
   const fittedTitle = terminalWidth(title) <= titleRoom ? title : fitStatus(title, titleRoom);
-  const topPrefix = `╭─ ${fittedTitle} `;
-  const topTail = `${'─'.repeat(Math.max(0, outerWidth - terminalWidth(topPrefix) - 1))}╮`;
-  const top = `${style.muted('╭─ ')}${style.brand(fittedTitle)}${style.muted(` ${topTail}`)}`;
-  const body = content.map((line) => `${style.muted('│')} ${padVisible(line, innerWidth)} ${style.muted('│')}`);
-  const bottom = style.muted(`╰${'─'.repeat(Math.max(0, outerWidth - 2))}╯`);
+  const topPrefix = `${chrome.topLeft}${chrome.horizontal} ${fittedTitle} `;
+  const topTail = `${chrome.horizontal.repeat(Math.max(0, outerWidth - terminalWidth(topPrefix) - 1))}${chrome.topRight}`;
+  const top = `${style.muted(`${chrome.topLeft}${chrome.horizontal} `)}${style.brand(fittedTitle)}${style.muted(` ${topTail}`)}`;
+  const body = content.map((line) => `${style.muted(chrome.vertical)} ${padVisible(line, innerWidth)} ${style.muted(chrome.vertical)}`);
+  const bottom = style.muted(`${chrome.bottomLeft}${chrome.horizontal.repeat(Math.max(0, outerWidth - 2))}${chrome.bottomRight}`);
   const fittedStatus = fitStatus(status, outerWidth);
   const topRow = rows - laneRows + 1;
   return {
@@ -374,7 +401,7 @@ export class BottomRegion {
     const next = reduceOperatorProjection(this.projection, { type: 'activity.remove', id });
     if (next === this.projection) return;
     this.projection = next;
-    if (this.active) this.paintAll();
+    if (this.active) this.paintAll(true);
   }
 
   /** Replace a live row with its final transcript row exactly once. */
@@ -392,14 +419,16 @@ export class BottomRegion {
       });
       this.projection = reduceOperatorProjection(this.projection, { type: 'activity.remove', id });
     }
-    const terminal = text.endsWith('\n') ? text : `${text}\n`;
-    this.recordTranscript(terminal);
+    const priorSource = transcriptSource(this.projection);
+    const lineBreak = this.active && priorSource.length > 0 && !priorSource.endsWith('\n') ? '\n' : '';
+    const terminal = `${lineBreak}${text.endsWith('\n') ? text : `${text}\n`}`;
+    if (!this.recordTranscript(terminal, `activity-terminal:${id}`)) return;
     if (!this.active) {
       this.sink.write(terminal);
       return;
     }
     this.sink.write(`${RESTORE_TRANSCRIPT}${terminal}${SAVE_TRANSCRIPT}`);
-    this.paintAll();
+    this.paintAll(true);
   }
 
   /** Move the transcript viewport away from or toward the live tail. */
@@ -472,14 +501,23 @@ export class BottomRegion {
    * cursor to the draft insertion point without repainting or mutating draft.
    */
   writeAbove(text: string): void {
-    this.recordTranscript(text);
+    const priorSource = transcriptSource(this.projection);
+    const ownsTranscriptBoundary = this.active || this.rebuildTranscriptOnActivation;
+    const lineBreak = ownsTranscriptBoundary && priorSource.length > 0 && !priorSource.endsWith('\n') ? '\n' : '';
+    const output = `${lineBreak}${text}`;
+    this.recordTranscript(output);
     if (!this.active) {
-      this.sink.write(text);
+      this.sink.write(output);
       return;
     }
     const surface = this.surface();
+    const width = Math.max(1, this.sink.cols() - 1);
+    const wrapped = output
+      .split('\n')
+      .map((line) => wrapAnsiText(line, width, { trim: false, hard: true }))
+      .join('\n');
     this.sink.write(
-      `${RESTORE_TRANSCRIPT}${text}${SAVE_TRANSCRIPT}` +
+      `${RESTORE_TRANSCRIPT}${wrapped}${SAVE_TRANSCRIPT}` +
       `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`,
     );
   }
@@ -524,15 +562,17 @@ export class BottomRegion {
     };
   }
 
-  private recordTranscript(text: string): void {
+  private recordTranscript(text: string, identity?: string): boolean {
     const semantic = text.replace(TERMINAL_CONTROL_PATTERN, '');
-    if (!/[^\s]/u.test(semantic)) return;
-    this.projection = reduceOperatorProjection(this.projection, {
+    if (!/[^\s]/u.test(semantic)) return false;
+    const next = reduceOperatorProjection(this.projection, {
       type: 'transcript.append',
-      id: `transcript:${++this.projectionIdentity}`,
+      id: identity ?? `transcript:${++this.projectionIdentity}`,
       kind: 'system',
       sourceText: text,
     });
+    if (next === this.projection) return false;
+    this.projection = next;
     if (transcriptSource(this.projection).length > BottomRegion.MAX_TRANSCRIPT_CHARS) {
       let remaining = BottomRegion.MAX_TRANSCRIPT_CHARS;
       const retained: Array<OperatorProjectionState['transcript'][number]> = [];
@@ -546,15 +586,19 @@ export class BottomRegion {
       }
       this.projection = { ...this.projection, transcript: retained };
     }
+    return true;
   }
 
   private transcriptFrame(surface: RenderedSurface): string {
     const bottom = Math.max(0, this.sink.rows() - surface.laneRows);
     if (bottom === 0) return '';
     const width = Math.max(1, this.sink.cols() - 1);
-    const rows = wrapTranscriptText(visibleTranscriptSource(this.projection), width);
+    const source = visibleTranscriptSource(this.projection);
+    const rows = wrapTranscriptText(source, width);
+    const cursorNeedsBlankRow = source.endsWith('\n');
+    const contentRows = Math.max(0, bottom - (cursorNeedsBlankRow ? 1 : 0));
     const end = Math.max(0, rows.length - this.projection.viewport.scrollOffset);
-    const visible = rows.slice(Math.max(0, end - bottom), end);
+    const visible = rows.slice(Math.max(0, end - contentRows), end);
     if (!this.projection.viewport.stickyTail && bottom > 0) {
       const indicator = this.projection.viewport.newEventsBelow > 0
         ? `↓ ${this.projection.viewport.newEventsBelow} new events below · End to follow`
@@ -562,7 +606,7 @@ export class BottomRegion {
       if (visible.length === bottom) visible[visible.length - 1] = indicator;
       else visible.push(indicator);
     }
-    const start = bottom - visible.length + 1;
+    const start = bottom - visible.length - (cursorNeedsBlankRow ? 1 : 0) + 1;
     let sequence = '';
     for (let row = 1; row <= bottom; row += 1) {
       sequence += `${ESC}[${row};1H${ESC}[2K`;
@@ -570,7 +614,13 @@ export class BottomRegion {
     visible.forEach((line, index) => {
       sequence += `${ESC}[${start + index};1H${fitStatus(line, width)}`;
     });
-    return sequence;
+    const cursorRow = cursorNeedsBlankRow
+      ? bottom
+      : Math.max(1, start + Math.max(0, visible.length - 1));
+    const cursorCol = cursorNeedsBlankRow || visible.length === 0
+      ? 1
+      : Math.min(width, terminalWidth(visible[visible.length - 1]) + 1);
+    return `${sequence}${ESC}[${cursorRow};${cursorCol}H${SAVE_TRANSCRIPT}`;
   }
 
   private clearOwnedRows(count: number): string {

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -514,7 +514,7 @@ export class BottomRegion {
     const width = Math.max(1, this.sink.cols() - 1);
     const wrapped = output
       .split('\n')
-      .map((line) => wrapAnsiText(line, width, { trim: false, hard: true }))
+      .map((line) => wrapAnsiText(line, width, { trim: false, hard: false }))
       .join('\n');
     this.sink.write(
       `${RESTORE_TRANSCRIPT}${wrapped}${SAVE_TRANSCRIPT}` +

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -93,6 +93,8 @@ import {
 } from './composerLane';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 import type { ActivitySnapshot } from './activityRegistry';
+import { projectFileEffect, projectRepositoryState } from './effectPresentation';
+import { terminalStateSymbol, terminalSupportsUnicode } from './terminalSymbols';
 // v4.1.4 reply-quality polish: shared frame math for width + indent.
 // `cols()`, `rule()`, `agentTurn`, and `tryRerenderInPlace` all route
 // through frame helpers so the visible left edge / right margin / wrap
@@ -1080,7 +1082,7 @@ export class Display {
     // surface family (▎ Aiden header, status footer, bottom hint).
     // Timestamp variant unchanged — the timestamp gutter already
     // provides its own consistent left edge.
-    const tri = this.skin.applyColors('▲', 'brand');
+    const tri = this.skin.applyColors(terminalStateSymbol('user'), 'brand');
     if (process.env.AIDEN_UI_TIMESTAMPS === '1') {
       return `${this.timestampPrefix()}  ${tri} `;
     }
@@ -1685,7 +1687,7 @@ export class Display {
     // v4.1.3-repl-polish: icons default ON; set AIDEN_UI_ICONS=0 to
     // disable (CI / dumb terminals / narrow SSH sessions).
     // Read at call-time so env changes take effect without restart.
-    const useIcons = process.env.AIDEN_UI_ICONS !== '0';
+    const useIcons = process.env.AIDEN_UI_ICONS !== '0' && terminalSupportsUnicode();
     const { icon, verb } = trailIconForTool(name);
     const glyph = useIcons ? icon : sk.applyColors('·', 'muted');
 
@@ -1723,7 +1725,7 @@ export class Display {
       const liveSuffix = elapsed >= 1000
         ? `  ${sk.applyColors(`${phaseLabel} ${formatToolDuration(elapsed)}…`, 'muted')}`
         : '';
-      const runningGlyph = useIcons ? sk.applyColors('⚙', 'tool') : sk.applyColors('·', 'muted');
+      const runningGlyph = useIcons ? sk.applyColors('⚙', 'tool') : sk.applyColors(terminalStateSymbol('running'), 'muted');
       const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph}  ` +
         `${sk.applyColors(padVerb(verb), 'tool')} `;
       const suffix = `${liveSuffix}${this.composerSuffix()}`;
@@ -1740,7 +1742,9 @@ export class Display {
     // Outcome row — entire line colored by outcome kind.
     const outcomeRow = (suffix: string, kind: ColorKindForBracket): string => {
       const failed = kind === 'error' || kind === 'warn' || /^(?:cancelled|denied|blocked|timed out|fail)/u.test(suffix);
-      const outcomeGlyph = failed ? '!' : '✓';
+      const outcomeGlyph = terminalSupportsUnicode()
+        ? (failed ? '!' : '✓')
+        : terminalStateSymbol(failed ? 'failed' : 'completed');
       const terminalVerb = /^denied\b/u.test(suffix) ? 'denied'
         : /^cancelled\b/u.test(suffix) ? 'cancelled'
         : /^timed out\b/u.test(suffix) ? 'timed out'
@@ -2116,8 +2120,8 @@ export class Display {
   /** Format a user turn (e.g. echoed back from history). */
   userTurn(text: string): string {
     const sk = this.skin;
-    const arrow = sk.getActive().glyphs?.arrow ?? '>';
-    return `${sk.applyColors(`${arrow} you`, 'user')}\n${text}\n`;
+    const body = text.split('\n').map((line) => `  ${line}`).join('\n');
+    return `  ${this.rule()}\n${sk.applyColors(`  ${terminalStateSymbol('user')} You`, 'user')}\n${body}\n  ${this.rule()}\n`;
   }
 
   /**
@@ -2208,6 +2212,11 @@ export class Display {
     this.writeOutput(text);
   }
 
+  /** Write modal-only chrome without adding it to transcript projection. */
+  writeTransient(text: string): void {
+    this.out.write(text);
+  }
+
   /** Test-only control markers are emitted after fixed composer cursor setup. */
   writeAfterComposerCursor(text: string): void {
     if (this.composerSurfacePauseDepth === 0 && composerLaneEnabled() && this.out.isTTY) {
@@ -2286,7 +2295,8 @@ export class Display {
    * restore an empty ready composer. Empty Enter remains a local no-op. */
   submitIdleComposer(value: string, hint: string): void {
     if (value.length > 0) {
-      this.write(`${this.promptPrefix()}You  ${value}\n`);
+      const body = value.split('\n').map((line) => `  ${line}`).join('\n');
+      this.write(`${this.promptPrefix()}You\n${body}\n  ${this.rule()}`);
     }
     this.idleComposerContent = `${this.promptPrefix()} ${hint}`;
     this.idleComposerDraft = '';
@@ -2517,7 +2527,7 @@ export class Display {
         case 'verified': return { glyph: '✓', label: outcome.label, role: 'success' as const };
         case 'failed':
         case 'timed_out': return { glyph: '×', label: outcome.label, role: 'error' as const };
-        case 'unverified_required': return { glyph: '?', label: 'Outcome unknown', role: 'warn' as const };
+        case 'unverified_required': return { glyph: '?', label: outcome.label, role: 'warn' as const };
         case 'cancelled': return { glyph: '■', label: outcome.label, role: 'muted' as const };
         case 'completed_limited':
         case 'partial':
@@ -2525,9 +2535,17 @@ export class Display {
         case 'completed': return { glyph: '✓', label: outcome.label, role: 'success' as const };
       }
     })();
+    const axes = projectTaskOutcomeAxes(outcome);
     const summary = outcome.summary ? ` · ${outcome.summary}` : '';
-    const glyph = this.skin.applyColors(projection.glyph, projection.role);
-    this.writeOutput(`${glyph} ${projection.label}${summary}${details}\n`);
+    const stateSymbol = outcome.kind === 'unverified_required' ? 'unknown'
+      : outcome.kind === 'failed' || outcome.kind === 'timed_out' || outcome.kind === 'cancelled' ? 'failed'
+        : outcome.kind === 'partial' || outcome.kind === 'completed_limited' || outcome.kind === 'denied' ? 'warning'
+          : 'completed';
+    const glyph = this.skin.applyColors(
+      terminalSupportsUnicode() ? projection.glyph : terminalStateSymbol(stateSymbol),
+      projection.role,
+    );
+    this.writeOutput(`${glyph} ${projection.label} · ${axes.join(' · ')}${summary}${details}\n`);
   }
 
   /**
@@ -3097,6 +3115,7 @@ export class Display {
   // echo it even when the model only sends task_id + status. Cleared
   // on done. Map is per-Display-instance; one REPL session.
   private uiTaskRows = new Map<string, { label: string }>();
+  private uiTaskTerminalIds = new Set<string>();
 
   // v4.8.0 Phase 2.3 fix — set true by renderUiEvent; tryRerenderInPlace
   // early-returns when set so the cursor-up + erase-to-end-of-screen
@@ -3104,15 +3123,7 @@ export class Display {
   // boundaries (streamPartial first-delta init + streamComplete).
   private uiEventsFiredThisTurn = false;
 
-  /**
-   * v4.8.0 Phase 2.3 — render a semantic ui_* event signalled by the
-   * model via a uiOnly tool call. Append-only: each event paints one
-   * row; in-place mutation is a v4.8.x upgrade if UX demands it.
-   *
-   * Currently handles `ui_task_update` and `ui_task_done`; other 5
-   * names land in Phase 2.4 (silent ignore until then). Non-TTY out
-   * surfaces silent — matches the activityIndicator precedent.
-   */
+  /** Render semantic ui_* events. Stable task IDs replace active cards in place. */
   /**
    * v4.8.0 Phase 2.3 fix-2 — reset the per-turn ui-event flag. Called
    * by chatSession at the top of each turn. The existing reset sites
@@ -3162,15 +3173,27 @@ export class Display {
     const kindArg = typeof args.kind    === 'string' ? args.kind    : 'task';
     const depth   = typeof args.depth   === 'number' && args.depth > 0 ? args.depth : 0;
     if (!taskId || !label) return;
+    if (this.uiTaskTerminalIds.has(taskId)) return;
     this.commitStreamChunk();
-    const glyph = status === 'paused' ? '⏸' : status === 'blocked' ? '⛔' : '⟳';
+    const glyph = terminalSupportsUnicode()
+      ? (status === 'paused' ? '⏸' : status === 'blocked' ? '!' : '◐')
+      : terminalStateSymbol(status === 'blocked' ? 'warning' : 'running');
     const colorKind: ColorKind = status === 'running' ? 'tool' : 'warn';
     this.uiTaskRows.set(taskId, { label });
     const short  = label.length > 80 ? label.slice(0, 79) + '…' : label;
     // v4.8.0 Phase 2.4 — subagent kind: indent by depth inside the
     // gutter so nested rows tier below their parent.
     const indent = kindArg === 'subagent' ? '  '.repeat(depth) : '';
-    this.writeOutput(this.uiTrailRow(`${indent}${glyph} ${short}`, colorKind));
+    const stateLabel = status === 'paused' ? 'Paused' : status === 'blocked' ? 'Blocked' : 'Working';
+    const rendered = this.uiTrailRow(
+      `${indent}┌ ${short}\n${indent}└ ${glyph} ${stateLabel}`,
+      colorKind,
+    ).replace(/\n$/u, '');
+    if (this.composerLane?.isActive()) {
+      this.composerLane.setLiveRow(`ui-task:${taskId}`, rendered);
+    } else {
+      this.writeOutput(`${rendered}\n`);
+    }
     this.streamLastEndedNewline = true;
   }
 
@@ -3179,18 +3202,30 @@ export class Display {
     const status  = typeof args.status  === 'string' ? args.status  : '';
     const summary = typeof args.summary === 'string' ? args.summary : '';
     if (!taskId) return;
+    if (this.uiTaskTerminalIds.has(taskId)) return;
+    this.uiTaskTerminalIds.add(taskId);
     this.commitStreamChunk();
     const tracked = this.uiTaskRows.get(taskId);
     const label = tracked?.label ?? taskId;
     this.uiTaskRows.delete(taskId);
-    const glyph = status === 'success' ? '✓' : status === 'failure' ? '✗' : '⊘';
+    const glyph = terminalSupportsUnicode()
+      ? (status === 'success' ? '✓' : status === 'failure' ? '✕' : '!')
+      : terminalStateSymbol(status === 'success' ? 'completed' : status === 'failure' ? 'failed' : 'warning');
     const kind: ColorKind =
       status === 'success' ? 'success' :
       status === 'failure' ? 'error'   : 'warn';
     const shortLabel = label.length > 80 ? label.slice(0, 79) + '…' : label;
     const shortSum   = summary.length > 120 ? summary.slice(0, 119) + '…' : summary;
-    const tail = shortSum ? ` — ${shortSum}` : '';
-    this.writeOutput(this.uiTrailRow(`${glyph} ${shortLabel}${tail}`, kind));
+    const terminalLabel = shortSum || (status === 'success' ? 'Completed' : status === 'failure' ? 'Failed' : 'Blocked');
+    const rendered = this.uiTrailRow(`┌ ${shortLabel}\n└ ${glyph} ${terminalLabel}`, kind).replace(/\n$/u, '');
+    if (this.composerLane?.isActive()) {
+      const terminalState = status === 'success'
+        ? 'succeeded'
+        : status === 'failure' ? 'failed' : 'cancelled';
+      this.composerLane.settleLiveRow(`ui-task:${taskId}`, rendered, terminalState);
+    } else {
+      this.writeOutput(`${rendered}\n`);
+    }
     this.streamLastEndedNewline = true;
   }
 
@@ -3264,16 +3299,63 @@ export class Display {
     const path = typeof args.path === 'string' ? args.path : '';
     if (!path) return;
     const kindArg = typeof args.kind === 'string' ? args.kind : 'file';
+    if (kindArg === 'file') return;
+    const operation = typeof args.operation === 'string' ? args.operation : '';
     const preview = typeof args.preview === 'string' ? args.preview : '';
     this.commitStreamChunk();
     const glyph = kindArg === 'skill' ? '🛠' : kindArg === 'directory' ? '📁' : '📄';
-    let out = this.uiTrailRow(`${glyph} Created: ${path}`, 'accent');
+    const effectLabel = operation === 'create' ? 'Created'
+      : operation === 'modify' ? 'Modified'
+        : operation === 'delete' ? 'Deleted'
+          : operation === 'move' ? 'Moved'
+            : operation === 'rename' ? 'Renamed'
+              : 'Changed';
+    let out = this.uiTrailRow(`${glyph} ${effectLabel}: ${path}`, 'accent');
     if (preview) {
       const shortP = preview.length > 200 ? preview.slice(0, 199) + '…' : preview;
       out += this.uiTrailRow(`  ${shortP}`, 'muted');
     }
     this.writeOutput(out);
     this.streamLastEndedNewline = true;
+  }
+
+  /** Render an executed file effect from the canonical tool result. */
+  toolEffect(toolName: string, result: unknown, cwd = process.cwd()): void {
+    const effect = projectFileEffect({ toolName, result, cwd });
+    if (!effect) return;
+    const target = effect.destination ? `${effect.path} → ${effect.destination}` : effect.path;
+    this.writeOutput(`${effect.blocked ? 'Conflict' : 'Changed'}\n  ${effect.marker}  ${target}\n`);
+  }
+
+  /** Render canonical repository state without exposing expected Git probe errors. */
+  repositoryState(input: { vcsKind: 'git' | 'none'; branch: string | null; headCommit: string | null }): void {
+    const state = projectRepositoryState(input);
+    this.writeOutput(
+      `Repository\n  Branch    ${state.branch}\n  HEAD      ${state.head}\n  State     ${state.state}\n`,
+    );
+  }
+}
+
+export function projectTaskOutcomeAxes(outcome: TaskOutcomePresentation): string[] {
+  switch (outcome.kind) {
+    case 'verified': return ['Execution succeeded', 'Validation not reported', 'Verification verified', 'Verdict complete'];
+    case 'completed': return ['Execution completed', 'Validation not reported', 'Verification not required', 'Verdict complete'];
+    case 'completed_limited': return ['Execution completed', 'Validation not reported', 'Verification limited', 'Verdict complete'];
+    case 'partial': return ['Execution partial', 'Validation partial', 'Verification partial', 'Verdict partial'];
+    case 'unverified_required': return [
+      outcome.executionStarted ? 'Execution succeeded' : 'Execution unknown',
+      'Validation unknown', 'Verification unknown', 'Verdict incomplete',
+    ];
+    case 'failed': return ['Execution failed', 'Validation unknown', 'Verification not completed', 'Verdict failed'];
+    case 'denied': return ['Execution not started', 'Validation not applicable', 'Verification not applicable', 'Verdict denied'];
+    case 'cancelled': return [
+      outcome.executionStarted ? 'Execution interrupted' : 'Execution not started',
+      'Validation not completed', 'Verification not completed', 'Verdict cancelled',
+    ];
+    case 'timed_out': return [
+      outcome.executionStarted ? 'Execution timed out' : 'Execution not started',
+      'Validation not completed', 'Verification not completed', 'Verdict timed out',
+    ];
   }
 }
 

--- a/cli/v4/effectPresentation.ts
+++ b/cli/v4/effectPresentation.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Pure terminal projection for already-authoritative file effects.
+ */
+import path from 'node:path';
+
+export type FileEffectOperation = 'create' | 'modify' | 'patch' | 'delete' | 'move' | 'rename';
+
+export interface FileEffectPresentation {
+  marker: 'A' | 'M' | 'D' | 'R' | '=' | '!';
+  label: 'Created' | 'Modified' | 'Deleted' | 'Moved' | 'Renamed' | 'Unchanged' | 'Conflict blocked';
+  path: string;
+  destination?: string;
+  verified: boolean;
+  blocked: boolean;
+}
+
+export interface RepositoryStatePresentation {
+  branch: string;
+  head: string;
+  state: 'repository' | 'unborn repository' | 'non-Git directory';
+}
+
+export function projectRepositoryState(input: {
+  vcsKind: 'git' | 'none';
+  branch: string | null;
+  headCommit: string | null;
+}): RepositoryStatePresentation {
+  if (input.vcsKind === 'none') {
+    return { branch: 'not applicable', head: 'not applicable', state: 'non-Git directory' };
+  }
+  return {
+    branch: input.branch ?? 'detached',
+    head: input.headCommit ? input.headCommit.slice(0, 12) : 'no commits yet',
+    state: input.headCommit ? 'repository' : 'unborn repository',
+  };
+}
+
+function relativeDisplayPath(cwd: string, value: string): string {
+  if (!value) return value;
+  const pathApi = /^[A-Za-z]:[\\/]/u.test(value) || /^[A-Za-z]:[\\/]/u.test(cwd)
+    ? path.win32 : path;
+  if (!pathApi.isAbsolute(value)) return value.replace(/\\/gu, '/');
+  const relative = pathApi.relative(pathApi.resolve(cwd), pathApi.resolve(value));
+  return (relative && !relative.startsWith(`..${pathApi.sep}`) && relative !== '..'
+    ? relative : value).replace(/\\/gu, '/');
+}
+
+export function projectFileEffect(input: {
+  toolName: string;
+  result: unknown;
+  cwd: string;
+}): FileEffectPresentation | null {
+  if (!['file_write', 'file_patch', 'file_delete', 'file_move'].includes(input.toolName)) return null;
+  if (!input.result || typeof input.result !== 'object') return null;
+  const result = input.result as Record<string, unknown>;
+  const operation = typeof result.operation === 'string'
+    ? result.operation as FileEffectOperation : null;
+  const rawPath = typeof result.path === 'string' ? result.path
+    : typeof result.from === 'string' ? result.from : '';
+  const destination = typeof result.destination === 'string' ? result.destination
+    : typeof result.to === 'string' ? result.to : undefined;
+  const conflict = typeof result.conflict === 'string' ? result.conflict
+    : typeof result.error === 'string' && /source changed|stale.*(?:source|snapshot)|conflict/iu.test(result.error)
+      ? result.error : null;
+
+  if (conflict && rawPath) {
+    return {
+      marker: '!', label: 'Conflict blocked', path: relativeDisplayPath(input.cwd, rawPath),
+      verified: false, blocked: true,
+    };
+  }
+  if (result.success !== true || !rawPath) return null;
+  if (result.skipped === true) {
+    return {
+      marker: '=', label: 'Unchanged', path: relativeDisplayPath(input.cwd, rawPath),
+      verified: result.verified === true, blocked: false,
+    };
+  }
+  const projection = operation === 'create' ? { marker: 'A' as const, label: 'Created' as const }
+    : operation === 'modify' || operation === 'patch' ? { marker: 'M' as const, label: 'Modified' as const }
+      : operation === 'delete' ? { marker: 'D' as const, label: 'Deleted' as const }
+        : operation === 'rename' ? { marker: 'R' as const, label: 'Renamed' as const }
+          : operation === 'move' ? { marker: 'R' as const, label: 'Moved' as const }
+            : null;
+  if (!projection) return null;
+  return {
+    ...projection,
+    path: relativeDisplayPath(input.cwd, rawPath),
+    ...(destination ? { destination: relativeDisplayPath(input.cwd, destination) } : {}),
+    verified: result.verified === true,
+    blocked: false,
+  };
+}

--- a/cli/v4/terminalSymbols.ts
+++ b/cli/v4/terminalSymbols.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+export type TerminalStateSymbol = 'running' | 'completed' | 'failed' | 'warning' | 'unknown' | 'user' | 'agent';
+
+export function terminalSupportsUnicode(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.AIDEN_UI_UNICODE !== '0' && env.TERM?.toLowerCase() !== 'dumb';
+}
+
+export function terminalStateSymbol(
+  state: TerminalStateSymbol,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const unicode: Record<TerminalStateSymbol, string> = {
+    running: '◐', completed: '✓', failed: '✕', warning: '!', unknown: '?',
+    user: '▲', agent: '│',
+  };
+  const ascii: Record<TerminalStateSymbol, string> = {
+    running: '[>]', completed: '[+]', failed: '[x]', warning: '[!]', unknown: '[?]',
+    user: '>', agent: '|',
+  };
+  return (terminalSupportsUnicode(env) ? unicode : ascii)[state];
+}

--- a/core/playwrightBridge.ts
+++ b/core/playwrightBridge.ts
@@ -14,6 +14,7 @@ import path   from 'path'
 import fs     from 'fs'
 import crypto from 'crypto'
 import { getUserDataDir } from './paths'
+import { runtimeArtifactDirectory } from './v4/runtimeStorage'
 import { getTabRegistry, type TabMeta } from './v4/browser/tabRegistry'
 import { getDialogSupervisor, type DialogRecord, type FileEventRecord } from './v4/browser/dialogState'
 
@@ -551,11 +552,11 @@ export async function pwNavigate(url: string): Promise<{ ok: boolean; url: strin
   finally { release() }
 }
 
-/** Take a full-page screenshot, saved to workspace/screenshots/. Returns the file path. */
+/** Take a full-page screenshot in Aiden's artifact storage. Returns the file path. */
 export async function pwScreenshot(): Promise<{ ok: boolean; path?: string; error?: string }> {
   try {
     const page   = await ensurePage()
-    const dir    = path.join(process.cwd(), 'workspace', 'screenshots')
+    const dir    = runtimeArtifactDirectory('screenshots')
     fs.mkdirSync(dir, { recursive: true })
     const file   = path.join(dir, `screenshot_${Date.now()}.png`)
     await page.screenshot({ path: file, fullPage: false })

--- a/core/v4/codebase/runtimePlanProjection.ts
+++ b/core/v4/codebase/runtimePlanProjection.ts
@@ -113,6 +113,9 @@ export function projectCommittedRepositoryChange(input: {
 
   if (!existing) {
     const inspectedPath = input.intent.expectedScope[0];
+    const inspectedEntry = inspectedPath
+      ? input.context.engine.repository.getEntry(input.intent.baseSnapshotId, inspectedPath)
+      : undefined;
     completeStep({
       context: input.context,
       step: {
@@ -120,7 +123,7 @@ export function projectCommittedRepositoryChange(input: {
         label: 'Capture source state',
         repositorySnapshotId: input.intent.baseSnapshotId,
       },
-      references: inspectedPath ? [{
+      references: inspectedPath && inspectedEntry?.captureStatus === 'captured' ? [{
         kind: 'inspected_file',
         snapshotId: input.intent.baseSnapshotId,
         path: inspectedPath,

--- a/core/v4/runtimeStorage.ts
+++ b/core/v4/runtimeStorage.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Canonical location for runtime-owned state and artifacts.
+ */
+import path from 'node:path';
+
+import { resolveAidenPaths, resolveUserPath, type AidenPaths } from './paths';
+
+export function resolveRuntimeStorageRoot(
+  env: NodeJS.ProcessEnv = process.env,
+  paths: Pick<AidenPaths, 'root'> = resolveAidenPaths(),
+): string {
+  return resolveUserPath(env.AIDEN_USER_DATA) ?? paths.root;
+}
+
+export function runtimeArtifactDirectory(kind: string, root = resolveRuntimeStorageRoot()): string {
+  return path.join(root, 'artifacts', kind);
+}

--- a/moat/dangerousPatterns.ts
+++ b/moat/dangerousPatterns.ts
@@ -134,6 +134,10 @@ const READ_ONLY_COMMANDS: ReadonlySet<string> = new Set([
 const UNSAFE_META = /(?:>>?|<\(|>\(|\$\(|[;&\x60\n])/;
 // `find` flags that let it run or delete arbitrary things.
 const FIND_SIDE_EFFECTS = /\s-(?:delete|exec|execdir|ok|okdir|fprintf?|fls)\b/;
+const GIT_READ_ONLY_SUBCOMMANDS = new Set([
+  'status', 'diff', 'log', 'show', 'rev-parse', 'ls-files', 'grep', 'blame',
+]);
+const GIT_UNSAFE_READ_OPTIONS = /^(?:--output(?:=|$)|--ext-diff$|--textconv$|--exec(?:=|$)|-[MmDdCc]$|--delete$|--move$|--copy$|--edit-description$)/i;
 
 /** Remove fully-literal quoted spans so a `|`/`>` INSIDE a quoted search pattern
  *  (e.g. `rg 'foo|bar'`) can't be mistaken for a pipe/redirect. Double-quoted
@@ -151,6 +155,69 @@ function leadingToken(stage: string): string | null {
   return base || null;
 }
 
+function shellTokens(stage: string): string[] {
+  const tokens: string[] = [];
+  let token = '';
+  let quote: '"' | "'" | null = null;
+  for (const character of stage.trim()) {
+    if (quote) {
+      if (character === quote) quote = null;
+      else token += character;
+      continue;
+    }
+    if (character === '"' || character === "'") { quote = character; continue; }
+    if (/\s/u.test(character)) {
+      if (token) { tokens.push(token); token = ''; }
+      continue;
+    }
+    token += character;
+  }
+  if (token) tokens.push(token);
+  return tokens;
+}
+
+function splitPipeline(command: string): string[] {
+  const stages: string[] = [];
+  let stage = '';
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  for (const character of command) {
+    if (escaped) { stage += character; escaped = false; continue; }
+    if (character === '\\' && quote === '"') { stage += character; escaped = true; continue; }
+    if (quote) {
+      stage += character;
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") { quote = character; stage += character; continue; }
+    if (character === '|') { stages.push(stage); stage = ''; continue; }
+    stage += character;
+  }
+  stages.push(stage);
+  return stages;
+}
+
+function isReadOnlyGit(stage: string): boolean {
+  const tokens = shellTokens(stage);
+  if ((tokens.shift() ?? '').replace(/^.*[\\/]/u, '').replace(/\.exe$/iu, '').toLowerCase() !== 'git') {
+    return false;
+  }
+  while (tokens[0] === '-C' || tokens[0] === '--git-dir' || tokens[0] === '--work-tree'
+    || tokens[0]?.startsWith('--git-dir=') || tokens[0]?.startsWith('--work-tree=')) {
+    if (tokens[0]?.includes('=')) { tokens.shift(); continue; }
+    tokens.shift();
+    if (!tokens.shift()) return false;
+  }
+  const subcommand = tokens.shift()?.toLowerCase();
+  if (!subcommand) return false;
+  if (subcommand === 'branch') {
+    return tokens.length > 0 && tokens.every((token) =>
+      /^(?:--show-current|--list|-a|--all|-r|--remotes|-v|-vv|--contains(?:=.+)?|--merged(?:=.+)?|--no-merged(?:=.+)?)$/u.test(token));
+  }
+  if (!GIT_READ_ONLY_SUBCOMMANDS.has(subcommand)) return false;
+  return tokens.every((token) => !GIT_UNSAFE_READ_OPTIONS.test(token));
+}
+
 /**
  * True when `command` is a genuinely read-only shell invocation — a single
  * command or a pipeline where EVERY stage leads with a known read-only command,
@@ -164,9 +231,14 @@ export function isReadOnlyCommand(command: string): boolean {
   const bare = stripLiterals(raw);
   if (UNSAFE_META.test(bare)) return false;               // redirect / chain / subst / background
   if (classifyCommand(raw).tier !== 'safe') return false; // any dangerous/caution pattern
-  for (const stage of bare.split('|')) {
-    const lead = leadingToken(stage);
-    if (!lead || !READ_ONLY_COMMANDS.has(lead)) return false;
+  for (const stage of splitPipeline(raw)) {
+    const lead = leadingToken(stripLiterals(stage));
+    if (!lead) return false;
+    if (lead === 'git') {
+      if (!isReadOnlyGit(stage)) return false;
+      continue;
+    }
+    if (!READ_ONLY_COMMANDS.has(lead)) return false;
     if (lead === 'find' && FIND_SIDE_EFFECTS.test(raw)) return false;
   }
   return true;

--- a/tests/v4/cli/activityLifecycle.test.ts
+++ b/tests/v4/cli/activityLifecycle.test.ts
@@ -4,6 +4,7 @@ import { CliCallbacks, type PromptApi } from '../../../cli/v4/callbacks';
 import { Display, type LiveActivityRowHandle, type ToolRowHandle } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import type { ToolCallRequest, ToolCallResult } from '../../../providers/v4/types';
+import { TerminalScreen } from '../harness/terminalScreen';
 
 function makeDisplay(): Display {
   const out = new Writable({
@@ -68,6 +69,40 @@ const resolveBuiltInInteraction = (name: string) =>
       : undefined;
 
 describe('central CLI activity lifecycle', () => {
+  it('does not restore approval navigation hints after modal settlement', async () => {
+    class ScreenStream extends Writable {
+      isTTY = true;
+      columns = 80;
+      rows = 20;
+      constructor(readonly screen: TerminalScreen) {
+        super({ write: (chunk, _encoding, done) => { screen.write(chunk); done(); } });
+      }
+    }
+    const screen = new TerminalScreen(80, 20);
+    const stream = new ScreenStream(screen);
+    const display = new Display({
+      skin: new SkinEngine({ forceMono: true }),
+      stdout: stream as unknown as NodeJS.WriteStream,
+    });
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setBusyHint('Enter → queue · Ctrl+C stop');
+    const callbacks = new CliCallbacks({
+      display,
+      promptModule: {
+        select: vi.fn(async () => 'allow'),
+        confirm: vi.fn(async () => true),
+        input: vi.fn(async () => ''),
+      },
+    });
+
+    await callbacks.promptApproval({
+      toolName: 'file_write', category: 'write', args: { path: 'src/math.mjs' },
+      riskTier: 'caution', effects: { writesFiles: true },
+    });
+
+    expect(screen.snapshot()).not.toMatch(/navigate|enter select|esc cancel/iu);
+    expect(screen.lines().at(-1)).toContain('provider');
+  });
   it('replaces each timer frame with one atomic terminal write', () => {
     vi.useFakeTimers();
     try {
@@ -240,6 +275,25 @@ describe('central CLI activity lifecycle', () => {
     expect(display.toolRow).toHaveBeenCalledTimes(1);
     expect(row.ok).toHaveBeenCalledTimes(1);
     expect(callbacks.activeActivityCount()).toBe(0);
+  });
+
+  it('projects one canonical file effect for duplicate terminal callbacks', () => {
+    const display = makeDisplay();
+    const row = makeRow();
+    vi.spyOn(display, 'toolRow').mockReturnValue(row);
+    const effect = vi.spyOn(display, 'toolEffect');
+    const callbacks = new CliCallbacks({ display });
+    const fileCall = call('write-1', 'file_write');
+    const done = result('write-1', 'file_write', {
+      success: true, operation: 'modify', path: 'src/math.mjs', verified: true,
+    });
+
+    callbacks.onToolCall(fileCall, 'before');
+    callbacks.onToolCall(fileCall, 'after', done);
+    callbacks.onToolCall(fileCall, 'after', done);
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(effect).toHaveBeenCalledWith('file_write', done.result);
   });
 
   it('sweeps orphaned rows at turn completion and stale callbacks cannot revive them', () => {

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -9,6 +9,7 @@ import { Writable } from 'node:stream';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import { renderBottomSurface } from '../../../cli/v4/composerLane';
+import { primeFrameAsync } from '../../../cli/v4/display/frame';
 import { TerminalScreen } from '../harness/terminalScreen';
 
 class ScreenStream extends Writable {
@@ -266,7 +267,8 @@ describe('compact hybrid transcript geometry', () => {
     expect(transcript.slice(userRow, toolRow).some((line) => /^\s*─{10,}\s*$/u.test(line))).toBe(true);
     expect(transcript.slice(toolRow, answerRow).some((line) => /^\s*─{10,}\s*$/u.test(line))).toBe(true);
   });
-  it('wraps transcript prose at word boundaries when the word fits the terminal', () => {
+  it('wraps transcript prose at word boundaries when the word fits the terminal', async () => {
+    await primeFrameAsync();
     delete process.env.AIDEN_COMPOSER_LANE;
     const { display, screen } = createDisplay(44, 18);
     display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -243,6 +243,71 @@ function semanticGap(lines: string[], before: string, after: string): number {
 }
 
 describe('compact hybrid transcript geometry', () => {
+  it('renders distinct prompt and answer blocks without attaching to activity output', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(80, 24);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.submitIdleComposer('Fix `src/math.mjs` and run its focused test.', 'Type your message · /help');
+    const activity = display.toolRow('shell_exec', { command: 'npm test -- math' }, undefined, {
+      activityId: 'tool_test', externalTicker: true,
+    });
+    activity.ok(40);
+    display.printTurnSeparator();
+    display.write(display.agentTurn('Fixed `src/math.mjs`. The focused test passed.'));
+
+    const transcript = screen.lines().slice(0, composerGeometry(screen).top);
+    const userRow = transcript.findIndex((line) => line.includes('You'));
+    const toolRow = transcript.findIndex((line) => line.includes('npm test'));
+    const answerRow = transcript.findIndex((line) => line.includes('Aiden'));
+    expect(userRow).toBeGreaterThanOrEqual(0);
+    expect(toolRow).toBeGreaterThan(userRow);
+    expect(answerRow).toBeGreaterThan(toolRow);
+    expect(transcript.slice(userRow, toolRow).some((line) => /^\s*─{10,}\s*$/u.test(line))).toBe(true);
+    expect(transcript.slice(toolRow, answerRow).some((line) => /^\s*─{10,}\s*$/u.test(line))).toBe(true);
+  });
+  it('wraps transcript prose at word boundaries when the word fits the terminal', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(44, 18);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+    display.write('12345678901234567890123456789012345678 ownership remains stable\n');
+
+    const surface = composerGeometry(screen);
+    const transcript = screen.lines().slice(0, surface.top);
+    expect(transcript.some((line) => line.includes('ownership')), screen.snapshot()).toBe(true);
+    expect(transcript.some((line) => /owner$|^ship\b/u.test(line.trim()))).toBe(false);
+  });
+
+  it('replaces repeated task updates in one stable live row before settlement', () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen } = createDisplay(80, 18);
+    display.setStatusFooter('◆ provider · model │ ◉ context │ ⧖ 0s');
+    display.setIdleComposer('', 'Type your message · /help');
+
+    display.renderUiEvent('ui_task_update', {
+      task_id: 'task_index', label: 'Index repository', status: 'running',
+    });
+    display.renderUiEvent('ui_task_update', {
+      task_id: 'task_index', label: 'Index repository: 42 files', status: 'running',
+    });
+
+    const visible = screen.snapshot();
+    expect(visible.match(/Index repository/gu)).toHaveLength(1);
+    expect(visible).toContain('Index repository: 42 files');
+
+    display.renderUiEvent('ui_task_done', {
+      task_id: 'task_index', status: 'success', summary: '42 files indexed',
+    });
+    display.renderUiEvent('ui_task_done', {
+      task_id: 'task_index', status: 'success', summary: '42 files indexed',
+    });
+    const completed = screen.snapshot();
+    expect(completed.match(/Index repository: 42 files/gu)).toHaveLength(1);
+    expect(completed.match(/42 files indexed/gu)).toHaveLength(1);
+    expect(completed).toContain('✓ 42 files indexed');
+    expect(completed).not.toContain('◐ Working');
+  });
   it.each([16, 24, 35, 45, 60])(
     'keeps provider activity adjacent to a short prompt at %i rows',
     (rows) => {

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -219,7 +219,10 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         expect(rowsAboveFooter.filter((line) => line.includes(draft)), name).toEqual([]);
       } else {
         expect(submittedRows, `${name}\n${frame}`).toHaveLength(1);
-        expect(submittedRows[0], name).toContain(draft);
+        const headerIndex = rowsAboveFooter.indexOf(submittedRows[0]);
+        const draftRows = rowsAboveFooter.filter((line) => line.includes(draft));
+        expect(draftRows, `${name}\n${frame}`).toHaveLength(1);
+        expect(rowsAboveFooter.indexOf(draftRows[0]), name).toBeGreaterThan(headerIndex);
       }
     }
   });

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -130,7 +130,7 @@ describe('Display', () => {
 
   it('userTurn formats with a "you" marker', () => {
     const out = stripAnsi(display.userTurn('hello'));
-    expect(out).toMatch(/you/);
+    expect(out).toMatch(/You/);
     expect(out).toContain('hello');
   });
 
@@ -209,17 +209,19 @@ describe('Display Phase 14b helpers', () => {
       inspectable: true,
       prominent: true,
     });
-    expect(chunks.join('')).toContain('? Outcome unknown · Task: 7');
+    expect(chunks.join('')).toContain('? Could not verify required outcome');
+    expect(chunks.join('')).toContain('Verification unknown');
+    expect(chunks.join('')).toContain('Task: 7');
     expect(chunks.join('')).not.toContain('Next:');
-    expect(chunks.join('').match(/Outcome unknown/g)).toHaveLength(1);
+    expect(chunks.join('').match(/Could not verify required outcome/g)).toHaveLength(1);
   });
 
   it.each([
-    ['verified', 'success', 'Verified', '✓ Verified'],
-    ['completed_limited', 'warning', 'Completed · limited evidence', '! Completed · limited evidence'],
-    ['failed', 'error', 'Failed', '× Failed'],
-    ['unverified_required', 'error', 'Could not verify required outcome', '? Outcome unknown'],
-    ['cancelled', 'info', 'Cancelled', '■ Cancelled'],
+    ['verified', 'success', 'Verified', '✓ Verified · Execution succeeded · Validation not reported · Verification verified · Verdict complete'],
+    ['completed_limited', 'warning', 'Completed · limited evidence', '! Completed · limited evidence · Execution completed · Validation not reported · Verification limited · Verdict complete'],
+    ['failed', 'error', 'Failed', '× Failed · Execution failed · Validation unknown · Verification not completed · Verdict failed'],
+    ['unverified_required', 'error', 'Could not verify required outcome', '? Could not verify required outcome · Execution succeeded · Validation unknown · Verification unknown · Verdict incomplete'],
+    ['cancelled', 'info', 'Cancelled', '■ Cancelled · Execution interrupted · Validation not completed · Verification not completed · Verdict cancelled'],
   ] as const)('renders the compact %s verdict badge', (kind, severity, label, expected) => {
     const { d, chunks } = captureDisplay();
     d.taskOutcome({
@@ -1493,7 +1495,8 @@ describe('Display v4.8.0 ui_* event renderers', () => {
     d.renderUiEvent('ui_task_update', { task_id: 't1', label: 'researching', status: 'running' });
     const out = stripAnsi(chunks.join(''));
     expect(out).toContain('┊');
-    expect(out).toContain('⟳');
+    expect(out).toContain('◐ Working');
+    expect(out).toContain('┌ researching');
     expect(out).toContain('researching');
   });
 
@@ -1510,8 +1513,9 @@ describe('Display v4.8.0 ui_* event renderers', () => {
       task_id: 's1', label: 'nested', status: 'running', kind: 'subagent', depth: 2,
     });
     const out = stripAnsi(chunks.join(''));
-    // `┊ ` then 4-space indent (depth 2 × 2 spaces) then glyph + label
-    expect(out).toMatch(/┊ {5}⟳ nested/);
+    // `┊ ` then 4-space indent (depth 2 × 2 spaces) before both card rows.
+    expect(out).toMatch(/┊ {5}┌ nested/);
+    expect(out).toMatch(/┊ {5}└ ◐ Working/);
   });
 
   // ── ui_task_done ──────────────────────────────────────────────────────
@@ -1531,7 +1535,7 @@ describe('Display v4.8.0 ui_* event renderers', () => {
     const { d, chunks } = captureDisplay({ tty: true });
     d.renderUiEvent('ui_task_done', { task_id: 'orphan', status: 'failure' });
     const out = stripAnsi(chunks.join(''));
-    expect(out).toContain('✗');
+    expect(out).toContain('✕');
     expect(out).toContain('orphan');
   });
 
@@ -1608,15 +1612,47 @@ describe('Display v4.8.0 ui_* event renderers', () => {
 
   // ── ui_artifact_created ───────────────────────────────────────────────
 
-  it('ui_artifact_created paints kind-glyph + path + optional preview; kind:skill uses 🛠', () => {
+  it('ui_artifact_created defers file effects to canonical tool results', () => {
     const a = captureDisplay({ tty: true });
-    a.d.renderUiEvent('ui_artifact_created', { path: '/tmp/hello.py', kind: 'file', preview: 'print(1)' });
-    const fileOut = stripAnsi(a.chunks.join(''));
-    expect(fileOut).toContain('📄 Created: /tmp/hello.py');
-    expect(fileOut).toContain('print(1)');
+    a.d.renderUiEvent('ui_artifact_created', {
+      path: '/tmp/hello.py', kind: 'file', operation: 'modify', preview: 'print(1)',
+    });
+    expect(a.chunks.join('')).toBe('');
     const b = captureDisplay({ tty: true });
-    b.d.renderUiEvent('ui_artifact_created', { path: 'mySkill', kind: 'skill' });
+    b.d.renderUiEvent('ui_artifact_created', { path: 'mySkill', kind: 'skill', operation: 'create' });
     expect(stripAnsi(b.chunks.join(''))).toContain('🛠 Created: mySkill');
+
+  });
+
+  it('identifies the unknown axis instead of using a vague terminal label', () => {
+    const { d, chunks } = captureDisplay({ tty: false });
+    d.taskOutcome({
+      kind: 'unverified_required', severity: 'error',
+      label: 'Could not verify required outcome', evidenceCount: 0,
+      hasRequiredEvidenceGap: true, executionStarted: true,
+      inspectable: true, prominent: true,
+      requiredCompletedCount: 1, requiredDeniedCount: 0,
+      requiredFailedCount: 0, requiredSkippedCount: 0,
+      requiredUnresolvedCount: 0, optionalDeniedCount: 0,
+    });
+    const rendered = chunks.join('');
+    expect(rendered).toContain('Execution succeeded');
+    expect(rendered).toContain('Verification unknown');
+    expect(rendered).toContain('Verdict incomplete');
+    expect(rendered).not.toContain('Outcome unknown');
+  });
+
+  it('renders unborn and non-Git repository states without raw probe diagnostics', () => {
+    const unborn = captureDisplay({ tty: false });
+    unborn.d.repositoryState({ vcsKind: 'git', branch: 'master', headCommit: null });
+    const unbornOutput = stripAnsi(unborn.chunks.join(''));
+    expect(unbornOutput).toContain('HEAD      no commits yet');
+    expect(unbornOutput).toContain('State     unborn repository');
+    expect(unbornOutput).not.toContain('fatal:');
+
+    const nonGit = captureDisplay({ tty: false });
+    nonGit.d.repositoryState({ vcsKind: 'none', branch: null, headCommit: null });
+    expect(stripAnsi(nonGit.chunks.join(''))).toContain('State     non-Git directory');
   });
 });
 

--- a/tests/v4/cli/effectPresentation.test.ts
+++ b/tests/v4/cli/effectPresentation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { projectFileEffect, projectRepositoryState } from '../../../cli/v4/effectPresentation';
+
+describe('canonical file-effect presentation', () => {
+  it.each([
+    ['create', 'A', 'Created'],
+    ['modify', 'M', 'Modified'],
+    ['patch', 'M', 'Modified'],
+    ['delete', 'D', 'Deleted'],
+  ] as const)('projects %s from the durable operation', (operation, marker, label) => {
+    expect(projectFileEffect({
+      toolName: 'file_write', cwd: 'C:/repo',
+      result: { success: true, operation, path: 'C:/repo/src/math.mjs', verified: true },
+    })).toMatchObject({ marker, label, path: 'src/math.mjs', verified: true });
+  });
+
+  it.each([
+    ['rename', 'R', 'Renamed'],
+    ['move', 'R', 'Moved'],
+  ] as const)('projects %s source and destination', (operation, marker, label) => {
+    expect(projectFileEffect({
+      toolName: 'file_move', cwd: 'C:/repo',
+      result: {
+        success: true, operation, path: 'C:/repo/src/old.ts',
+        destination: 'C:/repo/src/new.ts', verified: true,
+      },
+    })).toMatchObject({ marker, label, path: 'src/old.ts', destination: 'src/new.ts' });
+  });
+
+  it('projects stale conflicts as blocked without claiming a change', () => {
+    expect(projectFileEffect({
+      toolName: 'file_write', cwd: 'C:/repo',
+      result: {
+        success: false, operation: 'modify', path: 'C:/repo/src/race.ts',
+        conflict: 'source changed after approval',
+      },
+    })).toMatchObject({ marker: '!', label: 'Conflict blocked', blocked: true, verified: false });
+  });
+
+  it('does not project failed writes or failed atomic readback as successful effects', () => {
+    expect(projectFileEffect({
+      toolName: 'file_write', cwd: 'C:/repo',
+      result: { success: false, operation: 'modify', path: 'C:/repo/src/a.ts', error: 'write failed' },
+    })).toBeNull();
+    expect(projectFileEffect({
+      toolName: 'file_write', cwd: 'C:/repo',
+      result: { success: false, operation: 'modify', path: 'C:/repo/src/a.ts', error: 'readback mismatch' },
+    })).toBeNull();
+  });
+
+  it('projects a skipped absent delete as unchanged', () => {
+    expect(projectFileEffect({
+      toolName: 'file_delete', cwd: 'C:/repo',
+      result: { success: true, skipped: true, operation: 'delete', path: 'C:/repo/old.ts' },
+    })).toMatchObject({ marker: '=', label: 'Unchanged', path: 'old.ts' });
+  });
+});
+
+describe('repository state presentation', () => {
+  it('projects an unborn repository without raw probe errors', () => {
+    expect(projectRepositoryState({ vcsKind: 'git', branch: 'master', headCommit: null })).toEqual({
+      branch: 'master', head: 'no commits yet', state: 'unborn repository',
+    });
+  });
+
+  it('projects a non-Git directory without inventing a branch', () => {
+    expect(projectRepositoryState({ vcsKind: 'none', branch: null, headCommit: null })).toEqual({
+      branch: 'not applicable', head: 'not applicable', state: 'non-Git directory',
+    });
+  });
+});

--- a/tests/v4/cli/interactionDecision.pty.test.ts
+++ b/tests/v4/cli/interactionDecision.pty.test.ts
@@ -35,8 +35,7 @@ function stripAnsi(value: string): string {
 }
 
 function currentTurn(output: string, prompt: string): string {
-  const marker = `▲ You  ${prompt}`;
-  const start = output.lastIndexOf(marker);
+  const start = output.lastIndexOf(prompt);
   return start >= 0 ? output.slice(start) : output;
 }
 
@@ -199,7 +198,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (
           state === 'single-denial-settle'
           && provider!.callCount() >= 3
-          && plain.slice(turnStart).includes('Denied · Task:')
+          && plain.slice(turnStart).includes('Verdict denied · Task:')
           && readyCount >= 3
         ) {
           settled.denial = currentTurn(plain, 'request explicitly denied command');
@@ -219,7 +218,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (
           state === 'single-allow-settle'
           && provider!.callCount() >= 5
-          && plain.slice(turnStart).includes('Completed · Task:')
+          && plain.slice(turnStart).includes('Verdict complete · Task:')
           && readyCount >= 5
         ) {
           settled.allow = currentTurn(plain, 'request approved command');
@@ -239,7 +238,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (
           state === 'batch-valid-settle'
           && provider!.callCount() >= 8
-          && /(?:Partially completed|Verified) · Task:/.test(plain.slice(turnStart))
+          && /Verdict (?:partial|complete) · Task:/.test(plain.slice(turnStart))
           && readyCount >= 7
         ) {
           settled.retry = currentTurn(plain, 'request partial batch');
@@ -256,7 +255,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (
           state === 'batch-cancel-settle'
           && provider!.callCount() >= 10
-          && plain.slice(turnStart).includes('Cancelled · Task:')
+          && plain.slice(turnStart).includes('Verdict cancelled · Task:')
           && readyCount >= 9
         ) {
           settled.cancel = currentTurn(plain, 'request cancelled batch');
@@ -273,7 +272,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
         } else if (
           state === 'batch-none-settle'
           && provider!.callCount() >= 12
-          && plain.slice(turnStart).includes('Denied · Task:')
+          && plain.slice(turnStart).includes('Verdict denied · Task:')
           && readyCount >= 11
         ) {
           settled.none = currentTurn(plain, 'request denied batch');
@@ -288,7 +287,9 @@ describe.skipIf(process.platform !== 'win32')('built CLI interactive decision ou
 
       child!.onExit(({ exitCode }) => {
         clearTimeout(timeout);
-        if (state !== 'done') reject(new Error(`decision CLI exited ${exitCode} in ${state}`));
+        if (state !== 'done') reject(new Error(
+          `decision CLI exited ${exitCode} in ${state}:\n${stripAnsi(output).slice(-4000)}`,
+        ));
       });
     });
 

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -153,6 +153,16 @@ describe('responsive startup status rows', () => {
 });
 
 describe('responsive startup dashboard integration', () => {
+  it('renders startup once when the same session is asked to render again', async () => {
+    const { session, chunks } = buildSession('Partner', 100);
+    await session.renderStartupCard();
+    await session.renderStartupCard();
+    const output = stripAnsi(chunks.join(''));
+
+    expect(output.match(/Autonomous AI Engine/g)).toHaveLength(1);
+    expect(output.match(/built solo/gi)).toHaveLength(1);
+  });
+
   it.each([
     { columns: 120, tier: 'wide', sections: true, frame: true },
     { columns: 80, tier: 'wide', sections: true, frame: true },

--- a/tests/v4/cli/taskVerificationGate.test.ts
+++ b/tests/v4/cli/taskVerificationGate.test.ts
@@ -190,8 +190,9 @@ describe('verify-before-done gate (real runAgentTurn seam)', () => {
     expect(task!.status).toBe('verification_failed');
     expect(task!.evidence!.verdict).toBe('verification_failed');
     expect(task!.evidence!.failures[0].tool).toBe('file_write');
-    expect(chunks.join('')).toMatch(/\? Outcome unknown/i);
-    expect(chunks.join('').match(/Outcome unknown/gi)).toHaveLength(1);
+    expect(chunks.join('')).toMatch(/\? Could not verify required outcome/i);
+    expect(chunks.join('').match(/Could not verify required outcome/gi)).toHaveLength(1);
+    expect(chunks.join('')).toContain('Verification unknown');
     expect(chunks.join('')).not.toMatch(/\u2713 Verified/i);
   });
 

--- a/tests/v4/cli/terminalSymbols.test.ts
+++ b/tests/v4/cli/terminalSymbols.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderBottomSurface } from '../../../cli/v4/composerLane';
+import { terminalStateSymbol, terminalSupportsUnicode } from '../../../cli/v4/terminalSymbols';
+
+describe('terminal symbol fallback', () => {
+  it('uses explicit ASCII state labels when Unicode is disabled', () => {
+    const env = { AIDEN_UI_UNICODE: '0' } as NodeJS.ProcessEnv;
+    expect(terminalSupportsUnicode(env)).toBe(false);
+    expect(terminalStateSymbol('running', env)).toBe('[>]');
+    expect(terminalStateSymbol('completed', env)).toBe('[+]');
+    expect(terminalStateSymbol('failed', env)).toBe('[x]');
+    expect(terminalStateSymbol('warning', env)).toBe('[!]');
+    expect(terminalStateSymbol('unknown', env)).toBe('[?]');
+  });
+
+  it('uses ASCII composer chrome for a dumb terminal', () => {
+    const surface = renderBottomSurface(16, 44, { draft: 'plain', mode: 'idle' }, 'provider', {
+      brand: (value) => value, muted: (value) => value, unicode: false,
+    });
+    expect(surface.lines[0]).toMatch(/^\+- > You -+\+$/u);
+    expect(surface.lines[1]).toMatch(/^\| plain\s+\|$/u);
+    expect(surface.lines[2]).toMatch(/^\+-+\+$/u);
+  });
+});

--- a/tests/v4/codebase/safeChangeToolIntegration.test.ts
+++ b/tests/v4/codebase/safeChangeToolIntegration.test.ts
@@ -175,6 +175,13 @@ describe('safe change file-tool integration', () => {
     expect(first.result).toMatchObject({ success: true, changeId: expect.any(String) });
     expect(second.result).toEqual(first.result);
     expect(engine.changes.listRecords(context.admission.jobId)).toHaveLength(1);
+    expect(engine.graph.getCodingPlan(context.admission.jobId)).toMatchObject({
+      remainingStepIds: [],
+      steps: [
+        expect.objectContaining({ stepId: 'inspect-source', state: 'completed', filesInspected: [] }),
+        expect.objectContaining({ state: 'completed', label: 'Apply create' }),
+      ],
+    });
   });
 
   it('repairs patch proof by linking one fresh readback to the patch Effect', async () => {

--- a/tests/v4/core/runtimeStorage.test.ts
+++ b/tests/v4/core/runtimeStorage.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { resolveRuntimeStorageRoot, runtimeArtifactDirectory } from '../../../core/v4/runtimeStorage';
+
+describe('runtime storage location', () => {
+  it('keeps internal state out of the active repository', () => {
+    const repository = path.resolve('C:/user/project');
+    const aidenHome = path.resolve('C:/isolated/aiden-home');
+    const root = resolveRuntimeStorageRoot({}, { root: aidenHome });
+    expect(root).toBe(aidenHome);
+    expect(root).not.toBe(repository);
+    expect(runtimeArtifactDirectory('screenshots', root)).toBe(path.join(aidenHome, 'artifacts', 'screenshots'));
+  });
+
+  it('honors an explicit packaged user-data root', () => {
+    const packaged = path.resolve('C:/packaged/user-data');
+    expect(resolveRuntimeStorageRoot(
+      { AIDEN_USER_DATA: packaged },
+      { root: path.resolve('C:/fallback') },
+    )).toBe(packaged);
+  });
+});

--- a/tests/v4/moat/readOnlyCommand.test.ts
+++ b/tests/v4/moat/readOnlyCommand.test.ts
@@ -38,6 +38,17 @@ describe('isReadOnlyCommand — safe reads run without approval', () => {
     'Get-Content file.txt',
     'Select-String -Path *.ts foo',
     'cat a < input.txt',         // bare input redirect is a read
+    'git status --short',
+    'git diff --stat',
+    'git diff --cached --name-status',
+    'git log -1 --oneline',
+    'git show HEAD:package.json',
+    'git rev-parse HEAD',
+    'git branch --show-current',
+    'git ls-files --modified',
+    'git -C "C:\\repo with spaces" status --short',
+    'git --git-dir="C:\\repo with spaces\\.git" --work-tree="C:\\repo with spaces" diff --stat',
+    'git status --short | head -5',
   ];
   for (const cmd of READ_ONLY) {
     it(`read-only: ${cmd}`, () => { expect(isReadOnlyCommand(cmd)).toBe(true); });
@@ -66,6 +77,18 @@ describe('isReadOnlyCommand — writes/deletes/chains STILL prompt', () => {
     'python script.py',          // arbitrary exec
     'Get-ChildItem | Remove-Item', // second stage mutates
     'node -e "require(\'fs\').unlinkSync(\'x\')"',
+    'git add package.json',
+    'git commit -m "change"',
+    'git checkout -- package.json',
+    'git switch main',
+    'git reset --hard HEAD',
+    'git clean -fd',
+    'git push origin main',
+    'git pull',
+    'git fetch origin',
+    'git config user.name Shiva',
+    'git branch topic',
+    'git tag v1',
     '',                          // empty
     '   ',                       // whitespace only
   ];

--- a/tools/v4/browser/browserScreenshot.ts
+++ b/tools/v4/browser/browserScreenshot.ts
@@ -10,7 +10,7 @@
  * Captures a screenshot of the current Playwright page. The bridge
  * (`core/playwrightBridge.ts`) maintains one persistent Chromium
  * context across all browser tools — no fresh browser is launched
- * per call. The screenshot file lives under `workspace/screenshots/`.
+ * per call. The screenshot file lives in Aiden's runtime artifact storage.
  *
  * Capturing does not mutate the page, but it does persist an artifact.
  *
@@ -38,8 +38,8 @@ const _browserScreenshotTool: ToolHandler = {
   buildPreview() {
     return {
       tool: 'browser_screenshot', args: {}, riskTier: 'safe',
-      sideEffects: [{ type: 'create_file', path: 'workspace/screenshots/<timestamp>.png', bytes: 0 }],
-      detectedRisks: [], summary: 'Would capture the current page to a workspace screenshot artifact.',
+      sideEffects: [{ type: 'create_file', path: '<aiden-home>/artifacts/screenshots/<timestamp>.png', bytes: 0 }],
+      detectedRisks: [], summary: 'Would capture the current page to Aiden artifact storage.',
     };
   },
   async execute() {

--- a/tools/v4/files/fileDelete.ts
+++ b/tools/v4/files/fileDelete.ts
@@ -94,6 +94,7 @@ export const fileDeleteTool: ToolHandler = {
       return {
         success: true,
         skipped: true,
+        operation: 'delete',
         reason:  'source_absent',
         likely:  'already handled by an earlier operation',
         path:    resolved,
@@ -101,7 +102,7 @@ export const fileDeleteTool: ToolHandler = {
     }
     try {
       await fs.rm(resolved, { recursive, force: false });
-      return { success: true, path: resolved };
+      return { success: true, operation: 'delete', path: resolved };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       return { success: false, error: message, path: resolved };

--- a/tools/v4/files/fileMove.ts
+++ b/tools/v4/files/fileMove.ts
@@ -101,6 +101,7 @@ export const fileMoveTool: ToolHandler = {
     }
     const from = srcPolicy.resolvedPath;
     const to   = dstPolicy.resolvedPath;
+    const operation = path.dirname(from) === path.dirname(to) ? 'rename' : 'move';
     // v4.13 — batch-staleness guard. An approved plan may reference a
     // source an EARLIER operation already relocated/deleted (the plan
     // goes stale as it executes). An absent source is a benign SKIP —
@@ -113,6 +114,7 @@ export const fileMoveTool: ToolHandler = {
       return {
         success: true,
         skipped: true,
+        operation,
         reason:  'source_absent',
         likely:  'already handled by an earlier operation',
         from,
@@ -132,7 +134,7 @@ export const fileMoveTool: ToolHandler = {
           throw err;
         }
       }
-      return { success: true, from, to };
+      return { success: true, operation, path: from, destination: to, from, to };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       return { success: false, error: message, from, to };

--- a/tools/v4/files/filePatch.ts
+++ b/tools/v4/files/filePatch.ts
@@ -104,6 +104,7 @@ export const filePatchTool: ToolHandler = {
       return {
         success: true,
         skipped: true,
+        operation: 'patch',
         reason:  'source_absent',
         likely:  'already handled by an earlier operation',
         path:    resolved,
@@ -135,6 +136,7 @@ export const filePatchTool: ToolHandler = {
       const verified = await writeFileVerified(resolved, next);
       return {
         success: true,
+        operation: 'patch',
         path: resolved,
         replacements: replaceAll ? occurrences : 1,
         bytes: verified.bytes,

--- a/tools/v4/files/fileWrite.ts
+++ b/tools/v4/files/fileWrite.ts
@@ -83,6 +83,8 @@ export const fileWriteTool: ToolHandler = {
     }
     const content = typeof args.content === 'string' ? args.content : '';
     const resolved = policy.resolvedPath;
+    let existed = false;
+    try { existed = (await fs.stat(resolved)).isFile(); } catch { /* absent */ }
     try {
       // Shared choke-point: atomic write + read-back verification. `bytes` is
       // the ACTUAL on-disk length (verified), not the intended-length guess a
@@ -91,6 +93,7 @@ export const fileWriteTool: ToolHandler = {
       const verified = await writeFileVerified(resolved, content);
       return {
         success: true,
+        operation: existed ? 'modify' : 'create',
         path: resolved,
         bytes: verified.bytes,
         verified: true,


### PR DESCRIPTION
## Summary

- gives the display layer one transcript and bottom-region ownership path;
- separates user prompts, live activity, terminal effects, outcomes and responses;
- keeps approval chrome transient and makes terminal activity settlement idempotent;
- projects file effects and repository state from structured results;
- classifies local read-only repository inspection without weakening mutation gates;
- stores runtime artifacts outside the active repository;
- prevents newly created paths from leaving durable execution-plan nodes unfinished.

## Validation

- focused TUI, activity, approval, repository and storage tests passed;
- Windows ConPTY acceptance passed at normal, medium and narrow widths;
- deterministic suite: 7,295 passed, 39 skipped;
- integration suite: 39 passed, 7 external-service skips;
- Node 22 typecheck passed;
- production build passed;
- package dry-run passed;
- diff, NUL, secret, attribution, protected-file and process-cleanup checks passed.