### PR TITLE
feat(worker): add durable worker contracts and persistence

### DIFF
--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1850,6 +1850,140 @@ function applyV36(db: Database.Database): void {
   `);
 }
 
+/** Immutable Worker contracts and thin child-Attempt relations. */
+function applyV37(db: Database.Database): void {
+  addMissingColumns(db, 'execution_graph_node_references', [
+    ['reference_generation', 'INTEGER'],
+  ]);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS worker_provider_bindings (
+      provider_binding_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      provider_id TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      provider_runtime_identity TEXT NOT NULL,
+      credential_reference TEXT,
+      endpoint_reference TEXT,
+      capability_snapshot_hash TEXT NOT NULL,
+      selection_reason TEXT NOT NULL,
+      fallback_policy_id TEXT,
+      context_window INTEGER NOT NULL,
+      max_output_tokens INTEGER NOT NULL,
+      binding_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS worker_context_envelopes (
+      context_envelope_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      assignment_id TEXT NOT NULL,
+      repository_snapshot_id TEXT,
+      plan_step_ids_json TEXT NOT NULL,
+      claim_ids_json TEXT NOT NULL,
+      source_reference_ids_json TEXT NOT NULL,
+      instruction_reference_ids_json TEXT NOT NULL,
+      bounded_parent_note TEXT,
+      tool_schema_digest TEXT NOT NULL,
+      content_digest TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (repository_snapshot_id) REFERENCES repository_snapshots(snapshot_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS worker_assignments (
+      assignment_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      idempotency_key TEXT NOT NULL UNIQUE,
+      worker_definition_id TEXT NOT NULL,
+      worker_definition_version INTEGER NOT NULL,
+      parent_job_id TEXT NOT NULL,
+      parent_attempt_id TEXT NOT NULL,
+      parent_generation INTEGER NOT NULL,
+      parent_fence_digest TEXT NOT NULL,
+      child_contract_id TEXT NOT NULL,
+      child_job_id TEXT NOT NULL,
+      repository_snapshot_id TEXT,
+      execution_graph_node_id TEXT,
+      context_envelope_id TEXT NOT NULL,
+      provider_binding_id TEXT NOT NULL,
+      capability_set_id TEXT,
+      goal TEXT NOT NULL,
+      expected_result_schema_id TEXT NOT NULL,
+      expected_evidence_schema_id TEXT,
+      input_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (parent_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (child_contract_id) REFERENCES child_job_contracts(child_job_id) ON DELETE CASCADE,
+      FOREIGN KEY (repository_snapshot_id) REFERENCES repository_snapshots(snapshot_id),
+      FOREIGN KEY (context_envelope_id) REFERENCES worker_context_envelopes(context_envelope_id),
+      FOREIGN KEY (provider_binding_id) REFERENCES worker_provider_bindings(provider_binding_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_assignments_parent
+      ON worker_assignments(parent_job_id, parent_attempt_id, parent_generation, created_at);
+    CREATE INDEX IF NOT EXISTS idx_worker_assignments_child
+      ON worker_assignments(child_job_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS worker_runs (
+      worker_run_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      assignment_id TEXT NOT NULL,
+      child_job_id TEXT NOT NULL,
+      child_attempt_id TEXT NOT NULL,
+      child_generation INTEGER NOT NULL,
+      execution_graph_node_id TEXT,
+      provider_binding_id TEXT NOT NULL,
+      context_envelope_id TEXT NOT NULL,
+      accepted_result_id TEXT,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (assignment_id) REFERENCES worker_assignments(assignment_id) ON DELETE CASCADE,
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (provider_binding_id) REFERENCES worker_provider_bindings(provider_binding_id),
+      FOREIGN KEY (context_envelope_id) REFERENCES worker_context_envelopes(context_envelope_id),
+      UNIQUE (child_attempt_id, child_generation),
+      UNIQUE (assignment_id, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_runs_assignment
+      ON worker_runs(assignment_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_worker_runs_child
+      ON worker_runs(child_job_id, child_attempt_id, child_generation);
+
+    CREATE TABLE IF NOT EXISTS worker_results (
+      worker_result_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      worker_run_id TEXT NOT NULL,
+      assignment_id TEXT NOT NULL,
+      child_job_id TEXT NOT NULL,
+      child_attempt_id TEXT NOT NULL,
+      child_generation INTEGER NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('completed','partial','failed','cancelled','timed_out','blocked','invalid')),
+      summary TEXT NOT NULL,
+      structured_payload_json TEXT,
+      evidence_ids_json TEXT NOT NULL,
+      provider_attempt_ids_json TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      result_hash TEXT NOT NULL,
+      acceptance_state TEXT NOT NULL CHECK (acceptance_state IN ('received','accepted','rejected')),
+      rejection_code TEXT,
+      rejection_reason TEXT,
+      created_at INTEGER NOT NULL,
+      accepted_at INTEGER,
+      rejected_at INTEGER,
+      FOREIGN KEY (worker_run_id) REFERENCES worker_runs(worker_run_id) ON DELETE CASCADE,
+      FOREIGN KEY (assignment_id) REFERENCES worker_assignments(assignment_id) ON DELETE CASCADE,
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (worker_run_id, idempotency_key, result_hash)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_results_run
+      ON worker_results(worker_run_id, created_at, worker_result_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_results_final_accepted
+      ON worker_results(worker_run_id)
+      WHERE acceptance_state = 'accepted' AND status <> 'partial';
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -1887,6 +2021,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 34, name: 'snapshot-bound structured validation', apply: applyV34 },
   { version: 35, name: 'durable Git effects and reconciliation', apply: applyV35 },
   { version: 36, name: 'repository understanding and durable coding plans', apply: applyV36 },
+  { version: 37, name: 'durable Worker contracts and authority boundaries', apply: applyV37 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -1926,7 +2061,8 @@ function validateLatestSchema(db: Database.Database): void {
     'test_run_details', 'build_run_details', 'validation_artifacts', 'validation_diagnostics',
     'git_effect_operations', 'repository_understanding_indexes', 'repository_understanding_records',
     'repository_understanding_snapshot_records', 'repository_architecture_notes',
-    'execution_graph_node_references'];
+    'execution_graph_node_references', 'worker_assignments', 'worker_runs',
+    'worker_provider_bindings', 'worker_context_envelopes', 'worker_results'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/executionGraph.ts
+++ b/core/v4/daemon/executionGraph.ts
@@ -6,10 +6,12 @@
 import { createHash } from 'node:crypto';
 
 import type { Db } from './db/connection';
+import type { WorkerReferenceKind } from '../worker/types';
 
 export type ExecutionNodeKind =
   | 'planning' | 'tool' | 'verification' | 'approval' | 'wait'
-  | 'child_job' | 'aggregation' | 'reconciliation' | 'finalization' | 'coding_step';
+  | 'child_job' | 'aggregation' | 'reconciliation' | 'finalization' | 'coding_step'
+  | 'worker_assignment' | 'worker_run';
 export type ExecutionNodeState = 'pending' | 'runnable' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'blocked' | 'superseded';
 
 export type CodingPlanReferenceKind =
@@ -91,6 +93,13 @@ export interface ExecutionGraphEvent {
   createdAt: number;
 }
 
+export interface WorkerGraphReferenceRecord {
+  nodeId: string;
+  kind: WorkerReferenceKind;
+  id: string;
+  generation: number | null;
+}
+
 export interface GraphTransitionResult {
   applied: boolean;
   duplicate?: boolean;
@@ -127,6 +136,20 @@ interface GraphAuthority {
   retireNode(command: AuthorityCommand & {
     nodeId: string; state: 'blocked' | 'superseded' | 'cancelled'; reason?: string | null;
   }): GraphTransitionResult;
+  attachWorkerAssignment(command: {
+    parentJobId: string; parentAttemptId: string; parentGeneration: number; parentFenceToken: string;
+    assignmentId: string; producer: string; idempotencyKey: string; now?: number;
+  }): GraphTransitionResult & { nodeId?: string };
+  attachWorkerRun(command: {
+    parentJobId: string; parentAttemptId: string; parentGeneration: number; parentFenceToken: string;
+    assignmentNodeId: string; workerRunId: string; childJobId: string; childAttemptId: string;
+    childGeneration: number; producer: string; idempotencyKey: string; now?: number;
+  }): GraphTransitionResult & { nodeId?: string };
+  attachWorkerResultReference(command: {
+    parentJobId: string; parentAttemptId: string; parentGeneration: number; parentFenceToken: string;
+    workerRunNodeId: string; workerResultId: string; producer: string; idempotencyKey: string; now?: number;
+  }): GraphTransitionResult;
+  workerReferences(parentJobId: string): WorkerGraphReferenceRecord[];
 }
 
 interface AuthorityCommand {
@@ -322,6 +345,24 @@ export function createExecutionGraphAuthority(db: Db): GraphAuthority {
         reference.lineEnd ?? null, now,
       );
     }
+  };
+
+  const insertWorkerReference = (
+    graph: GraphRow,
+    nodeKey: string,
+    kind: WorkerReferenceKind,
+    referenceId: string,
+    generation: number | null,
+    now: number,
+  ): void => {
+    const nodeId = physicalNodeId(graph.graph_id, nodeKey);
+    const referenceKey = `graphref_${digest(JSON.stringify({ nodeId, kind, referenceId, generation }))}`;
+    db.prepare(
+      `INSERT OR IGNORE INTO execution_graph_node_references
+         (reference_key,graph_id,node_id,reference_kind,reference_id,reference_generation,
+          repository_snapshot_id,relative_path,line_start,line_end,created_at)
+       VALUES (?,?,?,?,?,?,NULL,NULL,NULL,NULL,?)`,
+    ).run(referenceKey, graph.graph_id, nodeId, kind, referenceId, generation, now);
   };
 
   const referencesFor = (nodeId: string): CodingPlanReference[] => (
@@ -730,6 +771,177 @@ export function createExecutionGraphAuthority(db: Db): GraphAuthority {
       });
       tx.immediate();
       return { applied: true };
+    },
+    attachWorkerAssignment(command) {
+      const result = authority({
+        jobId: command.parentJobId,
+        attemptId: command.parentAttemptId,
+        generation: command.parentGeneration,
+        fenceToken: command.parentFenceToken,
+        producer: command.producer,
+        idempotencyKey: command.idempotencyKey,
+        now: command.now,
+      });
+      if (result.terminal) return { applied: false, conflict: 'terminal_job' };
+      if (!result.ok) return { applied: false, conflict: 'stale_fence' };
+      const nodeId = `worker-assignment:${command.assignmentId}`;
+      const duplicate = db.prepare(
+        'SELECT 1 FROM execution_graph_events WHERE graph_id=? AND idempotency_key=?',
+      ).get(result.graph.graph_id, command.idempotencyKey);
+      if (duplicate) return { applied: false, duplicate: true, nodeId };
+      const existing = db.prepare(
+        'SELECT kind FROM execution_graph_nodes WHERE graph_id=? AND node_key=?',
+      ).get(result.graph.graph_id, nodeId) as { kind: ExecutionNodeKind } | undefined;
+      if (existing) {
+        if (existing.kind !== 'worker_assignment') return { applied: false, conflict: 'illegal_transition' };
+        return { applied: false, duplicate: true, nodeId };
+      }
+      const now = command.now ?? Date.now();
+      const ordinal = (db.prepare(
+        'SELECT COALESCE(MAX(ordinal), -1) + 1 AS next FROM execution_graph_nodes WHERE graph_id=?',
+      ).get(result.graph.graph_id) as { next: number }).next;
+      const tx = db.transaction(() => {
+        db.prepare(
+          `INSERT INTO execution_graph_nodes
+             (node_id,node_key,graph_id,job_id,kind,state,label,input_ref,requires_verification,
+              ordinal,state_version,created_at,updated_at)
+           VALUES (?,?,?,?,?,'pending',?,?,0,?,0,?,?)`,
+        ).run(
+          physicalNodeId(result.graph.graph_id, nodeId), nodeId, result.graph.graph_id,
+          command.parentJobId, 'worker_assignment', 'Worker assignment',
+          `worker_assignment:${command.assignmentId}`, ordinal, now, now,
+        );
+        insertWorkerReference(result.graph, nodeId, 'worker_assignment', command.assignmentId, null, now);
+        db.prepare('UPDATE execution_graphs SET version=version+1,updated_at=? WHERE graph_id=?')
+          .run(now, result.graph.graph_id);
+        appendEvent(result.graph, 'graph.worker_assignment_attached', {
+          nodeId, assignmentId: command.assignmentId,
+          attemptId: command.parentAttemptId, generation: command.parentGeneration,
+        }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return { applied: true, nodeId };
+    },
+    attachWorkerRun(command) {
+      const result = authority({
+        jobId: command.parentJobId,
+        attemptId: command.parentAttemptId,
+        generation: command.parentGeneration,
+        fenceToken: command.parentFenceToken,
+        producer: command.producer,
+        idempotencyKey: command.idempotencyKey,
+        now: command.now,
+      });
+      if (result.terminal) return { applied: false, conflict: 'terminal_job' };
+      if (!result.ok) return { applied: false, conflict: 'stale_fence' };
+      const assignment = db.prepare(
+        'SELECT kind FROM execution_graph_nodes WHERE graph_id=? AND node_key=?',
+      ).get(result.graph.graph_id, command.assignmentNodeId) as { kind: ExecutionNodeKind } | undefined;
+      if (!assignment || assignment.kind !== 'worker_assignment') return { applied: false, conflict: 'not_found' };
+      const child = db.prepare(
+        'SELECT task_id,generation FROM runs WHERE attempt_id=?',
+      ).get(command.childAttemptId) as { task_id: string | null; generation: number } | undefined;
+      if (!child || child.task_id !== command.childJobId || child.generation !== command.childGeneration) {
+        return { applied: false, conflict: 'stale_fence' };
+      }
+      const nodeId = `worker-run:${command.workerRunId}`;
+      const duplicate = db.prepare(
+        'SELECT 1 FROM execution_graph_events WHERE graph_id=? AND idempotency_key=?',
+      ).get(result.graph.graph_id, command.idempotencyKey);
+      if (duplicate) return { applied: false, duplicate: true, nodeId };
+      const existing = db.prepare(
+        'SELECT kind FROM execution_graph_nodes WHERE graph_id=? AND node_key=?',
+      ).get(result.graph.graph_id, nodeId) as { kind: ExecutionNodeKind } | undefined;
+      if (existing) {
+        if (existing.kind !== 'worker_run') return { applied: false, conflict: 'illegal_transition' };
+        return { applied: false, duplicate: true, nodeId };
+      }
+      const now = command.now ?? Date.now();
+      const ordinal = (db.prepare(
+        'SELECT COALESCE(MAX(ordinal), -1) + 1 AS next FROM execution_graph_nodes WHERE graph_id=?',
+      ).get(result.graph.graph_id) as { next: number }).next;
+      const tx = db.transaction(() => {
+        db.prepare(
+          `INSERT INTO execution_graph_nodes
+             (node_id,node_key,graph_id,job_id,kind,state,label,input_ref,requires_verification,
+              ordinal,state_version,created_at,updated_at)
+           VALUES (?,?,?,?,?,'pending',?,?,1,?,0,?,?)`,
+        ).run(
+          physicalNodeId(result.graph.graph_id, nodeId), nodeId, result.graph.graph_id,
+          command.parentJobId, 'worker_run', 'Worker run',
+          `child_attempt:${command.childJobId}:${command.childAttemptId}:${command.childGeneration}`,
+          ordinal, now, now,
+        );
+        db.prepare(
+          'INSERT INTO execution_graph_edges (graph_id,from_node_id,to_node_id,created_at) VALUES (?,?,?,?)',
+        ).run(
+          result.graph.graph_id,
+          physicalNodeId(result.graph.graph_id, command.assignmentNodeId),
+          physicalNodeId(result.graph.graph_id, nodeId),
+          now,
+        );
+        insertWorkerReference(result.graph, nodeId, 'worker_run', command.workerRunId, null, now);
+        insertWorkerReference(result.graph, nodeId, 'child_attempt', command.childAttemptId, command.childGeneration, now);
+        db.prepare('UPDATE execution_graphs SET version=version+1,updated_at=? WHERE graph_id=?')
+          .run(now, result.graph.graph_id);
+        appendEvent(result.graph, 'graph.worker_run_attached', {
+          nodeId, assignmentNodeId: command.assignmentNodeId, workerRunId: command.workerRunId,
+          childJobId: command.childJobId, childAttemptId: command.childAttemptId,
+          childGeneration: command.childGeneration,
+        }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return { applied: true, nodeId };
+    },
+    attachWorkerResultReference(command) {
+      const result = authority({
+        jobId: command.parentJobId,
+        attemptId: command.parentAttemptId,
+        generation: command.parentGeneration,
+        fenceToken: command.parentFenceToken,
+        producer: command.producer,
+        idempotencyKey: command.idempotencyKey,
+        now: command.now,
+      });
+      if (result.terminal) return { applied: false, conflict: 'terminal_job' };
+      if (!result.ok) return { applied: false, conflict: 'stale_fence' };
+      const node = db.prepare(
+        'SELECT kind FROM execution_graph_nodes WHERE graph_id=? AND node_key=?',
+      ).get(result.graph.graph_id, command.workerRunNodeId) as { kind: ExecutionNodeKind } | undefined;
+      if (!node || node.kind !== 'worker_run') return { applied: false, conflict: 'not_found' };
+      const duplicate = db.prepare(
+        'SELECT 1 FROM execution_graph_events WHERE graph_id=? AND idempotency_key=?',
+      ).get(result.graph.graph_id, command.idempotencyKey);
+      if (duplicate) return { applied: false, duplicate: true };
+      const now = command.now ?? Date.now();
+      const tx = db.transaction(() => {
+        insertWorkerReference(result.graph, command.workerRunNodeId, 'worker_result', command.workerResultId, null, now);
+        appendEvent(result.graph, 'graph.worker_result_referenced', {
+          nodeId: command.workerRunNodeId, workerResultId: command.workerResultId,
+        }, command.producer, command.idempotencyKey, now);
+      });
+      tx.immediate();
+      return { applied: true };
+    },
+    workerReferences(parentJobId) {
+      const graph = graphFor(parentJobId);
+      if (!graph) return [];
+      return (db.prepare(
+        `SELECT n.node_key,r.reference_kind,r.reference_id,r.reference_generation
+           FROM execution_graph_node_references r
+           JOIN execution_graph_nodes n ON n.node_id=r.node_id
+          WHERE r.graph_id=?
+            AND r.reference_kind IN ('worker_assignment','worker_run','child_attempt','worker_result')
+          ORDER BY n.ordinal,r.reference_kind,r.reference_key`,
+      ).all(graph.graph_id) as Array<{
+        node_key: string; reference_kind: WorkerReferenceKind;
+        reference_id: string; reference_generation: number | null;
+      }>).map((row) => ({
+        nodeId: row.node_key,
+        kind: row.reference_kind,
+        id: row.reference_id,
+        generation: row.reference_generation,
+      }));
     },
     nodes(jobId) {
       const graph = graphFor(jobId);

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -41,6 +41,7 @@ import {
   createRepositoryUnderstandingAuthority,
   type RepositoryUnderstandingAuthority,
 } from '../codebase/repositoryUnderstandingAuthority';
+import { createWorkerAuthority, type WorkerAuthority } from '../worker/workerAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -200,6 +201,7 @@ export interface LeaseResult extends TransitionResult {
 
 export interface JobEngine {
   readonly graph: ExecutionGraphAuthority;
+  readonly worker: WorkerAuthority;
   readonly resources: JobResourceAuthority;
   readonly proof: JobProofAuthority;
   readonly projection: JobEventProjectionAuthority;
@@ -2335,9 +2337,43 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
     appendJobEvent: appendJobEventTx,
   });
+  const worker = createWorkerAuthority({
+    db,
+    graph,
+    validateActiveFence(command) {
+      const attempt = activeFence(
+        command.attemptId,
+        command.generation,
+        command.fenceToken,
+        command.now,
+      );
+      const job = attempt ? getJobRow(command.jobId) : undefined;
+      const valid = Boolean(
+        attempt
+        && attempt.task_id === command.jobId
+        && job?.active_attempt_id === command.attemptId
+        && !JOB_TERMINAL.has(job.status),
+      );
+      return { valid, runId: valid ? attempt?.id : undefined };
+    },
+    appendOrderedEvent(command) {
+      const result = appendEvent({
+        jobId: command.jobId,
+        runId: command.runId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        type: command.kind,
+        payload: command.payload,
+        producer: command.producer,
+        idempotencyKey: command.idempotencyKey,
+      });
+      return { duplicate: result.duplicate, sequence: result.jobSequence };
+    },
+  });
 
   return {
     graph,
+    worker,
     resources,
     proof,
     projection,

--- a/core/v4/worker/types.ts
+++ b/core/v4/worker/types.ts
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+export type WorkerId = string;
+export type WorkerTimestamp = number;
+
+export interface WorkerDefinitionV1 {
+  readonly schemaVersion: 1;
+  readonly workerDefinitionId: WorkerId;
+  readonly workerDefinitionVersion: number;
+  readonly expectedResultSchemaId: string;
+  readonly expectedEvidenceSchemaId: string | null;
+  readonly requiredCapabilities: readonly string[];
+}
+
+export interface WorkerAssignmentRecord {
+  readonly assignmentId: WorkerId;
+  readonly schemaVersion: 1;
+  readonly idempotencyKey: string;
+  readonly workerDefinitionId: WorkerId;
+  readonly workerDefinitionVersion: number;
+  readonly parentJobId: string;
+  readonly parentAttemptId: string;
+  readonly parentGeneration: number;
+  readonly parentFenceDigest: string;
+  readonly childContractId: string;
+  readonly childJobId: string;
+  readonly repositorySnapshotId: string | null;
+  readonly executionGraphNodeId: string | null;
+  readonly contextEnvelopeId: WorkerId;
+  readonly providerBindingId: WorkerId;
+  readonly capabilitySetId: string | null;
+  readonly goal: string;
+  readonly expectedResultSchemaId: string;
+  readonly expectedEvidenceSchemaId: string | null;
+  readonly inputHash: string;
+  readonly createdAt: WorkerTimestamp;
+}
+
+export interface WorkerRunRecord {
+  readonly workerRunId: WorkerId;
+  readonly schemaVersion: 1;
+  readonly assignmentId: WorkerId;
+  readonly childJobId: string;
+  readonly childAttemptId: string;
+  readonly childGeneration: number;
+  readonly executionGraphNodeId: string | null;
+  readonly providerBindingId: WorkerId;
+  readonly contextEnvelopeId: WorkerId;
+  readonly acceptedResultId: WorkerId | null;
+  readonly createdAt: WorkerTimestamp;
+}
+
+export interface WorkerProviderBindingRecord {
+  readonly providerBindingId: WorkerId;
+  readonly schemaVersion: 1;
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly providerRuntimeIdentity: string;
+  readonly credentialReference: string | null;
+  readonly endpointReference: string | null;
+  readonly capabilitySnapshotHash: string;
+  readonly selectionReason: string;
+  readonly fallbackPolicyId: string | null;
+  readonly contextWindow: number;
+  readonly maxOutputTokens: number;
+  readonly bindingHash: string;
+  readonly createdAt: WorkerTimestamp;
+}
+
+export interface WorkerContextEnvelopeRecord {
+  readonly contextEnvelopeId: WorkerId;
+  readonly schemaVersion: 1;
+  readonly assignmentId: WorkerId;
+  readonly repositorySnapshotId: string | null;
+  readonly planStepIds: string[];
+  readonly claimIds: string[];
+  readonly sourceReferenceIds: string[];
+  readonly instructionReferenceIds: string[];
+  readonly boundedParentNote: string | null;
+  readonly toolSchemaDigest: string;
+  readonly contentDigest: string;
+  readonly tokenEstimate: number;
+  readonly createdAt: WorkerTimestamp;
+}
+
+export type WorkerResultAcceptanceState = 'received' | 'accepted' | 'rejected';
+
+export type WorkerResultRejectionCode =
+  | 'malformed_payload'
+  | 'payload_too_large'
+  | 'linkage_mismatch'
+  | 'stale_generation'
+  | 'authority_lost'
+  | 'input_hash_mismatch'
+  | 'result_hash_mismatch'
+  | 'idempotency_conflict'
+  | 'evidence_reference_invalid'
+  | 'final_result_conflict';
+
+export type WorkerResultStatus =
+  | 'completed'
+  | 'partial'
+  | 'failed'
+  | 'cancelled'
+  | 'timed_out'
+  | 'blocked';
+
+export interface WorkerResultSourceReference {
+  readonly snapshotId: string;
+  readonly snapshotEntryId: string;
+  readonly path: string;
+  readonly startLine?: number;
+  readonly endLine?: number;
+  readonly contentHash: string;
+}
+
+export interface WorkerResultPayloadV1 {
+  schemaVersion: 1;
+  status: WorkerResultStatus;
+  summary: string;
+  findings: Array<{
+    findingId: string;
+    statement: string;
+    sourceReferences: WorkerResultSourceReference[];
+    evidenceIds: string[];
+    uncertainty: 'low' | 'medium' | 'high';
+  }>;
+  sourceReferences: WorkerResultSourceReference[];
+  filesInspected: Array<{ snapshotEntryId: string; path: string; contentHash: string }>;
+  commandsExecuted: Array<{ toolCallId: string; tool: string; inputHash: string; status: string }>;
+  diagnostics: Array<{ code: string; message: string; severity: 'info' | 'warning' | 'error' }>;
+  evidenceIds: string[];
+  unresolvedQuestions: string[];
+  uncertainty: { level: 'low' | 'medium' | 'high'; reasons: string[] };
+  providerAttemptIds: string[];
+  budgetUsage: Array<{ kind: string; amount: number | null; debitId?: string; unknownReason?: string }>;
+  timing: { startedAt: number; completedAt: number; wallClockMs: number };
+  failure: null | {
+    category: 'provider' | 'auth' | 'budget' | 'timeout' | 'cancelled' | 'tool' | 'validation' | 'authority_lost' | 'unknown';
+    code: string;
+    message: string;
+    retryable: boolean;
+    externalOutcomeUnknown: boolean;
+  };
+  inputHash: string;
+  resultHash: string;
+}
+
+export interface WorkerResultRecord {
+  readonly workerResultId: WorkerId;
+  readonly schemaVersion: 1;
+  readonly workerRunId: WorkerId;
+  readonly assignmentId: WorkerId;
+  readonly childJobId: string;
+  readonly childAttemptId: string;
+  readonly childGeneration: number;
+  readonly idempotencyKey: string;
+  readonly status: WorkerResultStatus | 'invalid';
+  readonly summary: string;
+  readonly payload: WorkerResultPayloadV1 | null;
+  readonly evidenceIds: string[];
+  readonly providerAttemptIds: string[];
+  readonly inputHash: string;
+  readonly resultHash: string;
+  readonly acceptanceState: WorkerResultAcceptanceState;
+  readonly rejectionCode: WorkerResultRejectionCode | null;
+  readonly rejectionReason: string | null;
+  readonly createdAt: WorkerTimestamp;
+  readonly acceptedAt: WorkerTimestamp | null;
+  readonly rejectedAt: WorkerTimestamp | null;
+}
+
+export type WorkerEventKind =
+  | 'worker.assignment_created'
+  | 'worker.provider_binding_created'
+  | 'worker.context_finalized'
+  | 'worker.run_bound'
+  | 'worker.result_received'
+  | 'worker.result_accepted'
+  | 'worker.result_rejected';
+
+export type WorkerReferenceKind = 'worker_assignment' | 'worker_run' | 'child_attempt' | 'worker_result';
+
+export interface WorkerEventRecord {
+  readonly sequence: number;
+  readonly kind: WorkerEventKind;
+  readonly payload: Record<string, unknown>;
+  readonly createdAt: number;
+}
+
+export interface WorkerProjection {
+  assignmentIds: string[];
+  providerBindingIds: string[];
+  contextEnvelopeIds: string[];
+  workerRunIds: string[];
+  receivedResultIds: string[];
+  acceptedResultIds: string[];
+  rejectedResultIds: string[];
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+function canonical(value: unknown): JsonValue {
+  if (value === null) return null;
+  if (typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (Array.isArray(value)) return value.map(canonical);
+  if (typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonical(item)]));
+  }
+  return String(value);
+}
+
+export function computeWorkerDigest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(canonical(value))).digest('hex');
+}
+
+export function computeWorkerResultHash(payload: WorkerResultPayloadV1): string {
+  return computeWorkerDigest({ ...payload, resultHash: '' });
+}

--- a/core/v4/worker/workerAuthority.ts
+++ b/core/v4/worker/workerAuthority.ts
@@ -1,0 +1,884 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { Db } from '../daemon/db/connection';
+import type { ExecutionGraphAuthority } from '../daemon/executionGraph';
+import {
+  computeWorkerDigest,
+  computeWorkerResultHash,
+  type WorkerAssignmentRecord,
+  type WorkerContextEnvelopeRecord,
+  type WorkerEventKind,
+  type WorkerEventRecord,
+  type WorkerProjection,
+  type WorkerProviderBindingRecord,
+  type WorkerResultPayloadV1,
+  type WorkerResultRecord,
+  type WorkerResultRejectionCode,
+  type WorkerResultStatus,
+  type WorkerRunRecord,
+} from './types';
+
+const HASH = /^[a-f0-9]{64}$/u;
+const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u;
+const FINAL_RESULT_STATUS = new Set<WorkerResultStatus>(['completed', 'failed', 'cancelled', 'timed_out', 'blocked']);
+const RESULT_STATUS = new Set<WorkerResultStatus>(['completed', 'partial', 'failed', 'cancelled', 'timed_out', 'blocked']);
+const MAX_LIST_ITEMS = 256;
+const MAX_NOTE_CHARS = 4_096;
+const MAX_GOAL_CHARS = 16_384;
+const MAX_SUMMARY_CHARS = 65_536;
+const MAX_FIELD_CHARS = 8_192;
+const MAX_RESULT_BYTES = 512 * 1024;
+
+export class WorkerAuthorityError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'WorkerAuthorityError';
+    this.code = code;
+  }
+}
+
+interface ParentAuthorityCommand {
+  parentJobId: string;
+  parentAttemptId: string;
+  parentGeneration: number;
+  parentFenceToken: string;
+  producer: string;
+  idempotencyKey: string;
+  now?: number;
+}
+
+interface ChildAuthorityCommand {
+  childJobId: string;
+  childAttemptId: string;
+  childGeneration: number;
+  childFenceToken: string;
+}
+
+interface WorkerAuthorityDeps {
+  db: Db;
+  graph: ExecutionGraphAuthority;
+  validateActiveFence(command: {
+    jobId: string; attemptId: string; generation: number; fenceToken: string; now?: number;
+  }): { valid: boolean; runId?: number };
+  appendOrderedEvent(command: {
+    jobId: string; runId: number; attemptId: string; generation: number;
+    kind: WorkerEventKind; payload: Record<string, unknown>;
+    producer: string; idempotencyKey: string;
+  }): { duplicate: boolean; sequence: number };
+}
+
+type ProviderBindingCommand = ParentAuthorityCommand & Omit<WorkerProviderBindingRecord,
+  'bindingHash' | 'createdAt'>;
+
+type ContextEnvelopeCommand = ParentAuthorityCommand & Omit<WorkerContextEnvelopeRecord,
+  'contentDigest' | 'createdAt'>;
+
+type AssignmentCommand = ParentAuthorityCommand & Omit<WorkerAssignmentRecord,
+  'idempotencyKey' | 'parentFenceDigest' | 'executionGraphNodeId' | 'inputHash' | 'createdAt'>;
+
+type BindRunCommand = ParentAuthorityCommand & ChildAuthorityCommand & Omit<WorkerRunRecord,
+  'idempotencyKey' | 'childJobId' | 'childAttemptId' | 'childGeneration'
+  | 'executionGraphNodeId' | 'acceptedResultId' | 'createdAt'>;
+
+interface RecordResultCommand extends ParentAuthorityCommand, ChildAuthorityCommand {
+  workerResultId: string;
+  workerRunId: string;
+  assignmentId: string;
+  payload: unknown;
+}
+
+export interface WorkerAuthority {
+  createWorkerProviderBinding(command: ProviderBindingCommand): WorkerProviderBindingRecord;
+  createWorkerContextEnvelope(command: ContextEnvelopeCommand): WorkerContextEnvelopeRecord;
+  createWorkerAssignment(command: AssignmentCommand): WorkerAssignmentRecord;
+  bindWorkerRun(command: BindRunCommand): WorkerRunRecord;
+  recordWorkerResult(command: RecordResultCommand): WorkerResultRecord;
+  getWorkerAssignment(id: string): WorkerAssignmentRecord | null;
+  getWorkerRun(id: string): WorkerRunRecord | null;
+  getWorkerProviderBinding(id: string): WorkerProviderBindingRecord | null;
+  getWorkerContextEnvelope(id: string): WorkerContextEnvelopeRecord | null;
+  getWorkerResult(id: string): WorkerResultRecord | null;
+  listWorkerRunsForParent(parentJobId: string): WorkerRunRecord[];
+  listWorkerRunsForChild(childJobId: string): WorkerRunRecord[];
+  listWorkerEvents(parentJobId: string): WorkerEventRecord[];
+  rebuildWorkerProjection(parentJobId: string): WorkerProjection;
+}
+
+type AssignmentRow = {
+  assignment_id: string; schema_version: number; idempotency_key: string;
+  worker_definition_id: string; worker_definition_version: number;
+  parent_job_id: string; parent_attempt_id: string; parent_generation: number; parent_fence_digest: string;
+  child_contract_id: string; child_job_id: string; repository_snapshot_id: string | null;
+  execution_graph_node_id: string | null; context_envelope_id: string; provider_binding_id: string;
+  capability_set_id: string | null; goal: string; expected_result_schema_id: string;
+  expected_evidence_schema_id: string | null; input_hash: string; created_at: number;
+};
+
+type RunRow = {
+  worker_run_id: string; schema_version: number; idempotency_key: string; assignment_id: string;
+  child_job_id: string; child_attempt_id: string; child_generation: number;
+  execution_graph_node_id: string | null; provider_binding_id: string; context_envelope_id: string;
+  accepted_result_id: string | null; created_at: number;
+};
+
+type BindingRow = {
+  provider_binding_id: string; schema_version: number; provider_id: string; model_id: string;
+  provider_runtime_identity: string; credential_reference: string | null; endpoint_reference: string | null;
+  capability_snapshot_hash: string; selection_reason: string; fallback_policy_id: string | null;
+  context_window: number; max_output_tokens: number; binding_hash: string; created_at: number;
+};
+
+type ContextRow = {
+  context_envelope_id: string; schema_version: number; assignment_id: string;
+  repository_snapshot_id: string | null; plan_step_ids_json: string; claim_ids_json: string;
+  source_reference_ids_json: string; instruction_reference_ids_json: string; bounded_parent_note: string | null;
+  tool_schema_digest: string; content_digest: string; token_estimate: number; created_at: number;
+};
+
+type ResultRow = {
+  worker_result_id: string; schema_version: number; worker_run_id: string; assignment_id: string;
+  child_job_id: string; child_attempt_id: string; child_generation: number; idempotency_key: string;
+  status: WorkerResultStatus | 'invalid'; summary: string; structured_payload_json: string | null;
+  evidence_ids_json: string; provider_attempt_ids_json: string; input_hash: string; result_hash: string;
+  acceptance_state: WorkerResultRecord['acceptanceState']; rejection_code: WorkerResultRejectionCode | null;
+  rejection_reason: string | null; created_at: number; accepted_at: number | null; rejected_at: number | null;
+};
+
+function array(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch { return []; }
+}
+
+function mapAssignment(row: AssignmentRow): WorkerAssignmentRecord {
+  return {
+    assignmentId: row.assignment_id, schemaVersion: 1, idempotencyKey: row.idempotency_key,
+    workerDefinitionId: row.worker_definition_id, workerDefinitionVersion: row.worker_definition_version,
+    parentJobId: row.parent_job_id, parentAttemptId: row.parent_attempt_id,
+    parentGeneration: row.parent_generation, parentFenceDigest: row.parent_fence_digest,
+    childContractId: row.child_contract_id, childJobId: row.child_job_id,
+    repositorySnapshotId: row.repository_snapshot_id, executionGraphNodeId: row.execution_graph_node_id,
+    contextEnvelopeId: row.context_envelope_id, providerBindingId: row.provider_binding_id,
+    capabilitySetId: row.capability_set_id, goal: row.goal,
+    expectedResultSchemaId: row.expected_result_schema_id,
+    expectedEvidenceSchemaId: row.expected_evidence_schema_id,
+    inputHash: row.input_hash, createdAt: row.created_at,
+  };
+}
+
+function mapRun(row: RunRow): WorkerRunRecord {
+  return {
+    workerRunId: row.worker_run_id, schemaVersion: 1, assignmentId: row.assignment_id,
+    childJobId: row.child_job_id, childAttemptId: row.child_attempt_id,
+    childGeneration: row.child_generation, executionGraphNodeId: row.execution_graph_node_id,
+    providerBindingId: row.provider_binding_id, contextEnvelopeId: row.context_envelope_id,
+    acceptedResultId: row.accepted_result_id, createdAt: row.created_at,
+  };
+}
+
+function mapBinding(row: BindingRow): WorkerProviderBindingRecord {
+  return {
+    providerBindingId: row.provider_binding_id, schemaVersion: 1,
+    providerId: row.provider_id, modelId: row.model_id,
+    providerRuntimeIdentity: row.provider_runtime_identity,
+    credentialReference: row.credential_reference, endpointReference: row.endpoint_reference,
+    capabilitySnapshotHash: row.capability_snapshot_hash, selectionReason: row.selection_reason,
+    fallbackPolicyId: row.fallback_policy_id, contextWindow: row.context_window,
+    maxOutputTokens: row.max_output_tokens, bindingHash: row.binding_hash, createdAt: row.created_at,
+  };
+}
+
+function mapContext(row: ContextRow): WorkerContextEnvelopeRecord {
+  return {
+    contextEnvelopeId: row.context_envelope_id, schemaVersion: 1, assignmentId: row.assignment_id,
+    repositorySnapshotId: row.repository_snapshot_id, planStepIds: array(row.plan_step_ids_json),
+    claimIds: array(row.claim_ids_json), sourceReferenceIds: array(row.source_reference_ids_json),
+    instructionReferenceIds: array(row.instruction_reference_ids_json), boundedParentNote: row.bounded_parent_note,
+    toolSchemaDigest: row.tool_schema_digest, contentDigest: row.content_digest,
+    tokenEstimate: row.token_estimate, createdAt: row.created_at,
+  };
+}
+
+function mapResult(row: ResultRow): WorkerResultRecord {
+  return {
+    workerResultId: row.worker_result_id, schemaVersion: 1, workerRunId: row.worker_run_id,
+    assignmentId: row.assignment_id, childJobId: row.child_job_id,
+    childAttemptId: row.child_attempt_id, childGeneration: row.child_generation,
+    idempotencyKey: row.idempotency_key, status: row.status, summary: row.summary,
+    payload: row.structured_payload_json === null
+      ? null
+      : JSON.parse(row.structured_payload_json) as WorkerResultPayloadV1,
+    evidenceIds: array(row.evidence_ids_json), providerAttemptIds: array(row.provider_attempt_ids_json),
+    inputHash: row.input_hash, resultHash: row.result_hash,
+    acceptanceState: row.acceptance_state, rejectionCode: row.rejection_code,
+    rejectionReason: row.rejection_reason, createdAt: row.created_at,
+    acceptedAt: row.accepted_at, rejectedAt: row.rejected_at,
+  };
+}
+
+function assertId(value: string, label: string): void {
+  if (!ID.test(value)) throw new WorkerAuthorityError('invalid_identity', `${label} is invalid`);
+}
+
+function assertHash(value: string, label: string): void {
+  if (!HASH.test(value)) throw new WorkerAuthorityError('invalid_hash', `${label} must be a SHA-256 digest`);
+}
+
+function assertString(value: unknown, label: string, max: number, allowEmpty = false): asserts value is string {
+  if (typeof value !== 'string' || (!allowEmpty && value.length === 0) || value.length > max) {
+    throw new WorkerAuthorityError('invalid_contract', `${label} is invalid`);
+  }
+}
+
+function assertStringList(value: unknown, label: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.length > MAX_LIST_ITEMS
+    || value.some((item) => typeof item !== 'string' || item.length === 0 || item.length > 512)) {
+    throw new WorkerAuthorityError('invalid_contract', `${label} is invalid`);
+  }
+}
+
+function normalizedKey(key: string): string {
+  return key.replace(/[^a-z0-9]/giu, '').toLowerCase();
+}
+
+function hasForbiddenKey(value: unknown, forbidden: ReadonlySet<string>, seen = new Set<object>()): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) return value.some((item) => hasForbiddenKey(item, forbidden, seen));
+  return Object.entries(value as Record<string, unknown>).some(([key, item]) => (
+    forbidden.has(normalizedKey(key)) || hasForbiddenKey(item, forbidden, seen)
+  ));
+}
+
+function secretValuePath(value: unknown, path = 'record', seen = new Set<object>()): string | null {
+  if (typeof value === 'string') {
+    return /(?:bearer\s+[a-z0-9._-]{12,}|(?:^|[^a-z0-9])(?:sk|gsk|ghp|gho|npm)_[a-z0-9_-]{12,}|-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----)/iu.test(value)
+      ? path
+      : null;
+  }
+  if (value === null || typeof value !== 'object') return null;
+  if (seen.has(value)) return null;
+  seen.add(value);
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    const match = secretValuePath(item, `${path}.${key}`, seen);
+    if (match) return match;
+  }
+  return null;
+}
+
+function assertSafeInput(value: unknown, forbidden: ReadonlySet<string>): void {
+  if (hasForbiddenKey(value, forbidden)) {
+    throw new WorkerAuthorityError('sensitive_input', 'Sensitive fields are not permitted in Worker records');
+  }
+  const secretPath = secretValuePath(value);
+  if (secretPath) {
+    throw new WorkerAuthorityError('sensitive_input', `Secret values are not permitted in Worker records (${secretPath})`);
+  }
+}
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function boundedString(value: unknown, max = MAX_FIELD_CHARS): value is string {
+  return typeof value === 'string' && value.length <= max;
+}
+
+function boundedStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length <= MAX_LIST_ITEMS
+    && value.every((item) => boundedString(item, 512));
+}
+
+function validSourceReference(value: unknown): boolean {
+  const item = object(value);
+  if (!item || !boundedString(item.snapshotId, 512) || !boundedString(item.snapshotEntryId, 512)
+    || !boundedString(item.path) || !boundedString(item.contentHash, 64) || !HASH.test(item.contentHash)) return false;
+  const start = item.startLine;
+  const end = item.endLine;
+  if (start === undefined && end === undefined) return true;
+  return Number.isSafeInteger(start) && Number.isSafeInteger(end)
+    && Number(start) >= 1 && Number(end) >= Number(start);
+}
+
+function validResultShape(item: Partial<WorkerResultPayloadV1>): boolean {
+  const findings = item.findings;
+  const files = item.filesInspected;
+  const commands = item.commandsExecuted;
+  const diagnostics = item.diagnostics;
+  const budgets = item.budgetUsage;
+  const uncertainty = object(item.uncertainty);
+  const timing = object(item.timing);
+  const failure = item.failure === null ? null : object(item.failure);
+  return item.schemaVersion === 1
+    && typeof item.status === 'string' && RESULT_STATUS.has(item.status as WorkerResultStatus)
+    && boundedString(item.summary, MAX_SUMMARY_CHARS)
+    && Array.isArray(findings) && findings.every((value) => {
+      const finding = object(value);
+      return Boolean(finding && boundedString(finding.findingId, 512)
+        && boundedString(finding.statement, MAX_SUMMARY_CHARS)
+        && Array.isArray(finding.sourceReferences) && finding.sourceReferences.every(validSourceReference)
+        && boundedStringArray(finding.evidenceIds)
+        && ['low', 'medium', 'high'].includes(String(finding.uncertainty)));
+    })
+    && Array.isArray(item.sourceReferences) && item.sourceReferences.every(validSourceReference)
+    && Array.isArray(files) && files.every((value) => {
+      const file = object(value);
+      return Boolean(file && boundedString(file.snapshotEntryId, 512) && boundedString(file.path)
+        && boundedString(file.contentHash, 64) && HASH.test(file.contentHash));
+    })
+    && Array.isArray(commands) && commands.every((value) => {
+      const command = object(value);
+      return Boolean(command && boundedString(command.toolCallId, 512) && boundedString(command.tool, 512)
+        && boundedString(command.inputHash, 64) && HASH.test(command.inputHash)
+        && boundedString(command.status, 128));
+    })
+    && Array.isArray(diagnostics) && diagnostics.every((value) => {
+      const diagnostic = object(value);
+      return Boolean(diagnostic && boundedString(diagnostic.code, 512)
+        && boundedString(diagnostic.message, MAX_FIELD_CHARS)
+        && ['info', 'warning', 'error'].includes(String(diagnostic.severity)));
+    })
+    && boundedStringArray(item.evidenceIds)
+    && boundedStringArray(item.unresolvedQuestions)
+    && Boolean(uncertainty && ['low', 'medium', 'high'].includes(String(uncertainty.level))
+      && boundedStringArray(uncertainty.reasons))
+    && boundedStringArray(item.providerAttemptIds)
+    && Array.isArray(budgets) && budgets.every((value) => {
+      const budget = object(value);
+      return Boolean(budget && boundedString(budget.kind, 128)
+        && (budget.amount === null || (typeof budget.amount === 'number' && Number.isFinite(budget.amount)))
+        && (budget.debitId === undefined || boundedString(budget.debitId, 512))
+        && (budget.unknownReason === undefined || boundedString(budget.unknownReason, MAX_FIELD_CHARS)));
+    })
+    && Boolean(timing && typeof timing.startedAt === 'number' && Number.isFinite(timing.startedAt)
+      && typeof timing.completedAt === 'number' && Number.isFinite(timing.completedAt)
+      && timing.completedAt >= timing.startedAt
+      && typeof timing.wallClockMs === 'number' && Number.isFinite(timing.wallClockMs)
+      && timing.wallClockMs >= 0)
+    && (item.failure === null || Boolean(failure
+      && ['provider', 'auth', 'budget', 'timeout', 'cancelled', 'tool', 'validation', 'authority_lost', 'unknown']
+        .includes(String(failure.category))
+      && boundedString(failure.code, 512) && boundedString(failure.message, MAX_FIELD_CHARS)
+      && typeof failure.retryable === 'boolean' && typeof failure.externalOutcomeUnknown === 'boolean'))
+    && typeof item.inputHash === 'string' && HASH.test(item.inputHash)
+    && typeof item.resultHash === 'string' && HASH.test(item.resultHash);
+}
+
+function resultPayload(value: unknown): { payload: WorkerResultPayloadV1 | null; serialized: string | null; tooLarge: boolean } {
+  let serialized: string;
+  try { serialized = JSON.stringify(value); } catch { return { payload: null, serialized: null, tooLarge: false }; }
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_RESULT_BYTES) return { payload: null, serialized: null, tooLarge: true };
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { payload: null, serialized: null, tooLarge: false };
+  const item = value as Partial<WorkerResultPayloadV1>;
+  const boundedLists = [
+    item.findings, item.sourceReferences, item.filesInspected, item.commandsExecuted,
+    item.diagnostics, item.evidenceIds, item.unresolvedQuestions,
+    item.providerAttemptIds, item.budgetUsage, item.uncertainty?.reasons,
+  ];
+  if ((typeof item.summary === 'string' && item.summary.length > MAX_SUMMARY_CHARS)
+    || boundedLists.some((list) => Array.isArray(list) && list.length > MAX_LIST_ITEMS)) {
+    return { payload: null, serialized: null, tooLarge: true };
+  }
+  if (!validResultShape(item)) return { payload: null, serialized: null, tooLarge: false };
+  if (hasForbiddenKey(item, new Set(['apikey', 'accesstoken', 'refreshtoken', 'cookie', 'cookies', 'authorization', 'authorizationheader']))
+    || secretValuePath(item)) return { payload: null, serialized: null, tooLarge: false };
+  return { payload: item as WorkerResultPayloadV1, serialized, tooLarge: false };
+}
+
+export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthority {
+  const { db, graph } = deps;
+
+  const getAssignment = (id: string): WorkerAssignmentRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_assignments WHERE assignment_id=?').get(id) as AssignmentRow | undefined;
+    return row ? mapAssignment(row) : null;
+  };
+  const getRun = (id: string): WorkerRunRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_runs WHERE worker_run_id=?').get(id) as RunRow | undefined;
+    return row ? mapRun(row) : null;
+  };
+  const getBinding = (id: string): WorkerProviderBindingRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_provider_bindings WHERE provider_binding_id=?').get(id) as BindingRow | undefined;
+    return row ? mapBinding(row) : null;
+  };
+  const getContext = (id: string): WorkerContextEnvelopeRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_context_envelopes WHERE context_envelope_id=?').get(id) as ContextRow | undefined;
+    return row ? mapContext(row) : null;
+  };
+  const getResult = (id: string): WorkerResultRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_results WHERE worker_result_id=?').get(id) as ResultRow | undefined;
+    return row ? mapResult(row) : null;
+  };
+
+  const parentFence = (command: ParentAuthorityCommand): { runId: number } => {
+    const result = deps.validateActiveFence({
+      jobId: command.parentJobId, attemptId: command.parentAttemptId,
+      generation: command.parentGeneration, fenceToken: command.parentFenceToken, now: command.now,
+    });
+    if (!result.valid || result.runId === undefined) {
+      throw new WorkerAuthorityError('stale_authority', 'Parent Attempt authority is no longer active');
+    }
+    return { runId: result.runId };
+  };
+
+  const append = (command: ParentAuthorityCommand, runId: number, kind: WorkerEventKind, payload: Record<string, unknown>, suffix: string): void => {
+    deps.appendOrderedEvent({
+      jobId: command.parentJobId, runId, attemptId: command.parentAttemptId,
+      generation: command.parentGeneration, kind, payload, producer: command.producer,
+      idempotencyKey: `${command.idempotencyKey}:${suffix}`,
+    });
+  };
+
+  const createBinding = db.transaction((command: ProviderBindingCommand): WorkerProviderBindingRecord => {
+    assertSafeInput(command, new Set(['apikey', 'accesstoken', 'refreshtoken', 'cookie', 'cookies', 'authorization', 'authorizationheader', 'environment', 'env']));
+    assertId(command.providerBindingId, 'Provider binding identity');
+    if (command.schemaVersion !== 1) throw new WorkerAuthorityError('invalid_contract', 'Unsupported provider binding schema');
+    for (const [value, label] of [[command.providerId, 'Provider'], [command.modelId, 'Model'], [command.providerRuntimeIdentity, 'Runtime identity']] as const) {
+      assertString(value, label, 512);
+    }
+    assertHash(command.capabilitySnapshotHash, 'Capability snapshot hash');
+    assertString(command.selectionReason, 'Selection reason', 2_048);
+    if (!Number.isSafeInteger(command.contextWindow) || command.contextWindow < 1
+      || !Number.isSafeInteger(command.maxOutputTokens) || command.maxOutputTokens < 1) {
+      throw new WorkerAuthorityError('invalid_contract', 'Provider token limits are invalid');
+    }
+    const bindingHash = computeWorkerDigest({
+      schemaVersion: 1, providerId: command.providerId, modelId: command.modelId,
+      providerRuntimeIdentity: command.providerRuntimeIdentity,
+      credentialReference: command.credentialReference, endpointReference: command.endpointReference,
+      capabilitySnapshotHash: command.capabilitySnapshotHash, selectionReason: command.selectionReason,
+      fallbackPolicyId: command.fallbackPolicyId, contextWindow: command.contextWindow,
+      maxOutputTokens: command.maxOutputTokens,
+    });
+    const existing = getBinding(command.providerBindingId);
+    if (existing) {
+      if (existing.bindingHash !== bindingHash) throw new WorkerAuthorityError('immutable_conflict', 'Provider binding identity already exists');
+      return existing;
+    }
+    const { runId } = parentFence(command);
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO worker_provider_bindings
+         (provider_binding_id,schema_version,provider_id,model_id,provider_runtime_identity,
+          credential_reference,endpoint_reference,capability_snapshot_hash,selection_reason,
+          fallback_policy_id,context_window,max_output_tokens,binding_hash,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      command.providerBindingId, 1, command.providerId, command.modelId, command.providerRuntimeIdentity,
+      command.credentialReference, command.endpointReference, command.capabilitySnapshotHash,
+      command.selectionReason, command.fallbackPolicyId, command.contextWindow,
+      command.maxOutputTokens, bindingHash, now,
+    );
+    append(command, runId, 'worker.provider_binding_created', {
+      providerBindingId: command.providerBindingId, bindingHash,
+    }, 'provider-binding-created');
+    return getBinding(command.providerBindingId)!;
+  }).immediate;
+
+  const createContext = db.transaction((command: ContextEnvelopeCommand): WorkerContextEnvelopeRecord => {
+    assertSafeInput(command, new Set(['env', 'environment', 'environmentvariables', 'conversationhistory', 'messages', 'fencetoken', 'apikey', 'accesstoken', 'refreshtoken', 'authorization']));
+    assertId(command.contextEnvelopeId, 'Context envelope identity');
+    assertId(command.assignmentId, 'Assignment identity');
+    if (command.schemaVersion !== 1) throw new WorkerAuthorityError('invalid_contract', 'Unsupported context schema');
+    assertStringList(command.planStepIds, 'Plan step references');
+    assertStringList(command.claimIds, 'Claim references');
+    assertStringList(command.sourceReferenceIds, 'Source references');
+    assertStringList(command.instructionReferenceIds, 'Instruction references');
+    if (command.boundedParentNote !== null) assertString(command.boundedParentNote, 'Parent note', MAX_NOTE_CHARS, true);
+    assertHash(command.toolSchemaDigest, 'Tool schema digest');
+    if (!Number.isSafeInteger(command.tokenEstimate) || command.tokenEstimate < 0) {
+      throw new WorkerAuthorityError('invalid_contract', 'Token estimate is invalid');
+    }
+    if (command.repositorySnapshotId) {
+      const snapshot = db.prepare('SELECT job_id FROM repository_snapshots WHERE snapshot_id=?')
+        .get(command.repositorySnapshotId) as { job_id: string } | undefined;
+      if (!snapshot || snapshot.job_id !== command.parentJobId) {
+        throw new WorkerAuthorityError('reference_mismatch', 'Repository snapshot does not belong to the parent Job');
+      }
+    }
+    for (const claimId of command.claimIds) {
+      if (!db.prepare('SELECT 1 FROM job_claims WHERE claim_id=? AND job_id=?').get(claimId, command.parentJobId)) {
+        throw new WorkerAuthorityError('reference_mismatch', 'Claim reference does not belong to the parent Job');
+      }
+    }
+    const graphNodeIds = new Set(graph.nodes(command.parentJobId).map((node) => node.nodeId));
+    if (command.planStepIds.some((id) => !graphNodeIds.has(id))) {
+      throw new WorkerAuthorityError('reference_mismatch', 'Plan step reference does not belong to the parent graph');
+    }
+    const contentDigest = computeWorkerDigest({
+      schemaVersion: 1, assignmentId: command.assignmentId,
+      repositorySnapshotId: command.repositorySnapshotId,
+      planStepIds: command.planStepIds, claimIds: command.claimIds,
+      sourceReferenceIds: command.sourceReferenceIds,
+      instructionReferenceIds: command.instructionReferenceIds,
+      boundedParentNote: command.boundedParentNote,
+      toolSchemaDigest: command.toolSchemaDigest, tokenEstimate: command.tokenEstimate,
+    });
+    const existing = getContext(command.contextEnvelopeId);
+    if (existing) {
+      if (existing.contentDigest !== contentDigest) throw new WorkerAuthorityError('immutable_conflict', 'Context envelope identity already exists');
+      return existing;
+    }
+    const { runId } = parentFence(command);
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO worker_context_envelopes
+         (context_envelope_id,schema_version,assignment_id,repository_snapshot_id,
+          plan_step_ids_json,claim_ids_json,source_reference_ids_json,instruction_reference_ids_json,
+          bounded_parent_note,tool_schema_digest,content_digest,token_estimate,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      command.contextEnvelopeId, 1, command.assignmentId, command.repositorySnapshotId,
+      JSON.stringify(command.planStepIds), JSON.stringify(command.claimIds),
+      JSON.stringify(command.sourceReferenceIds), JSON.stringify(command.instructionReferenceIds),
+      command.boundedParentNote, command.toolSchemaDigest, contentDigest, command.tokenEstimate, now,
+    );
+    append(command, runId, 'worker.context_finalized', {
+      contextEnvelopeId: command.contextEnvelopeId, assignmentId: command.assignmentId, contentDigest,
+    }, 'context-finalized');
+    return getContext(command.contextEnvelopeId)!;
+  }).immediate;
+
+  const createAssignment = db.transaction((command: AssignmentCommand): WorkerAssignmentRecord => {
+    assertId(command.assignmentId, 'Assignment identity');
+    if (command.schemaVersion !== 1) throw new WorkerAuthorityError('invalid_contract', 'Unsupported assignment schema');
+    assertString(command.workerDefinitionId, 'Worker definition', 192);
+    if (!Number.isSafeInteger(command.workerDefinitionVersion) || command.workerDefinitionVersion < 1) {
+      throw new WorkerAuthorityError('invalid_contract', 'Worker definition version is invalid');
+    }
+    assertString(command.goal, 'Worker goal', MAX_GOAL_CHARS);
+    const inputHash = computeWorkerDigest({
+      schemaVersion: 1, workerDefinitionId: command.workerDefinitionId,
+      workerDefinitionVersion: command.workerDefinitionVersion,
+      parentJobId: command.parentJobId, parentAttemptId: command.parentAttemptId,
+      parentGeneration: command.parentGeneration, childContractId: command.childContractId,
+      childJobId: command.childJobId, repositorySnapshotId: command.repositorySnapshotId,
+      contextEnvelopeId: command.contextEnvelopeId, providerBindingId: command.providerBindingId,
+      capabilitySetId: command.capabilitySetId, goal: command.goal,
+      expectedResultSchemaId: command.expectedResultSchemaId,
+      expectedEvidenceSchemaId: command.expectedEvidenceSchemaId,
+    });
+    const idempotent = db.prepare('SELECT * FROM worker_assignments WHERE idempotency_key=?')
+      .get(command.idempotencyKey) as AssignmentRow | undefined;
+    if (idempotent) {
+      if (idempotent.input_hash !== inputHash) throw new WorkerAuthorityError('idempotency_conflict', 'Assignment idempotency key has different input');
+      return mapAssignment(idempotent);
+    }
+    if (getAssignment(command.assignmentId)) throw new WorkerAuthorityError('immutable_conflict', 'Assignment identity already exists');
+    const { runId } = parentFence(command);
+    const child = db.prepare('SELECT parent_task_id FROM tasks WHERE id=?').get(command.childJobId) as { parent_task_id: string | null } | undefined;
+    const contract = db.prepare('SELECT parent_job_id,worker_id FROM child_job_contracts WHERE child_job_id=?')
+      .get(command.childContractId) as { parent_job_id: string; worker_id: string } | undefined;
+    if (!child || child.parent_task_id !== command.parentJobId || command.childContractId !== command.childJobId
+      || !contract || contract.parent_job_id !== command.parentJobId || contract.worker_id !== command.workerDefinitionId) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Child Job contract does not belong to the parent assignment');
+    }
+    const binding = getBinding(command.providerBindingId);
+    const context = getContext(command.contextEnvelopeId);
+    if (!binding || !context || context.assignmentId !== command.assignmentId) {
+      throw new WorkerAuthorityError('reference_mismatch', 'Assignment references are incomplete or inconsistent');
+    }
+    if (command.repositorySnapshotId !== context.repositorySnapshotId) {
+      throw new WorkerAuthorityError('reference_mismatch', 'Assignment and context snapshot references differ');
+    }
+    if (command.capabilitySetId
+      && !db.prepare('SELECT 1 FROM job_capability_sets WHERE job_id=?').get(command.capabilitySetId)) {
+      throw new WorkerAuthorityError('reference_mismatch', 'Capability set does not exist');
+    }
+    let executionGraphNodeId: string | null = null;
+    if (graph.nodes(command.parentJobId).length > 0) {
+      const linked = graph.attachWorkerAssignment({
+        parentJobId: command.parentJobId, parentAttemptId: command.parentAttemptId,
+        parentGeneration: command.parentGeneration, parentFenceToken: command.parentFenceToken,
+        assignmentId: command.assignmentId, producer: command.producer,
+        idempotencyKey: `${command.idempotencyKey}:graph`, now: command.now,
+      });
+      if (!linked.applied && !linked.duplicate) throw new WorkerAuthorityError('graph_conflict', 'Assignment graph reference was rejected');
+      executionGraphNodeId = linked.nodeId ?? null;
+    }
+    const now = command.now ?? Date.now();
+    const parentFenceDigest = createHash('sha256').update(command.parentFenceToken).digest('hex');
+    db.prepare(
+      `INSERT INTO worker_assignments
+         (assignment_id,schema_version,idempotency_key,worker_definition_id,worker_definition_version,
+          parent_job_id,parent_attempt_id,parent_generation,parent_fence_digest,child_contract_id,child_job_id,
+          repository_snapshot_id,execution_graph_node_id,context_envelope_id,provider_binding_id,capability_set_id,
+          goal,expected_result_schema_id,expected_evidence_schema_id,input_hash,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      command.assignmentId, 1, command.idempotencyKey, command.workerDefinitionId,
+      command.workerDefinitionVersion, command.parentJobId, command.parentAttemptId,
+      command.parentGeneration, parentFenceDigest, command.childContractId, command.childJobId,
+      command.repositorySnapshotId, executionGraphNodeId, command.contextEnvelopeId,
+      command.providerBindingId, command.capabilitySetId, command.goal,
+      command.expectedResultSchemaId, command.expectedEvidenceSchemaId, inputHash, now,
+    );
+    append(command, runId, 'worker.assignment_created', {
+      assignmentId: command.assignmentId, childJobId: command.childJobId,
+      workerDefinitionId: command.workerDefinitionId, inputHash,
+    }, 'assignment-created');
+    return getAssignment(command.assignmentId)!;
+  }).immediate;
+
+  const bindRun = db.transaction((command: BindRunCommand): WorkerRunRecord => {
+    assertId(command.workerRunId, 'Worker run identity');
+    if (command.schemaVersion !== 1) throw new WorkerAuthorityError('invalid_contract', 'Unsupported WorkerRun schema');
+    const sameBinding = (existing: WorkerRunRecord): boolean => (
+      existing.assignmentId === command.assignmentId
+      && existing.childJobId === command.childJobId
+      && existing.childAttemptId === command.childAttemptId
+      && existing.childGeneration === command.childGeneration
+      && existing.providerBindingId === command.providerBindingId
+      && existing.contextEnvelopeId === command.contextEnvelopeId
+    );
+    const idempotent = db.prepare('SELECT * FROM worker_runs WHERE assignment_id=? AND idempotency_key=?')
+      .get(command.assignmentId, command.idempotencyKey) as RunRow | undefined;
+    if (idempotent) {
+      const existing = mapRun(idempotent);
+      if (!sameBinding(existing)) {
+        throw new WorkerAuthorityError('idempotency_conflict', 'WorkerRun idempotency key has different input');
+      }
+      return existing;
+    }
+    const existing = getRun(command.workerRunId);
+    if (existing) {
+      if (!sameBinding(existing)) {
+        throw new WorkerAuthorityError('immutable_conflict', 'WorkerRun identity already exists');
+      }
+      return existing;
+    }
+    const conflict = db.prepare('SELECT worker_run_id FROM worker_runs WHERE child_attempt_id=? AND child_generation=?')
+      .get(command.childAttemptId, command.childGeneration) as { worker_run_id: string } | undefined;
+    if (conflict) throw new WorkerAuthorityError('binding_conflict', 'Child Attempt generation is already bound');
+    const assignment = getAssignment(command.assignmentId);
+    if (!assignment || assignment.parentJobId !== command.parentJobId || assignment.parentAttemptId !== command.parentAttemptId
+      || assignment.parentGeneration !== command.parentGeneration || assignment.childJobId !== command.childJobId
+      || assignment.providerBindingId !== command.providerBindingId
+      || assignment.contextEnvelopeId !== command.contextEnvelopeId) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'WorkerRun does not match its assignment');
+    }
+    const { runId } = parentFence(command);
+    const childFence = deps.validateActiveFence({
+      jobId: command.childJobId, attemptId: command.childAttemptId,
+      generation: command.childGeneration, fenceToken: command.childFenceToken, now: command.now,
+    });
+    const childAttempt = db.prepare('SELECT task_id,generation FROM runs WHERE attempt_id=?')
+      .get(command.childAttemptId) as { task_id: string | null; generation: number } | undefined;
+    if (!childFence.valid || !childAttempt || childAttempt.task_id !== command.childJobId
+      || childAttempt.generation !== command.childGeneration) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Child Attempt authority does not match the WorkerRun');
+    }
+    let executionGraphNodeId: string | null = null;
+    if (assignment.executionGraphNodeId) {
+      const linked = graph.attachWorkerRun({
+        parentJobId: command.parentJobId, parentAttemptId: command.parentAttemptId,
+        parentGeneration: command.parentGeneration, parentFenceToken: command.parentFenceToken,
+        assignmentNodeId: assignment.executionGraphNodeId, workerRunId: command.workerRunId,
+        childJobId: command.childJobId, childAttemptId: command.childAttemptId,
+        childGeneration: command.childGeneration, producer: command.producer,
+        idempotencyKey: `${command.idempotencyKey}:graph`, now: command.now,
+      });
+      if (!linked.applied && !linked.duplicate) throw new WorkerAuthorityError('graph_conflict', 'WorkerRun graph reference was rejected');
+      executionGraphNodeId = linked.nodeId ?? null;
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO worker_runs
+         (worker_run_id,schema_version,idempotency_key,assignment_id,child_job_id,child_attempt_id,
+          child_generation,execution_graph_node_id,provider_binding_id,context_envelope_id,
+          accepted_result_id,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,NULL,?)`,
+    ).run(
+      command.workerRunId, 1, command.idempotencyKey, command.assignmentId,
+      command.childJobId, command.childAttemptId, command.childGeneration,
+      executionGraphNodeId, command.providerBindingId, command.contextEnvelopeId, now,
+    );
+    append(command, runId, 'worker.run_bound', {
+      assignmentId: command.assignmentId, workerRunId: command.workerRunId,
+      childJobId: command.childJobId, childAttemptId: command.childAttemptId,
+      childGeneration: command.childGeneration,
+    }, 'run-bound');
+    return getRun(command.workerRunId)!;
+  }).immediate;
+
+  const recordResult = db.transaction((command: RecordResultCommand): WorkerResultRecord => {
+    assertId(command.workerResultId, 'Worker result identity');
+    const run = getRun(command.workerRunId);
+    const assignment = getAssignment(command.assignmentId);
+    if (!run || !assignment) throw new WorkerAuthorityError('not_found', 'WorkerRun or Assignment was not found');
+
+    const decoded = resultPayload(command.payload);
+    const rawHash = computeWorkerDigest(command.payload);
+    const candidateHash = decoded.payload ? computeWorkerResultHash(decoded.payload) : rawHash;
+    const exact = db.prepare(
+      'SELECT * FROM worker_results WHERE worker_run_id=? AND idempotency_key=? AND result_hash=?',
+    ).get(command.workerRunId, command.idempotencyKey, candidateHash) as ResultRow | undefined;
+    if (exact) return mapResult(exact);
+    const conflicting = db.prepare(
+      'SELECT worker_result_id FROM worker_results WHERE worker_run_id=? AND idempotency_key=? LIMIT 1',
+    ).get(command.workerRunId, command.idempotencyKey) as { worker_result_id: string } | undefined;
+    if (getResult(command.workerResultId)) throw new WorkerAuthorityError('immutable_conflict', 'Worker result identity already exists');
+
+    let rejectionCode: WorkerResultRejectionCode | null = null;
+    let rejectionReason: string | null = null;
+    const reject = (code: WorkerResultRejectionCode, reason: string): void => {
+      if (rejectionCode === null) { rejectionCode = code; rejectionReason = reason; }
+    };
+
+    if (conflicting) reject('idempotency_conflict', 'Result idempotency key was reused with different content');
+    if (decoded.tooLarge) reject('payload_too_large', 'Worker result exceeds the accepted size limit');
+    if (!decoded.payload) reject('malformed_payload', 'Worker result payload does not match schema version 1');
+    if (run.assignmentId !== command.assignmentId || run.childJobId !== command.childJobId
+      || run.childAttemptId !== command.childAttemptId) {
+      reject('linkage_mismatch', 'Worker result linkage does not match the WorkerRun');
+    }
+    if (run.childGeneration !== command.childGeneration) {
+      reject('stale_generation', 'Worker result generation is stale');
+    }
+    if (decoded.payload) {
+      if (decoded.payload.inputHash !== assignment.inputHash) {
+        reject('input_hash_mismatch', 'Worker result input hash does not match the Assignment');
+      }
+      if (candidateHash !== decoded.payload.resultHash) {
+        reject('result_hash_mismatch', 'Worker result hash does not match its payload');
+      }
+      for (const evidenceId of decoded.payload.evidenceIds) {
+        if (!ID.test(evidenceId) || !db.prepare(
+          'SELECT 1 FROM job_evidence WHERE evidence_id=? AND job_id=? AND attempt_id=? AND generation=?',
+        ).get(evidenceId, command.childJobId, command.childAttemptId, command.childGeneration)) {
+          reject('evidence_reference_invalid', 'Worker result Evidence reference is not authorized');
+          break;
+        }
+      }
+    }
+    const parentActive = deps.validateActiveFence({
+      jobId: command.parentJobId, attemptId: command.parentAttemptId,
+      generation: command.parentGeneration, fenceToken: command.parentFenceToken, now: command.now,
+    });
+    const childActive = deps.validateActiveFence({
+      jobId: command.childJobId, attemptId: command.childAttemptId,
+      generation: command.childGeneration, fenceToken: command.childFenceToken, now: command.now,
+    });
+    if (!parentActive.valid || !childActive.valid) reject('authority_lost', 'Worker result authority is no longer active');
+    const finalAccepted = db.prepare(
+      `SELECT worker_result_id FROM worker_results
+        WHERE worker_run_id=? AND acceptance_state='accepted' AND status<>'partial' LIMIT 1`,
+    ).get(command.workerRunId) as { worker_result_id: string } | undefined;
+    if (decoded.payload && FINAL_RESULT_STATUS.has(decoded.payload.status) && finalAccepted) {
+      reject('final_result_conflict', 'WorkerRun already has an accepted final result');
+    }
+
+    const now = command.now ?? Date.now();
+    const accepted = rejectionCode === null;
+    const status: WorkerResultStatus | 'invalid' = decoded.payload?.status ?? 'invalid';
+    const summary = decoded.payload?.summary ?? '';
+    db.prepare(
+      `INSERT INTO worker_results
+         (worker_result_id,schema_version,worker_run_id,assignment_id,child_job_id,child_attempt_id,
+          child_generation,idempotency_key,status,summary,structured_payload_json,evidence_ids_json,
+          provider_attempt_ids_json,input_hash,result_hash,acceptance_state,rejection_code,rejection_reason,
+          created_at,accepted_at,rejected_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      command.workerResultId, 1, command.workerRunId, command.assignmentId,
+      command.childJobId, command.childAttemptId, command.childGeneration,
+      command.idempotencyKey, status, summary, decoded.serialized,
+      JSON.stringify(decoded.payload?.evidenceIds ?? []),
+      JSON.stringify(decoded.payload?.providerAttemptIds ?? []),
+      decoded.payload?.inputHash ?? '', candidateHash, accepted ? 'accepted' : 'rejected',
+      rejectionCode, rejectionReason, now, accepted ? now : null, accepted ? null : now,
+    );
+    const fallbackRun = db.prepare('SELECT id FROM runs WHERE attempt_id=?')
+      .get(command.parentAttemptId) as { id: number } | undefined;
+    const parentRunId = parentActive.runId ?? fallbackRun?.id;
+    if (parentRunId !== undefined) {
+      append(command, parentRunId, 'worker.result_received', {
+        workerResultId: command.workerResultId, workerRunId: command.workerRunId,
+        assignmentId: command.assignmentId, status,
+      }, `result-received:${command.workerResultId}`);
+      append(command, parentRunId, accepted ? 'worker.result_accepted' : 'worker.result_rejected', {
+        workerResultId: command.workerResultId, workerRunId: command.workerRunId,
+        rejectionCode, status,
+      }, `result-${accepted ? 'accepted' : 'rejected'}:${command.workerResultId}`);
+    }
+    if (accepted && decoded.payload && FINAL_RESULT_STATUS.has(decoded.payload.status)) {
+      db.prepare('UPDATE worker_runs SET accepted_result_id=? WHERE worker_run_id=? AND accepted_result_id IS NULL')
+        .run(command.workerResultId, command.workerRunId);
+    }
+    if (accepted && run.executionGraphNodeId) {
+      const linked = graph.attachWorkerResultReference({
+        parentJobId: command.parentJobId, parentAttemptId: command.parentAttemptId,
+        parentGeneration: command.parentGeneration, parentFenceToken: command.parentFenceToken,
+        workerRunNodeId: run.executionGraphNodeId, workerResultId: command.workerResultId,
+        producer: command.producer, idempotencyKey: `${command.idempotencyKey}:graph-result`, now,
+      });
+      if (!linked.applied && !linked.duplicate) {
+        throw new WorkerAuthorityError('graph_conflict', 'Worker result graph reference was rejected');
+      }
+    }
+    return getResult(command.workerResultId)!;
+  }).immediate;
+
+  const listEvents = (parentJobId: string): WorkerEventRecord[] => (
+    db.prepare(
+      `SELECT job_sequence,kind,payload,ts FROM run_events
+        WHERE job_id=? AND kind LIKE 'worker.%' ORDER BY job_sequence`,
+    ).all(parentJobId) as Array<{ job_sequence: number; kind: WorkerEventKind; payload: string; ts: number }>
+  ).map((row) => ({
+    sequence: row.job_sequence, kind: row.kind,
+    payload: JSON.parse(row.payload) as Record<string, unknown>, createdAt: row.ts,
+  }));
+
+  return {
+    createWorkerProviderBinding: createBinding,
+    createWorkerContextEnvelope: createContext,
+    createWorkerAssignment: createAssignment,
+    bindWorkerRun: bindRun,
+    recordWorkerResult: recordResult,
+    getWorkerAssignment: getAssignment,
+    getWorkerRun: getRun,
+    getWorkerProviderBinding: getBinding,
+    getWorkerContextEnvelope: getContext,
+    getWorkerResult: getResult,
+    listWorkerRunsForParent(parentJobId) {
+      return (db.prepare(
+        `SELECT r.* FROM worker_runs r JOIN worker_assignments a ON a.assignment_id=r.assignment_id
+          WHERE a.parent_job_id=? ORDER BY r.created_at,r.worker_run_id`,
+      ).all(parentJobId) as RunRow[]).map(mapRun);
+    },
+    listWorkerRunsForChild(childJobId) {
+      return (db.prepare(
+        'SELECT * FROM worker_runs WHERE child_job_id=? ORDER BY created_at,worker_run_id',
+      ).all(childJobId) as RunRow[]).map(mapRun);
+    },
+    listWorkerEvents: listEvents,
+    rebuildWorkerProjection(parentJobId) {
+      const projection: WorkerProjection = {
+        assignmentIds: [], providerBindingIds: [], contextEnvelopeIds: [], workerRunIds: [],
+        receivedResultIds: [], acceptedResultIds: [], rejectedResultIds: [],
+      };
+      const add = (values: string[], value: unknown): void => {
+        if (typeof value === 'string' && !values.includes(value)) values.push(value);
+      };
+      for (const event of listEvents(parentJobId)) {
+        if (event.kind === 'worker.assignment_created') add(projection.assignmentIds, event.payload.assignmentId);
+        if (event.kind === 'worker.provider_binding_created') add(projection.providerBindingIds, event.payload.providerBindingId);
+        if (event.kind === 'worker.context_finalized') add(projection.contextEnvelopeIds, event.payload.contextEnvelopeId);
+        if (event.kind === 'worker.run_bound') add(projection.workerRunIds, event.payload.workerRunId);
+        if (event.kind === 'worker.result_received') add(projection.receivedResultIds, event.payload.workerResultId);
+        if (event.kind === 'worker.result_accepted') add(projection.acceptedResultIds, event.payload.workerResultId);
+        if (event.kind === 'worker.result_rejected') add(projection.rejectedResultIds, event.payload.workerResultId);
+      }
+      return projection;
+    },
+  };
+}

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,13 +31,13 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(36);
+    expect(LATEST_SCHEMA_VERSION).toBe(37);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 36 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: 37 });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
       { name: 'repository_change_intents' }, { name: 'repository_change_records' },
     ]);
@@ -53,7 +53,7 @@ describe('repository snapshot migration v32', () => {
       ]);
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('repository_architecture_notes','execution_graph_node_references') ORDER BY name").all())
       .toEqual([{ name: 'execution_graph_node_references' }, { name: 'repository_architecture_notes' }]);
-    expect(runMigrations(db)).toEqual({ from: 36, to: 36 });
+    expect(runMigrations(db)).toEqual({ from: 37, to: 37 });
   });
 
   it('adds validation records to a v33 database without changing repository history', () => {
@@ -77,7 +77,7 @@ describe('repository snapshot migration v32', () => {
       (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence)
       VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
 
-    expect(runMigrations(db)).toEqual({ from: 33, to: 36 });
+    expect(runMigrations(db)).toEqual({ from: 33, to: 37 });
     expect(db.prepare('SELECT id,status FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued' });
     expect(db.prepare('SELECT attempt_id,status FROM runs WHERE attempt_id=?').get('attempt'))
       .toEqual({ attempt_id: 'attempt', status: 'queued' });

--- a/tests/v4/worker/fixture.ts
+++ b/tests/v4/worker/fixture.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import {
+  computeWorkerResultHash,
+  type WorkerResultPayloadV1,
+} from '../../../core/v4/worker/types';
+
+export interface WorkerFixture {
+  db: Database.Database;
+  engine: JobEngine;
+  parent: ReturnType<JobEngine['submitJob']>;
+  child: ReturnType<JobEngine['submitJob']>;
+  parentAuthority: { parentJobId: string; parentAttemptId: string; parentGeneration: number; parentFenceToken: string };
+  childAuthority: { childJobId: string; childAttemptId: string; childGeneration: number; childFenceToken: string };
+}
+
+export function createWorkerFixture(): WorkerFixture {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  db.prepare(
+    `INSERT INTO daemon_instances
+       (instance_id, pid, hostname, started_at, last_heartbeat, version)
+     VALUES ('worker-instance', 1, 'localhost', 1, 1, '4.18.0')`,
+  ).run();
+  const engine = createJobEngine({ db });
+  const parent = engine.submitJob({
+    entryPoint: 'test', source: 'test', sessionId: 'worker-session', instanceId: 'worker-instance',
+    idempotencyNamespace: 'worker-parent', idempotencyKey: 'parent', goal: 'coordinate worker',
+  });
+  const parentLease = engine.claimAttempt({ attemptId: parent.attemptId, ownerId: 'parent-owner', ttlMs: 60_000, now: 10 });
+  const child = engine.submitJob({
+    entryPoint: 'worker', source: 'worker', sessionId: 'worker-session', instanceId: 'worker-instance',
+    idempotencyNamespace: 'worker-child', idempotencyKey: 'child', goal: 'inspect repository',
+    parentJobId: parent.jobId,
+    childContract: {
+      required: true,
+      workerId: 'repository-reader',
+      capabilities: ['repository_snapshot_read'],
+      allowedResources: { repository: 'snapshot' },
+      budget: { modelCalls: 1 },
+    },
+  });
+  const childLease = engine.claimAttempt({ attemptId: child.attemptId, ownerId: 'child-owner', ttlMs: 60_000, now: 10 });
+  engine.graph.create({
+    jobId: parent.jobId,
+    planDigest: 'worker-plan',
+    nodes: [{ nodeId: 'parent-attempt', kind: 'planning' }],
+    producer: 'test',
+    idempotencyKey: 'worker-graph',
+    now: 10,
+  });
+  return {
+    db,
+    engine,
+    parent,
+    child,
+    parentAuthority: {
+      parentJobId: parent.jobId,
+      parentAttemptId: parent.attemptId,
+      parentGeneration: parentLease.generation!,
+      parentFenceToken: parentLease.fenceToken!,
+    },
+    childAuthority: {
+      childJobId: child.jobId,
+      childAttemptId: child.attemptId,
+      childGeneration: childLease.generation!,
+      childFenceToken: childLease.fenceToken!,
+    },
+  };
+}
+
+export function createAssignment(fixture: WorkerFixture, suffix = 'one') {
+  const { engine, parentAuthority, childAuthority } = fixture;
+  const assignmentId = `worker_assignment_${suffix}`;
+  const providerBinding = engine.worker.createWorkerProviderBinding({
+    ...parentAuthority,
+    providerBindingId: `worker_provider_${suffix}`,
+    schemaVersion: 1,
+    providerId: 'custom_openai',
+    modelId: 'custom-default',
+    providerRuntimeIdentity: 'runtime:custom_openai',
+    credentialReference: 'credential:custom_openai',
+    endpointReference: 'endpoint:configured',
+    capabilitySnapshotHash: 'a'.repeat(64),
+    selectionReason: 'configured provider',
+    fallbackPolicyId: null,
+    contextWindow: 32_768,
+    maxOutputTokens: 4_096,
+    producer: 'test',
+    idempotencyKey: `provider-${suffix}`,
+    now: 20,
+  });
+  const contextEnvelope = engine.worker.createWorkerContextEnvelope({
+    ...parentAuthority,
+    contextEnvelopeId: `worker_context_${suffix}`,
+    schemaVersion: 1,
+    assignmentId,
+    repositorySnapshotId: null,
+    planStepIds: ['parent-attempt'],
+    claimIds: [],
+    sourceReferenceIds: [],
+    instructionReferenceIds: [],
+    boundedParentNote: 'Inspect only the supplied immutable references.',
+    toolSchemaDigest: 'b'.repeat(64),
+    tokenEstimate: 64,
+    producer: 'test',
+    idempotencyKey: `context-${suffix}`,
+    now: 21,
+  });
+  const assignment = engine.worker.createWorkerAssignment({
+    ...parentAuthority,
+    assignmentId,
+    schemaVersion: 1,
+    workerDefinitionId: 'repository-reader',
+    workerDefinitionVersion: 1,
+    childContractId: childAuthority.childJobId,
+    childJobId: childAuthority.childJobId,
+    repositorySnapshotId: null,
+    contextEnvelopeId: contextEnvelope.contextEnvelopeId,
+    providerBindingId: providerBinding.providerBindingId,
+    capabilitySetId: null,
+    goal: 'Inspect the repository snapshot.',
+    expectedResultSchemaId: 'worker-result-v1',
+    expectedEvidenceSchemaId: null,
+    producer: 'test',
+    idempotencyKey: `assignment-${suffix}`,
+    now: 22,
+  });
+  return { assignment, providerBinding, contextEnvelope };
+}
+
+export function bindRun(fixture: WorkerFixture, suffix = 'one') {
+  const records = createAssignment(fixture, suffix);
+  const run = fixture.engine.worker.bindWorkerRun({
+    ...fixture.parentAuthority,
+    ...fixture.childAuthority,
+    workerRunId: `worker_run_${suffix}`,
+    schemaVersion: 1,
+    assignmentId: records.assignment.assignmentId,
+    providerBindingId: records.providerBinding.providerBindingId,
+    contextEnvelopeId: records.contextEnvelope.contextEnvelopeId,
+    producer: 'test',
+    idempotencyKey: `run-${suffix}`,
+    now: 23,
+  });
+  return { ...records, run };
+}
+
+export function resultPayload(inputHash: string, overrides: Partial<WorkerResultPayloadV1> = {}): WorkerResultPayloadV1 {
+  const base: WorkerResultPayloadV1 = {
+    schemaVersion: 1,
+    status: 'completed',
+    summary: 'Repository inspection completed.',
+    findings: [],
+    sourceReferences: [],
+    filesInspected: [],
+    commandsExecuted: [],
+    diagnostics: [],
+    evidenceIds: [],
+    unresolvedQuestions: [],
+    uncertainty: { level: 'low', reasons: [] },
+    providerAttemptIds: [],
+    budgetUsage: [],
+    timing: { startedAt: 24, completedAt: 25, wallClockMs: 1 },
+    failure: null,
+    inputHash,
+    resultHash: '',
+  };
+  const payload = { ...base, ...overrides };
+  payload.resultHash = computeWorkerResultHash(payload);
+  return payload;
+}
+
+export function recordResult(fixture: WorkerFixture, suffix = 'one') {
+  const records = bindRun(fixture, suffix);
+  const payload = resultPayload(records.assignment.inputHash);
+  const result = fixture.engine.worker.recordWorkerResult({
+    ...fixture.parentAuthority,
+    ...fixture.childAuthority,
+    workerResultId: `worker_result_${suffix}`,
+    workerRunId: records.run.workerRunId,
+    assignmentId: records.assignment.assignmentId,
+    payload,
+    producer: 'test',
+    idempotencyKey: `result-${suffix}`,
+    now: 26,
+  });
+  return { ...records, payload, result };
+}

--- a/tests/v4/worker/workerAuthority.test.ts
+++ b/tests/v4/worker/workerAuthority.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { computeWorkerResultHash } from '../../../core/v4/worker/types';
+import {
+  bindRun,
+  createAssignment,
+  createWorkerFixture,
+  recordResult,
+  resultPayload,
+  type WorkerFixture,
+} from './fixture';
+
+describe('WorkerAuthority', () => {
+  let fixture: WorkerFixture | undefined;
+  const make = () => (fixture = createWorkerFixture());
+  afterEach(() => fixture?.db.close());
+
+  it('creates one immutable assignment for an active parent Attempt', () => {
+    const current = make();
+    const { assignment } = createAssignment(current);
+    expect(current.engine.worker.getWorkerAssignment(assignment.assignmentId)).toEqual(assignment);
+    expect(assignment).toMatchObject({
+      parentJobId: current.parent.jobId,
+      parentAttemptId: current.parent.attemptId,
+      childJobId: current.child.jobId,
+      workerDefinitionId: 'repository-reader',
+    });
+    expect(assignment.parentFenceDigest).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it('returns the original assignment for an identical idempotent request', () => {
+    const current = make();
+    const first = createAssignment(current);
+    const second = current.engine.worker.createWorkerAssignment({
+      ...current.parentAuthority,
+      assignmentId: 'different-id-is-ignored-on-replay',
+      schemaVersion: 1,
+      workerDefinitionId: 'repository-reader', workerDefinitionVersion: 1,
+      childContractId: current.child.jobId, childJobId: current.child.jobId,
+      repositorySnapshotId: null,
+      contextEnvelopeId: first.contextEnvelope.contextEnvelopeId,
+      providerBindingId: first.providerBinding.providerBindingId,
+      capabilitySetId: null,
+      goal: 'Inspect the repository snapshot.',
+      expectedResultSchemaId: 'worker-result-v1', expectedEvidenceSchemaId: null,
+      producer: 'test', idempotencyKey: 'assignment-one', now: 30,
+    });
+    expect(second).toEqual(first.assignment);
+  });
+
+  it('rejects an idempotency key reused with different assignment input', () => {
+    const current = make();
+    const first = createAssignment(current);
+    expect(() => current.engine.worker.createWorkerAssignment({
+      ...current.parentAuthority,
+      assignmentId: 'worker_assignment_conflict', schemaVersion: 1,
+      workerDefinitionId: 'repository-reader', workerDefinitionVersion: 1,
+      childContractId: current.child.jobId, childJobId: current.child.jobId,
+      repositorySnapshotId: null,
+      contextEnvelopeId: first.contextEnvelope.contextEnvelopeId,
+      providerBindingId: first.providerBinding.providerBindingId,
+      capabilitySetId: null,
+      goal: 'Different goal', expectedResultSchemaId: 'worker-result-v1', expectedEvidenceSchemaId: null,
+      producer: 'test', idempotencyKey: 'assignment-one', now: 30,
+    })).toThrowError(expect.objectContaining({ code: 'idempotency_conflict' }));
+  });
+
+  it('rejects assignment creation under a stale parent generation', () => {
+    const current = make();
+    const { providerBinding, contextEnvelope } = createAssignment(current);
+    expect(() => current.engine.worker.createWorkerAssignment({
+      ...current.parentAuthority, parentGeneration: current.parentAuthority.parentGeneration + 1,
+      assignmentId: 'worker_assignment_stale', schemaVersion: 1,
+      workerDefinitionId: 'repository-reader', workerDefinitionVersion: 1,
+      childContractId: current.child.jobId, childJobId: current.child.jobId, repositorySnapshotId: null,
+      contextEnvelopeId: contextEnvelope.contextEnvelopeId, providerBindingId: providerBinding.providerBindingId,
+      capabilitySetId: null, goal: 'stale', expectedResultSchemaId: 'worker-result-v1', expectedEvidenceSchemaId: null,
+      producer: 'test', idempotencyKey: 'assignment-stale', now: 31,
+    })).toThrowError(expect.objectContaining({ code: 'stale_authority' }));
+  });
+
+  it('rejects assignment creation with the wrong parent fence', () => {
+    const current = make();
+    const { providerBinding, contextEnvelope } = createAssignment(current);
+    expect(() => current.engine.worker.createWorkerAssignment({
+      ...current.parentAuthority, parentFenceToken: 'wrong-fence',
+      assignmentId: 'worker_assignment_wrong_fence', schemaVersion: 1,
+      workerDefinitionId: 'repository-reader', workerDefinitionVersion: 1,
+      childContractId: current.child.jobId, childJobId: current.child.jobId, repositorySnapshotId: null,
+      contextEnvelopeId: contextEnvelope.contextEnvelopeId, providerBindingId: providerBinding.providerBindingId,
+      capabilitySetId: null, goal: 'wrong fence', expectedResultSchemaId: 'worker-result-v1', expectedEvidenceSchemaId: null,
+      producer: 'test', idempotencyKey: 'assignment-wrong-fence', now: 31,
+    })).toThrowError(expect.objectContaining({ code: 'stale_authority' }));
+  });
+
+  it('rejects an assignment that references an unrelated child contract', () => {
+    const current = make();
+    const unrelatedParent = current.engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'worker-session', instanceId: 'worker-instance',
+      idempotencyNamespace: 'unrelated-parent', idempotencyKey: 'job', goal: 'unrelated parent',
+    });
+    const unrelated = current.engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'worker-session', instanceId: 'worker-instance',
+      idempotencyNamespace: 'unrelated', idempotencyKey: 'job', goal: 'unrelated',
+      parentJobId: unrelatedParent.jobId,
+      childContract: { workerId: 'repository-reader', capabilities: [], allowedResources: {}, budget: {} },
+    });
+    const { providerBinding, contextEnvelope } = createAssignment(current);
+    expect(() => current.engine.worker.createWorkerAssignment({
+      ...current.parentAuthority,
+      assignmentId: 'worker_assignment_unrelated', schemaVersion: 1,
+      workerDefinitionId: 'repository-reader', workerDefinitionVersion: 1,
+      childContractId: unrelated.jobId, childJobId: unrelated.jobId, repositorySnapshotId: null,
+      contextEnvelopeId: contextEnvelope.contextEnvelopeId, providerBindingId: providerBinding.providerBindingId,
+      capabilitySetId: null, goal: 'unrelated', expectedResultSchemaId: 'worker-result-v1', expectedEvidenceSchemaId: null,
+      producer: 'test', idempotencyKey: 'assignment-unrelated', now: 31,
+    })).toThrowError(expect.objectContaining({ code: 'lineage_mismatch' }));
+  });
+
+  it.each(['apiKey', 'accessToken', 'refreshToken', 'cookie', 'authorization', 'environment'])(
+    'rejects provider binding secret field %s',
+    (field) => {
+      const current = make();
+      const command: Record<string, unknown> = {
+        ...current.parentAuthority,
+        providerBindingId: `provider_${field}`, schemaVersion: 1,
+        providerId: 'custom_openai', modelId: 'custom-default', providerRuntimeIdentity: 'runtime:custom',
+        credentialReference: 'credential:custom', endpointReference: 'endpoint:configured',
+        capabilitySnapshotHash: 'a'.repeat(64), selectionReason: 'configured', fallbackPolicyId: null,
+        contextWindow: 32_768, maxOutputTokens: 4_096, producer: 'test', idempotencyKey: `provider-${field}`,
+        [field]: 'secret-material',
+      };
+      expect(() => current.engine.worker.createWorkerProviderBinding(command as never))
+        .toThrowError(expect.objectContaining({ code: 'sensitive_input' }));
+    },
+  );
+
+  it('rejects a raw token supplied through a credential reference field', () => {
+    const current = make();
+    expect(() => current.engine.worker.createWorkerProviderBinding({
+      ...current.parentAuthority,
+      providerBindingId: 'provider_raw_token', schemaVersion: 1,
+      providerId: 'custom_openai', modelId: 'custom-default', providerRuntimeIdentity: 'runtime:custom',
+      credentialReference: `gsk_${'a'.repeat(32)}`, endpointReference: 'endpoint:configured',
+      capabilitySnapshotHash: 'a'.repeat(64), selectionReason: 'configured', fallbackPolicyId: null,
+      contextWindow: 32_768, maxOutputTokens: 4_096, producer: 'test', idempotencyKey: 'provider-raw-token',
+    })).toThrowError(expect.objectContaining({ code: 'sensitive_input' }));
+  });
+
+  it('replays provider and context creation idempotently without duplicate events', () => {
+    const current = make();
+    const first = createAssignment(current);
+    const second = createAssignment(current);
+    expect(second.providerBinding).toEqual(first.providerBinding);
+    expect(second.contextEnvelope).toEqual(first.contextEnvelope);
+    expect(current.engine.worker.listWorkerEvents(current.parent.jobId).map((event) => event.kind)).toEqual([
+      'worker.provider_binding_created', 'worker.context_finalized', 'worker.assignment_created',
+    ]);
+  });
+
+  it.each(['env', 'environment', 'conversationHistory', 'messages', 'fenceToken'])(
+    'rejects context envelope ambient field %s',
+    (field) => {
+      const current = make();
+      const command: Record<string, unknown> = {
+        ...current.parentAuthority,
+        contextEnvelopeId: `context_${field}`, schemaVersion: 1, assignmentId: `assignment_${field}`,
+        repositorySnapshotId: null, planStepIds: [], claimIds: [], sourceReferenceIds: [],
+        instructionReferenceIds: [], boundedParentNote: null, toolSchemaDigest: 'b'.repeat(64),
+        tokenEstimate: 0, producer: 'test', idempotencyKey: `context-${field}`,
+        [field]: field === 'fenceToken' ? 'raw-fence' : { HOME: 'private' },
+      };
+      expect(() => current.engine.worker.createWorkerContextEnvelope(command as never))
+        .toThrowError(expect.objectContaining({ code: 'sensitive_input' }));
+    },
+  );
+
+  it('persists only bounded context references and digests', () => {
+    const current = make();
+    const { contextEnvelope } = createAssignment(current);
+    expect(contextEnvelope).toMatchObject({
+      planStepIds: ['parent-attempt'], claimIds: [], sourceReferenceIds: [], instructionReferenceIds: [],
+      boundedParentNote: 'Inspect only the supplied immutable references.', tokenEstimate: 64,
+    });
+    expect(contextEnvelope.contentDigest).toMatch(/^[a-f0-9]{64}$/u);
+    const raw = JSON.stringify(contextEnvelope);
+    expect(raw).not.toMatch(/fenceToken|conversationHistory|process\.env|apiKey|accessToken/u);
+  });
+
+  it('binds one WorkerRun to one exact child Attempt generation', () => {
+    const current = make();
+    const { run } = bindRun(current);
+    expect(run).toMatchObject({
+      childJobId: current.child.jobId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+    });
+    expect(current.engine.worker.getWorkerRun(run.workerRunId)).toEqual(run);
+  });
+
+  it('replays an identical WorkerRun binding idempotently', () => {
+    const current = make();
+    const first = bindRun(current);
+    const second = current.engine.worker.bindWorkerRun({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerRunId: 'different-run-id-is-ignored-on-replay', schemaVersion: 1,
+      assignmentId: first.assignment.assignmentId,
+      providerBindingId: first.providerBinding.providerBindingId,
+      contextEnvelopeId: first.contextEnvelope.contextEnvelopeId,
+      producer: 'test', idempotencyKey: 'run-one', now: 24,
+    });
+    expect(second).toEqual(first.run);
+    expect(current.engine.worker.listWorkerRunsForChild(current.child.jobId)).toEqual([first.run]);
+  });
+
+  it('rejects a WorkerRun bound to an Attempt from another child Job', () => {
+    const current = make();
+    const records = createAssignment(current);
+    const other = current.engine.submitJob({
+      entryPoint: 'worker', source: 'worker', sessionId: 'worker-session', instanceId: 'worker-instance',
+      idempotencyNamespace: 'other-child', idempotencyKey: 'other', goal: 'other', parentJobId: current.parent.jobId,
+      childContract: { workerId: 'repository-reader', capabilities: [], allowedResources: {}, budget: {} },
+    });
+    const lease = current.engine.claimAttempt({ attemptId: other.attemptId, ownerId: 'other', ttlMs: 60_000, now: 10 });
+    expect(() => current.engine.worker.bindWorkerRun({
+      ...current.parentAuthority,
+      childJobId: current.child.jobId, childAttemptId: other.attemptId,
+      childGeneration: lease.generation!, childFenceToken: lease.fenceToken!,
+      workerRunId: 'worker_run_wrong_job', schemaVersion: 1, assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      contextEnvelopeId: records.contextEnvelope.contextEnvelopeId,
+      producer: 'test', idempotencyKey: 'run-wrong-job', now: 23,
+    })).toThrowError(expect.objectContaining({ code: 'lineage_mismatch' }));
+  });
+
+  it('rejects a conflicting second run binding for one child Attempt generation', () => {
+    const current = make();
+    bindRun(current);
+    const records = createAssignment(current, 'two');
+    expect(() => current.engine.worker.bindWorkerRun({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerRunId: 'worker_run_two', schemaVersion: 1, assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      contextEnvelopeId: records.contextEnvelope.contextEnvelopeId,
+      producer: 'test', idempotencyKey: 'run-two', now: 23,
+    })).toThrowError(expect.objectContaining({ code: 'binding_conflict' }));
+  });
+
+  it('accepts a WorkerResult with the exact run, generation, and input hash', () => {
+    const current = make();
+    const { result } = recordResult(current);
+    expect(result.acceptanceState).toBe('accepted');
+    expect(current.engine.worker.getWorkerRun('worker_run_one')?.acceptedResultId).toBe(result.workerResultId);
+  });
+
+  it('returns the original result for an identical duplicate delivery', () => {
+    const current = make();
+    const first = recordResult(current);
+    const duplicate = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_duplicate-id', workerRunId: first.run.workerRunId,
+      assignmentId: first.assignment.assignmentId, payload: first.payload,
+      producer: 'test', idempotencyKey: 'result-one', now: 27,
+    });
+    expect(duplicate).toEqual(first.result);
+  });
+
+  it('retains a conflicting result hash under the same idempotency key as rejected', () => {
+    const current = make();
+    const first = recordResult(current);
+    const payload = resultPayload(first.assignment.inputHash, { summary: 'conflicting result' });
+    const conflict = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_conflict', workerRunId: first.run.workerRunId,
+      assignmentId: first.assignment.assignmentId, payload,
+      producer: 'test', idempotencyKey: 'result-one', now: 27,
+    });
+    expect(conflict).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'idempotency_conflict' });
+    expect(current.engine.worker.getWorkerRun(first.run.workerRunId)?.acceptedResultId).toBe(first.result.workerResultId);
+  });
+
+  it('does not treat different forged payloads with the same declared hash as identical', () => {
+    const current = make();
+    const records = bindRun(current);
+    const firstPayload = resultPayload(records.assignment.inputHash, { summary: 'first forged result' });
+    firstPayload.resultHash = 'c'.repeat(64);
+    const first = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_forged_first', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload: firstPayload,
+      producer: 'test', idempotencyKey: 'result-forged', now: 25,
+    });
+    const secondPayload = resultPayload(records.assignment.inputHash, { summary: 'second forged result' });
+    secondPayload.resultHash = 'c'.repeat(64);
+    const second = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_forged_second', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload: secondPayload,
+      producer: 'test', idempotencyKey: 'result-forged', now: 26,
+    });
+    expect(first).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'result_hash_mismatch' });
+    expect(second).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'idempotency_conflict' });
+    expect(second.workerResultId).not.toBe(first.workerResultId);
+  });
+
+  it('retains a stale child-generation result as rejected', () => {
+    const current = make();
+    const records = bindRun(current);
+    const payload = resultPayload(records.assignment.inputHash);
+    const stale = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      childGeneration: current.childAuthority.childGeneration + 1,
+      workerResultId: 'worker_result_stale', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload,
+      producer: 'test', idempotencyKey: 'result-stale', now: 27,
+    });
+    expect(stale).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'stale_generation' });
+    expect(current.engine.worker.getWorkerRun(records.run.workerRunId)?.acceptedResultId).toBeNull();
+  });
+
+  it('rejects a result after parent cancellation without altering Claims or parent truth', () => {
+    const current = make();
+    const records = bindRun(current);
+    const claim = current.engine.proof.createClaim({
+      jobId: current.parent.jobId, attemptId: current.parent.attemptId,
+      generation: current.parentAuthority.parentGeneration, category: 'contract', statement: 'Parent outcome', required: true,
+    });
+    current.engine.cancelJob({ jobId: current.parent.jobId, reason: 'stop', producer: 'test', eventIdempotencyKey: 'cancel-parent', now: 24 });
+    const rejected = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_cancelled', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload: resultPayload(records.assignment.inputHash),
+      producer: 'test', idempotencyKey: 'result-cancelled', now: 25,
+    });
+    expect(rejected).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'authority_lost' });
+    expect(current.engine.proof.listClaims(current.parent.jobId)).toContainEqual(expect.objectContaining({ claimId: claim.claimId, state: 'unverified' }));
+    expect(current.engine.getJob(current.parent.jobId)?.status).toBe('cancelled');
+  });
+
+  it('retains a result after child cancellation without changing parent truth', () => {
+    const current = make();
+    const records = bindRun(current);
+    current.engine.cancelJob({
+      jobId: current.child.jobId, reason: 'stop child', producer: 'test',
+      eventIdempotencyKey: 'cancel-child', now: 24,
+    });
+    const rejected = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_child_cancelled', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload: resultPayload(records.assignment.inputHash),
+      producer: 'test', idempotencyKey: 'result-child-cancelled', now: 25,
+    });
+    expect(rejected).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'authority_lost' });
+    expect(current.engine.getJob(current.child.jobId)?.status).toBe('cancelled');
+    expect(current.engine.getJob(current.parent.jobId)?.status).toBe('queued');
+  });
+
+  it('retains malformed WorkerResult payload as a typed rejection', () => {
+    const current = make();
+    const records = bindRun(current);
+    const rejected = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_malformed', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      payload: { status: 'completed', summary: ['not-a-string'] } as never,
+      producer: 'test', idempotencyKey: 'result-malformed', now: 25,
+    });
+    expect(rejected).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'malformed_payload' });
+    expect(rejected.rejectionReason).not.toContain('not-a-string');
+  });
+
+  it('rejects malformed nested result fields and sensitive extension fields', () => {
+    const current = make();
+    const records = bindRun(current);
+    const malformed = resultPayload(records.assignment.inputHash) as unknown as Record<string, unknown>;
+    malformed.findings = [1];
+    malformed.apiKey = 'not-persisted';
+    const rejected = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_nested_malformed', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload: malformed,
+      producer: 'test', idempotencyKey: 'result-nested-malformed', now: 25,
+    });
+    expect(rejected).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'malformed_payload' });
+    expect(JSON.stringify(rejected)).not.toContain('not-persisted');
+  });
+
+  it('rejects an incorrect declared result hash', () => {
+    const current = make();
+    const records = bindRun(current);
+    const payload = resultPayload(records.assignment.inputHash);
+    payload.resultHash = 'c'.repeat(64);
+    expect(computeWorkerResultHash(payload)).not.toBe(payload.resultHash);
+    const rejected = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_bad_hash', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload,
+      producer: 'test', idempotencyKey: 'result-bad-hash', now: 25,
+    });
+    expect(rejected).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'result_hash_mismatch' });
+  });
+
+  it('does not create or verify a Claim for completed output without Evidence', () => {
+    const current = make();
+    const claim = current.engine.proof.createClaim({
+      jobId: current.parent.jobId, attemptId: current.parent.attemptId,
+      generation: current.parentAuthority.parentGeneration, category: 'contract', statement: 'Requires proof', required: true,
+    });
+    const { result } = recordResult(current);
+    expect(result.acceptanceState).toBe('accepted');
+    expect(current.engine.proof.listClaims(current.parent.jobId)).toEqual([
+      expect.objectContaining({ claimId: claim.claimId, state: 'unverified' }),
+    ]);
+  });
+
+  it('does not create a parent Verdict or Proof when a WorkerResult is accepted', () => {
+    const current = make();
+    recordResult(current);
+    expect(current.engine.proof.getVerdict(current.parent.jobId)).toBeNull();
+    expect(current.engine.getJob(current.parent.jobId)?.status).toBe('queued');
+  });
+
+  it('replays ordered Worker events deterministically without sensitive payloads', () => {
+    const current = make();
+    recordResult(current);
+    const events = current.engine.worker.listWorkerEvents(current.parent.jobId);
+    expect(events.map((event) => event.kind)).toEqual([
+      'worker.provider_binding_created',
+      'worker.context_finalized',
+      'worker.assignment_created',
+      'worker.run_bound',
+      'worker.result_received',
+      'worker.result_accepted',
+    ]);
+    expect(current.engine.worker.rebuildWorkerProjection(current.parent.jobId)).toEqual({
+      assignmentIds: ['worker_assignment_one'],
+      providerBindingIds: ['worker_provider_one'],
+      contextEnvelopeIds: ['worker_context_one'],
+      workerRunIds: ['worker_run_one'],
+      receivedResultIds: ['worker_result_one'],
+      acceptedResultIds: ['worker_result_one'],
+      rejectedResultIds: [],
+    });
+    expect(JSON.stringify(events)).not.toMatch(/raw-fence|secret-material|authorization|credential:custom_openai/u);
+  });
+
+  it('bounds result payload size and diagnostic arrays', () => {
+    const current = make();
+    const records = bindRun(current);
+    const payload = resultPayload(records.assignment.inputHash, { summary: 'x'.repeat(70_000) });
+    const rejected = current.engine.worker.recordWorkerResult({
+      ...current.parentAuthority, ...current.childAuthority,
+      workerResultId: 'worker_result_oversize', workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId, payload,
+      producer: 'test', idempotencyKey: 'result-oversize', now: 25,
+    });
+    expect(rejected).toMatchObject({ acceptanceState: 'rejected', rejectionCode: 'payload_too_large' });
+  });
+});

--- a/tests/v4/worker/workerGraph.test.ts
+++ b/tests/v4/worker/workerGraph.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { bindRun, createWorkerFixture, recordResult, type WorkerFixture } from './fixture';
+
+describe('Worker execution-graph references', () => {
+  let fixture: WorkerFixture | undefined;
+  const make = () => (fixture = createWorkerFixture());
+  afterEach(() => fixture?.db.close());
+
+  it('places an assignment and run beneath the parent graph with an exact child Attempt reference', () => {
+    const current = make();
+    const { assignment, run } = bindRun(current);
+    expect(current.engine.graph.nodes(current.parent.jobId)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ nodeId: assignment.executionGraphNodeId, kind: 'worker_assignment' }),
+      expect.objectContaining({ nodeId: run.executionGraphNodeId, kind: 'worker_run', dependsOn: [assignment.executionGraphNodeId] }),
+    ]));
+    expect(current.engine.graph.workerReferences(current.parent.jobId)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ nodeId: run.executionGraphNodeId, kind: 'worker_run', id: run.workerRunId }),
+      expect.objectContaining({ nodeId: run.executionGraphNodeId, kind: 'child_attempt', id: current.child.attemptId, generation: current.childAuthority.childGeneration }),
+    ]));
+  });
+
+  it('adds an accepted result reference without completing the graph or parent Job', () => {
+    const current = make();
+    const { run, result } = recordResult(current);
+    expect(current.engine.graph.workerReferences(current.parent.jobId)).toContainEqual(expect.objectContaining({
+      nodeId: run.executionGraphNodeId, kind: 'worker_result', id: result.workerResultId,
+    }));
+    expect(current.engine.graph.nodes(current.parent.jobId).find((node) => node.nodeId === run.executionGraphNodeId)?.state)
+      .toBe('pending');
+    expect(current.engine.getJob(current.parent.jobId)?.status).toBe('queued');
+  });
+
+  it('rejects graph linkage from a stale parent fence', () => {
+    const current = make();
+    const records = bindRun(current);
+    expect(current.engine.graph.attachWorkerResultReference({
+      ...current.parentAuthority,
+      parentGeneration: current.parentAuthority.parentGeneration + 1,
+      workerRunNodeId: records.run.executionGraphNodeId!,
+      workerResultId: 'worker_result_stale_graph',
+      producer: 'test', idempotencyKey: 'stale-worker-graph', now: 30,
+    })).toMatchObject({ applied: false, conflict: 'stale_fence' });
+  });
+});

--- a/tests/v4/worker/workerMigration.test.ts
+++ b/tests/v4/worker/workerMigration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { LATEST_SCHEMA_VERSION, MIGRATIONS_FOR_TESTS, runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+
+describe('Worker persistence migration', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+  });
+  afterEach(() => db.close());
+
+  const tables = () => (db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{ name: string }>).map((row) => row.name);
+  const columns = (table: string) => (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name);
+
+  it('adds only the five v37 Worker contract tables', () => {
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= 36)) {
+      db.transaction(() => {
+        if (migration.apply) migration.apply(db);
+        else db.exec(migration.sql ?? '');
+        db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)').run(migration.version, 1);
+      })();
+    }
+    const before = new Set(tables());
+    expect(runMigrations(db)).toEqual({ from: 36, to: 37 });
+    expect(LATEST_SCHEMA_VERSION).toBe(37);
+    expect(tables().filter((table) => !before.has(table))).toEqual([
+      'worker_assignments', 'worker_context_envelopes', 'worker_provider_bindings', 'worker_results', 'worker_runs',
+    ]);
+  });
+
+  it('keeps WorkerRun as a relation without lifecycle, lease, fence, cancellation, or budget authority', () => {
+    runMigrations(db);
+    const names = columns('worker_runs');
+    expect(names).toEqual(expect.arrayContaining([
+      'worker_run_id', 'assignment_id', 'child_job_id', 'child_attempt_id', 'child_generation',
+      'execution_graph_node_id', 'provider_binding_id', 'context_envelope_id', 'accepted_result_id', 'created_at',
+    ]));
+    expect(names).not.toEqual(expect.arrayContaining([
+      'status', 'lifecycle_state', 'lease_id', 'lease_owner', 'lease_expiry', 'fence_token',
+      'cancellation_state', 'budget_remaining', 'effect_state', 'approval_state',
+      'verification_state', 'verdict_state', 'proof_state',
+    ]));
+  });
+
+  it('creates no duplicate Worker authority tables', () => {
+    runMigrations(db);
+    const forbidden = [
+      'worker_leases', 'worker_budgets', 'worker_cancellations', 'worker_evidence', 'worker_verdicts',
+      'worker_proofs', 'worker_effects', 'worker_approvals', 'worker_queue', 'worker_scheduler',
+      'worker_process_supervisor', 'worker_graphs',
+    ];
+    expect(tables().filter((name) => forbidden.includes(name))).toEqual([]);
+  });
+
+  it('upgrades an existing v36 database and keeps Jobs without Worker rows readable', () => {
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= 36)) {
+      db.transaction(() => {
+        if (migration.apply) migration.apply(db);
+        else db.exec(migration.sql ?? '');
+        db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)').run(migration.version, 1);
+      })();
+    }
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('fixture',1,'localhost',1,1,'4.18.0')`,
+    ).run();
+    const before = createJobEngine({ db }).submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'fixture', instanceId: 'fixture',
+      idempotencyNamespace: 'fixture', idempotencyKey: 'job', goal: 'legacy job',
+    });
+
+    expect(runMigrations(db)).toEqual({ from: 36, to: 37 });
+    const engine = createJobEngine({ db });
+    expect(engine.getJob(before.jobId)?.goal).toBe('legacy job');
+    expect(engine.worker.listWorkerRunsForParent(before.jobId)).toEqual([]);
+  });
+
+  it('is idempotent when v37 is already installed', () => {
+    expect(runMigrations(db)).toEqual({ from: 0, to: 37 });
+    expect(runMigrations(db)).toEqual({ from: 37, to: 37 });
+  });
+});


### PR DESCRIPTION
## Summary

- adds immutable, versioned Worker assignment, provider-binding, context, run, and result contracts;
- persists Worker records through an additive schema v37 migration;
- binds WorkerRun identity to the existing child Job and Attempt authority;
- links assignments, runs, and accepted result references through the existing execution graph;
- accepts or rejects Worker results idempotently while retaining stale and malformed submissions;
- keeps Job lifecycle, fencing, cancellation, evidence, proof, effects, and finalization under their existing authorities.

## Scope

This pull request establishes contracts and persistence only. It does not add Worker dispatch, provider execution, queues, runtime orchestration, user interfaces, or Job finalization behavior.

## Validation

- Worker authority, graph, and migration matrix: 46 passed
- Lifecycle, graph, proof, database, and child-Job compatibility matrix: 249 passed, 6 skipped
- Deterministic Node 22 suite: 7,423 passed, 48 skipped
- Offline integration: 1 passed
- Typecheck passed
- Production build passed
- Package dry run passed
- Diff, NUL, secret, attribution, scope, and duplicate-authority scans passed