### PR TITLE
feat(tui): add semantic activity and compact evidence

### DIFF
--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -7,6 +7,11 @@ import type {
   ToolActivityUpdate,
   ToolTerminalClassification,
 } from '../../providers/v4/types';
+import {
+  normalizeActivityPhase,
+  semanticPhaseForTool,
+  type SemanticActivityPhase,
+} from './semanticActivity';
 
 export type ActivityState = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -32,6 +37,7 @@ export interface ModalActivityOptions<T> {
 }
 
 export interface ActivitySnapshot {
+  frame?: number;
   phase: ToolActivityPhase;
   phaseElapsedMs: number;
   lifecycleElapsedMs: number;
@@ -57,6 +63,7 @@ export class ActivityRegistry {
   private readonly terminalStates = new Map<string, ActivityState>();
   private readonly pendingUpdates = new Map<string, ToolActivityUpdate>();
   private turnActivity?: LiveActivityRowHandle;
+  private turnVerb: string | null = null;
   private ticker: ReturnType<typeof setInterval> | null = null;
   private tickerFrame = 0;
   private modalDepth = 0;
@@ -75,6 +82,7 @@ export class ActivityRegistry {
 
   startTurnActivity(verb: string): boolean {
     if (this.turnActivity?.isActive() || !this.createTurnRow) return false;
+    this.turnVerb = verb;
     this.turnActivity = this.createTurnRow(verb);
     if (this.modalDepth > 0) this.turnActivity.pause();
     this.ensureTicker();
@@ -82,13 +90,18 @@ export class ActivityRegistry {
   }
 
   setTurnPhase(verb: string): void {
+    this.turnVerb = verb;
     this.turnActivity?.setVerb(verb);
   }
 
   settleTurnActivity(): boolean {
-    if (!this.turnActivity) return false;
+    if (!this.turnActivity) {
+      this.turnVerb = null;
+      return false;
+    }
     const row = this.turnActivity;
     this.turnActivity = undefined;
+    this.turnVerb = null;
     row.stop();
     this.stopTickerIfIdle();
     return true;
@@ -273,6 +286,12 @@ export class ActivityRegistry {
   activeCount(): number { return this.entries.size; }
   timerCount(): number { return this.ticker === null ? 0 : 1; }
   modalPauseDepth(): number { return this.modalDepth; }
+  currentPhase(): SemanticActivityPhase {
+    const activeEntries = [...this.entries.values()];
+    const activeTool = activeEntries[activeEntries.length - 1];
+    if (activeTool) return semanticPhaseForTool(activeTool.name, activeTool.phase);
+    return this.turnVerb ? normalizeActivityPhase(this.turnVerb) : 'ready';
+  }
   stateOf(id: string): ActivityState | null {
     return this.entries.get(id)?.state ?? this.terminalStates.get(id) ?? null;
   }
@@ -281,6 +300,7 @@ export class ActivityRegistry {
     const entry = this.entries.get(id);
     if (!entry) {
       return {
+        frame: this.tickerFrame,
         phase: 'terminal', phaseElapsedMs: 0, lifecycleElapsedMs: 0,
         approvalWaitMs: 0, executionDurationMs: 0, verificationDurationMs: 0,
         retryBackoffMs: 0, attemptCount: 0,
@@ -298,6 +318,7 @@ export class ActivityRegistry {
       (total, attempt) => total + Math.max(0, (attempt.endedAt ?? now) - attempt.startedAt), 0,
     ) ?? (entry.phase === 'running' ? Math.max(0, phaseEnd - entry.phaseStartedAt - entry.phasePausedMs) : 0);
     return {
+      frame: this.tickerFrame,
       phase: entry.phase,
       phaseElapsedMs: Math.max(0, phaseEnd - entry.phaseStartedAt - entry.phasePausedMs),
       lifecycleElapsedMs: Math.max(0, now - entry.lifecycleStartedAt),
@@ -324,12 +345,12 @@ export class ActivityRegistry {
   private ensureTicker(): void {
     if (this.ticker !== null || this.modalDepth > 0 || !this.hasRepaintableActivity()) return;
     this.ticker = setInterval(() => {
-      this.tickerFrame = (this.tickerFrame + 1) % 4;
+      // One shared counter drives every animation family. Sixty is the
+      // least common multiple of the 3-, 4-, and 5-frame projections.
+      this.tickerFrame = (this.tickerFrame + 1) % 60;
       this.turnActivity?.refresh(this.tickerFrame);
-      if (this.tickerFrame === 0) {
-        for (const entry of this.entries.values()) {
-          if (entry.repaintEligible) entry.handle.refresh?.();
-        }
+      for (const entry of this.entries.values()) {
+        if (entry.repaintEligible) entry.handle.refresh?.();
       }
     }, 250);
     this.ticker.unref?.();

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -3489,6 +3489,8 @@ export async function buildAgentRuntime(
     getHistoryCount: async () => (await loadRecent(HISTORY_MAX_ENTRIES)).length,
     listTasks:     (id) => replTaskStore.listRecent({ sessionId: id, limit: 200 }),
     listArtifacts: (id) => replArtifactStore.listRecent({ sessionId: id, limit: 200 }),
+    getPresentationMode: () => callbacks.getActivityPresentationMode(),
+    setPresentationMode: (mode) => callbacks.setActivityPresentationMode(mode),
   }));
 
   // ── v4.10 Slice 10.8 — /adjust slash command ───────────────────────

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -48,6 +48,7 @@ import type { BlockerKind, BlockerSurface } from '../../tools/v4/browser/browser
 import { isVerbose, glyphs } from './design/tokens';
 import type { ColorKind } from './skinEngine';
 import type { InputOwner, ModalStdin } from './inputAuthority';
+import type { ActivityPresentationMode, SemanticActivityPhase } from './semanticActivity';
 /* Phase 23.6 rollback — Ink controller bridge stashed to
  * docs/sprint/_internal/v4.1-ink-stash/.  Re-introduce when v4.1 picks
  * up the Ink rebuild. */
@@ -361,6 +362,12 @@ export class CliCallbacks {
   activeActivityCount(): number { return this.activities.activeCount(); }
   activityTimerCount(): number { return this.activities.timerCount(); }
   activityModalPauseDepth(): number { return this.activities.modalPauseDepth(); }
+  currentActivityPhase(): SemanticActivityPhase { return this.activities.currentPhase(); }
+  getActivityPresentationMode(): ActivityPresentationMode { return this.display.getActivityPresentationMode(); }
+  setActivityPresentationMode(mode: ActivityPresentationMode): void {
+    this.display.setActivityPresentationMode(mode);
+    this.activities.invalidateLayout();
+  }
   beginTurnActivity(verb = 'thinking'): boolean { return this.activities.startTurnActivity(verb); }
   setTurnActivityPhase(verb: string): void { this.activities.setTurnPhase(verb); }
   settleTurnActivity(): boolean { return this.activities.settleTurnActivity(); }
@@ -438,19 +445,19 @@ export class CliCallbacks {
   // mapping a lifecycle event to a verb string. Defensive try/catch so
   // a misbehaving display sink can't unwind the agent loop.
   onMemoryRefreshStart = (): void => {
-    this.activities.startTurnActivity('refreshing memory');
-    this.activities.setTurnPhase('refreshing memory');
-    try { this.phaseVerbHook?.('refreshing memory'); } catch { /* defensive */ }
+    this.activities.startTurnActivity('inspecting memory');
+    this.activities.setTurnPhase('inspecting memory');
+    try { this.phaseVerbHook?.('inspecting memory'); } catch { /* defensive */ }
   };
   onPromptBuilt = (_info: { tools: number; skills: number; memoryFacts: number }): void => {
-    this.activities.startTurnActivity('preparing prompt');
-    this.activities.setTurnPhase('preparing prompt');
-    try { this.phaseVerbHook?.('preparing prompt'); } catch { /* defensive */ }
+    this.activities.startTurnActivity('planning');
+    this.activities.setTurnPhase('planning');
+    try { this.phaseVerbHook?.('planning'); } catch { /* defensive */ }
   };
   onProviderRequestStart = (_providerId: string): void => {
-    this.activities.startTurnActivity('calling provider');
-    this.activities.setTurnPhase('calling provider');
-    try { this.phaseVerbHook?.('calling provider'); } catch { /* defensive */ }
+    this.activities.startTurnActivity('provider request');
+    this.activities.setTurnPhase('provider request');
+    try { this.phaseVerbHook?.('provider request'); } catch { /* defensive */ }
   };
 
   /**

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -38,6 +38,7 @@ import {
 import { LoopTracer } from '../../core/v4/loopTrace';
 import type { Display } from './display';
 import { summarizeChannelState, verbForActivity } from './display';
+import type { EvidenceProjectionInput } from './semanticActivity';
 // v4.10 Slice 10.7a — REPL-sacred defense-in-depth flag. Wired here so
 // any future stdout/stderr sink that wants to honor the
 // "user-is-typing" invariant can check isReplActive(). Pairs with the
@@ -2895,6 +2896,7 @@ export class ChatSession implements ChatSessionLike {
       let _fin: ReturnType<typeof computeTaskFinalization> | undefined;
       let _taskOutcome: TaskOutcomePresentation | undefined;
       let durableProofVerdict: ReturnType<NonNullable<typeof jobEngine>['proof']['finalize']> | undefined;
+      let durableEvidenceForDisplay: EvidenceProjectionInput[] = [];
       try {
         _fin = computeTaskFinalization(
           {
@@ -2914,6 +2916,12 @@ export class ChatSession implements ChatSessionLike {
             },
           },
         );
+        if (lifecycleContext && jobEngine) {
+          durableEvidenceForDisplay = jobEngine.proof.listEvidence(lifecycleContext.handle.jobId)
+            .filter((item) => item.attemptId === lifecycleContext!.handle.attemptId
+              && item.generation === lifecycleContext!.handle.generation
+              && !item.late);
+        }
         if (lifecycleContext && jobEngine?.proof.hasRequiredClaims(lifecycleContext.handle.jobId)) {
           durableProofVerdict = jobEngine.proof.finalize({
             jobId: lifecycleContext.handle.jobId,
@@ -2925,10 +2933,7 @@ export class ChatSession implements ChatSessionLike {
           const summary = durableProofVerdict.summary as {
             verifiedClaims?: number; failedClaims?: number; unknownClaims?: number;
           };
-          const proofEvidence = jobEngine.proof.listEvidence(lifecycleContext.handle.jobId)
-            .filter((item) => item.attemptId === lifecycleContext!.handle.attemptId
-              && item.generation === lifecycleContext!.handle.generation
-              && !item.late);
+          const proofEvidence = durableEvidenceForDisplay;
           const verifiedHandle = {
             tool: 'durable_proof', kind: 'note' as const,
             value: `${proofEvidence.length} linked evidence record${proofEvidence.length === 1 ? '' : 's'}`,
@@ -3106,6 +3111,13 @@ export class ChatSession implements ChatSessionLike {
         this.opts.display.dim('(turn interrupted)');
       }
 
+      // Durable proof is projected once from the canonical proof authority.
+      // Streaming replies may already be visible; non-streaming replies retain
+      // the preferred activity → evidence → answer ordering.
+      if (!streamingActive && durableEvidenceForDisplay.length > 0) {
+        this.opts.display.evidencePanel(durableEvidenceForDisplay);
+      }
+
       // v4.1.6 spike (TCE) — tool-loop terminal surface. When the
       // agent ended the turn via the recovery controller's surface
       // stage, render a structured-failure card instead of the
@@ -3130,6 +3142,10 @@ export class ChatSession implements ChatSessionLike {
         // `emitToolReplySeparator`.
         emitToolReplySeparator();
         this.opts.display.write(this.opts.display.agentTurn(result.finalContent));
+      }
+
+      if (streamingActive && durableEvidenceForDisplay.length > 0) {
+        this.opts.display.evidencePanel(durableEvidenceForDisplay);
       }
 
       // Pure conversation stays conversational. Tool/task turns receive one
@@ -3861,6 +3877,7 @@ export class ChatSession implements ChatSessionLike {
     // with brand prefix (`Aiden v<X.Y>`), session uptime (sessionMs
     // re-enabled), and spelled-out `last <elapsed>` for the per-turn
     // timer. Mid (≥100) and narrow (<100) tiers unchanged.
+    const registryPhase = this.opts.callbacks.currentActivityPhase?.() ?? 'ready';
     const statusArgs = {
         provider,
         model,
@@ -3870,6 +3887,12 @@ export class ChatSession implements ChatSessionLike {
         turnCount: this.turnCount,
         sessionMs: Date.now() - this.startedAt,
         state:     this.lastTurnOutcome,
+        phase:     this.statusState.kind === 'approve' ? 'approval_required'
+          : this.statusState.kind === 'retry' ? 'recovering'
+            : this.statusState.kind === 'ready' ? 'ready'
+              : registryPhase === 'ready'
+                ? this.statusState.kind === 'exec' ? 'working' : 'thinking'
+                : registryPhase,
     } as const;
 
     if (this.usesFixedBottomRegion()) {

--- a/cli/v4/commands/activity.ts
+++ b/cli/v4/commands/activity.ts
@@ -26,6 +26,7 @@
  */
 
 import type { SlashCommand, SlashCommandContext } from '../commandRegistry';
+import type { ActivityPresentationMode } from '../semanticActivity';
 
 /** Live accessors, supplied by the REPL boot. Each mirrors one command's source. */
 export interface ActivitySources {
@@ -41,16 +42,27 @@ export interface ActivitySources {
   listTasks: (sessionId: string) => Array<{ status: string }>;
   /** replArtifactStore.listRecent({sessionId}) — the /artifacts source (rows, for counting). */
   listArtifacts: (sessionId: string) => unknown[];
+  getPresentationMode?: () => ActivityPresentationMode;
+  setPresentationMode?: (mode: ActivityPresentationMode) => void;
 }
 
 /** Build the inline `/activity` command over the supplied live accessors. */
 export function makeActivityCommand(sources: ActivitySources): SlashCommand {
   return {
     name: 'activity',
-    description: 'Session roll-up: tokens, budget, history, tasks, artifacts.',
+    description: 'Session roll-up and activity detail mode. Usage: /activity [summary|full].',
     category: 'system',
     icon: '≋',
     handler: async (ctx: SlashCommandContext) => {
+      const requestedMode = ctx.args[0]?.toLowerCase();
+      if (requestedMode && requestedMode !== 'summary' && requestedMode !== 'full') {
+        ctx.display.warn('Usage: /activity [summary|full]');
+        return {};
+      }
+      if (requestedMode === 'summary' || requestedMode === 'full') {
+        sources.setPresentationMode?.(requestedMode);
+      }
+      const presentationMode = sources.getPresentationMode?.() ?? 'summary';
       const id = sources.sessionId();
       // /usage source — best-effort (session may lack the optional accessor).
       const usage = ctx.session?.getTotalUsage?.() ?? { inputTokens: 0, outputTokens: 0 };
@@ -62,6 +74,7 @@ export function makeActivityCommand(sources: ActivitySources): SlashCommand {
 
       const totalTok = usage.inputTokens + usage.outputTokens;
       ctx.display.info('Activity — this session');
+      ctx.display.write(`  View      : ${presentationMode} (/activity summary · /activity full)\n`);
       ctx.display.write(
         `  Tokens    : ${usage.inputTokens.toLocaleString()} in · ` +
         `${usage.outputTokens.toLocaleString()} out (${totalTok.toLocaleString()} total)\n`,

--- a/cli/v4/design/tokens.ts
+++ b/cli/v4/design/tokens.ts
@@ -64,6 +64,13 @@ export const colors = {
     warn:    '#e0a040',
     error:   '#e05a5a',
     info:    '#7da7c7',
+    thinking:   '#5BC0EB',
+    planning:   '#A78BFA',
+    inspecting: '#60A5FA',
+    working:    '#FB923C',
+    testing:    '#FACC15',
+    verifying:  '#2DD4BF',
+    recovering: '#A78BFA',
   },
   /**
    * v4.8.0 Slice 7 hotfix #2 — per-metric accent palette for the

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -43,6 +43,20 @@ import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
 import type { OperatorActivityState } from './operatorProjection';
 import { AIDEN_LOGO_LINES } from '../../core/v4/ui/identity';
+import {
+  normalizeActivityPhase,
+  phaseColorKind,
+  projectActivityFrame,
+  projectCommandPresentation,
+  projectEvidenceLines,
+  relativizeActivityText,
+  semanticPhaseForTool,
+  semanticPhaseStatusLabel,
+  shouldDeferActivityTransition,
+  type ActivityPresentationMode,
+  type EvidenceProjectionInput,
+  type SemanticActivityPhase,
+} from './semanticActivity';
 
 const DISPLAY_ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
 
@@ -436,6 +450,7 @@ export class Display {
   // depth pauses only composer painting and retains the exact draft/hint.
   private composerSurfacePauseDepth = 0;
   private nextLiveRowIdentity = 0;
+  private activityPresentationMode: ActivityPresentationMode = 'summary';
 
   constructor(opts: { skin?: SkinEngine; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream } = {}) {
     this.skin = opts.skin ?? getSkinEngine();
@@ -459,6 +474,14 @@ export class Display {
    */
   applyColors(text: string, kind: ColorKind): string {
     return this.skin.applyColors(text, kind);
+  }
+
+  setActivityPresentationMode(mode: ActivityPresentationMode): void {
+    this.activityPresentationMode = mode;
+  }
+
+  getActivityPresentationMode(): ActivityPresentationMode {
+    return this.activityPresentationMode;
   }
 
   /**
@@ -916,6 +939,7 @@ export class Display {
     turnCount?:  number;
     sessionMs?:  number;
     state?:      'ok' | 'warn' | 'error' | 'muted';
+    phase?:      SemanticActivityPhase;
   }): string {
     const sk = this.skin;
     const SEP = sk.applyColors(' │ ', 'muted');
@@ -943,25 +967,28 @@ export class Display {
       : 100;
     void args.turnCount;
     void args.sessionMs;
-    void args.state;
+    const phase = args.phase ?? (args.state === 'error' ? 'failed' : 'ready');
     const contextFull =
       `${sk.applyColors('◉ context', 'muted')} ${ctxRatio} ${bar} ${ctxPctText}`;
     const contextCompact = `${sk.applyColors('◉ context', 'muted')} ${ctxPctText}`;
+    const phaseText = sk.applyColors(`⌁ ${semanticPhaseStatusLabel(phase)}`, phaseColorKind(phase));
     const timer =
-      `${sk.applyColors('⧖', 'success')} ${sk.applyColors(formatElapsedShort(args.elapsedMs), 'success')}`;
+      `${sk.applyColors('⧖', 'muted')} ${sk.applyColors(formatElapsedShort(args.elapsedMs), 'muted')}`;
     let segments: string[];
-    if (cols >= 80) {
-      segments = [providerModel, contextFull, timer];
+    if (cols >= 100) {
+      segments = [providerModel, contextFull, phaseText, timer];
     } else if (cols >= 54) {
-      segments = [providerModel, contextCompact, timer];
+      segments = [providerModel, contextCompact, phaseText, timer];
     } else {
-      const compactContext = `◉ ${pct}%`;
+      const compactContext = `◉${pct}%`;
+      const compactPhase = sk.applyColors(semanticPhaseStatusLabel(phase), phaseColorKind(phase));
       const providerModelBudget = Math.max(
         8,
         (cols - 1)
           - terminalVisibleLength(compactContext)
           - terminalVisibleLength(timer)
-          - 8,
+          - terminalVisibleLength(compactPhase)
+          - 12,
       );
       const fullProviderModel = `${args.provider}:${args.model}`;
       const abbreviatedProviderModel = `${args.provider.slice(0, 1)}:${args.model}`;
@@ -973,10 +1000,11 @@ export class Display {
       segments = [
         `${sk.applyColors('◆', 'brand')} ${sk.applyColors(compactProviderModel, 'tool')}`,
         sk.applyColors(compactContext, ctxKind),
+        compactPhase,
         timer,
       ];
     }
-    return truncateTerminalVisible(segments.join(SEP), Math.max(1, cols - 1));
+    return truncateTerminalVisible(segments.join(SEP), Math.max(1, cols - 2));
   }
 
   /**
@@ -1542,6 +1570,10 @@ export class Display {
     const isTty = !!out.isTTY;
     let startedAt = Date.now();
     let verb = initialVerb;
+    let phase = normalizeActivityPhase(initialVerb);
+    let source: 'provider' | 'runtime' = /provider/iu.test(initialVerb) ? 'provider' : 'runtime';
+    let phaseVisibleAt = startedAt;
+    let pendingVerb: string | null = null;
     let active = true;
     let paused = !isTty;
     let printed = false;
@@ -1551,29 +1583,27 @@ export class Display {
     const rowId = `provider:${++this.nextLiveRowIdentity}`;
     const screenOwner = this.composerLane?.isActive() ? this.composerLane : null;
 
-    const animation = (width: number): string => {
-      if (width >= 60) {
-        const cells = Array.from({ length: 6 }, (_, index) => index === frameIndex % 6
-          ? this.skin.applyColors(glyphs.shimmer.block, 'brand')
-          : this.skin.applyColors(glyphs.shimmer.track, 'muted'));
-        return `${cells.join('')} `;
-      }
-      const frames = ['◐', '◓', '◑', '◒'];
-      return `${this.skin.applyColors(frames[frameIndex % frames.length], 'brand')} `;
-    };
-
     const body = (): string => {
       const width = Math.max(1, this.terminalColumns() - 2);
-      const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+      const elapsedMs = Math.max(0, Date.now() - startedAt);
+      const elapsed = Math.floor(elapsedMs / 1000);
       const time = elapsed > 0 && width >= 28 ? ` (${elapsed}s)` : '';
       const prefix = width >= 60 ? '  ' : '';
-      const phase = width < 28 && verb === 'calling provider' ? 'provider' : verb;
+      const projection = projectActivityFrame({
+        phase,
+        frame: frameIndex,
+        elapsedMs,
+        unicode: terminalSupportsUnicode(),
+        mode: this.activityPresentationMode,
+        source,
+      });
       const busy = this.composerSuffix().length > 0;
       const suffix = !busy ? ''
         : width >= 80 ? this.composerSuffix()
         : width >= 36 ? '  Ctrl+C stop'
         : '  Ctrl+C';
-      return truncateVisible(`${prefix}${animation(width)}${phase}${time}${suffix}`, width);
+      const activity = this.skin.applyColors(projection.text, projection.color);
+      return truncateVisible(`${prefix}${activity}${time}${suffix}`, width);
     };
     const erase = (): void => {
       if (!printed || !isTty) return;
@@ -1591,6 +1621,14 @@ export class Display {
       this.refreshStatusFooter();
       if (!active || paused || !isTty) return;
       if (typeof frame === 'number') frameIndex = frame;
+      if (pendingVerb !== null) {
+        verb = pendingVerb;
+        phase = normalizeActivityPhase(verb);
+        source = /provider/iu.test(verb) ? 'provider' : 'runtime';
+        pendingVerb = null;
+        startedAt = Date.now();
+        phaseVisibleAt = startedAt;
+      }
       const next = body();
       if (printed && !invalidated && next === lastBody) return;
       if (screenOwner) screenOwner.setLiveRow(rowId, next);
@@ -1607,8 +1645,17 @@ export class Display {
       refresh,
       setVerb: (next: string) => {
         if (!active || !next || next === verb) return;
+        const nextPhase = normalizeActivityPhase(next);
+        if (shouldDeferActivityTransition(phase, nextPhase, Date.now() - phaseVisibleAt)) {
+          pendingVerb = next;
+          return;
+        }
         verb = next;
+        phase = nextPhase;
+        source = /provider/iu.test(next) ? 'provider' : 'runtime';
+        pendingVerb = null;
         startedAt = Date.now();
+        phaseVisibleAt = startedAt;
         invalidated = true;
         refresh();
       },
@@ -1698,7 +1745,10 @@ export class Display {
     // to the generic `previewToolArgs` scan for tools the map doesn't
     // know about so unregistered MCP tools etc. still render readably.
     const mapped = buildToolPreview(name, args);
-    const detail = truncDetail(mapped ?? previewToolArgs(args));
+    const rawDetail = mapped ?? previewToolArgs(args);
+    const detailForDisplay = (): string => this.activityPresentationMode === 'full'
+      ? rawDetail
+      : truncDetail(relativizeActivityText(rawDetail, process.cwd(), 'summary'));
 
     // Semantic elapsed time comes from ActivityRegistry. A compatibility row
     // without a source advances only on its own repaint ticks.
@@ -1717,19 +1767,22 @@ export class Display {
     const runningRow = (): string => {
       const snapshot = readActivity?.();
       const elapsed = snapshot?.phaseElapsedMs ?? fallbackPhaseElapsedMs;
-      const phaseLabel = snapshot?.phase === 'awaiting_approval' ? 'awaiting approval'
-        : snapshot?.phase === 'verifying' ? 'verifying'
-        : snapshot?.phase === 'retrying' ? 'retrying'
-        : snapshot?.phase === 'queued' ? 'queued'
-        : 'running';
-      const liveSuffix = elapsed >= 1000
-        ? `  ${sk.applyColors(`${phaseLabel} ${formatToolDuration(elapsed)}…`, 'muted')}`
-        : '';
-      const runningGlyph = useIcons ? sk.applyColors('⚙', 'tool') : sk.applyColors(terminalStateSymbol('running'), 'muted');
+      const semanticPhase = semanticPhaseForTool(name, snapshot?.phase ?? 'running');
+      const projection = projectActivityFrame({
+        phase: semanticPhase,
+        frame: snapshot?.frame ?? Math.floor(fallbackPhaseElapsedMs / 1_000),
+        elapsedMs: elapsed,
+        unicode: useIcons,
+        mode: this.activityPresentationMode,
+        source: 'runtime',
+      });
+      const duration = elapsed >= 1000 ? ` ${formatToolDuration(elapsed)}` : '';
+      const liveSuffix = `  ${sk.applyColors(`${semanticPhaseStatusLabel(semanticPhase)}${duration}…`, phaseColorKind(semanticPhase))}`;
+      const runningGlyph = sk.applyColors(projection.glyph, projection.color);
       const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph}  ` +
         `${sk.applyColors(padVerb(verb), 'tool')} `;
       const suffix = `${liveSuffix}${this.composerSuffix()}`;
-      const detailText = sk.applyColors(detail, 'muted');
+      const detailText = sk.applyColors(detailForDisplay(), 'muted');
       const width = terminalRowWidth();
       if (width === null) return `${prefix}${detailText}${suffix}\n`;
       const availableDetail = Math.max(
@@ -1760,9 +1813,10 @@ export class Display {
       const availableDetail = width === null
         ? Number.POSITIVE_INFINITY
         : Math.max(0, width - visibleLength(prefix) - visibleLength(suffixText));
+      const displayDetail = detailForDisplay();
       const content = `${prefix}${availableDetail === Number.POSITIVE_INFINITY
-        ? detail
-        : truncateVisible(detail, availableDetail)}${suffixText}`;
+        ? displayDetail
+        : truncateVisible(displayDetail, availableDetail)}${suffixText}`;
       return `${sk.applyColors(content, kind)}\n`;
     };
 
@@ -2023,7 +2077,7 @@ export class Display {
         // v4.8.0 Slice 11c — double-space between glyph and verb (see
         // runningRow comment above for the emoji-width rationale).
         const content =
-          `${TRAIL_PIPE} ${glyph}  ${padVerb(verb)} ${detail}  retry ${n}/${m} …`;
+          `${TRAIL_PIPE} ${glyph}  ${padVerb(verb)} ${detailForDisplay()}  retry ${n}/${m} …`;
         replaceLast(sk.applyColors(content, 'warn') + '\n');
       },
       blocked() {
@@ -2546,6 +2600,37 @@ export class Display {
       projection.role,
     );
     this.writeOutput(`${glyph} ${projection.label} · ${axes.join(' · ')}${summary}${details}\n`);
+  }
+
+  /** Project canonical durable evidence without manufacturing proof. */
+  evidencePanel(evidence: readonly EvidenceProjectionInput[]): void {
+    const projectedEvidence = this.activityPresentationMode === 'full'
+      ? evidence
+      : evidence.map((item) => {
+          if (!item.payload || typeof item.payload !== 'object' || Array.isArray(item.payload)) return item;
+          const payload = item.payload as Record<string, unknown>;
+          const adjusted = { ...payload };
+          let changed = false;
+          for (const key of ['path', 'target', 'message', 'reason'] as const) {
+            if (typeof adjusted[key] !== 'string') continue;
+            adjusted[key] = relativizeActivityText(String(adjusted[key]), process.cwd(), 'summary');
+            changed = true;
+          }
+          if (!changed) return item;
+          return {
+            ...item,
+            payload: adjusted,
+          };
+        });
+    const lines = projectEvidenceLines(projectedEvidence, this.activityPresentationMode);
+    if (lines.length === 0) return;
+    this.commitStreamChunk();
+    const rendered = lines.map((line, index) => this.uiTrailRow(
+      line,
+      index === 0 ? 'heading' : 'muted',
+    )).join('');
+    this.writeOutput(rendered);
+    this.streamLastEndedNewline = true;
   }
 
   /**
@@ -3236,12 +3321,20 @@ export class Display {
     const stderr  = typeof args.stderr  === 'string' ? args.stderr  : '';
     const exitCode = typeof args.exit_code === 'number' ? args.exit_code : 0;
     this.commitStreamChunk();
-    const ok = exitCode === 0;
-    const cap = (t: string): string => t.split('\n').slice(0, 5).join('\n');
-    let out = this.uiTrailRow(`▸ ${command}`, ok ? 'success' : 'error');
-    if (stdout) out += this.uiTrailRow(cap(stdout), 'muted');
-    if (stderr) out += this.uiTrailRow(cap(stderr), 'error');
-    if (!ok)    out += this.uiTrailRow(`(exit ${exitCode})`, 'error');
+    const projection = projectCommandPresentation({
+      command: relativizeActivityText(command, process.cwd(), this.activityPresentationMode),
+      stdout: relativizeActivityText(stdout, process.cwd(), this.activityPresentationMode),
+      stderr: relativizeActivityText(stderr, process.cwd(), this.activityPresentationMode),
+      exitCode,
+      mode: this.activityPresentationMode,
+    });
+    const kind: ColorKind = projection.outcome === 'failure'
+      ? 'error'
+      : projection.outcome === 'warning' ? 'warn' : 'success';
+    const out = projection.lines.map((line, index) => this.uiTrailRow(
+      line,
+      index === 0 ? kind : projection.outcome === 'failure' ? 'error' : 'muted',
+    )).join('');
     this.writeOutput(out);
     this.streamLastEndedNewline = true;
   }

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -50,6 +50,7 @@ import {
   projectCommandPresentation,
   projectEvidenceLines,
   relativizeActivityText,
+  semanticPhaseCompactToken,
   semanticPhaseForTool,
   semanticPhaseStatusLabel,
   shouldDeferActivityTransition,
@@ -974,37 +975,31 @@ export class Display {
     const phaseText = sk.applyColors(`⌁ ${semanticPhaseStatusLabel(phase)}`, phaseColorKind(phase));
     const timer =
       `${sk.applyColors('⧖', 'muted')} ${sk.applyColors(formatElapsedShort(args.elapsedMs), 'muted')}`;
+    const maxWidth = Math.max(1, cols - 2);
     let segments: string[];
     if (cols >= 100) {
       segments = [providerModel, contextFull, phaseText, timer];
-    } else if (cols >= 54) {
-      segments = [providerModel, contextCompact, phaseText, timer];
     } else {
-      const compactContext = `◉${pct}%`;
-      const compactPhase = sk.applyColors(semanticPhaseStatusLabel(phase), phaseColorKind(phase));
-      const providerModelBudget = Math.max(
-        8,
-        (cols - 1)
-          - terminalVisibleLength(compactContext)
-          - terminalVisibleLength(timer)
-          - terminalVisibleLength(compactPhase)
-          - 12,
+      const mediumSegments = [providerModel, contextCompact, phaseText, timer];
+      const medium = mediumSegments.join(SEP);
+      if (terminalVisibleLength(medium) <= maxWidth) return medium;
+
+      const unicode = terminalSupportsUnicode();
+      const compactSeparator = sk.applyColors(unicode ? '│' : '|', 'muted');
+      const compactIdentity =
+        `${sk.applyColors(unicode ? '◆' : '*', 'brand')}` +
+        `${sk.applyColors(`${args.provider}/${args.model}`, 'tool')}`;
+      const compactContext = sk.applyColors(`${unicode ? '◉' : ''}${pct}%`, ctxKind);
+      const compactPhase = sk.applyColors(
+        semanticPhaseCompactToken(phase, unicode),
+        phaseColorKind(phase),
       );
-      const fullProviderModel = `${args.provider}:${args.model}`;
-      const abbreviatedProviderModel = `${args.provider.slice(0, 1)}:${args.model}`;
-      const compactProviderModel = terminalVisibleLength(fullProviderModel) <= providerModelBudget
-        ? fullProviderModel
-        : terminalVisibleLength(abbreviatedProviderModel) <= providerModelBudget
-          ? abbreviatedProviderModel
-          : truncateTerminalVisible(fullProviderModel, providerModelBudget);
-      segments = [
-        `${sk.applyColors('◆', 'brand')} ${sk.applyColors(compactProviderModel, 'tool')}`,
-        sk.applyColors(compactContext, ctxKind),
-        compactPhase,
-        timer,
-      ];
+      const compactTimer = sk.applyColors(formatElapsedShort(args.elapsedMs), 'muted');
+      const compact = [compactIdentity, compactContext, compactPhase, compactTimer]
+        .join(compactSeparator);
+      return truncateTerminalVisible(compact, maxWidth);
     }
-    return truncateTerminalVisible(segments.join(SEP), Math.max(1, cols - 2));
+    return truncateTerminalVisible(segments.join(SEP), maxWidth);
   }
 
   /**

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -994,7 +994,7 @@ export class Display {
       const abbreviatedProviderModel = `${args.provider.slice(0, 1)}:${args.model}`;
       const compactProviderModel = terminalVisibleLength(fullProviderModel) <= providerModelBudget
         ? fullProviderModel
-        : args.provider.length <= 8 && terminalVisibleLength(abbreviatedProviderModel) <= providerModelBudget
+        : terminalVisibleLength(abbreviatedProviderModel) <= providerModelBudget
           ? abbreviatedProviderModel
           : truncateTerminalVisible(fullProviderModel, providerModelBudget);
       segments = [

--- a/cli/v4/semanticActivity.ts
+++ b/cli/v4/semanticActivity.ts
@@ -126,6 +126,27 @@ export function semanticPhaseStatusLabel(phase: SemanticActivityPhase): string {
   }
 }
 
+export function semanticPhaseCompactToken(
+  phase: SemanticActivityPhase,
+  unicode: boolean,
+): string {
+  switch (phase) {
+    case 'thinking': return 'T';
+    case 'planning': return 'P';
+    case 'inspecting': return 'I';
+    case 'working': return 'W';
+    case 'testing': return 'R';
+    case 'verifying': return 'V';
+    case 'recovering': return 'R';
+    case 'approval_required': return 'A';
+    case 'blocked': return 'B';
+    case 'completing': return 'V';
+    case 'ready':
+    case 'complete': return unicode ? '✓' : '+';
+    case 'failed': return unicode ? '✕' : 'x';
+  }
+}
+
 function unicodeGlyph(phase: SemanticActivityPhase, frame: number): string {
   switch (phase) {
     case 'thinking': return ['⠋', '⠙', '⠹', '⠸'][frame % 4]!;

--- a/cli/v4/semanticActivity.ts
+++ b/cli/v4/semanticActivity.ts
@@ -1,0 +1,338 @@
+import path from 'node:path';
+
+import type { ColorKind } from './skinEngine';
+
+export type ActivityPresentationMode = 'summary' | 'full';
+
+export type SemanticActivityPhase =
+  | 'ready'
+  | 'thinking'
+  | 'planning'
+  | 'inspecting'
+  | 'working'
+  | 'testing'
+  | 'verifying'
+  | 'recovering'
+  | 'approval_required'
+  | 'blocked'
+  | 'completing'
+  | 'complete'
+  | 'failed';
+
+export interface ActivityFrameInput {
+  phase: SemanticActivityPhase;
+  frame: number;
+  elapsedMs: number;
+  unicode: boolean;
+  mode: ActivityPresentationMode;
+  source?: 'provider' | 'runtime';
+}
+
+export interface ActivityFrameProjection {
+  glyph: string;
+  label: string;
+  text: string;
+  color: ColorKind;
+  animated: boolean;
+}
+
+const TERMINAL_PHASES = new Set<SemanticActivityPhase>([
+  'ready', 'approval_required', 'blocked', 'complete', 'failed',
+]);
+
+export function normalizeActivityPhase(value: string | undefined): SemanticActivityPhase {
+  const phase = (value ?? '').trim().toLowerCase().replace(/[\s-]+/gu, '_');
+  if (!phase) return 'thinking';
+  if (phase === 'ready') return 'ready';
+  if (/(approval|awaiting_approval|confirmation)/u.test(phase)) return 'approval_required';
+  if (/(blocked|stale|conflict)/u.test(phase)) return 'blocked';
+  if (/(failed|failure|error)/u.test(phase)) return 'failed';
+  if (/(complete|completed|verified)/u.test(phase) && !/verifying/u.test(phase)) return 'complete';
+  if (/(verify|readback|proof|evidence)/u.test(phase)) return 'verifying';
+  if (/(test|validation|check)/u.test(phase)) return 'testing';
+  if (/(recover|retry|resume|reconcile)/u.test(phase)) return 'recovering';
+  if (/(inspect|read|search|fetch|list|view|memory|repository)/u.test(phase)) return 'inspecting';
+  if (/(plan|prompt|prepare_prompt|understand)/u.test(phase)) return 'planning';
+  if (/(work|draft|write|edit|patch|save|run|exec|analyz|change)/u.test(phase)) return 'working';
+  if (/(final|complet)/u.test(phase)) return 'completing';
+  return 'thinking';
+}
+
+export function semanticPhaseForTool(
+  toolName: string,
+  runtimePhase: string = 'running',
+): SemanticActivityPhase {
+  const observed = normalizeActivityPhase(runtimePhase);
+  if (observed === 'approval_required' || observed === 'verifying' || observed === 'recovering') return observed;
+  const name = toolName.toLowerCase();
+  if (/(test|lint|typecheck|build|compile)/u.test(name)) return 'testing';
+  if (/(read|list|view|get|inspect|search|fetch|status|snapshot)/u.test(name)) return 'inspecting';
+  if (/(write|edit|patch|save|create|append|delete|remove|move|rename|shell|exec|run)/u.test(name)) return 'working';
+  return observed === 'thinking' ? 'working' : observed;
+}
+
+export function phaseColorKind(phase: SemanticActivityPhase): ColorKind {
+  switch (phase) {
+    case 'thinking': return 'thinking';
+    case 'planning': return 'planning';
+    case 'inspecting': return 'inspecting';
+    case 'working': return 'working';
+    case 'testing': return 'testing';
+    case 'verifying': return 'verifying';
+    case 'recovering': return 'recovering';
+    case 'approval_required':
+    case 'blocked': return 'warn';
+    case 'complete': return 'success';
+    case 'failed': return 'error';
+    case 'completing': return 'verifying';
+    case 'ready': return 'muted';
+  }
+}
+
+function slowThinkingLabel(elapsedMs: number): string {
+  if (elapsedMs >= 25_000) return 'Still working — checking the result before responding…';
+  if (elapsedMs >= 10_000) return 'Reviewing repository state and existing user changes…';
+  if (elapsedMs >= 3_000) return 'Planning the safest approach…';
+  return 'Aiden is thinking…';
+}
+
+function phaseLabel(phase: SemanticActivityPhase, elapsedMs: number): string {
+  switch (phase) {
+    case 'ready': return 'ready';
+    case 'thinking': return slowThinkingLabel(elapsedMs);
+    case 'planning': return 'Planning the work…';
+    case 'inspecting': return 'Inspecting the repository…';
+    case 'working': return 'Working on the requested action…';
+    case 'testing': return 'Running focused tests…';
+    case 'verifying': {
+      const labels = ['Checking fresh readback…', 'Verifying test evidence…', 'Building final proof…'];
+      return labels[Math.floor(elapsedMs / 1_000) % labels.length]!;
+    }
+    case 'recovering': return 'Recovering interrupted work…';
+    case 'approval_required': return 'Approval required';
+    case 'blocked': return 'Blocked — user action required';
+    case 'completing': return 'Finalizing…';
+    case 'complete': return 'Complete';
+    case 'failed': return 'Failed';
+  }
+}
+
+export function semanticPhaseStatusLabel(phase: SemanticActivityPhase): string {
+  switch (phase) {
+    case 'approval_required': return 'approval required';
+    case 'completing': return 'finalizing';
+    case 'complete': return 'complete';
+    default: return phase;
+  }
+}
+
+function unicodeGlyph(phase: SemanticActivityPhase, frame: number): string {
+  switch (phase) {
+    case 'thinking': return ['⠋', '⠙', '⠹', '⠸'][frame % 4]!;
+    case 'planning': return ['◇ ◆ ◇', '◇ ◇ ◆', '◆ ◇ ◇'][frame % 3]!;
+    case 'inspecting': {
+      const cells = Array.from({ length: 5 }, (_, index) => index === frame % 5 ? '■' : '□');
+      return `[${cells.join('')}]`;
+    }
+    case 'working': return ['>   ', ' >  ', '  > ', '   >'][frame % 4]!;
+    case 'testing': return ['◐', '◓', '◑', '◒'][frame % 4]!;
+    case 'verifying': return ['⌁', '⌁·', '⌁··'][frame % 3]!;
+    case 'recovering': return ['↶', '↺'][frame % 2]!;
+    case 'completing': return ['·', '··', '···'][frame % 3]!;
+    case 'approval_required':
+    case 'blocked': return '!';
+    case 'complete': return '✓';
+    case 'failed': return '✕';
+    case 'ready': return '◆';
+  }
+}
+
+function asciiGlyph(phase: SemanticActivityPhase, frame: number): string {
+  if (TERMINAL_PHASES.has(phase)) {
+    if (phase === 'complete') return '+';
+    if (phase === 'failed' || phase === 'blocked' || phase === 'approval_required') return '!';
+    return '*';
+  }
+  return ['|', '/', '-', '\\'][frame % 4]!;
+}
+
+export function projectActivityFrame(input: ActivityFrameInput): ActivityFrameProjection {
+  const glyph = input.unicode ? unicodeGlyph(input.phase, input.frame) : asciiGlyph(input.phase, input.frame);
+  const label = phaseLabel(input.phase, Math.max(0, input.elapsedMs));
+  const detail = input.mode === 'full' && input.source === 'provider' ? ' · provider request' : '';
+  return {
+    glyph,
+    label,
+    text: `${glyph} ${label}${detail}`,
+    color: phaseColorKind(input.phase),
+    animated: !TERMINAL_PHASES.has(input.phase),
+  };
+}
+
+export function shouldDeferActivityTransition(
+  current: SemanticActivityPhase,
+  next: SemanticActivityPhase,
+  currentVisibleMs: number,
+): boolean {
+  if (current === next || TERMINAL_PHASES.has(next)) return false;
+  return currentVisibleMs < 175;
+}
+
+export function relativizeActivityText(
+  value: string,
+  cwd: string,
+  mode: ActivityPresentationMode,
+): string {
+  if (mode === 'full' || !cwd) return value;
+  const normalizedRoot = cwd.replace(/[\\/]+$/u, '');
+  const escaped = normalizedRoot.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const replaced = value.replace(new RegExp(`${escaped}[\\\\/]`, process.platform === 'win32' ? 'giu' : 'gu'), '');
+  return replaced.replace(/\\/gu, '/');
+}
+
+function isPowerShellProgressClixml(value: string): boolean {
+  const text = value.trim();
+  return /^#< CLIXML\s*<Objs\b[\s\S]*<Obj\b[^>]*\bS="progress"[\s\S]*<PR\b[\s\S]*<\/Objs>$/u.test(text);
+}
+
+function isGitLineEndingNotice(value: string): boolean {
+  const text = value.trim();
+  if (!text) return false;
+  return text.split(/\r?\n/u).every((line) => (
+    /^warning: in the working copy of .+, (?:LF|CRLF) will be replaced by (?:LF|CRLF) the next time Git touches it$/iu.test(line.trim())
+  ));
+}
+
+export interface CommandPresentationInput {
+  command: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  mode: ActivityPresentationMode;
+}
+
+export interface CommandPresentation {
+  lines: string[];
+  details: string;
+  outcome: 'success' | 'warning' | 'failure';
+}
+
+export function projectCommandPresentation(input: CommandPresentationInput): CommandPresentation {
+  const command = input.command.trim() || 'command';
+  const details = [input.stdout, input.stderr].filter(Boolean).join('\n');
+  const progressNoise = input.exitCode === 0 && isPowerShellProgressClixml(input.stderr);
+  const lineEndingNoise = input.exitCode === 0 && isGitLineEndingNotice(input.stderr);
+
+  if (input.mode === 'full') {
+    const lines = [`${input.exitCode === 0 ? '✓' : '✕'} ${command} — ${input.exitCode === 0 ? 'completed' : 'failed'}`];
+    if (input.stdout) lines.push(...input.stdout.split(/\r?\n/u));
+    if (input.stderr) lines.push(...input.stderr.split(/\r?\n/u));
+    if (input.exitCode !== 0) lines.push(`exit ${input.exitCode}`);
+    return { lines, details, outcome: input.exitCode === 0 ? 'success' : 'failure' };
+  }
+
+  if (input.exitCode === 0) {
+    const lines = [`✓ ${command} — completed`];
+    if (progressNoise) lines.push('! PowerShell emitted progress metadata; ignored');
+    else if (lineEndingNoise) lines.push('! Git line-ending notice available');
+    else if (input.stderr.trim()) lines.push(...input.stderr.split(/\r?\n/u).slice(0, 5));
+    if (/^git\s+diff\b/iu.test(command) && input.stdout.trim()) lines.push(...compactDiffLines(input.stdout));
+    return { lines, details, outcome: progressNoise || lineEndingNoise || input.stderr.trim() ? 'warning' : 'success' };
+  }
+
+  const diagnostics = [
+    ...input.stdout.split(/\r?\n/u).filter(Boolean).slice(0, 5),
+    ...input.stderr.split(/\r?\n/u).filter(Boolean).slice(0, 5),
+  ];
+  return {
+    lines: [`✕ ${command} — failed`, ...diagnostics, `exit ${input.exitCode}`],
+    details,
+    outcome: 'failure',
+  };
+}
+
+export function compactDiffLines(diff: string): string[] {
+  const binary = /^Binary files (?:a\/)?(.+?) and (?:b\/)?(.+?) differ$/mu.exec(diff);
+  if (binary) return [`Binary change: ${binary[2] ?? binary[1]}`];
+  const file = /^\+\+\+\s+b\/(.+)$/mu.exec(diff)?.[1]
+    ?? /^diff --git a\/(.+?) b\/(.+)$/mu.exec(diff)?.[2];
+  if (!file) return ['Diff available in full activity'];
+  const removed = diff.split(/\r?\n/u).find((line) => line.startsWith('-') && !line.startsWith('---'));
+  const added = diff.split(/\r?\n/u).find((line) => line.startsWith('+') && !line.startsWith('+++'));
+  const lines = [`M ${file}`];
+  if (removed) lines.push(`  - ${removed.slice(1).trimStart()}`);
+  if (added) lines.push(`  + ${added.slice(1).trimStart()}`);
+  return lines;
+}
+
+export interface EvidenceProjectionInput {
+  evidenceId: string;
+  source: string;
+  verificationResult: string;
+  repositorySnapshotId?: string | null;
+  payload?: unknown;
+}
+
+function evidencePayload(input: EvidenceProjectionInput): Record<string, unknown> {
+  return input.payload && typeof input.payload === 'object' && !Array.isArray(input.payload)
+    ? input.payload as Record<string, unknown>
+    : {};
+}
+
+function evidenceKind(source: string): string {
+  const value = source.toLowerCase();
+  if (/conflict|stale/u.test(value)) return 'Conflict';
+  if (/diff|patch/u.test(value)) return 'Diff';
+  if (/test|validation/u.test(value)) return 'TestRun';
+  if (/snapshot/u.test(value)) return 'Snapshot';
+  if (/readback|file_read/u.test(value)) return 'Readback';
+  return 'Evidence';
+}
+
+export function projectEvidenceLines(
+  evidence: readonly EvidenceProjectionInput[],
+  mode: ActivityPresentationMode,
+): string[] {
+  if (evidence.length === 0) return [];
+  const lines = ['Evidence'];
+  const visible = mode === 'full' ? evidence : evidence.slice(0, 4);
+  for (const item of visible) {
+    const payload = evidencePayload(item);
+    const kind = evidenceKind(item.source);
+    const reason = typeof payload.reason === 'string' ? payload.reason
+      : typeof payload.message === 'string' ? payload.message : '';
+    const pathValue = typeof payload.path === 'string' ? payload.path
+      : typeof payload.target === 'string' ? payload.target : '';
+    const validationState = typeof payload.state === 'string' ? payload.state : '';
+    const snapshot = item.repositorySnapshotId ?? (typeof payload.repositorySnapshotId === 'string'
+      ? payload.repositorySnapshotId : '');
+    const value = reason
+      || (kind === 'Snapshot' && snapshot ? snapshot : '')
+      || (kind === 'TestRun' && validationState ? `${validationState} · ${item.verificationResult}` : '')
+      || (pathValue ? `${pathValue} · ${item.verificationResult}` : item.verificationResult);
+    const id = mode === 'full' ? ` · ${item.evidenceId}` : '';
+    lines.push(`  ${kind.padEnd(10)} ${value}${id}`);
+    if (kind === 'Conflict') {
+      if (payload.userEditPreserved === true || item.source === 'repository.change.conflict') {
+        lines.push('  User edit  preserved');
+      }
+      lines.push('  Effect     reconciliation required');
+      lines.push(`  Claim      ${item.verificationResult}`);
+      lines.push('  Next step  replan from current snapshot');
+    }
+  }
+  if (mode === 'summary' && evidence.length > visible.length) {
+    lines.push(`  +${evidence.length - visible.length} more in full activity`);
+  }
+  return lines;
+}
+
+export function repositoryRelativePath(value: string, cwd: string): string {
+  try {
+    const relative = path.relative(cwd, value);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return value;
+    return relative.replace(/\\/gu, '/');
+  } catch {
+    return value;
+  }
+}

--- a/cli/v4/skinEngine.ts
+++ b/cli/v4/skinEngine.ts
@@ -121,6 +121,8 @@ function ansiRgb(
       success: 92, warn: 93, degraded: 93, error: 31,
       tool: 96, session: 96, agent: 97, muted: 37,
       tertiary: 90, metric_turn: 95,
+      thinking: 96, planning: 95, inspecting: 94, working: 33,
+      testing: 93, verifying: 36, recovering: 95,
     };
     return `\x1b[${semanticCode[kind!] ?? rgbTo16(r, g, b)}m${text}\x1b[39m`;
   }
@@ -153,6 +155,13 @@ const COLOR_KIND_TO_TOKEN_PATH: Partial<Record<string, string>> = {
   tertiary:    'content.tertiary',
   metric_turn: 'metrics.turnCount',
   degraded:    'semantic.warn',
+  thinking:    'semantic.thinking',
+  planning:    'semantic.planning',
+  inspecting:  'semantic.inspecting',
+  working:     'semantic.working',
+  testing:     'semantic.testing',
+  verifying:   'semantic.verifying',
+  recovering:  'semantic.recovering',
   agent:       'content.primary',
   user:        'brand.primary',
 };
@@ -194,7 +203,14 @@ export type ColorKind =
   /** Dim cool grey — least-important text (unchecked task glyphs,
    *  deprecated rows, captions). v4.8.0 Slice 8 — bridges
    *  `colors.content.tertiary` from tokens.ts into runtime. */
-  | 'tertiary';
+  | 'tertiary'
+  | 'thinking'
+  | 'planning'
+  | 'inspecting'
+  | 'working'
+  | 'testing'
+  | 'verifying'
+  | 'recovering';
 
 export interface SkinDefinition {
   name: string;
@@ -247,6 +263,13 @@ const DEFAULT_SKIN: SkinDefinition = {
     // v4.8.0 Slice 8 — tertiary dim grey, dimmer than `muted` (warm
     // tint) for lowest-priority text like unchecked task markers.
     tertiary: [0x6a, 0x6a, 0x6a],
+    thinking: [0x5b, 0xc0, 0xeb],
+    planning: [0xa7, 0x8b, 0xfa],
+    inspecting: [0x60, 0xa5, 0xfa],
+    working: [0xfb, 0x92, 0x3c],
+    testing: [0xfa, 0xcc, 0x15],
+    verifying: [0x2d, 0xd4, 0xbf],
+    recovering: [0xa7, 0x8b, 0xfa],
   },
   glyphs: {
     bullet: '•',
@@ -285,6 +308,13 @@ const LIGHT_SKIN: SkinDefinition = {
     metric_turn: [0x6e, 0x50, 0xaa],
     // Slice 8 — lighter grey on light bg keeps the dim-but-readable feel.
     tertiary: [0x9a, 0x9a, 0x9a],
+    thinking: [0x00, 0x66, 0x88],
+    planning: [0x5b, 0x3f, 0xa8],
+    inspecting: [0x1d, 0x4e, 0xa0],
+    working: [0xa6, 0x3f, 0x00],
+    testing: [0x7a, 0x5a, 0x00],
+    verifying: [0x00, 0x66, 0x66],
+    recovering: [0x5b, 0x3f, 0xa8],
   },
   glyphs: { ...DEFAULT_SKIN.glyphs },
 };
@@ -307,6 +337,13 @@ const MONOCHROME_SKIN: SkinDefinition = {
     degraded: null,
     metric_turn: null,
     tertiary: null,
+    thinking: null,
+    planning: null,
+    inspecting: null,
+    working: null,
+    testing: null,
+    verifying: null,
+    recovering: null,
   },
   glyphs: {
     bullet: '*',

--- a/tests/v4/cli/activityRegistry.test.ts
+++ b/tests/v4/cli/activityRegistry.test.ts
@@ -6,7 +6,7 @@ function handle(): ToolRowHandle {
   return {
     ok: vi.fn(), fail: vi.fn(), degraded: vi.fn(), retry: vi.fn(), blocked: vi.fn(),
     emptyRetry: vi.fn(), emptyFail: vi.fn(), cancel: vi.fn(), dismiss: vi.fn(),
-    pause: vi.fn(), resume: vi.fn(), isActive: vi.fn(() => true),
+    pause: vi.fn(), resume: vi.fn(), refresh: vi.fn(), isActive: vi.fn(() => true),
   };
 }
 
@@ -109,5 +109,30 @@ describe('ActivityRegistry', () => {
 
     expect(snapshot?.().phase).toBe('running');
     expect(snapshot?.().phaseElapsedMs).toBe(1_000);
+  });
+
+  it('projects semantic tool phase and advances animation from its single ticker', () => {
+    vi.useFakeTimers();
+    try {
+      const row = handle();
+      let read: (() => { frame: number }) | undefined;
+      const registry = new ActivityRegistry(((_name, _args, snapshot) => {
+        read = snapshot;
+        return row;
+      }) as never);
+      registry.start('read-1', 'file_read', { path: 'README.md' });
+      expect(registry.currentPhase()).toBe('inspecting');
+      expect(registry.timerCount()).toBe(1);
+      expect(read?.().frame).toBe(0);
+      vi.advanceTimersByTime(250);
+      expect(read?.().frame).toBe(1);
+      expect(row.refresh).toHaveBeenCalledTimes(1);
+      expect(registry.timerCount()).toBe(1);
+      registry.settle('read-1', { state: 'completed' });
+      expect(registry.currentPhase()).toBe('ready');
+      expect(registry.timerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/v4/cli/activityTimer.pty.test.ts
+++ b/tests/v4/cli/activityTimer.pty.test.ts
@@ -54,23 +54,23 @@ describe.skipIf(process.platform !== 'win32')('activity timer ConPTY rendering',
 
     const frames = [...raw.matchAll(/\x1b\[(?:H|\d+;1H)([^\r\n]*)/g)]
       .map((match) => stripAnsi(match[1]))
-      .filter((line) => line.includes('calling') || line.includes('running'))
+      .filter((line) => line.includes('working'))
       // ConPTY reflows its existing screen into one synthetic chunk while a
       // resize is applied. It is not an application repaint frame.
-      .filter((line) => (line.match(/calling/g) ?? []).length <= 1);
+      .filter((line) => (line.match(/┊/gu) ?? []).length <= 1);
     expect(frames.length, JSON.stringify(raw)).toBeGreaterThanOrEqual(5);
     for (const frame of frames) {
       expect(frame.length, JSON.stringify({ frame, raw })).toBeLessThanOrEqual(48);
-      expect((frame.match(/running/g) ?? []).length).toBeLessThanOrEqual(1);
+      expect((frame.match(/working/g) ?? []).length).toBeLessThanOrEqual(1);
     }
-    expect(frames.filter((frame) => frame.includes('running')).length).toBeGreaterThanOrEqual(4);
-    const finalActivityLines = screen.lines().filter((line) => line.includes('calling') || line.includes('running'));
+    expect(frames.filter((frame) => frame.includes('working')).length).toBeGreaterThanOrEqual(4);
+    const finalActivityLines = screen.lines().filter((line) => line.includes('working'));
     expect(finalActivityLines.length, JSON.stringify({ finalActivityLines, raw })).toBeLessThanOrEqual(1);
     for (const line of finalActivityLines) {
       expect(line.length, JSON.stringify({ line, raw })).toBeLessThanOrEqual(currentWidth);
     }
     const settledAt = raw.indexOf('__ACTIVITY_SETTLED__');
     expect(settledAt).toBeGreaterThan(0);
-    expect(raw.slice(settledAt)).not.toContain('running');
+    expect(raw.slice(settledAt)).not.toContain('working');
   }, 25_000);
 });

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -321,7 +321,7 @@ describe('compact hybrid transcript geometry', () => {
       display.setBusyHint('Enter → queue · Ctrl+C stop');
       const provider = display.liveActivityRow('calling provider');
 
-      expect(semanticGap(screen.lines(), 'compact provider request', 'calling provider')).toBeLessThanOrEqual(1);
+      expect(semanticGap(screen.lines(), 'compact provider request', 'Aiden is thinking')).toBeLessThanOrEqual(1);
       provider.stop();
     },
   );
@@ -338,7 +338,7 @@ describe('compact hybrid transcript geometry', () => {
     display.setBusyHint('Enter → queue · Ctrl+C stop');
     const provider = display.liveActivityRow('calling provider');
 
-    expect(semanticGap(screen.lines(), 'FINAL-PROMPT-LINE', 'calling provider')).toBeLessThanOrEqual(1);
+    expect(semanticGap(screen.lines(), 'FINAL-PROMPT-LINE', 'Aiden is thinking')).toBeLessThanOrEqual(1);
     provider.stop();
   });
 
@@ -354,7 +354,7 @@ describe('compact hybrid transcript geometry', () => {
     for (const rows of [60, 16, 35]) {
       stream.resize(100, rows);
       await new Promise<void>((resolve) => setImmediate(resolve));
-      expect(semanticGap(screen.lines(), 'resize provider request', 'calling provider')).toBeLessThanOrEqual(1);
+      expect(semanticGap(screen.lines(), 'resize provider request', 'Aiden is thinking')).toBeLessThanOrEqual(1);
     }
     provider.stop();
   });
@@ -372,8 +372,8 @@ describe('compact hybrid transcript geometry', () => {
     });
 
     const lines = screen.lines();
-    expect(semanticGap(lines, 'inspect the package manifest', 'calling provider')).toBeLessThanOrEqual(1);
-    expect(semanticGap(lines, 'calling provider', 'package.json')).toBe(0);
+    expect(semanticGap(lines, 'inspect the package manifest', 'Aiden is thinking')).toBeLessThanOrEqual(1);
+    expect(semanticGap(lines, 'Aiden is thinking', 'package.json')).toBe(0);
     tool.ok(20);
     provider.stop();
   });
@@ -386,7 +386,7 @@ describe('compact hybrid transcript geometry', () => {
     display.submitIdleComposer('return one concise answer', 'Type your message · /help');
     display.setBusyHint('Enter → queue · Ctrl+C stop');
     const provider = display.liveActivityRow('calling provider');
-    expect(semanticGap(screen.lines(), 'return one concise answer', 'calling provider')).toBeLessThanOrEqual(1);
+    expect(semanticGap(screen.lines(), 'return one concise answer', 'Aiden is thinking')).toBeLessThanOrEqual(1);
 
     provider.stop();
     display.write(display.agentHeader());
@@ -403,7 +403,7 @@ describe('compact hybrid transcript geometry', () => {
     display.submitIdleComposer('request a guarded action', 'Type your message · /help');
     display.setBusyHint('Enter → queue · Ctrl+C stop');
     const provider = display.liveActivityRow('calling provider');
-    expect(semanticGap(screen.lines(), 'request a guarded action', 'calling provider')).toBeLessThanOrEqual(1);
+    expect(semanticGap(screen.lines(), 'request a guarded action', 'Aiden is thinking')).toBeLessThanOrEqual(1);
 
     provider.stop();
     display.pauseComposerSurface();
@@ -426,7 +426,7 @@ describe('compact hybrid transcript geometry', () => {
     const provider = display.liveActivityRow('calling provider');
 
     expect(screen.snapshot()).not.toContain('OLD VISIBLE REQUEST');
-    expect(semanticGap(screen.lines(), `request after ${command}`, 'calling provider')).toBeLessThanOrEqual(1);
+    expect(semanticGap(screen.lines(), `request after ${command}`, 'Aiden is thinking')).toBeLessThanOrEqual(1);
     provider.stop();
   });
 });

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -484,7 +484,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         if (state === 'boot' && readyCount >= 1) {
           state = 'active';
           typeLikeKeyboard(child!, 'hold the provider open');
-        } else if (state === 'active' && plain.includes('calling provider')) {
+        } else if (state === 'active' && plain.includes('Aiden is thinking')) {
           state = 'queueing';
           child!.write(`\x1b[200~${queued}\x1b[201~`);
           setTimeout(() => child!.resize(44, 40), 120);
@@ -587,7 +587,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
     });
     await completion;
     const afterInterrupt = stripAnsi(output.slice(interruptedAt));
-    expect(afterInterrupt).not.toContain('calling provider');
+    expect(afterInterrupt).not.toContain('Aiden is thinking');
     expect(afterInterrupt).not.toContain('UNEXPECTED PROVIDER CONTINUATION');
     expect(afterInterrupt).toContain('(turn interrupted)');
     expect(afterInterrupt).toContain('Cancelled');
@@ -654,7 +654,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
       child!.onData((chunk) => {
         if (state === 'provider' || state === 'resizing') {
           for (const line of stripAnsi(chunk).split(/\r?\n/)) {
-            const match = line.match(/([─█◐◓◑◒ ]+)calling provider/);
+            const match = line.match(/^(.+?)Aiden is thinking/);
             if (match) providerAnimationPrefixes.push(match[1].trim());
           }
         }
@@ -664,7 +664,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
         if (state === 'boot' && isBootReady(plain, readyCount)) {
           state = 'provider';
           typeLikeKeyboard(child!, 'request resize approval');
-        } else if (state === 'provider' && plain.includes('calling provider')) {
+        } else if (state === 'provider' && plain.includes('Aiden is thinking')) {
           state = 'resizing';
           setTimeout(() => child!.resize(44, 40), 500);
           setTimeout(() => child!.resize(110, 40), 1_700);
@@ -700,7 +700,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', ()
     const plain = stripAnsi(output);
     expect(provider.callCount()).toBe(3);
     expect(new Set(providerAnimationPrefixes).size).toBeGreaterThanOrEqual(2);
-    expect(stripAnsi(output.slice(modalStart, modalEnd))).not.toContain('calling provider');
+    expect(stripAnsi(output.slice(modalStart, modalEnd))).not.toContain('Aiden is thinking');
     expect(plain).not.toContain('[preflight]');
     expect(plain).toContain('queue is empty');
     await expect(fs.access(deniedPath)).rejects.toThrow();

--- a/tests/v4/cli/commands/activity.test.ts
+++ b/tests/v4/cli/commands/activity.test.ts
@@ -25,6 +25,7 @@ function mkCtx(usage?: { inputTokens: number; outputTokens: number }) {
       info:  (m: string) => out.push(m),
       write: (m: string) => out.push(m),
       dim:   (m: string) => out.push(m),
+      warn:  (m: string) => out.push(m),
     },
     session: usage ? { getTotalUsage } : undefined,
   } as any;
@@ -104,5 +105,28 @@ describe('/activity — reads the same accessors (aggregates, no recompute)', ()
     expect(getUsedTokens).not.toHaveBeenCalled();
     expect(listTasks).not.toHaveBeenCalled();
     expect(listArtifacts).not.toHaveBeenCalled();
+  });
+
+  it('switches between summary and full presentation without adding another activity source', async () => {
+    let mode: 'summary' | 'full' = 'summary';
+    const sources = {
+      sessionId: () => undefined,
+      getCap: () => 0,
+      getUsedTokens: () => 0,
+      getHistoryCount: () => 0,
+      listTasks: () => [],
+      listArtifacts: () => [],
+      getPresentationMode: () => mode,
+      setPresentationMode: vi.fn((next: 'summary' | 'full') => { mode = next; }),
+    };
+    const { ctx, out } = mkCtx();
+    ctx.args = ['full'];
+    await makeActivityCommand(sources).handler(ctx);
+    expect(sources.setPresentationMode).toHaveBeenCalledWith('full');
+    expect(out.join('\n')).toContain('View      : full');
+
+    ctx.args = ['summary'];
+    await makeActivityCommand(sources).handler(ctx);
+    expect(sources.setPresentationMode).toHaveBeenCalledWith('summary');
   });
 });

--- a/tests/v4/cli/compactTranscript.pty.test.ts
+++ b/tests/v4/cli/compactTranscript.pty.test.ts
@@ -146,7 +146,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
           state = 'provider';
           armTimeout(20_000);
           setTimeout(() => typeLine(child!, 'COMPACT HEIGHT REQUEST'), 250);
-        } else if (state === 'provider' && rendered.includes('calling provider')) {
+        } else if (state === 'provider' && rendered.includes('Aiden is thinking')) {
           state = 'resizing';
           armTimeout(20_000);
           let index = 0;
@@ -182,7 +182,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
 
     expect([...frames.keys()]).toEqual(heights);
     for (const [rows, frame] of frames) {
-      expect(semanticGap(frame, 'COMPACT HEIGHT REQUEST', 'calling provider'), `${rows} rows\n${frame}`)
+      expect(semanticGap(frame, 'COMPACT HEIGHT REQUEST', 'Aiden is thinking'), `${rows} rows\n${frame}`)
         .toBeLessThanOrEqual(1);
     }
   }, 90_000);

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -468,19 +468,19 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
       // Advance to the 1s tick — interval fires, eraseLast + rewrite.
       vi.advanceTimersByTime(1000);
       let flat = stripAnsi(chunks.join(''));
-      expect(flat).toMatch(/running 1\.0s…|running 1000ms…/);
+      expect(flat).toMatch(/working 1\.0s…|working 1000ms…/);
 
       // 2s tick.
       chunks.length = 0;
       vi.advanceTimersByTime(1000);
       flat = stripAnsi(chunks.join(''));
-      expect(flat).toMatch(/running 2\.0s…|running 2000ms…/);
+      expect(flat).toMatch(/working 2\.0s…|working 2000ms…/);
 
       // 3s tick.
       chunks.length = 0;
       vi.advanceTimersByTime(1000);
       flat = stripAnsi(chunks.join(''));
-      expect(flat).toMatch(/running 3\.0s…|running 3000ms…/);
+      expect(flat).toMatch(/working 3\.0s…|working 3000ms…/);
     } finally {
       vi.useRealTimers();
     }
@@ -575,13 +575,13 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
       retryBackoffMs: 0, attemptCount: 0,
     };
     const row = d.toolRow('shell_exec', { command: 'echo ok' }, () => snapshot);
-    expect(stripAnsi(chunks.join(''))).toContain('awaiting approval 8.0s');
+    expect(stripAnsi(chunks.join(''))).toContain('approval required 8.0s');
     snapshot = { ...snapshot, phase: 'running', phaseElapsedMs: 6_100, executionDurationMs: 6_100, attemptCount: 1 };
     row.refresh?.();
-    expect(stripAnsi(chunks.at(-1) ?? '')).toContain('running 6.1s');
+    expect(stripAnsi(chunks.at(-1) ?? '')).toContain('working 6.1s');
     snapshot = { ...snapshot, phase: 'verifying', phaseElapsedMs: 180, verificationDurationMs: 180 };
     row.refresh?.();
-    expect(stripAnsi(chunks.at(-1) ?? '')).not.toContain('running 6.1s');
+    expect(stripAnsi(chunks.at(-1) ?? '')).not.toContain('working 6.1s');
     row.dismiss();
   });
 
@@ -1547,25 +1547,54 @@ describe('Display v4.8.0 ui_* event renderers', () => {
       command: 'npm test', stdout: 'one\ntwo', stderr: 'boom', exit_code: 2,
     });
     const out = stripAnsi(chunks.join(''));
-    expect(out).toContain('▸ npm test');
+    expect(out).toContain('✕ npm test — failed');
     expect(out).toContain('one');
     expect(out).toContain('two');
     expect(out).toContain('boom');
-    expect(out).toContain('(exit 2)');
+    expect(out).toContain('exit 2');
     // Every physical line carries the gutter.
     for (const line of out.split('\n').filter(Boolean)) {
       expect(line.startsWith('┊')).toBe(true);
     }
   });
 
-  it('ui_command_result caps stdout/stderr at 5 lines each', () => {
+  it('ui_command_result collapses successful output in summary mode', () => {
     const { d, chunks } = captureDisplay({ tty: true });
     const long = Array.from({ length: 12 }, (_, i) => `line${i}`).join('\n');
     d.renderUiEvent('ui_command_result', { command: 'spam', stdout: long });
     const out = stripAnsi(chunks.join(''));
+    expect(out).toContain('✓ spam — completed');
+    expect(out).not.toContain('line0');
+  });
+
+  it('ui_command_result retains successful output in full activity mode', () => {
+    const { d, chunks } = captureDisplay({ tty: true });
+    d.setActivityPresentationMode('full');
+    d.renderUiEvent('ui_command_result', {
+      command: 'npm test', stdout: 'line0\nline1', stderr: '', exit_code: 0,
+    });
+    const out = stripAnsi(chunks.join(''));
+    expect(out).toContain('✓ npm test — completed');
     expect(out).toContain('line0');
-    expect(out).toContain('line4');
-    expect(out).not.toContain('line5');
+    expect(out).toContain('line1');
+  });
+
+  it('renders only supplied durable evidence and reveals full identifiers only in full mode', () => {
+    const summary = captureDisplay({ tty: true });
+    summary.d.evidencePanel([{
+      evidenceId: 'evidence_1234567890', source: 'fresh_readback',
+      verificationResult: 'verified', payload: { path: 'src/math.mjs' },
+    }]);
+    expect(stripAnsi(summary.chunks.join(''))).toContain('Readback');
+    expect(stripAnsi(summary.chunks.join(''))).not.toContain('evidence_1234567890');
+
+    const full = captureDisplay({ tty: true });
+    full.d.setActivityPresentationMode('full');
+    full.d.evidencePanel([{
+      evidenceId: 'evidence_1234567890', source: 'fresh_readback',
+      verificationResult: 'verified', payload: { path: 'src/math.mjs' },
+    }]);
+    expect(stripAnsi(full.chunks.join(''))).toContain('evidence_1234567890');
   });
 
   // ── ui_test_result ────────────────────────────────────────────────────
@@ -1690,7 +1719,8 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
       expect(out).toContain('chatgpt-plus');
       expect(out).toContain('gpt-5');
       expect(out).toContain('%');
-      expect(sepCount(out)).toBe(2);
+      expect(sepCount(out)).toBe(3);
+      expect(out).toContain('ready');
       expect(out).not.toContain('#');  // turn segment dropped
     });
   });
@@ -1701,7 +1731,8 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
       const out = stripAnsi(d.statusFooter(BASE));
       // v4.9.0 pre-ship UI: turn counter removed (value-to-pixel too low).
       expect(out).not.toMatch(/↻/);
-      expect(sepCount(out)).toBe(2);
+      expect(sepCount(out)).toBe(3);
+      expect(out).toContain('ready');
     });
   });
 
@@ -1713,7 +1744,8 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
       expect(out).toContain('◆');
       expect(out).toContain('◉ context');
       expect(out).toContain('⧖');
-      expect(sepCount(out)).toBe(2);
+      expect(sepCount(out)).toBe(3);
+      expect(out).toContain('ready');
     });
   });
 
@@ -1726,7 +1758,8 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
       expect(out).toContain('groq');
       expect(out).toContain('llama-3.3');
       expect(out).not.toContain('#');
-      expect(sepCount(out)).toBe(2);
+      expect(sepCount(out)).toBe(3);
+      expect(out).toContain('ready');
     });
   });
 
@@ -1748,6 +1781,16 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
     });
   });
 
+  it('projects semantic live, approval, blocked, and ready phases in the owned footer', () => {
+    withCols(120, () => {
+      const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
+      expect(stripAnsi(d.statusFooter({ ...BASE, phase: 'verifying' }))).toContain('verifying');
+      expect(stripAnsi(d.statusFooter({ ...BASE, phase: 'approval_required' }))).toContain('approval required');
+      expect(stripAnsi(d.statusFooter({ ...BASE, phase: 'blocked' }))).toContain('blocked');
+      expect(stripAnsi(d.statusFooter({ ...BASE, phase: 'ready' }))).toContain('ready');
+    });
+  });
+
   it('48-col output budgets the wide timer glyph by terminal cell width', () => {
     withCols(48, () => {
       const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
@@ -1759,7 +1802,7 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
         elapsedMs: 0,
       }));
       expect(stringWidth(out)).toBeLessThanOrEqual(46);
-      expect(out).toContain('◉ 0%');
+      expect(out).toContain('◉0%');
       expect(out).toContain('⧖');
     });
   });

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -1802,6 +1802,7 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
         elapsedMs: 0,
       }));
       expect(stringWidth(out)).toBeLessThanOrEqual(46);
+      expect(out).toContain('custom-default');
       expect(out).toContain('◉0%');
       expect(out).toContain('⧖');
     });

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -1791,20 +1791,80 @@ describe('Display v4.8.0 Slice 7 statusFooter — packed info density', () => {
     });
   });
 
-  it('48-col output budgets the wide timer glyph by terminal cell width', () => {
-    withCols(48, () => {
+  it.each([44, 60, 80, 100, 120])(
+    'preserves provider, model, context, phase, and timer identity at %i columns',
+    (cols) => {
+      withCols(cols, () => {
+        const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
+        const out = stripAnsi(d.statusFooter({
+          ...BASE,
+          provider: 'custom_openai',
+          model: 'custom-default',
+          ctxUsed: 0,
+          elapsedMs: 8_000,
+          phase: 'thinking',
+        }));
+        expect(stringWidth(out)).toBeLessThanOrEqual(cols - 2);
+        expect(out).toContain('custom_openai');
+        expect(out).toContain('custom-default');
+        expect(out).toContain('0%');
+        expect(out).toContain('◉');
+        expect(out).toMatch(/thinking|T/u);
+        expect(out).toMatch(/8s/u);
+      });
+    },
+  );
+
+  it.each([
+    ['ready', '✓'],
+    ['thinking', 'T'],
+    ['planning', 'P'],
+    ['inspecting', 'I'],
+    ['working', 'W'],
+    ['testing', 'R'],
+    ['verifying', 'V'],
+    ['approval_required', 'A'],
+    ['blocked', 'B'],
+    ['failed', '✕'],
+  ] as const)('keeps compact %s phase visible at 44 columns', (phase, token) => {
+    withCols(44, () => {
       const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
       const out = stripAnsi(d.statusFooter({
         ...BASE,
         provider: 'custom_openai',
         model: 'custom-default',
         ctxUsed: 0,
-        elapsedMs: 0,
+        elapsedMs: 8_000,
+        phase,
       }));
-      expect(stringWidth(out)).toBeLessThanOrEqual(46);
-      expect(out).toContain('custom-default');
-      expect(out).toContain('◉0%');
-      expect(out).toContain('⧖');
+      expect(stringWidth(out)).toBeLessThanOrEqual(42);
+      expect(out).toContain('custom_openai/custom-default');
+      expect(out).toContain(`│${token}│`);
     });
+  });
+
+  it('uses the compact ASCII identity and phase fallback without ANSI', () => {
+    const previous = process.env.AIDEN_UI_UNICODE;
+    process.env.AIDEN_UI_UNICODE = '0';
+    try {
+      withCols(44, () => {
+        const d = new Display({ skin: new SkinEngine({ forceMono: true }) });
+        const out = d.statusFooter({
+          ...BASE,
+          provider: 'custom_openai',
+          model: 'custom-default',
+          ctxUsed: 0,
+          elapsedMs: 8_000,
+          phase: 'thinking',
+        });
+        expect(out).not.toContain('\x1b[');
+        expect(out).toContain('*custom_openai/custom-default');
+        expect(out).toContain('|T|');
+        expect(stringWidth(out)).toBeLessThanOrEqual(42);
+      });
+    } finally {
+      if (previous === undefined) delete process.env.AIDEN_UI_UNICODE;
+      else process.env.AIDEN_UI_UNICODE = previous;
+    }
   });
 });

--- a/tests/v4/cli/operatorScreenResize.test.ts
+++ b/tests/v4/cli/operatorScreenResize.test.ts
@@ -151,17 +151,17 @@ describe('operator screen resize transactions', () => {
     display.setBusyHint('Enter → queue · Ctrl+C stop');
     const activity = display.liveActivityRow('calling provider');
     activity.refresh(1);
-    expect(screen.lines().slice(0, -4).filter((line) => line.includes('provider'))).toHaveLength(1);
+    expect(screen.lines().slice(0, -4).filter((line) => line.includes('Aiden is thinking'))).toHaveLength(1);
 
     stream.resize(44, 16);
     activity.refresh(2);
     await settleResize();
-    expect(screen.lines().slice(0, -4).filter((line) => line.includes('provider'))).toHaveLength(1);
+    expect(screen.lines().slice(0, -4).filter((line) => line.includes('Aiden is thinking'))).toHaveLength(1);
 
     stream.resize(160, 45);
     activity.refresh(3);
     await settleResize();
-    expect(screen.lines().slice(0, -4).filter((line) => line.includes('provider'))).toHaveLength(1);
+    expect(screen.lines().slice(0, -4).filter((line) => line.includes('Aiden is thinking'))).toHaveLength(1);
     assertOneCurrentSurface(screen, '');
     activity.stop();
   });

--- a/tests/v4/cli/responsiveActivity.test.ts
+++ b/tests/v4/cli/responsiveActivity.test.ts
@@ -120,11 +120,12 @@ describe('responsive registry-owned turn activity', () => {
       skin: new SkinEngine({ forceMono: true }),
     });
     display.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
-    const row = display.liveActivityRow('calling provider');
+    const row = display.liveActivityRow('provider request');
     const assertLatestFrameFits = (width: number): void => {
-      const frames = screen.lines().filter((line) => line.includes('provider'));
+      const frames = screen.lines().filter((line) => line.includes('Aiden is thinking'));
       expect(frames).toHaveLength(1);
       expect(frames[0].length).toBeLessThanOrEqual(width - 1);
+      expect(frames[0]).not.toContain('provider');
     };
     assertLatestFrameFits(120);
     out.columns = 44;
@@ -135,6 +136,9 @@ describe('responsive registry-owned turn activity', () => {
     screen.resize(100, 30);
     row.refresh();
     assertLatestFrameFits(100);
+    display.setActivityPresentationMode('full');
+    row.refresh();
+    expect(screen.lines().filter((line) => line.includes('provider request'))).toHaveLength(1);
     row.stop();
   });
 
@@ -234,7 +238,9 @@ describe('responsive registry-owned turn activity', () => {
     };
     const narrow = stripAnsi(display.statusFooter(args));
     expect(narrow.length).toBeLessThanOrEqual(42);
-    expect(narrow).toContain('recognizable-model');
+    expect(narrow).toContain('recog');
+    expect(narrow).toContain('ready');
+    expect(narrow).toContain('2.5s');
     out.columns = 120;
     const wide = stripAnsi(display.statusFooter(args));
     expect(wide.length).toBeLessThanOrEqual(118);

--- a/tests/v4/cli/responsiveActivity.test.ts
+++ b/tests/v4/cli/responsiveActivity.test.ts
@@ -238,8 +238,8 @@ describe('responsive registry-owned turn activity', () => {
     };
     const narrow = stripAnsi(display.statusFooter(args));
     expect(narrow.length).toBeLessThanOrEqual(42);
-    expect(narrow).toContain('recog');
-    expect(narrow).toContain('ready');
+    expect(narrow).toContain('provider/recognizable-model');
+    expect(narrow).toContain('│✓│');
     expect(narrow).toContain('2.5s');
     out.columns = 120;
     const wide = stripAnsi(display.statusFooter(args));

--- a/tests/v4/cli/semanticActivity.test.ts
+++ b/tests/v4/cli/semanticActivity.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compactDiffLines,
+  normalizeActivityPhase,
+  phaseColorKind,
+  projectActivityFrame,
+  projectCommandPresentation,
+  projectEvidenceLines,
+  relativizeActivityText,
+  shouldDeferActivityTransition,
+  type SemanticActivityPhase,
+} from '../../../cli/v4/semanticActivity';
+
+const animated: SemanticActivityPhase[] = [
+  'thinking', 'planning', 'inspecting', 'working', 'testing',
+  'verifying', 'recovering', 'completing',
+];
+
+describe('semantic activity projection', () => {
+  it.each([
+    ['calling provider', 'thinking'],
+    ['preparing prompt', 'planning'],
+    ['refreshing memory', 'inspecting'],
+    ['reading', 'inspecting'],
+    ['searching', 'inspecting'],
+    ['drafting', 'working'],
+    ['analyzing', 'working'],
+    ['running focused tests', 'testing'],
+    ['verifying', 'verifying'],
+    ['retrying', 'recovering'],
+    ['awaiting_approval', 'approval_required'],
+  ] as const)('maps %s to %s', (input, expected) => {
+    expect(normalizeActivityPhase(input)).toBe(expected);
+  });
+
+  it.each(animated)('changes the visible %s frame without changing its purpose', (phase) => {
+    const first = projectActivityFrame({ phase, frame: 0, elapsedMs: 1_000, unicode: true, mode: 'summary' });
+    const second = projectActivityFrame({ phase, frame: 1, elapsedMs: 1_250, unicode: true, mode: 'summary' });
+    expect(first.text).not.toBe(second.text);
+    expect(first.label).toBeTruthy();
+    expect(second.label).toBeTruthy();
+  });
+
+  it.each([
+    ['approval_required', 'Approval required'],
+    ['blocked', 'Blocked — user action required'],
+    ['complete', 'Complete'],
+    ['failed', 'Failed'],
+    ['ready', 'ready'],
+  ] as const)('keeps terminal phase %s static', (phase, label) => {
+    const first = projectActivityFrame({ phase, frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' });
+    const second = projectActivityFrame({ phase, frame: 3, elapsedMs: 5_000, unicode: true, mode: 'summary' });
+    expect(first.text).toBe(second.text);
+    expect(first.label).toContain(label);
+  });
+
+  it('uses truthful slow-state wording and hides provider mechanics in summary mode', () => {
+    expect(projectActivityFrame({ phase: 'thinking', frame: 0, elapsedMs: 2_000, unicode: true, mode: 'summary', source: 'provider' }).text)
+      .toContain('Aiden is thinking');
+    expect(projectActivityFrame({ phase: 'thinking', frame: 0, elapsedMs: 5_000, unicode: true, mode: 'summary', source: 'provider' }).text)
+      .toContain('Planning the safest approach');
+    expect(projectActivityFrame({ phase: 'thinking', frame: 0, elapsedMs: 12_000, unicode: true, mode: 'summary', source: 'provider' }).text)
+      .toContain('Reviewing repository state');
+    const long = projectActivityFrame({ phase: 'thinking', frame: 0, elapsedMs: 26_000, unicode: true, mode: 'summary', source: 'provider' });
+    expect(long.text).toContain('Still working');
+    expect(long.text).not.toMatch(/provider|model request/iu);
+
+    const full = projectActivityFrame({ phase: 'thinking', frame: 0, elapsedMs: 1_000, unicode: true, mode: 'full', source: 'provider' });
+    expect(full.text).toContain('provider request');
+  });
+
+  it('provides an ASCII animation fallback and semantic color mapping', () => {
+    const frame = projectActivityFrame({ phase: 'testing', frame: 1, elapsedMs: 200, unicode: false, mode: 'summary' });
+    expect(frame.text).toMatch(/^[|/\\-]/u);
+    expect(phaseColorKind('thinking')).toBe('thinking');
+    expect(phaseColorKind('planning')).toBe('planning');
+    expect(phaseColorKind('verifying')).toBe('verifying');
+    expect(phaseColorKind('complete')).toBe('success');
+    expect(phaseColorKind('failed')).toBe('error');
+  });
+
+  it('defers fast transient phase churn but never delays terminal/user phases', () => {
+    expect(shouldDeferActivityTransition('thinking', 'planning', 100)).toBe(true);
+    expect(shouldDeferActivityTransition('thinking', 'planning', 200)).toBe(false);
+    expect(shouldDeferActivityTransition('working', 'approval_required', 10)).toBe(false);
+    expect(shouldDeferActivityTransition('working', 'blocked', 10)).toBe(false);
+  });
+});
+
+describe('compact command and evidence projection', () => {
+  it('collapses successful output in summary mode and retains it in full mode', () => {
+    const summary = projectCommandPresentation({ command: 'npm test', stdout: 'line one\nline two', stderr: '', exitCode: 0, mode: 'summary' });
+    expect(summary.lines).toEqual(['✓ npm test — completed']);
+    expect(summary.details).toContain('line one');
+    const full = projectCommandPresentation({ command: 'npm test', stdout: 'line one\nline two', stderr: '', exitCode: 0, mode: 'full' });
+    expect(full.lines.join('\n')).toContain('line two');
+  });
+
+  it('expands useful diagnostics for failure without hiding the exit code', () => {
+    const failed = projectCommandPresentation({
+      command: 'npm test', stdout: '', stderr: 'tests/math.test.mjs:7\nExpected 5\nReceived -1', exitCode: 1, mode: 'summary',
+    });
+    expect(failed.lines[0]).toContain('failed');
+    expect(failed.lines.join('\n')).toContain('Expected 5');
+    expect(failed.lines.at(-1)).toContain('exit 1');
+  });
+
+  it('recognizes only structured PowerShell progress CLIXML', () => {
+    const clixml = '#< CLIXML\n<Objs Version="1.1.0.1"><Obj S="progress"><MS><PR N="Record"><AV>Working</AV></PR></MS></Obj></Objs>';
+    const projected = projectCommandPresentation({ command: 'pwsh -File task.ps1', stdout: '', stderr: clixml, exitCode: 0, mode: 'summary' });
+    expect(projected.lines).toContain('! PowerShell emitted progress metadata; ignored');
+    const arbitrary = projectCommandPresentation({ command: 'pwsh', stdout: '', stderr: '#< CLIXML\nnot xml', exitCode: 0, mode: 'summary' });
+    expect(arbitrary.lines.join('\n')).toContain('not xml');
+  });
+
+  it('classifies Git line-ending output as a notice, not a hard failure', () => {
+    const warning = "warning: in the working copy of 'src/math.mjs', LF will be replaced by CRLF the next time Git touches it";
+    const projected = projectCommandPresentation({ command: 'git diff', stdout: '', stderr: warning, exitCode: 0, mode: 'summary' });
+    expect(projected.lines).toContain('! Git line-ending notice available');
+    expect(projected.lines.join('\n')).not.toContain('failed');
+    expect(projected.details).toContain('LF will be replaced');
+  });
+
+  it('uses repository-relative text in summary mode and exact paths in full mode', () => {
+    const root = process.platform === 'win32' ? 'C:\\repo' : '/repo';
+    const path = process.platform === 'win32' ? 'C:\\repo\\src\\math.mjs' : '/repo/src/math.mjs';
+    expect(relativizeActivityText(`read ${path}`, root, 'summary')).toBe('read src/math.mjs');
+    expect(relativizeActivityText(`read ${path}`, root, 'full')).toBe(`read ${path}`);
+  });
+
+  it('renders a compact one-hunk diff and keeps binary changes explicit', () => {
+    expect(compactDiffLines('diff --git a/src/math.mjs b/src/math.mjs\n--- a/src/math.mjs\n+++ b/src/math.mjs\n@@\n-return a - b;\n+return a + b;'))
+      .toEqual(['M src/math.mjs', '  - return a - b;', '  + return a + b;']);
+    expect(compactDiffLines('Binary files a/logo.png and b/logo.png differ')).toEqual(['Binary change: logo.png']);
+  });
+
+  it('projects only real durable evidence and preserves unknown/conflict truth', () => {
+    const verified = projectEvidenceLines([{
+      evidenceId: 'evidence_1234567890', source: 'fresh_readback', verificationResult: 'verified', payload: { path: 'src/math.mjs' },
+    }], 'summary');
+    expect(verified).toContain('Evidence');
+    expect(verified.join('\n')).toContain('Readback');
+    expect(verified.join('\n')).toContain('verified');
+    expect(verified.join('\n')).not.toContain('evidence_1234567890');
+
+    const full = projectEvidenceLines([{
+      evidenceId: 'evidence_1234567890', source: 'repository.change.conflict', verificationResult: 'unknown',
+      payload: { message: 'source changed after approval', target: 'src/math.mjs' },
+    }], 'full');
+    expect(full.join('\n')).toContain('source changed after approval');
+    expect(full.join('\n')).toContain('preserved');
+    expect(full.join('\n')).toContain('unknown');
+    expect(full.join('\n')).toContain('reconciliation required');
+    expect(full.join('\n')).toContain('replan from current snapshot');
+    expect(full.join('\n')).toContain('evidence_1234567890');
+  });
+});

--- a/tests/v4/cli/skinEngine.yaml.test.ts
+++ b/tests/v4/cli/skinEngine.yaml.test.ts
@@ -233,4 +233,27 @@ describe('SkinEngine terminal color capability', () => {
     const engine = new SkinEngine({ colorDepth: 'truecolor' });
     expect(engine.applyColors('You', 'user')).toContain('\x1b[38;2;255;107;53m');
   });
+
+  it('renders phase colors in truecolor, ANSI 16, and monochrome modes', () => {
+    const truecolor = new SkinEngine({ colorDepth: 'truecolor' });
+    expect(truecolor.applyColors('thinking', 'thinking')).toContain('\x1b[38;2;91;192;235m');
+    expect(truecolor.applyColors('working', 'working')).toContain('\x1b[38;2;251;146;60m');
+
+    const ansi16 = new SkinEngine({ colorDepth: '16' });
+    expect(ansi16.applyColors('thinking', 'thinking')).toContain('\x1b[96m');
+    expect(ansi16.applyColors('testing', 'testing')).toContain('\x1b[93m');
+
+    const mono = new SkinEngine({ colorDepth: 'none' });
+    expect(mono.applyColors('verifying', 'verifying')).toBe('verifying');
+  });
+
+  it('keeps semantic phase colors readable in neighboring light and dark skins', () => {
+    const engine = new SkinEngine({ colorDepth: 'truecolor' });
+    const dark = engine.applyColors('phase', 'inspecting');
+    engine.setActive('light');
+    const light = engine.applyColors('phase', 'inspecting');
+    expect(dark).toContain('\x1b[38;2;96;165;250m');
+    expect(light).toContain('\x1b[38;2;29;78;160m');
+    expect(light).not.toBe(dark);
+  });
 });

--- a/tests/v4/cli/viewportEpoch.test.ts
+++ b/tests/v4/cli/viewportEpoch.test.ts
@@ -132,7 +132,7 @@ describe('physical viewport epochs', () => {
     tool.refresh?.();
 
     expect(screen.snapshot()).not.toContain('OLD ACTIVE TURN');
-    expectCleanViewport(screen, { active: 'calling provider' });
+    expectCleanViewport(screen, { active: 'Aiden is thinking' });
     expect(count(screen.lines(), 'active.txt')).toBe(1);
     tool.ok(25);
     provider.stop();
@@ -179,7 +179,7 @@ describe('physical viewport epochs', () => {
     provider.refresh(3);
 
     expect(screen.snapshot()).not.toContain('OLD BEFORE REPAINT');
-    expectCleanViewport(screen, { active: 'calling provider' });
+    expectCleanViewport(screen, { active: 'Aiden is thinking' });
     provider.stop();
   });
 
@@ -196,7 +196,7 @@ describe('physical viewport epochs', () => {
     expect(screen.snapshot()).not.toContain('OLD MODEL CONTEXT ROW');
     expect(screen.snapshot()).toContain('NEW PROMPT');
     expect(count(screen.lines(), 'NEW PROMPT')).toBe(1);
-    expect(count(screen.lines(), 'calling provider')).toBe(1);
+    expect(count(screen.lines(), 'Aiden is thinking')).toBe(1);
     provider.stop();
   });
 

--- a/themes/aiden-ember.yaml
+++ b/themes/aiden-ember.yaml
@@ -13,6 +13,13 @@ colors:
     warn: "#E0A040"
     error: "#E05A5A"
     info: "#7DA7C7"
+    thinking: "#5BC0EB"
+    planning: "#A78BFA"
+    inspecting: "#60A5FA"
+    working: "#FB923C"
+    testing: "#FACC15"
+    verifying: "#2DD4BF"
+    recovering: "#A78BFA"
   metrics:
     model: "#9CDCFE"
     tokens: "#E0A040"

--- a/themes/aurora.yaml
+++ b/themes/aurora.yaml
@@ -13,6 +13,13 @@ colors:
     warn: "#FDE68A"
     error: "#FDA4AF"
     info: "#93C5FD"
+    thinking: "#67E8F9"
+    planning: "#C084FC"
+    inspecting: "#93C5FD"
+    working: "#FB923C"
+    testing: "#FDE68A"
+    verifying: "#5EEAD4"
+    recovering: "#C084FC"
   metrics:
     model: "#67E8F9"
     tokens: "#FDE68A"

--- a/themes/default.yaml
+++ b/themes/default.yaml
@@ -21,6 +21,13 @@ colors:
     warn:    "#e0a040"
     error:   "#e05a5a"
     info:    "#7da7c7"
+    thinking: "#5bc0eb"
+    planning: "#a78bfa"
+    inspecting: "#60a5fa"
+    working: "#fb923c"
+    testing: "#facc15"
+    verifying: "#2dd4bf"
+    recovering: "#a78bfa"
   metrics:
     model:     "#9cdcfe" # status bar — model name (cyan)
     tokens:    "#e0a040" # status bar — token ratio (amber)

--- a/themes/dracula.yaml
+++ b/themes/dracula.yaml
@@ -20,6 +20,13 @@ colors:
     warn:    "#F1FA8C"
     error:   "#FF5555"
     info:    "#8BE9FD"
+    thinking: "#8BE9FD"
+    planning: "#BD93F9"
+    inspecting: "#8BE9FD"
+    working: "#FF9E64"
+    testing: "#F1FA8C"
+    verifying: "#50FA7B"
+    recovering: "#BD93F9"
   metrics:
     model:     "#8BE9FD"
     tokens:    "#F1FA8C"

--- a/themes/high-contrast.yaml
+++ b/themes/high-contrast.yaml
@@ -13,6 +13,13 @@ colors:
     warn: "#FFFF00"
     error: "#FF5C5C"
     info: "#65C7FF"
+    thinking: "#65C7FF"
+    planning: "#FF7CFF"
+    inspecting: "#65C7FF"
+    working: "#FF9A3D"
+    testing: "#FFFF00"
+    verifying: "#57FFFF"
+    recovering: "#FF7CFF"
   metrics:
     model: "#65C7FF"
     tokens: "#FFFF00"

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -20,6 +20,13 @@ colors:
     warn:    "#B8860B"
     error:   "#C8202C"
     info:    "#1F5FA8"
+    thinking: "#0E7490"
+    planning: "#6D28D9"
+    inspecting: "#1D4ED8"
+    working: "#C2410C"
+    testing: "#A16207"
+    verifying: "#0F766E"
+    recovering: "#6D28D9"
   metrics:
     model:     "#1F5FA8"
     tokens:    "#B8860B"

--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -13,6 +13,13 @@ colors:
     warn: "#D7BA7D"
     error: "#E07178"
     info: "#82AAFF"
+    thinking: "#89DDFF"
+    planning: "#C792EA"
+    inspecting: "#82AAFF"
+    working: "#F78C6C"
+    testing: "#FFCB6B"
+    verifying: "#7FDBCA"
+    recovering: "#C792EA"
   metrics:
     model: "#9CB8FF"
     tokens: "#D7BA7D"

--- a/themes/monochrome.yaml
+++ b/themes/monochrome.yaml
@@ -19,6 +19,13 @@ colors:
     warn:    "#999999"
     error:   "#D97777"
     info:    "#AAAAAA"
+    thinking: "#CCCCCC"
+    planning: "#BBBBBB"
+    inspecting: "#AAAAAA"
+    working: "#DDDDDD"
+    testing: "#CCCCCC"
+    verifying: "#BBBBBB"
+    recovering: "#AAAAAA"
   metrics:
     model:     "#AAAAAA"
     tokens:    "#AAAAAA"

--- a/themes/tokyo-night.yaml
+++ b/themes/tokyo-night.yaml
@@ -20,6 +20,13 @@ colors:
     warn:    "#E0AF68"
     error:   "#F7768E"
     info:    "#7DCFFF"
+    thinking: "#7DCFFF"
+    planning: "#BB9AF7"
+    inspecting: "#7AA2F7"
+    working: "#FF9E64"
+    testing: "#E0AF68"
+    verifying: "#73DACA"
+    recovering: "#BB9AF7"
   metrics:
     model:     "#7DCFFF"
     tokens:    "#E0AF68"


### PR DESCRIPTION
## Summary

- adds semantic activity phases driven by the existing ActivityRegistry ticker;
- provides summary and full activity presentation without exposing provider mechanics by default;
- collapses successful command output while retaining failure details and full inspection;
- projects compact durable evidence, repository-relative paths and known terminal notices;
- adds semantic theme tokens and responsive status-strip phases.

## Validation

- semantic activity projection: 34 passed
- focused display, callback and session coverage: 289 passed, 1 skipped
- viewport and theme coverage: 349 passed
- Codebase Mode focused matrix: 87 passed
- lifecycle, recovery and approval coverage: 246 passed
- focused rendered-terminal coverage passed at normal and narrow widths
- integration suite: 39 passed, 7 skipped
- typecheck passed
- production build passed

## Notes

A broad local Windows run exposed existing ConPTY `AttachConsole` resource contention. The affected semantic PTY files passed in isolation; required platform CI remains the authoritative cross-platform gate.