### PR TITLE
feat(worker): add durable read-only repository worker

### DIFF
--- a/cli/v4/daemonAgentBuilder.ts
+++ b/cli/v4/daemonAgentBuilder.ts
@@ -101,7 +101,7 @@ export function buildDaemonAgentBuilder(
   const log = deps.log ?? ((msg) => process.stderr.write(msg + '\n'));
   const maxTurns = deps.maxTurns ?? DEFAULT_MAX_TURNS;
 
-  return async (input) => {
+  const builder: AgentBuilder = async (input) => {
     const turnStartMs = Date.now();
 
     // Resolve a provider adapter for the chosen (provider, model)
@@ -209,4 +209,13 @@ export function buildDaemonAgentBuilder(
 
     return agent;
   };
+  builder.resolveReadOnlyWorkerProvider = async (binding) => ({
+    adapter: await deps.resolver.resolve({
+      providerId: binding.providerId,
+      modelId: binding.modelId,
+      paths: deps.paths,
+    }),
+    paths: deps.paths,
+  });
+  return builder;
 }

--- a/core/v4/daemon/dispatcher/agentRunner.ts
+++ b/core/v4/daemon/dispatcher/agentRunner.ts
@@ -40,7 +40,7 @@ import type { Message } from '../../../../providers/v4/types';
 import type { TriggerSource } from '../types';
 import type { RunStore } from '../runStore';
 import type { JobEngine } from '../jobEngine';
-import { executeDurableJob, type DurableJobFinalization } from '../jobLifecycle';
+import { executeDurableJob, type DurableJobDisposition } from '../jobLifecycle';
 // v4.10 Slice 10.2b — shared event taxonomy.
 import { categorizeEvent } from '../eventCategories';
 
@@ -83,6 +83,8 @@ export interface DaemonAgentInput {
     generation?: number;
     fenceToken?: string;
   };
+  /** Immutable Worker Assignment carried by the durable trigger payload. */
+  workerAssignmentId?: string;
   /**
    * v4.13 Gap 4 — set when this invocation RESUMES a dead run. The
    * runner reuses the existing task row (the job-card accumulates
@@ -106,7 +108,7 @@ export interface DaemonAgentResult {
   /** Populated when finishReason === 'error'. */
   error?:       string;
   /** Verification-derived settlement supplied to the durable lifecycle. */
-  finalization?: DurableJobFinalization;
+  finalization?: DurableJobDisposition;
 }
 
 /** The function-shaped agent invocation seam. */

--- a/core/v4/daemon/dispatcher/dispatcher.ts
+++ b/core/v4/daemon/dispatcher/dispatcher.ts
@@ -340,6 +340,9 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
       const durable = (event.payload as {
         durable_job?: { job_id?: unknown; attempt_id?: unknown; run_id?: unknown };
       } | null)?.durable_job;
+      const workerAssignmentId = typeof event.payload.worker_assignment_id === 'string'
+        ? event.payload.worker_assignment_id
+        : undefined;
       const existingAdmission = durable
         && typeof durable.job_id === 'string'
         && typeof durable.attempt_id === 'string'
@@ -365,6 +368,7 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
         initialMessage: message,
         deliverOnly,
         ...(admission ? { admission } : {}),
+        ...(workerAssignmentId ? { workerAssignmentId } : {}),
         ...(resume ? { resume } : {}),
       };
 

--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -102,6 +102,10 @@ import {
   consumePostTurn,
   createPerTurnBudgetWatcher,
 } from './budgetGate';
+import {
+  executeReadOnlyRepositoryWorker,
+  type ReadOnlyWorkerProviderResolver,
+} from '../../worker/readOnlyRepositoryWorker';
 
 // ── Public types ───────────────────────────────────────────────────────────
 
@@ -125,7 +129,7 @@ import {
  * pieces the REPL does, or skip them for speed. That choice lives
  * in `bootstrap.ts` / the CLI's `installDaemonAgentBuilder()` hook.
  */
-export type AgentBuilder = (input: {
+export type AgentBuilder = ((input: {
   sessionId:        string;
   resolvedModel:    ResolvedDaemonModel;
   approvalPolicy:   DaemonApprovalPolicy;
@@ -135,7 +139,9 @@ export type AgentBuilder = (input: {
     onBudgetWarning:   (level: 'caution' | 'warning', turn: number, max: number) => void;
   };
   abortSignal:      AbortSignal;
-}) => Promise<AidenAgent> | AidenAgent;
+}) => Promise<AidenAgent> | AidenAgent) & {
+  resolveReadOnlyWorkerProvider?: ReadOnlyWorkerProviderResolver;
+};
 
 export interface CreateRealAgentRunnerOptions {
   db:                Db;
@@ -694,6 +700,35 @@ async function invokeDurableDaemon(
       },
       execute: async (handle) => {
         activeHandle = handle;
+        const workerAssignment = opts.jobEngine.worker.getWorkerAssignmentForChild(handle.jobId);
+        if (workerAssignment) {
+          if (input.workerAssignmentId && input.workerAssignmentId !== workerAssignment.assignmentId) {
+            throw new Error('Durable Worker trigger does not match the child Job assignment');
+          }
+          const resolveProvider = opts.agentBuilder.resolveReadOnlyWorkerProvider;
+          if (!resolveProvider) throw new Error('Read-only repository Worker provider resolver is unavailable');
+          const worker = await executeReadOnlyRepositoryWorker({
+            engine: opts.jobEngine,
+            handle,
+            assignmentId: workerAssignment.assignmentId,
+            resolveProvider,
+          });
+          projectedResult = {
+            runId: handle.runId,
+            finishReason: worker.finalization.status === 'failed' ? 'error' : 'stop',
+            totalTokens: worker.totalTokens,
+            ...(worker.finalization.status === 'failed' ? { error: worker.workerResult.summary } : {}),
+            finalization: worker.finalization,
+          };
+          currentProviderAttemptLedger()?.reconcileJobLinkage({
+            taskId: handle.jobId,
+            runId: handle.runId,
+            jobId: handle.jobId,
+            attemptId: handle.attemptId,
+            attemptGeneration: handle.generation,
+          });
+          return projectedResult;
+        }
         const projectedRunStore: RunStore = {
           ...opts.runStore,
           create: () => handle.runId,

--- a/core/v4/daemon/jobProofAuthority.ts
+++ b/core/v4/daemon/jobProofAuthority.ts
@@ -217,7 +217,30 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       if (command.repositorySnapshotId) {
         const snapshot = db.prepare('SELECT job_id,attempt_id,generation FROM repository_snapshots WHERE snapshot_id=?')
           .get(command.repositorySnapshotId) as { job_id: string; attempt_id: string; generation: number } | undefined;
-        if (!snapshot || snapshot.job_id !== command.jobId || snapshot.attempt_id !== command.attemptId || snapshot.generation !== command.generation) {
+        const assignedParentSnapshot = snapshot && db.prepare(
+          `SELECT 1
+             FROM worker_assignments a
+             JOIN worker_runs r ON r.assignment_id=a.assignment_id
+             JOIN child_job_contracts c ON c.child_job_id=a.child_job_id
+            WHERE a.repository_snapshot_id=?
+              AND a.parent_job_id=? AND a.parent_attempt_id=? AND a.parent_generation=?
+              AND a.child_job_id=? AND r.child_attempt_id=? AND r.child_generation=?
+              AND c.parent_job_id=a.parent_job_id
+            LIMIT 1`,
+        ).get(
+          command.repositorySnapshotId,
+          snapshot.job_id,
+          snapshot.attempt_id,
+          snapshot.generation,
+          command.jobId,
+          command.attemptId,
+          command.generation,
+        );
+        const producingSnapshot = snapshot
+          && snapshot.job_id === command.jobId
+          && snapshot.attempt_id === command.attemptId
+          && snapshot.generation === command.generation;
+        if (!producingSnapshot && !assignedParentSnapshot) {
           throw new Error('Evidence repository snapshot does not match the producing Attempt');
         }
       }

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -255,6 +255,12 @@ export interface ToolHandler {
   mutates: boolean;
   /** Group label — `web`, `files`, `browser`, `sessions`, `skills`, etc. */
   toolset?: string;
+  /**
+   * Resolves a path argument into the durable capability namespace before the
+   * generic Job resource gate evaluates it. Snapshot-bound tools use this to
+   * bind repository-relative input to their assigned snapshot root.
+   */
+  resolveCapabilityPath?: (argument: string, value: string, context: ToolContext) => string;
   /** Runtime-only interaction metadata; never included in provider schemas. */
   interaction?: ToolInteraction;
   /**
@@ -668,15 +674,26 @@ export class ToolRegistry {
         }
         for (const key of ['path', 'from', 'to', 'source', 'destination']) {
           const value = args[key];
-          if (
-            typeof value === 'string' && value.length > 0
-            && !resourceAuthority.authorize({
+          if (typeof value === 'string' && value.length > 0) {
+            let capabilityPath: string;
+            try {
+              capabilityPath = handler.resolveCapabilityPath?.(key, value, context)
+                ?? resolvePath(context.cwd ?? process.cwd(), value);
+            } catch (error) {
+              return finish({
+                id: call.id,
+                name: call.name,
+                result: null,
+                error: error instanceof Error ? error.message : 'Path is not valid for this Job capability',
+              }, 'blocked');
+            }
+            if (!resourceAuthority.authorize({
               jobId: durableJobContext.jobId,
               kind: 'path',
-              value: resolvePath(context.cwd ?? process.cwd(), value),
-            })
-          ) {
-            return finish({ id: call.id, name: call.name, result: null, error: 'Path is outside this Job capability boundary' }, 'blocked');
+              value: capabilityPath,
+            })) {
+              return finish({ id: call.id, name: call.name, result: null, error: 'Path is outside this Job capability boundary' }, 'blocked');
+            }
           }
         }
         if (

--- a/core/v4/worker/readOnlyRepositoryWorker.ts
+++ b/core/v4/worker/readOnlyRepositoryWorker.ts
@@ -1,0 +1,1155 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { AidenAgent } from '../aidenAgent';
+import type { DurableJobDisposition, DurableJobHandle } from '../daemon/jobLifecycle';
+import type { JobEngine, AdmissionResult } from '../daemon/jobEngine';
+import { currentJobExecutionContext } from '../daemon/jobExecutionContext';
+import type { TriggerBus } from '../daemon/triggerBus';
+import type { AidenPaths } from '../paths';
+import { ToolRegistry, type ToolHandler } from '../toolRegistry';
+import {
+  currentProviderAttemptLedger,
+  runWithProviderUsageContext,
+} from '../../../providers/v4/providerAttemptAccounting';
+import type { ProviderAdapter, ToolCallRequest, ToolCallResult } from '../../../providers/v4/types';
+import {
+  computeWorkerDigest,
+  computeWorkerResultHash,
+  type WorkerAssignmentRecord,
+  type WorkerContextEnvelopeRecord,
+  type WorkerDefinitionV1,
+  type WorkerProviderBindingRecord,
+  type WorkerResultPayloadV1,
+  type WorkerResultRecord,
+  type WorkerResultSourceReference,
+  type WorkerRunRecord,
+} from './types';
+
+export const READ_ONLY_REPOSITORY_WORKER_TOOLS = Object.freeze([
+  'repository_snapshot_search',
+  'repository_snapshot_read',
+  'repository_instruction_read',
+] as const);
+
+export const READ_ONLY_REPOSITORY_WORKER: WorkerDefinitionV1 = Object.freeze({
+  schemaVersion: 1,
+  workerDefinitionId: 'repository-read-worker',
+  workerDefinitionVersion: 1,
+  expectedResultSchemaId: 'repository-read-worker-result-v1',
+  expectedEvidenceSchemaId: 'repository-read-worker-evidence-v1',
+  requiredCapabilities: READ_ONLY_REPOSITORY_WORKER_TOOLS,
+});
+
+export interface ReadOnlyWorkerParentAuthority {
+  jobId: string;
+  attemptId: string;
+  generation: number;
+  fenceToken: string;
+}
+
+export interface ReadOnlyWorkerProviderSelection {
+  providerId: string;
+  modelId: string;
+  providerRuntimeIdentity: string;
+  credentialReference: string | null;
+  endpointReference: string | null;
+  supportsToolCalling: boolean;
+  contextWindow: number;
+  maxOutputTokens: number;
+  selectionReason: string;
+}
+
+export interface AdmitReadOnlyRepositoryWorkerInput {
+  engine: JobEngine;
+  triggerBus: TriggerBus;
+  parent: ReadOnlyWorkerParentAuthority;
+  idempotencyKey: string;
+  goal: string;
+  repositorySnapshotId: string;
+  planStepIds?: readonly string[];
+  claimIds?: readonly string[];
+  sourceReferenceIds?: readonly string[];
+  instructionReferenceIds?: readonly string[];
+  boundedParentNote?: string | null;
+  provider: ReadOnlyWorkerProviderSelection;
+  producer?: string;
+  maxModelCalls?: number;
+  maxToolCalls?: number;
+  maxRuntimeMs?: number;
+}
+
+export interface ReadOnlyRepositoryWorkerAdmission {
+  child: AdmissionResult;
+  assignment: WorkerAssignmentRecord;
+  providerBinding: WorkerProviderBindingRecord;
+  contextEnvelope: WorkerContextEnvelopeRecord;
+  triggerEvent: { id: number; inserted: boolean };
+}
+
+export interface ReadOnlyRepositoryWorkerToolRegistryInput {
+  engine: JobEngine;
+  assignmentId: string;
+  workerRunId: string;
+}
+
+export interface ResolvedReadOnlyWorkerProvider {
+  adapter: ProviderAdapter;
+  paths: AidenPaths;
+}
+
+export type ReadOnlyWorkerProviderResolver = (
+  binding: WorkerProviderBindingRecord,
+) => Promise<ResolvedReadOnlyWorkerProvider>;
+
+export interface ExecuteReadOnlyRepositoryWorkerInput {
+  engine: JobEngine;
+  handle: DurableJobHandle;
+  assignmentId: string;
+  resolveProvider: ReadOnlyWorkerProviderResolver;
+}
+
+export interface ReadOnlyRepositoryWorkerExecution {
+  workerRun: WorkerRunRecord;
+  workerResult: WorkerResultRecord;
+  finalization: DurableJobDisposition;
+  totalTokens: number;
+}
+
+export interface VerifyReadOnlyRepositoryWorkerResultInput {
+  engine: JobEngine;
+  parent: ReadOnlyWorkerParentAuthority;
+  workerResultId: string;
+  producer?: string;
+  idempotencyKey: string;
+}
+
+const TERMINAL_JOB = new Set(['cancelled', 'completed', 'failed', 'blocked', 'unknown', 'crashed', 'dead_letter']);
+
+function identity(prefix: string, value: unknown): string {
+  return `${prefix}_${computeWorkerDigest(value).slice(0, 32)}`;
+}
+
+function assertPositiveInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${label} must be a positive integer`);
+}
+
+export function admitReadOnlyRepositoryWorker(
+  input: AdmitReadOnlyRepositoryWorkerInput,
+): ReadOnlyRepositoryWorkerAdmission {
+  const producer = input.producer ?? 'repository-worker-admission';
+  const maxModelCalls = input.maxModelCalls ?? 4;
+  const maxToolCalls = input.maxToolCalls ?? 12;
+  const maxRuntimeMs = input.maxRuntimeMs ?? 120_000;
+  assertPositiveInteger(maxModelCalls, 'Worker model-call budget');
+  assertPositiveInteger(maxToolCalls, 'Worker tool-call budget');
+  assertPositiveInteger(maxRuntimeMs, 'Worker runtime budget');
+  if (!input.provider.supportsToolCalling) {
+    throw new Error('Read-only repository Worker requires a tool-capable provider model');
+  }
+  assertPositiveInteger(input.provider.contextWindow, 'Provider context window');
+  assertPositiveInteger(input.provider.maxOutputTokens, 'Provider output limit');
+  const estimatedInputTokens = Math.ceil((input.goal.length + (input.boundedParentNote?.length ?? 0)) / 4) + 512;
+  if (input.provider.maxOutputTokens >= input.provider.contextWindow
+    || estimatedInputTokens + input.provider.maxOutputTokens > input.provider.contextWindow) {
+    throw new Error('Read-only repository Worker context exceeds the pinned provider window');
+  }
+
+  const parent = input.engine.getJob(input.parent.jobId);
+  const parentAttempt = input.engine.getAttempt(input.parent.attemptId);
+  if (!parent || parent.activeAttemptId !== input.parent.attemptId
+    || parentAttempt?.generation !== input.parent.generation
+    || parentAttempt.fenceToken !== input.parent.fenceToken
+    || TERMINAL_JOB.has(parent.status)) {
+    throw new Error('Parent Attempt authority is no longer active');
+  }
+  const snapshot = input.engine.repository.getSnapshot(input.repositorySnapshotId);
+  if (!snapshot || snapshot.jobId !== input.parent.jobId
+    || snapshot.attemptId !== input.parent.attemptId
+    || snapshot.generation !== input.parent.generation) {
+    throw new Error('Assigned repository snapshot does not belong to the active parent Attempt');
+  }
+  const workspace = input.engine.repository.getWorkspace(snapshot.workspaceId);
+  if (!workspace) throw new Error('Assigned repository workspace is unavailable');
+  const repositoryRoot = snapshot.repositoryRoot ?? workspace.canonicalPath;
+
+  const requestIdentity = {
+    parentJobId: input.parent.jobId,
+    parentAttemptId: input.parent.attemptId,
+    parentGeneration: input.parent.generation,
+    idempotencyKey: input.idempotencyKey,
+  };
+  const assignmentId = identity('worker_assignment', requestIdentity);
+  const childKey = identity('worker_child', requestIdentity);
+  const existingAssignment = input.engine.worker.getWorkerAssignment(assignmentId);
+  const activeOther = input.engine.worker.listWorkerAssignmentsForParent(input.parent.jobId)
+    .find((candidate) => candidate.assignmentId !== assignmentId
+      && candidate.parentAttemptId === input.parent.attemptId
+      && candidate.parentGeneration === input.parent.generation
+      && !TERMINAL_JOB.has(input.engine.getJob(candidate.childJobId)?.status ?? 'unknown'));
+  if (activeOther) throw new Error('Only one active read-only repository Worker is permitted for a parent Attempt');
+
+  const providerBindingId = identity('worker_provider', requestIdentity);
+  const contextEnvelopeId = identity('worker_context', requestIdentity);
+  const capabilitySnapshotHash = computeWorkerDigest({
+    providerId: input.provider.providerId,
+    modelId: input.provider.modelId,
+    supportsToolCalling: true,
+    tools: READ_ONLY_REPOSITORY_WORKER_TOOLS,
+    contextWindow: input.provider.contextWindow,
+    maxOutputTokens: input.provider.maxOutputTokens,
+  });
+  const toolSchemaDigest = computeWorkerDigest({
+    workerDefinitionId: READ_ONLY_REPOSITORY_WORKER.workerDefinitionId,
+    workerDefinitionVersion: READ_ONLY_REPOSITORY_WORKER.workerDefinitionVersion,
+    tools: READ_ONLY_REPOSITORY_WORKER_TOOLS,
+  });
+
+  const authority = {
+    parentJobId: input.parent.jobId,
+    parentAttemptId: input.parent.attemptId,
+    parentGeneration: input.parent.generation,
+    parentFenceToken: input.parent.fenceToken,
+    producer,
+  };
+  input.engine.appendJobEvent({
+    jobId: input.parent.jobId,
+    attemptId: input.parent.attemptId,
+    generation: input.parent.generation,
+    type: 'worker.admission_started',
+    payload: { assignmentId, repositorySnapshotId: input.repositorySnapshotId },
+    producer,
+    idempotencyKey: `worker-admission-started:${assignmentId}`,
+  });
+  const providerBinding = input.engine.worker.createWorkerProviderBinding({
+    ...authority,
+    providerBindingId,
+    schemaVersion: 1,
+    providerId: input.provider.providerId,
+    modelId: input.provider.modelId,
+    providerRuntimeIdentity: input.provider.providerRuntimeIdentity,
+    credentialReference: input.provider.credentialReference,
+    endpointReference: input.provider.endpointReference,
+    capabilitySnapshotHash,
+    selectionReason: input.provider.selectionReason,
+    fallbackPolicyId: null,
+    contextWindow: input.provider.contextWindow,
+    maxOutputTokens: input.provider.maxOutputTokens,
+    idempotencyKey: `${input.idempotencyKey}:provider`,
+  });
+  const contextEnvelope = input.engine.worker.createWorkerContextEnvelope({
+    ...authority,
+    contextEnvelopeId,
+    schemaVersion: 1,
+    assignmentId,
+    repositorySnapshotId: input.repositorySnapshotId,
+    planStepIds: [...(input.planStepIds ?? [])],
+    claimIds: [...(input.claimIds ?? [])],
+    sourceReferenceIds: [...(input.sourceReferenceIds ?? [])],
+    instructionReferenceIds: [...(input.instructionReferenceIds ?? [])],
+    boundedParentNote: input.boundedParentNote ?? null,
+    toolSchemaDigest,
+    tokenEstimate: estimatedInputTokens,
+    idempotencyKey: `${input.idempotencyKey}:context`,
+  });
+
+  const child = input.engine.submitJob({
+    entryPoint: 'worker',
+    source: producer,
+    sessionId: parent.sessionId,
+    workspaceId: parent.workspaceId ?? null,
+    instanceId: parentAttempt.leaseOwner ?? 'repository-worker',
+    idempotencyNamespace: `worker:${input.parent.jobId}:${input.parent.attemptId}:${input.parent.generation}`,
+    idempotencyKey: childKey,
+    requestFingerprint: computeWorkerDigest({ requestIdentity, goal: input.goal, snapshotId: input.repositorySnapshotId }),
+    goal: input.goal,
+    title: input.goal,
+    parentJobId: input.parent.jobId,
+    rootJobId: parent.rootJobId,
+    childContract: {
+      required: true,
+      workerId: READ_ONLY_REPOSITORY_WORKER.workerDefinitionId,
+      capabilities: READ_ONLY_REPOSITORY_WORKER_TOOLS,
+      allowedResources: { repositorySnapshotId: input.repositorySnapshotId },
+      budget: { modelCalls: maxModelCalls, toolCalls: maxToolCalls, runtimeMs: maxRuntimeMs },
+    },
+    resourcePolicy: {
+      budgets: {
+        model_calls: maxModelCalls,
+        tool_calls: maxToolCalls,
+        runtime_ms: maxRuntimeMs,
+        input_tokens: input.provider.contextWindow * maxModelCalls,
+        output_tokens: input.provider.maxOutputTokens * maxModelCalls,
+        output_bytes: 512 * 1024,
+        effects: 0,
+        workers: 0,
+      },
+      capabilities: {
+        tools: READ_ONLY_REPOSITORY_WORKER_TOOLS,
+        paths: [repositoryRoot], hosts: [], applications: [], connections: [], accounts: [], workers: [], effectKinds: [],
+      },
+    },
+  });
+  const assignment = existingAssignment ?? input.engine.worker.createWorkerAssignment({
+    ...authority,
+    assignmentId,
+    schemaVersion: 1,
+    workerDefinitionId: READ_ONLY_REPOSITORY_WORKER.workerDefinitionId,
+    workerDefinitionVersion: READ_ONLY_REPOSITORY_WORKER.workerDefinitionVersion,
+    childContractId: child.jobId,
+    childJobId: child.jobId,
+    repositorySnapshotId: input.repositorySnapshotId,
+    contextEnvelopeId: contextEnvelope.contextEnvelopeId,
+    providerBindingId: providerBinding.providerBindingId,
+    capabilitySetId: child.jobId,
+    goal: input.goal,
+    expectedResultSchemaId: READ_ONLY_REPOSITORY_WORKER.expectedResultSchemaId,
+    expectedEvidenceSchemaId: READ_ONLY_REPOSITORY_WORKER.expectedEvidenceSchemaId,
+    idempotencyKey: input.idempotencyKey,
+  });
+  const triggerEvent = input.triggerBus.insert({
+    source: 'manual',
+    sourceKey: `worker:${assignment.assignmentId}`,
+    idempotencyKey: `worker-dispatch:${assignment.assignmentId}`,
+    payload: {
+      fireReason: 'worker_assignment',
+      worker_assignment_id: assignment.assignmentId,
+      durable_job: {
+        job_id: child.jobId,
+        attempt_id: child.attemptId,
+        run_id: child.runId,
+      },
+    },
+  });
+  input.engine.appendJobEvent({
+    jobId: input.parent.jobId,
+    attemptId: input.parent.attemptId,
+    generation: input.parent.generation,
+    type: 'worker.admitted',
+    payload: { assignmentId: assignment.assignmentId, childJobId: child.jobId },
+    producer,
+    idempotencyKey: `worker-admitted:${assignment.assignmentId}`,
+  });
+  input.engine.appendJobEvent({
+    jobId: input.parent.jobId,
+    attemptId: input.parent.attemptId,
+    generation: input.parent.generation,
+    type: 'worker.dispatch_enqueued',
+    payload: { assignmentId: assignment.assignmentId, childJobId: child.jobId, triggerEventId: triggerEvent.id },
+    producer,
+    idempotencyKey: `worker-dispatch-enqueued:${assignment.assignmentId}`,
+  });
+  return { child, assignment, providerBinding, contextEnvelope, triggerEvent };
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) throw new Error(`${label} is required`);
+  return value;
+}
+
+function boundedInteger(value: unknown, fallback: number, maximum: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isSafeInteger(value) || Number(value) < 0) throw new Error('Worker tool range must be a non-negative integer');
+  return Math.min(Number(value), maximum);
+}
+
+export function createReadOnlyRepositoryWorkerToolRegistry(
+  input: ReadOnlyRepositoryWorkerToolRegistryInput,
+): ToolRegistry {
+  const assignment = input.engine.worker.getWorkerAssignment(input.assignmentId);
+  const run = input.engine.worker.getWorkerRun(input.workerRunId);
+  if (!assignment || !run || run.assignmentId !== assignment.assignmentId
+    || !assignment.repositorySnapshotId || run.childJobId !== assignment.childJobId) {
+    throw new Error('Read-only repository Worker authority is incomplete');
+  }
+  if (assignment.capabilitySetId !== assignment.childJobId
+    || !READ_ONLY_REPOSITORY_WORKER_TOOLS.every((tool) => input.engine.resources.authorize({
+      jobId: assignment.childJobId, kind: 'tool', value: tool,
+    }))) {
+    throw new Error('Read-only repository Worker capability set is missing or incomplete');
+  }
+  const snapshotId = assignment.repositorySnapshotId;
+  const snapshot = input.engine.repository.getSnapshot(snapshotId);
+  if (!snapshot || snapshot.jobId !== assignment.parentJobId) {
+    throw new Error('Assigned repository snapshot is unavailable');
+  }
+
+  const assertChildAuthority = (): void => {
+    const current = currentJobExecutionContext();
+    if (!current || current.engine !== input.engine || current.jobId !== run.childJobId
+      || current.attemptId !== run.childAttemptId || current.generation !== run.childGeneration) {
+      throw new Error('Worker tool call is outside the assigned child Attempt authority');
+    }
+    const attempt = input.engine.getAttempt(current.attemptId);
+    if (attempt?.fenceToken !== current.fenceToken) {
+      throw new Error('Worker tool call has stale child Attempt authority');
+    }
+  };
+  const readSnapshot = async (relativePath: string, offset = 0, limit = 64 * 1024): Promise<Record<string, unknown>> => {
+    assertChildAuthority();
+    const entry = input.engine.repository.getEntry(snapshotId, relativePath);
+    if (!entry || entry.captureStatus !== 'captured' || !entry.contentHash) {
+      throw new Error('Path is not readable from the assigned repository snapshot');
+    }
+    const result = await input.engine.repository.readFile(snapshotId, relativePath, { offset, limit });
+    if (result.stale === true || result.fullContentHash !== entry.contentHash
+      || result.canonicalIdentity !== entry.canonicalIdentity) {
+      throw new Error('Assigned repository snapshot is stale');
+    }
+    return {
+      snapshotId,
+      snapshotEntryId: entry.canonicalIdentity,
+      path: entry.path,
+      contentHash: entry.contentHash,
+      offset: result.offset,
+      content: result.content,
+      truncated: result.truncated,
+      stale: false,
+    };
+  };
+
+  const handlers: ToolHandler[] = [
+    {
+      schema: {
+        name: 'repository_snapshot_search',
+        description: 'Search text only within the assigned immutable repository snapshot.',
+        inputSchema: {
+          type: 'object', additionalProperties: false, required: ['query'],
+          properties: {
+            query: { type: 'string', minLength: 1 },
+            limit: { type: 'integer', minimum: 1, maximum: 50 },
+          },
+        },
+      },
+      category: 'read', mutates: false, toolset: 'repository-worker', contexts: ['daemon'], riskTier: 'safe',
+      async execute(args) {
+        assertChildAuthority();
+        const query = requireString(args.query, 'Search query');
+        const limit = Math.max(1, boundedInteger(args.limit, 20, 50));
+        const result = await input.engine.repository.search(snapshotId, query, { limit });
+        if (result.stale) throw new Error('Assigned repository snapshot is stale');
+        return {
+          snapshotId,
+          stateDigest: result.stateDigest,
+          matches: result.matches.map((match) => {
+            const entry = input.engine.repository.getEntry(snapshotId, match.path);
+            if (!entry?.contentHash) throw new Error('Search result is not captured by the assigned snapshot');
+            return {
+              ...match,
+              snapshotEntryId: entry.canonicalIdentity,
+              contentHash: entry.contentHash,
+            };
+          }),
+          truncated: result.truncated,
+          stale: false,
+        };
+      },
+    },
+    {
+      schema: {
+        name: 'repository_snapshot_read',
+        description: 'Read bounded content from one captured file in the assigned repository snapshot.',
+        inputSchema: {
+          type: 'object', additionalProperties: false, required: ['path'],
+          properties: {
+            path: { type: 'string', minLength: 1 },
+            offset: { type: 'integer', minimum: 0 },
+            limit: { type: 'integer', minimum: 1, maximum: 65_536 },
+          },
+        },
+      },
+      category: 'read', mutates: false, toolset: 'repository-worker', contexts: ['daemon'], riskTier: 'safe',
+      async execute(args) {
+        const relativePath = requireString(args.path, 'Snapshot path');
+        return readSnapshot(
+          relativePath,
+          boundedInteger(args.offset, 0, Number.MAX_SAFE_INTEGER),
+          Math.max(1, boundedInteger(args.limit, 64 * 1024, 64 * 1024)),
+        );
+      },
+    },
+    {
+      schema: {
+        name: 'repository_instruction_read',
+        description: 'List or read captured repository instruction files from the assigned snapshot.',
+        inputSchema: {
+          type: 'object', additionalProperties: false,
+          properties: {
+            path: { type: 'string', minLength: 1 },
+            limit: { type: 'integer', minimum: 1, maximum: 32_768 },
+          },
+        },
+      },
+      category: 'read', mutates: false, toolset: 'repository-worker', contexts: ['daemon'], riskTier: 'safe',
+      async execute(args) {
+        assertChildAuthority();
+        const instructions = input.engine.repository.discoverInstructions(snapshotId);
+        if (args.path === undefined) return { snapshotId, instructions, stale: false };
+        const relativePath = requireString(args.path, 'Instruction path');
+        if (!instructions.some((item) => item.path === relativePath)) {
+          throw new Error('Path is not an instruction file in the assigned repository snapshot');
+        }
+        return readSnapshot(relativePath, 0, Math.max(1, boundedInteger(args.limit, 32 * 1024, 32 * 1024)));
+      },
+    },
+  ];
+  const registry = new ToolRegistry();
+  for (const handler of handlers) registry.register(handler);
+  return registry;
+}
+
+type ModelFinding = {
+  findingId: string;
+  statement: string;
+  sourceReferences: WorkerResultSourceReference[];
+  uncertainty: 'low' | 'medium' | 'high';
+};
+
+type ModelResult = {
+  schemaVersion: 1;
+  status: 'completed' | 'partial' | 'failed' | 'blocked';
+  summary: string;
+  findings: ModelFinding[];
+  unresolvedQuestions: string[];
+  uncertainty: { level: 'low' | 'medium' | 'high'; reasons: string[] };
+};
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const keys = Object.keys(value).sort();
+  return keys.length === allowed.length && keys.every((key, index) => key === [...allowed].sort()[index]);
+}
+
+function stringList(value: unknown, maximum = 128): value is string[] {
+  return Array.isArray(value) && value.length <= maximum
+    && value.every((item) => typeof item === 'string' && item.length > 0 && item.length <= 8_192);
+}
+
+function sourceReference(value: unknown): WorkerResultSourceReference | null {
+  const item = record(value);
+  if (!item || !exactKeys(item, ['snapshotId', 'snapshotEntryId', 'path', 'startLine', 'endLine', 'contentHash'])) return null;
+  if (typeof item.snapshotId !== 'string' || typeof item.snapshotEntryId !== 'string'
+    || typeof item.path !== 'string' || typeof item.contentHash !== 'string'
+    || !/^[a-f0-9]{64}$/u.test(item.contentHash)
+    || !Number.isSafeInteger(item.startLine) || !Number.isSafeInteger(item.endLine)
+    || Number(item.startLine) < 1 || Number(item.endLine) < Number(item.startLine)) return null;
+  return {
+    snapshotId: item.snapshotId,
+    snapshotEntryId: item.snapshotEntryId,
+    path: item.path,
+    startLine: Number(item.startLine),
+    endLine: Number(item.endLine),
+    contentHash: item.contentHash,
+  };
+}
+
+function parseModelResult(content: string): ModelResult {
+  const trimmed = content.trim();
+  const json = /^```json\s*([\s\S]*?)\s*```$/u.exec(trimmed)?.[1] ?? trimmed;
+  let parsed: unknown;
+  try { parsed = JSON.parse(json); } catch { throw new Error('Worker result is not valid JSON'); }
+  const item = record(parsed);
+  if (!item || !exactKeys(item, ['schemaVersion', 'status', 'summary', 'findings', 'unresolvedQuestions', 'uncertainty'])
+    || item.schemaVersion !== 1
+    || !['completed', 'partial', 'failed', 'blocked'].includes(String(item.status))
+    || typeof item.summary !== 'string' || item.summary.length === 0 || item.summary.length > 65_536
+    || !Array.isArray(item.findings) || item.findings.length > 128
+    || !stringList(item.unresolvedQuestions)) {
+    throw new Error('Worker result does not match the repository Worker schema');
+  }
+  const uncertainty = record(item.uncertainty);
+  if (!uncertainty || !exactKeys(uncertainty, ['level', 'reasons'])
+    || !['low', 'medium', 'high'].includes(String(uncertainty.level))
+    || !stringList(uncertainty.reasons)) {
+    throw new Error('Worker result uncertainty is invalid');
+  }
+  const findings: ModelFinding[] = item.findings.map((value) => {
+    const finding = record(value);
+    if (!finding || !exactKeys(finding, ['findingId', 'statement', 'sourceReferences', 'uncertainty'])
+      || typeof finding.findingId !== 'string' || finding.findingId.length === 0 || finding.findingId.length > 512
+      || typeof finding.statement !== 'string' || finding.statement.length === 0 || finding.statement.length > 65_536
+      || !['low', 'medium', 'high'].includes(String(finding.uncertainty))
+      || !Array.isArray(finding.sourceReferences) || finding.sourceReferences.length > 128) {
+      throw new Error('Worker finding does not match the repository Worker schema');
+    }
+    const references = finding.sourceReferences.map(sourceReference);
+    if (references.some((reference) => reference === null)) {
+      throw new Error('Worker source reference does not match the repository Worker schema');
+    }
+    return {
+      findingId: finding.findingId,
+      statement: finding.statement,
+      sourceReferences: references as WorkerResultSourceReference[],
+      uncertainty: finding.uncertainty as ModelFinding['uncertainty'],
+    };
+  });
+  if ((item.status === 'completed' || item.status === 'partial')
+    && !findings.some((finding) => finding.sourceReferences.length > 0)) {
+    throw new Error('Completed Worker findings require repository source references');
+  }
+  return {
+    schemaVersion: 1,
+    status: item.status as ModelResult['status'],
+    summary: item.summary,
+    findings,
+    unresolvedQuestions: item.unresolvedQuestions as string[],
+    uncertainty: {
+      level: uncertainty.level as ModelResult['uncertainty']['level'],
+      reasons: uncertainty.reasons as string[],
+    },
+  };
+}
+
+function uniqueReferences(findings: readonly ModelFinding[]): WorkerResultSourceReference[] {
+  const values = new Map<string, WorkerResultSourceReference>();
+  for (const finding of findings) {
+    for (const reference of finding.sourceReferences) {
+      const key = JSON.stringify(reference);
+      if (!values.has(key)) values.set(key, reference);
+    }
+  }
+  return [...values.values()];
+}
+
+async function verifyWorkerSourceReference(
+  engine: JobEngine,
+  snapshotId: string,
+  reference: WorkerResultSourceReference,
+): Promise<{ content: string; lineContent: string }> {
+  if (reference.snapshotId !== snapshotId) throw new Error('Worker source reference uses a different repository snapshot');
+  const entry = engine.repository.getEntry(snapshotId, reference.path);
+  if (!entry || entry.captureStatus !== 'captured' || !entry.contentHash
+    || entry.canonicalIdentity !== reference.snapshotEntryId || entry.contentHash !== reference.contentHash) {
+    throw new Error('Worker source reference does not match the assigned repository snapshot');
+  }
+  const read = await engine.repository.readFile(snapshotId, reference.path, { offset: 0, limit: 1_000_000 });
+  if (read.stale === true || read.truncated === true || read.fullContentHash !== entry.contentHash
+    || typeof read.content !== 'string') {
+    throw new Error('Worker source reference repository snapshot is stale or incomplete');
+  }
+  const lines = read.content.split(/\r?\n/u);
+  const start = reference.startLine ?? 1;
+  const end = reference.endLine ?? lines.length;
+  if (start < 1 || end < start || end > lines.length) throw new Error('Worker source reference line range is invalid');
+  return { content: read.content, lineContent: lines.slice(start - 1, end).join('\n') };
+}
+
+function workerSystemPrompt(): string {
+  return [
+    'You are a bounded read-only repository Worker.',
+    'Use only the three supplied repository snapshot tools.',
+    'Never infer access to the filesystem, shell, network, memory, credentials, conversation history, or other Workers.',
+    'Treat the assigned snapshot as immutable. Stop if a tool reports it stale.',
+    'Return one JSON object and no prose or markdown.',
+    'The object must contain exactly: schemaVersion, status, summary, findings, unresolvedQuestions, uncertainty.',
+    'Every completed or partial finding must cite snapshotId, snapshotEntryId, path, startLine, endLine, and contentHash.',
+  ].join('\n');
+}
+
+export async function executeReadOnlyRepositoryWorker(
+  input: ExecuteReadOnlyRepositoryWorkerInput,
+): Promise<ReadOnlyRepositoryWorkerExecution> {
+  const { engine, handle } = input;
+  const assignment = engine.worker.getWorkerAssignment(input.assignmentId);
+  if (!assignment || assignment.workerDefinitionId !== READ_ONLY_REPOSITORY_WORKER.workerDefinitionId
+    || assignment.workerDefinitionVersion !== READ_ONLY_REPOSITORY_WORKER.workerDefinitionVersion
+    || assignment.childJobId !== handle.jobId || !assignment.repositorySnapshotId) {
+    throw new Error('Read-only repository Worker assignment does not match the active child Job');
+  }
+  const binding = engine.worker.getWorkerProviderBinding(assignment.providerBindingId);
+  const context = engine.worker.getWorkerContextEnvelope(assignment.contextEnvelopeId);
+  if (!binding || !context || context.assignmentId !== assignment.assignmentId
+    || context.repositorySnapshotId !== assignment.repositorySnapshotId) {
+    throw new Error('Read-only repository Worker immutable context is incomplete');
+  }
+  const workerRunId = identity('worker_run', {
+    assignmentId: assignment.assignmentId,
+    childAttemptId: handle.attemptId,
+    childGeneration: handle.generation,
+  });
+  const workerRun = engine.worker.bindWorkerRunFromAssignment({
+    childJobId: handle.jobId,
+    childAttemptId: handle.attemptId,
+    childGeneration: handle.generation,
+    childFenceToken: handle.fenceToken,
+    workerRunId,
+    schemaVersion: 1,
+    assignmentId: assignment.assignmentId,
+    providerBindingId: binding.providerBindingId,
+    contextEnvelopeId: context.contextEnvelopeId,
+    producer: 'repository-worker-runtime',
+    idempotencyKey: `worker-run:${handle.attemptId}:${handle.generation}`,
+  });
+  engine.appendJobEvent({
+    jobId: handle.jobId,
+    attemptId: handle.attemptId,
+    generation: handle.generation,
+    type: 'worker.execution_started',
+    payload: { assignmentId: assignment.assignmentId, workerRunId: workerRun.workerRunId },
+    producer: 'repository-worker-runtime',
+    idempotencyKey: `worker-execution-started:${workerRun.workerRunId}`,
+  });
+  const resolved = await input.resolveProvider(binding);
+  if (!resolved?.adapter || !resolved.paths) throw new Error('Worker provider binding could not be resolved');
+  const snapshot = engine.repository.getSnapshot(assignment.repositorySnapshotId);
+  const workspace = snapshot ? engine.repository.getWorkspace(snapshot.workspaceId) : undefined;
+  if (!snapshot || !workspace) throw new Error('Worker repository snapshot is unavailable');
+  const registry = createReadOnlyRepositoryWorkerToolRegistry({
+    engine,
+    assignmentId: assignment.assignmentId,
+    workerRunId: workerRun.workerRunId,
+  });
+  if (registry.list().join('\0') !== READ_ONLY_REPOSITORY_WORKER_TOOLS.join('\0')) {
+    throw new Error('Worker tool registry does not match the immutable capability set');
+  }
+  const calls = new Map<string, { call: ToolCallRequest; result?: ToolCallResult }>();
+  const agent = new AidenAgent({
+    provider: resolved.adapter,
+    tools: registry.getSchemas(undefined, 'daemon'),
+    toolExecutor: registry.buildExecutor({
+      cwd: snapshot.repositoryRoot ?? workspace.canonicalPath,
+      paths: resolved.paths,
+      sessionId: `worker:${assignment.assignmentId}`,
+    }),
+    maxTurns: 8,
+    iterationBudgetInjection: false,
+    providerId: binding.providerId,
+    modelId: binding.modelId,
+    sessionId: `worker:${assignment.assignmentId}`,
+    onToolCall(call, phase, result) {
+      const item = calls.get(call.id) ?? { call };
+      if (phase === 'after') item.result = result;
+      calls.set(call.id, item);
+      if (phase === 'after') {
+        engine.appendJobEvent({
+          jobId: handle.jobId,
+          attemptId: handle.attemptId,
+          generation: handle.generation,
+          type: 'worker.tool_completed',
+          payload: { workerRunId: workerRun.workerRunId, toolCallId: call.id, tool: call.name, status: result?.error ? 'failed' : 'completed' },
+          producer: 'repository-worker-runtime',
+          idempotencyKey: `worker-tool-completed:${workerRun.workerRunId}:${call.id}`,
+        });
+      }
+    },
+  });
+  const startedAt = Date.now();
+  const agentResult = await runWithProviderUsageContext({
+    sessionId: `worker:${assignment.assignmentId}`,
+    taskId: handle.jobId,
+    runId: handle.runId,
+    jobId: handle.jobId,
+    attemptId: handle.attemptId,
+    attemptGeneration: handle.generation,
+    entryPoint: 'worker',
+    purpose: 'primary',
+    providerConfigured: binding.providerId,
+    modelConfigured: binding.modelId,
+    contextSnapshotId: context.contentDigest,
+    toolSchemaSnapshotId: context.toolSchemaDigest,
+    coreSchemaCount: READ_ONLY_REPOSITORY_WORKER_TOOLS.length,
+    selectedProfile: 'repository-read-worker',
+    selectedMode: 'economy',
+  }, () => agent.runConversation([
+    { role: 'system', content: workerSystemPrompt() },
+    {
+      role: 'user',
+      content: JSON.stringify({
+        assignmentId: assignment.assignmentId,
+        repositorySnapshotId: assignment.repositorySnapshotId,
+        goal: assignment.goal,
+        planStepIds: context.planStepIds,
+        claimIds: context.claimIds,
+        sourceReferenceIds: context.sourceReferenceIds,
+        instructionReferenceIds: context.instructionReferenceIds,
+        boundedParentNote: context.boundedParentNote,
+      }),
+    },
+  ], {
+    stream: false,
+    sessionId: `worker:${assignment.assignmentId}`,
+    taskId: handle.jobId,
+    runId: handle.runId,
+    entryPoint: 'worker',
+    purpose: 'primary',
+    selectedMode: 'economy',
+    selectedProfile: 'repository-read-worker',
+    signal: handle.signal,
+  }));
+  if (agentResult.finishReason === 'interrupted') throw new Error('Worker execution was cancelled');
+  if (agentResult.finishReason !== 'stop') throw new Error(`Worker provider loop did not complete: ${agentResult.finishReason}`);
+  let modelResult: ModelResult;
+  try {
+    modelResult = parseModelResult(agentResult.finalContent);
+  } catch (error) {
+    engine.worker.recordWorkerResultFromRun({
+      childJobId: handle.jobId,
+      childAttemptId: handle.attemptId,
+      childGeneration: handle.generation,
+      childFenceToken: handle.fenceToken,
+      workerResultId: identity('worker_result', { workerRunId, invalid: computeWorkerDigest(agentResult.finalContent) }),
+      workerRunId,
+      assignmentId: assignment.assignmentId,
+      payload: { invalidWorkerResult: true },
+      producer: 'repository-worker-runtime',
+      idempotencyKey: `worker-result-invalid:${workerRunId}:${computeWorkerDigest(agentResult.finalContent)}`,
+    });
+    throw error;
+  }
+  const references = uniqueReferences(modelResult.findings);
+  const verifiedReferences = new Map<string, Awaited<ReturnType<typeof verifyWorkerSourceReference>>>();
+  try {
+    for (const reference of references) {
+      verifiedReferences.set(
+        JSON.stringify(reference),
+        await verifyWorkerSourceReference(engine, assignment.repositorySnapshotId, reference),
+      );
+    }
+  } catch (error) {
+    engine.worker.recordWorkerResultFromRun({
+      childJobId: handle.jobId,
+      childAttemptId: handle.attemptId,
+      childGeneration: handle.generation,
+      childFenceToken: handle.fenceToken,
+      workerResultId: identity('worker_result', {
+        workerRunId,
+        invalidSources: computeWorkerDigest(agentResult.finalContent),
+      }),
+      workerRunId,
+      assignmentId: assignment.assignmentId,
+      payload: { invalidWorkerResult: true },
+      producer: 'repository-worker-runtime',
+      idempotencyKey: `worker-result-invalid-sources:${workerRunId}:${computeWorkerDigest(agentResult.finalContent)}`,
+    });
+    throw error;
+  }
+  const evidenceByReference = new Map<string, string>();
+  for (const reference of references) {
+    const verified = verifiedReferences.get(JSON.stringify(reference));
+    if (!verified) throw new Error('Verified Worker source reference is unavailable');
+    const evidence = engine.proof.recordEvidence({
+      jobId: handle.jobId,
+      attemptId: handle.attemptId,
+      generation: handle.generation,
+      fenceToken: handle.fenceToken,
+      repositorySnapshotId: assignment.repositorySnapshotId,
+      source: 'repository_worker_readback',
+      producer: 'repository-worker-runtime',
+      observedAt: Date.now(),
+      coverage: 'full',
+      verificationResult: 'verified',
+      payload: {
+        assignmentId: assignment.assignmentId,
+        workerRunId: workerRun.workerRunId,
+        sourceReference: reference,
+        lineContent: verified.lineContent,
+      },
+    });
+    evidenceByReference.set(JSON.stringify(reference), evidence.evidenceId);
+    engine.appendJobEvent({
+      jobId: handle.jobId,
+      attemptId: handle.attemptId,
+      generation: handle.generation,
+      type: 'worker.child_evidence_recorded',
+      payload: { workerRunId: workerRun.workerRunId, evidenceId: evidence.evidenceId, path: reference.path },
+      producer: 'repository-worker-runtime',
+      idempotencyKey: `worker-child-evidence:${workerRun.workerRunId}:${computeWorkerDigest(reference)}`,
+    });
+  }
+  const completedAt = Date.now();
+  const providerAttemptIds = currentProviderAttemptLedger()?.query({
+    jobId: handle.jobId,
+    attemptId: handle.attemptId,
+  }).map((attempt) => attempt.callId) ?? [];
+  const commandsExecuted = [...calls.values()].map(({ call, result }) => ({
+    toolCallId: call.id,
+    tool: call.name,
+    inputHash: computeWorkerDigest(call.arguments),
+    status: result?.error ? 'failed' : result ? 'completed' : 'unknown',
+  }));
+  const payload: WorkerResultPayloadV1 = {
+    schemaVersion: 1,
+    status: modelResult.status,
+    summary: modelResult.summary,
+    findings: modelResult.findings.map((finding) => ({
+      ...finding,
+      evidenceIds: finding.sourceReferences.map((reference) => evidenceByReference.get(JSON.stringify(reference))!).filter(Boolean),
+    })),
+    sourceReferences: references,
+    filesInspected: [...new Map(references.map((reference) => [reference.path, {
+      snapshotEntryId: reference.snapshotEntryId,
+      path: reference.path,
+      contentHash: reference.contentHash,
+    }])).values()],
+    commandsExecuted,
+    diagnostics: [],
+    evidenceIds: [...evidenceByReference.values()],
+    unresolvedQuestions: modelResult.unresolvedQuestions,
+    uncertainty: modelResult.uncertainty,
+    providerAttemptIds,
+    budgetUsage: engine.resources.getBudgets(handle.jobId).map((budget) => ({
+      kind: budget.kind,
+      amount: budget.hasUnknownUsage ? null : budget.used,
+      ...(budget.hasUnknownUsage ? { unknownReason: 'provider usage was not fully reported' } : {}),
+    })),
+    timing: { startedAt, completedAt, wallClockMs: Math.max(0, completedAt - startedAt) },
+    failure: modelResult.status === 'failed' || modelResult.status === 'blocked'
+      ? {
+        category: modelResult.status === 'blocked' ? 'validation' : 'unknown',
+        code: modelResult.status,
+        message: modelResult.summary,
+        retryable: false,
+        externalOutcomeUnknown: false,
+      }
+      : null,
+    inputHash: assignment.inputHash,
+    resultHash: '',
+  };
+  payload.resultHash = computeWorkerResultHash(payload);
+  const workerResult = engine.worker.recordWorkerResultFromRun({
+    childJobId: handle.jobId,
+    childAttemptId: handle.attemptId,
+    childGeneration: handle.generation,
+    childFenceToken: handle.fenceToken,
+    workerResultId: identity('worker_result', { workerRunId, resultHash: payload.resultHash }),
+    workerRunId,
+    assignmentId: assignment.assignmentId,
+    payload,
+    producer: 'repository-worker-runtime',
+    idempotencyKey: `worker-result:${workerRunId}:${payload.resultHash}`,
+  });
+  if (workerResult.acceptanceState !== 'accepted') {
+    throw new Error(`Worker result was rejected: ${workerResult.rejectionCode ?? 'unknown'}`);
+  }
+  const childRecorded = engine.recordChildResult({
+    childJobId: handle.jobId,
+    attemptId: handle.attemptId,
+    generation: handle.generation,
+    fenceToken: handle.fenceToken,
+    status: workerResult.status,
+    evidence: { workerResultId: workerResult.workerResultId, summary: workerResult.summary },
+    evidenceHandles: workerResult.evidenceIds,
+    producer: 'repository-worker-runtime',
+    idempotencyKey: `worker-child-result:${workerResult.workerResultId}`,
+  });
+  if (!childRecorded.applied && !childRecorded.duplicate) throw new Error('Worker child result could not be recorded');
+  const finalization: DurableJobDisposition = workerResult.status === 'completed'
+    ? { status: 'completed', outcome: 'worker_completed', finishReason: 'stop', evidence: { workerResultId: workerResult.workerResultId } }
+    : workerResult.status === 'failed'
+      ? { status: 'failed', outcome: 'worker_failed', finishReason: 'error', evidence: { workerResultId: workerResult.workerResultId } }
+      : workerResult.status === 'blocked'
+        ? { status: 'blocked', outcome: 'worker_blocked', finishReason: 'blocked', evidence: { workerResultId: workerResult.workerResultId } }
+        : { status: 'unknown', outcome: 'worker_partial', finishReason: 'verification_incomplete', evidence: { workerResultId: workerResult.workerResultId } };
+  return {
+    workerRun,
+    workerResult,
+    finalization,
+    totalTokens: agentResult.totalUsage.inputTokens + agentResult.totalUsage.outputTokens,
+  };
+}
+
+export async function verifyReadOnlyRepositoryWorkerResult(
+  input: VerifyReadOnlyRepositoryWorkerResultInput,
+): Promise<{ claims: ReturnType<JobEngine['proof']['listClaims']>; evidence: ReturnType<JobEngine['proof']['listEvidence']> }> {
+  const producer = input.producer ?? 'repository-worker-parent-verifier';
+  const result = input.engine.worker.getWorkerResult(input.workerResultId);
+  if (!result || result.acceptanceState !== 'accepted' || !result.payload) {
+    throw new Error('Accepted Worker result was not found');
+  }
+  const run = input.engine.worker.getWorkerRun(result.workerRunId);
+  const assignment = input.engine.worker.getWorkerAssignment(result.assignmentId);
+  const context = assignment ? input.engine.worker.getWorkerContextEnvelope(assignment.contextEnvelopeId) : null;
+  if (!run || !assignment || !context || assignment.parentJobId !== input.parent.jobId
+    || assignment.parentAttemptId !== input.parent.attemptId
+    || assignment.parentGeneration !== input.parent.generation
+    || !assignment.repositorySnapshotId) {
+    throw new Error('Worker result does not belong to the parent verification authority');
+  }
+  const parent = input.engine.getJob(input.parent.jobId);
+  const attempt = input.engine.getAttempt(input.parent.attemptId);
+  if (!parent || parent.activeAttemptId !== input.parent.attemptId
+    || attempt?.generation !== input.parent.generation || attempt.fenceToken !== input.parent.fenceToken) {
+    throw new Error('Parent verification authority is no longer active');
+  }
+  input.engine.appendJobEvent({
+    jobId: input.parent.jobId,
+    attemptId: input.parent.attemptId,
+    generation: input.parent.generation,
+    type: 'worker.parent_verification_started',
+    payload: { workerResultId: result.workerResultId },
+    producer,
+    idempotencyKey: `${input.idempotencyKey}:started`,
+  });
+  const claims = context.claimIds.map((claimId) => input.engine.proof.listClaims(input.parent.jobId)
+    .find((claim) => claim.claimId === claimId));
+  if (claims.some((claim) => !claim)) throw new Error('Worker context Claim reference is unavailable');
+  const verifiedClaims: Array<{
+    claim: NonNullable<(typeof claims)[number]>;
+    sources: Array<{
+      reference: WorkerResultSourceReference;
+      lineContent: string;
+      verificationKey: string;
+    }>;
+  }> = [];
+  let verificationSubject: {
+    claim: NonNullable<(typeof claims)[number]>;
+    reference: WorkerResultSourceReference;
+    verificationKey: string;
+  } | null = null;
+  try {
+    for (const claim of claims) {
+      if (!claim || claim.repositorySnapshotId !== assignment.repositorySnapshotId
+        || claim.sourceReferences.length === 0) {
+        throw new Error('Parent verification requires a source-bound pre-existing Claim');
+      }
+      const sources: Array<{
+        reference: WorkerResultSourceReference;
+        lineContent: string;
+        verificationKey: string;
+      }> = [];
+      for (const claimReference of claim.sourceReferences) {
+        const workerReference = result.payload.sourceReferences.find((reference) => (
+          reference.snapshotId === claimReference.snapshotId
+          && reference.path === claimReference.path
+          && reference.startLine === claimReference.lineStart
+          && reference.endLine === claimReference.lineEnd
+        ));
+        if (!workerReference) throw new Error('Worker result does not support the parent Claim source reference');
+        const verificationKey = `${input.idempotencyKey}:${claim.claimId}:${computeWorkerDigest(workerReference)}`;
+        verificationSubject = { claim, reference: workerReference, verificationKey };
+        const verified = await verifyWorkerSourceReference(input.engine, assignment.repositorySnapshotId, workerReference);
+        sources.push({ reference: workerReference, lineContent: verified.lineContent, verificationKey });
+        verificationSubject = null;
+      }
+      verifiedClaims.push({ claim, sources });
+    }
+  } catch (error) {
+    if (verificationSubject) {
+      const { claim, reference, verificationKey } = verificationSubject;
+      const existing = input.engine.proof.listEvidence(input.parent.jobId).find((evidence) => (
+        evidence.source === 'repository_readback'
+        && record(evidence.payload)?.verificationKey === verificationKey
+      ));
+      const evidence = existing ?? input.engine.proof.recordEvidence({
+        jobId: input.parent.jobId,
+        attemptId: input.parent.attemptId,
+        generation: input.parent.generation,
+        fenceToken: input.parent.fenceToken,
+        repositorySnapshotId: assignment.repositorySnapshotId,
+        source: 'repository_readback',
+        producer,
+        observedAt: Date.now(),
+        coverage: 'unknown',
+        verificationResult: 'failed',
+        payload: {
+          verificationKey,
+          workerResultId: result.workerResultId,
+          claimId: claim.claimId,
+          sourceReference: reference,
+          failureCode: 'source_readback_failed',
+        },
+      });
+      if (claim.state !== 'failed') {
+        input.engine.proof.checkClaim({
+          claimId: claim.claimId,
+          attemptId: input.parent.attemptId,
+          generation: input.parent.generation,
+          evidenceIds: [evidence.evidenceId],
+          state: 'failed',
+        });
+      }
+      input.engine.appendJobEvent({
+        jobId: input.parent.jobId,
+        attemptId: input.parent.attemptId,
+        generation: input.parent.generation,
+        type: 'worker.parent_verification_failed',
+        payload: { workerResultId: result.workerResultId, claimId: claim.claimId, evidenceId: evidence.evidenceId },
+        producer,
+        idempotencyKey: `${input.idempotencyKey}:failed`,
+      });
+    }
+    throw error;
+  }
+  const parentEvidence = [] as ReturnType<JobEngine['proof']['listEvidence']>;
+  for (const { claim, sources } of verifiedClaims) {
+    const evidenceIds: string[] = [];
+    for (const { reference: workerReference, lineContent, verificationKey } of sources) {
+      const existing = input.engine.proof.listEvidence(input.parent.jobId).find((evidence) => (
+        evidence.source === 'repository_readback'
+        && record(evidence.payload)?.verificationKey === verificationKey
+      ));
+      const evidence = existing ?? input.engine.proof.recordEvidence({
+        jobId: input.parent.jobId,
+        attemptId: input.parent.attemptId,
+        generation: input.parent.generation,
+        fenceToken: input.parent.fenceToken,
+        repositorySnapshotId: assignment.repositorySnapshotId,
+        source: 'repository_readback',
+        producer,
+        observedAt: Date.now(),
+        coverage: 'full',
+        verificationResult: 'verified',
+        payload: {
+          verificationKey,
+          workerResultId: result.workerResultId,
+          claimId: claim.claimId,
+          sourceReference: workerReference,
+          lineContent,
+        },
+      });
+      evidenceIds.push(evidence.evidenceId);
+      if (!parentEvidence.some((item) => item.evidenceId === evidence.evidenceId)) parentEvidence.push(evidence);
+    }
+    if (claim.state !== 'verified') {
+      input.engine.proof.checkClaim({
+        claimId: claim.claimId,
+        attemptId: input.parent.attemptId,
+        generation: input.parent.generation,
+        evidenceIds,
+        state: 'verified',
+      });
+    }
+  }
+  for (const nodeId of context.planStepIds) {
+    if (!input.engine.graph.nodes(input.parent.jobId).some((node) => (
+      node.nodeId === nodeId && node.kind === 'coding_step'
+    ))) continue;
+    const referenceUpdate = input.engine.graph.addNodeReferences({
+      jobId: input.parent.jobId,
+      attemptId: input.parent.attemptId,
+      generation: input.parent.generation,
+      fenceToken: input.parent.fenceToken,
+      nodeId,
+      references: parentEvidence.map((evidence) => ({ kind: 'evidence' as const, id: evidence.evidenceId })),
+      producer,
+      idempotencyKey: `${input.idempotencyKey}:graph-evidence:${nodeId}`,
+    });
+    if (!referenceUpdate.applied && !referenceUpdate.duplicate) {
+      throw new Error('Parent verification Evidence could not be linked to the execution graph');
+    }
+  }
+  input.engine.appendJobEvent({
+    jobId: input.parent.jobId,
+    attemptId: input.parent.attemptId,
+    generation: input.parent.generation,
+    type: 'worker.parent_verification_completed',
+    payload: {
+      workerResultId: result.workerResultId,
+      evidenceIds: parentEvidence.map((evidence) => evidence.evidenceId),
+      claimIds: verifiedClaims.map(({ claim }) => claim.claimId),
+    },
+    producer,
+    idempotencyKey: `${input.idempotencyKey}:completed`,
+  });
+  return {
+    claims: input.engine.proof.listClaims(input.parent.jobId).filter((claim) => context.claimIds.includes(claim.claimId)),
+    evidence: parentEvidence,
+  };
+}

--- a/core/v4/worker/readOnlyRepositoryWorker.ts
+++ b/core/v4/worker/readOnlyRepositoryWorker.ts
@@ -3,6 +3,8 @@
  * Licensed under AGPL-3.0. See LICENSE for details.
  */
 
+import path from 'node:path';
+
 import { AidenAgent } from '../aidenAgent';
 import type { DurableJobDisposition, DurableJobHandle } from '../daemon/jobLifecycle';
 import type { JobEngine, AdmissionResult } from '../daemon/jobEngine';
@@ -349,6 +351,19 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
+function canonicalSnapshotPath(value: unknown, label: string): string {
+  const raw = requireString(value, label);
+  if (raw.includes('\0') || path.posix.isAbsolute(raw.replace(/\\/gu, '/'))
+    || path.win32.isAbsolute(raw) || raw.startsWith('\\\\')) {
+    throw new Error('Snapshot path must be repository-relative');
+  }
+  const relative = path.posix.normalize(raw.replace(/\\/gu, '/')).replace(/^\.\//u, '');
+  if (relative === '' || relative === '.' || relative === '..' || relative.startsWith('../')) {
+    throw new Error('Snapshot path escapes the assigned repository');
+  }
+  return relative;
+}
+
 function boundedInteger(value: unknown, fallback: number, maximum: number): number {
   if (value === undefined) return fallback;
   if (!Number.isSafeInteger(value) || Number(value) < 0) throw new Error('Worker tool range must be a non-negative integer');
@@ -375,6 +390,19 @@ export function createReadOnlyRepositoryWorkerToolRegistry(
   if (!snapshot || snapshot.jobId !== assignment.parentJobId) {
     throw new Error('Assigned repository snapshot is unavailable');
   }
+  const workspace = input.engine.repository.getWorkspace(snapshot.workspaceId);
+  if (!workspace) throw new Error('Assigned repository workspace is unavailable');
+  const snapshotRoot = snapshot.repositoryRoot ?? workspace.canonicalPath;
+
+  const resolveSnapshotCapabilityPath = (argument: string, value: string): string => {
+    if (argument !== 'path') throw new Error('Worker tool path argument is not supported');
+    const relativePath = canonicalSnapshotPath(value, 'Snapshot path');
+    const entry = input.engine.repository.getEntry(snapshotId, relativePath);
+    if (!entry || entry.captureStatus !== 'captured' || !entry.contentHash) {
+      throw new Error('Path is not readable from the assigned repository snapshot');
+    }
+    return path.resolve(snapshotRoot, ...relativePath.split('/'));
+  };
 
   const assertChildAuthority = (): void => {
     const current = currentJobExecutionContext();
@@ -387,8 +415,9 @@ export function createReadOnlyRepositoryWorkerToolRegistry(
       throw new Error('Worker tool call has stale child Attempt authority');
     }
   };
-  const readSnapshot = async (relativePath: string, offset = 0, limit = 64 * 1024): Promise<Record<string, unknown>> => {
+  const readSnapshot = async (requestedPath: string, offset = 0, limit = 64 * 1024): Promise<Record<string, unknown>> => {
     assertChildAuthority();
+    const relativePath = canonicalSnapshotPath(requestedPath, 'Snapshot path');
     const entry = input.engine.repository.getEntry(snapshotId, relativePath);
     if (!entry || entry.captureStatus !== 'captured' || !entry.contentHash) {
       throw new Error('Path is not readable from the assigned repository snapshot');
@@ -461,8 +490,9 @@ export function createReadOnlyRepositoryWorkerToolRegistry(
         },
       },
       category: 'read', mutates: false, toolset: 'repository-worker', contexts: ['daemon'], riskTier: 'safe',
+      resolveCapabilityPath: resolveSnapshotCapabilityPath,
       async execute(args) {
-        const relativePath = requireString(args.path, 'Snapshot path');
+        const relativePath = canonicalSnapshotPath(args.path, 'Snapshot path');
         return readSnapshot(
           relativePath,
           boundedInteger(args.offset, 0, Number.MAX_SAFE_INTEGER),
@@ -483,11 +513,12 @@ export function createReadOnlyRepositoryWorkerToolRegistry(
         },
       },
       category: 'read', mutates: false, toolset: 'repository-worker', contexts: ['daemon'], riskTier: 'safe',
+      resolveCapabilityPath: resolveSnapshotCapabilityPath,
       async execute(args) {
         assertChildAuthority();
         const instructions = input.engine.repository.discoverInstructions(snapshotId);
         if (args.path === undefined) return { snapshotId, instructions, stale: false };
-        const relativePath = requireString(args.path, 'Instruction path');
+        const relativePath = canonicalSnapshotPath(args.path, 'Instruction path');
         if (!instructions.some((item) => item.path === relativePath)) {
           throw new Error('Path is not an instruction file in the assigned repository snapshot');
         }

--- a/core/v4/worker/workerAuthority.ts
+++ b/core/v4/worker/workerAuthority.ts
@@ -93,17 +93,39 @@ interface RecordResultCommand extends ParentAuthorityCommand, ChildAuthorityComm
   payload: unknown;
 }
 
+type BindRunFromAssignmentCommand = ChildAuthorityCommand & Omit<WorkerRunRecord,
+  'idempotencyKey' | 'childJobId' | 'childAttemptId' | 'childGeneration'
+  | 'executionGraphNodeId' | 'acceptedResultId' | 'createdAt'> & {
+    producer: string;
+    idempotencyKey: string;
+    now?: number;
+  };
+
+interface RecordResultFromRunCommand extends ChildAuthorityCommand {
+  workerResultId: string;
+  workerRunId: string;
+  assignmentId: string;
+  payload: unknown;
+  producer: string;
+  idempotencyKey: string;
+  now?: number;
+}
+
 export interface WorkerAuthority {
   createWorkerProviderBinding(command: ProviderBindingCommand): WorkerProviderBindingRecord;
   createWorkerContextEnvelope(command: ContextEnvelopeCommand): WorkerContextEnvelopeRecord;
   createWorkerAssignment(command: AssignmentCommand): WorkerAssignmentRecord;
   bindWorkerRun(command: BindRunCommand): WorkerRunRecord;
+  bindWorkerRunFromAssignment(command: BindRunFromAssignmentCommand): WorkerRunRecord;
   recordWorkerResult(command: RecordResultCommand): WorkerResultRecord;
+  recordWorkerResultFromRun(command: RecordResultFromRunCommand): WorkerResultRecord;
   getWorkerAssignment(id: string): WorkerAssignmentRecord | null;
   getWorkerRun(id: string): WorkerRunRecord | null;
   getWorkerProviderBinding(id: string): WorkerProviderBindingRecord | null;
   getWorkerContextEnvelope(id: string): WorkerContextEnvelopeRecord | null;
   getWorkerResult(id: string): WorkerResultRecord | null;
+  listWorkerAssignmentsForParent(parentJobId: string): WorkerAssignmentRecord[];
+  getWorkerAssignmentForChild(childJobId: string): WorkerAssignmentRecord | null;
   listWorkerRunsForParent(parentJobId: string): WorkerRunRecord[];
   listWorkerRunsForChild(childJobId: string): WorkerRunRecord[];
   listWorkerEvents(parentJobId: string): WorkerEventRecord[];
@@ -428,6 +450,46 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
       throw new WorkerAuthorityError('stale_authority', 'Parent Attempt authority is no longer active');
     }
     return { runId: result.runId };
+  };
+
+  const parentAuthorityForAssignment = (
+    assignment: WorkerAssignmentRecord,
+    producer: string,
+    idempotencyKey: string,
+    now?: number,
+  ): ParentAuthorityCommand => {
+    const row = db.prepare(
+      `SELECT r.fence_token
+         FROM runs r JOIN tasks t ON t.id=r.task_id
+        WHERE r.attempt_id=? AND r.task_id=? AND r.generation=?
+          AND t.active_attempt_id=r.attempt_id
+          AND t.status IN ('queued','running','waiting','paused','cancelling','recovering')`,
+    ).get(
+      assignment.parentAttemptId,
+      assignment.parentJobId,
+      assignment.parentGeneration,
+    ) as { fence_token: string | null } | undefined;
+    if (!row?.fence_token
+      || createHash('sha256').update(row.fence_token).digest('hex') !== assignment.parentFenceDigest) {
+      throw new WorkerAuthorityError('stale_authority', 'Assignment parent authority is no longer active');
+    }
+    const active = deps.validateActiveFence({
+      jobId: assignment.parentJobId,
+      attemptId: assignment.parentAttemptId,
+      generation: assignment.parentGeneration,
+      fenceToken: row.fence_token,
+      now,
+    });
+    if (!active.valid) throw new WorkerAuthorityError('stale_authority', 'Assignment parent authority is no longer active');
+    return {
+      parentJobId: assignment.parentJobId,
+      parentAttemptId: assignment.parentAttemptId,
+      parentGeneration: assignment.parentGeneration,
+      parentFenceToken: row.fence_token,
+      producer,
+      idempotencyKey,
+      now,
+    };
   };
 
   const append = (command: ParentAuthorityCommand, runId: number, kind: WorkerEventKind, payload: Record<string, unknown>, suffix: string): void => {
@@ -843,12 +905,54 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
     createWorkerContextEnvelope: createContext,
     createWorkerAssignment: createAssignment,
     bindWorkerRun: bindRun,
+    bindWorkerRunFromAssignment(command) {
+      const assignment = getAssignment(command.assignmentId);
+      if (!assignment) throw new WorkerAuthorityError('not_found', 'Worker Assignment was not found');
+      return bindRun({
+        ...parentAuthorityForAssignment(assignment, command.producer, command.idempotencyKey, command.now),
+        childJobId: command.childJobId,
+        childAttemptId: command.childAttemptId,
+        childGeneration: command.childGeneration,
+        childFenceToken: command.childFenceToken,
+        workerRunId: command.workerRunId,
+        schemaVersion: command.schemaVersion,
+        assignmentId: command.assignmentId,
+        providerBindingId: command.providerBindingId,
+        contextEnvelopeId: command.contextEnvelopeId,
+      });
+    },
     recordWorkerResult: recordResult,
+    recordWorkerResultFromRun(command) {
+      const assignment = getAssignment(command.assignmentId);
+      if (!assignment) throw new WorkerAuthorityError('not_found', 'Worker Assignment was not found');
+      return recordResult({
+        ...parentAuthorityForAssignment(assignment, command.producer, command.idempotencyKey, command.now),
+        childJobId: command.childJobId,
+        childAttemptId: command.childAttemptId,
+        childGeneration: command.childGeneration,
+        childFenceToken: command.childFenceToken,
+        workerResultId: command.workerResultId,
+        workerRunId: command.workerRunId,
+        assignmentId: command.assignmentId,
+        payload: command.payload,
+      });
+    },
     getWorkerAssignment: getAssignment,
     getWorkerRun: getRun,
     getWorkerProviderBinding: getBinding,
     getWorkerContextEnvelope: getContext,
     getWorkerResult: getResult,
+    listWorkerAssignmentsForParent(parentJobId) {
+      return (db.prepare(
+        'SELECT * FROM worker_assignments WHERE parent_job_id=? ORDER BY created_at,assignment_id',
+      ).all(parentJobId) as AssignmentRow[]).map(mapAssignment);
+    },
+    getWorkerAssignmentForChild(childJobId) {
+      const row = db.prepare(
+        'SELECT * FROM worker_assignments WHERE child_job_id=? ORDER BY created_at,assignment_id LIMIT 1',
+      ).get(childJobId) as AssignmentRow | undefined;
+      return row ? mapAssignment(row) : null;
+    },
     listWorkerRunsForParent(parentJobId) {
       return (db.prepare(
         `SELECT r.* FROM worker_runs r JOIN worker_assignments a ON a.assignment_id=r.assignment_id

--- a/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createDispatcher } from '../../../core/v4/daemon/dispatcher/dispatcher';
+import { createRealAgentRunner, type AgentBuilder } from '../../../core/v4/daemon/dispatcher/realAgentRunner';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createRunStore } from '../../../core/v4/daemon/runStore';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import {
+  admitReadOnlyRepositoryWorker,
+  verifyReadOnlyRepositoryWorkerResult,
+} from '../../../core/v4/worker/readOnlyRepositoryWorker';
+import type { ProviderAdapter } from '../../../providers/v4/types';
+
+describe('read-only repository Worker durable dispatcher path', () => {
+  const cleanup: string[] = [];
+  afterEach(async () => {
+    await Promise.all(cleanup.splice(0).map((item) => rm(item, { recursive: true, force: true })));
+  });
+
+  it('delivers the child through TriggerBus and the canonical daemon lifecycle exactly once', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-e2e-'));
+    const home = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-e2e-home-'));
+    cleanup.push(root, home);
+    const sourceBytes = 'export const value = "dispatcher-worker";\n';
+    await writeFile(path.join(root, 'source.ts'), sourceBytes);
+    const dbPath = path.join(home, 'worker-e2e.db');
+    const db = new Database(dbPath);
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      'INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)',
+    ).run('worker-instance', 1, 'localhost', Date.now(), Date.now(), '4.18.0');
+
+    const engine = createJobEngine({ db });
+    const bus = createTriggerBus({ db });
+    const runStore = createRunStore({ db });
+    const parent = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'parent-session', workspaceId: root,
+      instanceId: 'worker-instance', idempotencyNamespace: 'parent', idempotencyKey: 'one', goal: 'verify value',
+    });
+    const parentLease = engine.claimAttempt({ attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000 });
+    if (!parentLease.acquired || !parentLease.fenceToken || parentLease.generation === undefined) throw new Error('parent lease');
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, requestedPath: root, producer: 'test',
+    });
+    engine.graph.createCodingPlan({
+      jobId: parent.jobId, planDigest: 'dispatcher-worker-plan', producer: 'test', idempotencyKey: 'worker-plan',
+      steps: [{
+        stepId: 'locate-auth-session', label: 'Locate session authentication',
+        repositorySnapshotId: snapshot.id, requiresVerification: true,
+      }],
+    });
+    const entry = engine.repository.getEntry(snapshot.id, 'source.ts')!;
+    const claim = engine.proof.createClaim({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      category: 'observed', statement: 'source.ts contains dispatcher-worker.', required: true,
+      repositorySnapshotId: snapshot.id,
+      sourceReferences: [{ snapshotId: snapshot.id, path: 'source.ts', lineStart: 1, lineEnd: 1 }],
+      requiredEvidenceCategories: ['repository_readback'],
+    });
+    const admission = admitReadOnlyRepositoryWorker({
+      engine, triggerBus: bus,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation, fenceToken: parentLease.fenceToken },
+      idempotencyKey: 'dispatcher-worker', goal: 'Read source.ts and report the value.',
+      repositorySnapshotId: snapshot.id, planStepIds: ['locate-auth-session'], claimIds: [claim.claimId],
+      provider: {
+        providerId: 'fixture', modelId: 'fixture-model', providerRuntimeIdentity: 'runtime:fixture',
+        credentialReference: null, endpointReference: null, supportsToolCalling: true,
+        contextWindow: 8_192, maxOutputTokens: 2_048, selectionReason: 'fixture',
+      },
+    });
+    let calls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            content: null,
+            toolCalls: [{ id: 'read', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } }],
+            finishReason: 'tool_use', usage: { inputTokens: 10, outputTokens: 5 },
+          };
+        }
+        return {
+          content: JSON.stringify({
+            schemaVersion: 1, status: 'completed', summary: 'The value is dispatcher-worker.',
+            findings: [{
+              findingId: 'value', statement: 'source.ts contains dispatcher-worker.', uncertainty: 'low',
+              sourceReferences: [{
+                snapshotId: snapshot.id, snapshotEntryId: entry.canonicalIdentity,
+                path: 'source.ts', startLine: 1, endLine: 1, contentHash: entry.contentHash,
+              }],
+            }],
+            unresolvedQuestions: [], uncertainty: { level: 'low', reasons: [] },
+          }),
+          toolCalls: [], finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5 },
+        };
+      },
+    };
+    let normalBuilderCalls = 0;
+    const builder = (async () => {
+      normalBuilderCalls += 1;
+      throw new Error('ordinary daemon builder must not run for Worker children');
+    }) as AgentBuilder;
+    builder.resolveReadOnlyWorkerProvider = async (binding) => {
+      expect(binding.providerId).toBe('fixture');
+      expect(binding.modelId).toBe('fixture-model');
+      return { adapter, paths: resolveAidenPaths({ rootOverride: home }) };
+    };
+    const runner = createRealAgentRunner({
+      db, runStore, jobEngine: engine, agentBuilder: builder,
+      persistedDefault: { provider: 'different-provider', model: 'different-model' },
+      dailyBudget: null,
+    });
+    const dispatcher = createDispatcher({
+      triggerBus: bus, runStore, db, jobEngine: engine,
+      ownerId: 'worker-instance', instanceId: 'worker-instance', workerCount: 1,
+      runnerFactory: () => runner, initialRunnerKind: 'real',
+    });
+
+    expect(await dispatcher._pumpOnce()).toBe(admission.triggerEvent.id);
+    expect(bus.get(admission.triggerEvent.id)).toMatchObject({ status: 'done', runId: admission.child.runId });
+    expect(engine.getJob(admission.child.jobId)).toMatchObject({ status: 'completed', terminalOutcome: 'worker_completed' });
+    expect(engine.worker.listWorkerRunsForChild(admission.child.jobId)).toHaveLength(1);
+    const [resultId] = engine.worker.rebuildWorkerProjection(parent.jobId).acceptedResultIds;
+    expect(resultId).toBeTruthy();
+    expect(normalBuilderCalls).toBe(0);
+    expect(calls).toBe(2);
+    expect(await dispatcher._pumpOnce()).toBeNull();
+    expect(engine.worker.listWorkerRunsForChild(admission.child.jobId)).toHaveLength(1);
+
+    const verification = await verifyReadOnlyRepositoryWorkerResult({
+      engine,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation, fenceToken: parentLease.fenceToken },
+      workerResultId: resultId!, idempotencyKey: 'parent-readback', producer: 'test',
+    });
+    expect(verification.claims[0]).toMatchObject({ claimId: claim.claimId, state: 'verified' });
+    expect(engine.graph.getCodingPlan(parent.jobId)?.steps[0].references).toContainEqual(expect.objectContaining({
+      kind: 'evidence', id: verification.evidence[0].evidenceId,
+    }));
+    expect(engine.proof.getVerdict(parent.jobId)).toBeNull();
+    const childEvidenceId = engine.proof.listEvidence(admission.child.jobId)[0].evidenceId;
+    const parentEvidenceId = verification.evidence[0].evidenceId;
+    expect(childEvidenceId).not.toBe(parentEvidenceId);
+    expect(await readFile(path.join(root, 'source.ts'), 'utf8')).toBe(sourceBytes);
+    db.close();
+
+    const reopenedDb = new Database(dbPath);
+    reopenedDb.pragma('foreign_keys = ON');
+    const reopened = createJobEngine({ db: reopenedDb });
+    expect(reopened.worker.getWorkerAssignment(admission.assignment.assignmentId)).toMatchObject({
+      childJobId: admission.child.jobId,
+      repositorySnapshotId: snapshot.id,
+    });
+    expect(reopened.getAttempt(admission.child.attemptId)).toMatchObject({ generation: 1 });
+    expect(reopened.worker.listWorkerRunsForChild(admission.child.jobId)[0]).toMatchObject({
+      childAttemptId: admission.child.attemptId,
+      childGeneration: 1,
+      acceptedResultId: resultId,
+    });
+    expect(reopened.worker.getWorkerResult(resultId!)).toMatchObject({ acceptanceState: 'accepted' });
+    expect(reopened.proof.listEvidence(admission.child.jobId).map((item) => item.evidenceId)).toEqual([childEvidenceId]);
+    expect(reopened.proof.listEvidence(parent.jobId).map((item) => item.evidenceId)).toContain(parentEvidenceId);
+    expect(reopened.proof.listClaims(parent.jobId)).toContainEqual(expect.objectContaining({
+      claimId: claim.claimId,
+      state: 'verified',
+    }));
+    expect(createTriggerBus({ db: reopenedDb }).get(admission.triggerEvent.id)).toMatchObject({ status: 'done' });
+    expect(reopened.proof.getVerdict(parent.jobId)).toBeNull();
+    expect(await readFile(path.join(root, 'source.ts'), 'utf8')).toBe(sourceBytes);
+    reopenedDb.close();
+  });
+});

--- a/tests/v4/worker/readOnlyRepositoryWorkerAdmission.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerAdmission.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createTriggerBus, type TriggerBus } from '../../../core/v4/daemon/triggerBus';
+import {
+  READ_ONLY_REPOSITORY_WORKER,
+  READ_ONLY_REPOSITORY_WORKER_TOOLS,
+  admitReadOnlyRepositoryWorker,
+} from '../../../core/v4/worker/readOnlyRepositoryWorker';
+
+describe('durable read-only repository Worker admission', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let triggerBus: TriggerBus;
+  let root: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances
+         (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES (?,?,?,?,?,?)`,
+    ).run('worker-instance', 1, 'localhost', Date.now(), Date.now(), '4.18.0');
+    engine = createJobEngine({ db });
+    triggerBus = createTriggerBus({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-read-worker-'));
+    await writeFile(path.join(root, 'AGENTS.md'), 'Inspect only the pinned repository snapshot.\n');
+    await writeFile(path.join(root, 'source.ts'), 'export const marker = "durable-worker";\n');
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function parentAuthority() {
+    const parent = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'worker-session', workspaceId: root,
+      instanceId: 'worker-instance', idempotencyNamespace: 'worker-parent',
+      idempotencyKey: 'parent', goal: 'Confirm the repository marker.',
+    });
+    const lease = engine.claimAttempt({
+      attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000,
+    });
+    if (!lease.acquired || !lease.fenceToken || lease.generation === undefined) throw new Error('parent lease');
+    engine.graph.create({
+      jobId: parent.jobId,
+      planDigest: 'worker-plan',
+      nodes: [{ nodeId: 'inspect-source', kind: 'inspection', requiresVerification: true }],
+      producer: 'test', idempotencyKey: 'worker-plan',
+    });
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: lease.generation,
+      fenceToken: lease.fenceToken, requestedPath: root, producer: 'test',
+    });
+    const claim = engine.proof.createClaim({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: lease.generation,
+      category: 'observed', statement: 'source.ts contains the durable Worker marker.',
+      required: true, repositorySnapshotId: snapshot.id,
+      sourceReferences: [{ snapshotId: snapshot.id, path: 'source.ts', lineStart: 1, lineEnd: 1 }],
+      requiredEvidenceCategories: ['repository_readback'],
+    });
+    return { parent, lease, snapshot, claim };
+  }
+
+  it('creates one immutable assignment, one child Job, and one durable dispatch', async () => {
+    const { parent, lease, snapshot, claim } = await parentAuthority();
+    const admitted = admitReadOnlyRepositoryWorker({
+      engine, triggerBus,
+      parent: {
+        jobId: parent.jobId, attemptId: parent.attemptId,
+        generation: lease.generation!, fenceToken: lease.fenceToken!,
+      },
+      idempotencyKey: 'inspect-marker',
+      goal: 'Inspect source.ts and report the exact marker with a source reference.',
+      repositorySnapshotId: snapshot.id,
+      planStepIds: ['inspect-source'],
+      claimIds: [claim.claimId],
+      boundedParentNote: 'Return only repository-grounded findings.',
+      provider: {
+        providerId: 'custom_openai', modelId: 'custom-default',
+        providerRuntimeIdentity: 'runtime:custom_openai',
+        credentialReference: 'credential:custom_openai', endpointReference: 'endpoint:configured',
+        supportsToolCalling: true, contextWindow: 32_768, maxOutputTokens: 4_096,
+        selectionReason: 'configured provider',
+      },
+    });
+
+    expect(admitted.assignment.workerDefinitionId).toBe(READ_ONLY_REPOSITORY_WORKER.workerDefinitionId);
+    expect(admitted.assignment.repositorySnapshotId).toBe(snapshot.id);
+    expect(admitted.child.reused).toBe(false);
+    expect(engine.getJob(admitted.child.jobId)?.parentJobId).toBe(parent.jobId);
+    expect(engine.getChildContract(admitted.child.jobId)).toMatchObject({
+      workerId: READ_ONLY_REPOSITORY_WORKER.workerDefinitionId,
+      capabilities: [...READ_ONLY_REPOSITORY_WORKER_TOOLS],
+    });
+    expect(READ_ONLY_REPOSITORY_WORKER_TOOLS.every((tool) => (
+      engine.resources.authorize({ jobId: admitted.child.jobId, kind: 'tool', value: tool })
+    ))).toBe(true);
+    expect(engine.resources.authorize({
+      jobId: admitted.child.jobId, kind: 'tool', value: 'shell_exec',
+    })).toBe(false);
+    expect(triggerBus.get(admitted.triggerEvent.id)?.payload).toMatchObject({
+      worker_assignment_id: admitted.assignment.assignmentId,
+      durable_job: {
+        job_id: admitted.child.jobId,
+        attempt_id: admitted.child.attemptId,
+        run_id: admitted.child.runId,
+      },
+    });
+    const persistedContext = engine.worker.getWorkerContextEnvelope(admitted.contextEnvelope.contextEnvelopeId)!;
+    expect(persistedContext).toMatchObject({
+      assignmentId: admitted.assignment.assignmentId,
+      repositorySnapshotId: snapshot.id,
+      planStepIds: ['inspect-source'],
+      claimIds: [claim.claimId],
+      boundedParentNote: 'Return only repository-grounded findings.',
+    });
+    const isolated = JSON.stringify(persistedContext);
+    for (const forbidden of [
+      'conversationHistory', 'messages', 'memory', 'environment', 'apiKey',
+      lease.fenceToken!, 'credential:custom_openai',
+    ]) expect(isolated).not.toContain(forbidden);
+    const publicEvents = JSON.stringify(engine.listEvents(parent.jobId));
+    expect(publicEvents).not.toContain(lease.fenceToken!);
+    expect(publicEvents).not.toContain('credential:custom_openai');
+    expect(engine.resources.getBudgets(admitted.child.jobId).map((item) => item.kind)).toEqual(expect.arrayContaining([
+      'effects', 'input_tokens', 'model_calls', 'output_bytes', 'output_tokens', 'runtime_ms', 'tool_calls', 'workers',
+    ]));
+  });
+
+  it('deduplicates the same request and refuses a second concurrent Worker', async () => {
+    const { parent, lease, snapshot, claim } = await parentAuthority();
+    const input = {
+      engine, triggerBus,
+      parent: {
+        jobId: parent.jobId, attemptId: parent.attemptId,
+        generation: lease.generation!, fenceToken: lease.fenceToken!,
+      },
+      idempotencyKey: 'inspect-marker', goal: 'Inspect source.ts.',
+      repositorySnapshotId: snapshot.id, planStepIds: ['inspect-source'], claimIds: [claim.claimId],
+      provider: {
+        providerId: 'custom_openai', modelId: 'custom-default',
+        providerRuntimeIdentity: 'runtime:custom_openai', credentialReference: null,
+        endpointReference: 'endpoint:configured', supportsToolCalling: true,
+        contextWindow: 32_768, maxOutputTokens: 4_096, selectionReason: 'configured provider',
+      },
+    } as const;
+    const first = admitReadOnlyRepositoryWorker(input);
+    const duplicate = admitReadOnlyRepositoryWorker(input);
+    expect(duplicate.assignment.assignmentId).toBe(first.assignment.assignmentId);
+    expect(duplicate.child.jobId).toBe(first.child.jobId);
+    expect(duplicate.triggerEvent).toMatchObject({ id: first.triggerEvent.id, inserted: false });
+
+    expect(() => admitReadOnlyRepositoryWorker({
+      ...input, idempotencyKey: 'second-worker', goal: 'Inspect AGENTS.md.',
+    })).toThrow(/one active read-only repository Worker/i);
+  });
+
+  it.each([
+    ['tool calls are unavailable', { supportsToolCalling: false }],
+    ['the snapshot belongs to another Job', { repositorySnapshotId: 'missing_snapshot' }],
+  ])('fails closed when %s', async (_label, override) => {
+    const { parent, lease, snapshot } = await parentAuthority();
+    expect(() => admitReadOnlyRepositoryWorker({
+      engine, triggerBus,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: lease.generation!, fenceToken: lease.fenceToken! },
+      idempotencyKey: 'rejected', goal: 'Inspect.',
+      repositorySnapshotId: override.repositorySnapshotId ?? snapshot.id,
+      provider: {
+        providerId: 'custom_openai', modelId: 'custom-default',
+        providerRuntimeIdentity: 'runtime:custom_openai', credentialReference: null,
+        endpointReference: null, supportsToolCalling: override.supportsToolCalling ?? true,
+        contextWindow: 32_768, maxOutputTokens: 4_096, selectionReason: 'configured provider',
+      },
+    })).toThrow();
+  });
+
+  it.each([
+    ['the parent generation is stale', { generationDelta: 1, fenceToken: null }],
+    ['the parent fence is wrong', { generationDelta: 0, fenceToken: 'wrong-parent-fence' }],
+  ])('rejects admission when %s', async (_label, override) => {
+    const { parent, lease, snapshot } = await parentAuthority();
+    expect(() => admitReadOnlyRepositoryWorker({
+      engine, triggerBus,
+      parent: {
+        jobId: parent.jobId,
+        attemptId: parent.attemptId,
+        generation: lease.generation! + override.generationDelta,
+        fenceToken: override.fenceToken ?? lease.fenceToken!,
+      },
+      idempotencyKey: 'stale-parent', goal: 'Inspect.', repositorySnapshotId: snapshot.id,
+      provider: {
+        providerId: 'fixture', modelId: 'fixture-model', providerRuntimeIdentity: 'runtime:fixture',
+        credentialReference: null, endpointReference: null, supportsToolCalling: true,
+        contextWindow: 8_192, maxOutputTokens: 1_024, selectionReason: 'test',
+      },
+    })).toThrow(/parent|authority|generation|fence/i);
+  });
+
+  it('blocks admission when the bounded context cannot fit the pinned provider window', async () => {
+    const { parent, lease, snapshot } = await parentAuthority();
+    expect(() => admitReadOnlyRepositoryWorker({
+      engine, triggerBus,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: lease.generation!, fenceToken: lease.fenceToken! },
+      idempotencyKey: 'context-overflow', goal: 'Inspect.', repositorySnapshotId: snapshot.id,
+      provider: {
+        providerId: 'fixture', modelId: 'fixture-model', providerRuntimeIdentity: 'runtime:fixture',
+        credentialReference: null, endpointReference: null, supportsToolCalling: true,
+        contextWindow: 512, maxOutputTokens: 511, selectionReason: 'test',
+      },
+    })).toThrow(/context.*window/i);
+  });
+});

--- a/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { executeDurableJob } from '../../../core/v4/daemon/jobLifecycle';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
+import {
+  admitReadOnlyRepositoryWorker,
+  executeReadOnlyRepositoryWorker,
+  verifyReadOnlyRepositoryWorkerResult,
+} from '../../../core/v4/worker/readOnlyRepositoryWorker';
+import {
+  beginPhysicalProviderAttempt,
+  createLogicalProviderCallId,
+  setProviderAttemptLedger,
+} from '../../../providers/v4/providerAttemptAccounting';
+import type { ProviderAdapter, ProviderCallInput, ProviderCallOutput } from '../../../providers/v4/types';
+
+describe('read-only repository Worker runtime', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let root: string;
+  let home: string;
+  let ledgerPath: string;
+  let ledger: ProviderAttemptLedger;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      'INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)',
+    ).run('worker-instance', 1, 'localhost', Date.now(), Date.now(), '4.18.0');
+    engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-runtime-'));
+    home = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-runtime-home-'));
+    ledgerPath = path.join(home, 'usage.db');
+    ledger = new ProviderAttemptLedger(ledgerPath);
+    setProviderAttemptLedger(ledger);
+    await writeFile(path.join(root, 'AGENTS.md'), 'Inspect source.ts before reporting.\n');
+    await writeFile(path.join(root, 'source.ts'), 'export const marker = "durable-worker";\n');
+  });
+
+  afterEach(async () => {
+    setProviderAttemptLedger(null);
+    ledger.close();
+    db.close();
+    await Promise.all([
+      rm(root, { recursive: true, force: true }),
+      rm(home, { recursive: true, force: true }),
+    ]);
+  });
+
+  async function setup() {
+    const parent = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'parent-session', workspaceId: root,
+      instanceId: 'worker-instance', idempotencyNamespace: 'worker-parent', idempotencyKey: 'one',
+      goal: 'Verify the durable Worker marker.',
+    });
+    const parentLease = engine.claimAttempt({ attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000 });
+    if (!parentLease.acquired || !parentLease.fenceToken || parentLease.generation === undefined) throw new Error('parent lease');
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, requestedPath: root, producer: 'test',
+    });
+    engine.graph.createCodingPlan({
+      jobId: parent.jobId, planDigest: 'read-worker-plan', producer: 'test', idempotencyKey: 'plan',
+      steps: [{
+        stepId: 'inspect-source', label: 'Inspect source', repositorySnapshotId: snapshot.id,
+        requiresVerification: true,
+      }],
+    });
+    const entry = engine.repository.getEntry(snapshot.id, 'source.ts')!;
+    const claim = engine.proof.createClaim({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      category: 'observed', statement: 'source.ts contains the durable Worker marker.', required: true,
+      repositorySnapshotId: snapshot.id,
+      sourceReferences: [{ snapshotId: snapshot.id, path: 'source.ts', lineStart: 1, lineEnd: 1 }],
+      requiredEvidenceCategories: ['repository_readback'],
+    });
+    const admitted = admitReadOnlyRepositoryWorker({
+      engine, triggerBus: createTriggerBus({ db }),
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation, fenceToken: parentLease.fenceToken },
+      idempotencyKey: 'inspect-source', goal: 'Find the marker in source.ts and cite line 1.',
+      repositorySnapshotId: snapshot.id, planStepIds: ['inspect-source'], claimIds: [claim.claimId],
+      boundedParentNote: 'Use only the pinned snapshot.',
+      provider: {
+        providerId: 'fixture', modelId: 'fixture-tool-model', providerRuntimeIdentity: 'runtime:fixture',
+        credentialReference: null, endpointReference: null, supportsToolCalling: true,
+        contextWindow: 8_192, maxOutputTokens: 2_048, selectionReason: 'deterministic test provider',
+      },
+    });
+    return { parent, parentLease, snapshot, entry, claim, admitted };
+  }
+
+  async function runWorker(
+    admitted: Awaited<ReturnType<typeof setup>>['admitted'],
+    adapter: ProviderAdapter,
+  ) {
+    return executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
+      execute: (handle) => executeReadOnlyRepositoryWorker({
+        engine, handle, assignmentId: admitted.assignment.assignmentId,
+        resolveProvider: async () => ({ adapter, paths: resolveAidenPaths({ rootOverride: home }) }),
+      }),
+      finalize: (value) => value.finalization,
+    });
+  }
+
+  it('runs one pinned provider binding, records child Evidence, and independently verifies the parent Claim', async () => {
+    const { parent, parentLease, snapshot, entry, claim, admitted } = await setup();
+    const inputs: ProviderCallInput[] = [];
+    const responses: ProviderCallOutput[] = [
+      {
+        content: null,
+        toolCalls: [
+          { id: 'search', name: 'repository_snapshot_search', arguments: { query: 'durable-worker' } },
+          { id: 'read', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } },
+          { id: 'instructions', name: 'repository_instruction_read', arguments: { path: 'AGENTS.md' } },
+        ],
+        finishReason: 'tool_use', usage: { inputTokens: 30, outputTokens: 10 },
+      },
+      {
+        content: JSON.stringify({
+          schemaVersion: 1,
+          status: 'completed',
+          summary: 'The marker is declared in source.ts.',
+          findings: [{
+            findingId: 'marker', statement: 'source.ts declares durable-worker.', uncertainty: 'low',
+            sourceReferences: [{
+              snapshotId: snapshot.id, snapshotEntryId: entry.canonicalIdentity,
+              path: 'source.ts', startLine: 1, endLine: 1, contentHash: entry.contentHash,
+            }],
+          }],
+          unresolvedQuestions: [],
+          uncertainty: { level: 'low', reasons: [] },
+        }),
+        toolCalls: [], finishReason: 'stop', usage: { inputTokens: 40, outputTokens: 20 },
+      },
+    ];
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call(input) {
+        inputs.push(input);
+        const output = responses.shift();
+        if (!output) throw new Error('unexpected provider call');
+        const lifecycle = beginPhysicalProviderAttempt(input, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+          transport: 'fixture', attemptIndex: inputs.length,
+          logicalCallId: input.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+          requestBytes: JSON.stringify(input.messages).length,
+        });
+        lifecycle.success(output, JSON.stringify(output).length);
+        return output;
+      },
+    };
+
+    const childExecution = await executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
+      execute: (handle) => executeReadOnlyRepositoryWorker({
+        engine, handle, assignmentId: admitted.assignment.assignmentId,
+        resolveProvider: async () => ({ adapter, paths: resolveAidenPaths({ rootOverride: home }) }),
+      }),
+      finalize: (value) => value.finalization,
+    });
+
+    expect(childExecution.value.workerResult.acceptanceState).toBe('accepted');
+    expect(childExecution.value.workerResult.providerAttemptIds).toHaveLength(2);
+    expect(engine.proof.listEvidence(admitted.child.jobId)).toHaveLength(1);
+    expect(engine.getChildContract(admitted.child.jobId)).toMatchObject({
+      resultAttemptId: admitted.child.attemptId,
+      resultGeneration: 1,
+      resultStatus: 'completed',
+    });
+    expect(engine.getJob(parent.jobId)?.terminalAt).toBeNull();
+    expect(engine.proof.getVerdict(parent.jobId)).toBeNull();
+
+    const verified = await verifyReadOnlyRepositoryWorkerResult({
+      engine,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation!, fenceToken: parentLease.fenceToken! },
+      workerResultId: childExecution.value.workerResult.workerResultId,
+      producer: 'parent-verifier', idempotencyKey: 'verify-marker',
+    });
+    expect(verified.claims).toEqual([expect.objectContaining({ claimId: claim.claimId, state: 'verified' })]);
+    expect(verified.evidence).toHaveLength(1);
+    expect(verified.evidence[0]).toMatchObject({
+      jobId: parent.jobId, attemptId: parent.attemptId,
+      repositorySnapshotId: snapshot.id, source: 'repository_readback', verificationResult: 'verified',
+    });
+    expect(engine.proof.listEvidence(admitted.child.jobId)[0].evidenceId)
+      .not.toBe(verified.evidence[0].evidenceId);
+    const repeated = await verifyReadOnlyRepositoryWorkerResult({
+      engine,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation!, fenceToken: parentLease.fenceToken! },
+      workerResultId: childExecution.value.workerResult.workerResultId,
+      producer: 'parent-verifier', idempotencyKey: 'verify-marker',
+    });
+    expect(repeated.evidence).toHaveLength(1);
+    expect(engine.proof.listEvidence(parent.jobId).filter((item) => item.source === 'repository_readback')).toHaveLength(1);
+    expect(engine.graph.getCodingPlan(parent.jobId)?.steps[0].references).toContainEqual({
+      kind: 'evidence', id: verified.evidence[0].evidenceId,
+      snapshotId: null, path: null, lineStart: null, lineEnd: null,
+    });
+    expect(inputs).toHaveLength(2);
+    expect(new Set(ledger.query({ jobId: admitted.child.jobId }).map((record) => `${record.providerActual}/${record.modelActual}`)))
+      .toEqual(new Set(['fixture/fixture-tool-model']));
+    expect(JSON.stringify(inputs[0].messages)).not.toContain(parentLease.fenceToken!);
+    expect(JSON.stringify(inputs[0].messages)).not.toContain(process.env.PATH ?? '<unset>');
+    expect(inputs[0].tools.map((tool) => tool.name).sort()).toEqual([
+      'repository_instruction_read', 'repository_snapshot_read', 'repository_snapshot_search',
+    ]);
+    expect(db.prepare('SELECT COUNT(*) AS n FROM side_effect_ledger WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 0 });
+    expect(engine.graph.workerReferences(parent.jobId).map((reference) => reference.kind)).toEqual([
+      'worker_assignment', 'child_attempt', 'worker_result', 'worker_run',
+    ]);
+  });
+
+  it('rejects a provider result that cites content outside the assigned snapshot', async () => {
+    const { admitted, snapshot } = await setup();
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        return {
+          content: JSON.stringify({
+            schemaVersion: 1, status: 'completed', summary: 'unsupported',
+            findings: [{
+              findingId: 'bad', statement: 'outside', uncertainty: 'low',
+              sourceReferences: [{
+                snapshotId: snapshot.id, snapshotEntryId: 'outside', path: '../outside.txt',
+                startLine: 1, endLine: 1, contentHash: 'a'.repeat(64),
+              }],
+            }],
+            unresolvedQuestions: [], uncertainty: { level: 'low', reasons: [] },
+          }),
+          toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 },
+        };
+      },
+    };
+    await expect(executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
+      execute: (handle) => executeReadOnlyRepositoryWorker({
+        engine, handle, assignmentId: admitted.assignment.assignmentId,
+        resolveProvider: async () => ({ adapter, paths: resolveAidenPaths({ rootOverride: home }) }),
+      }),
+      finalize: (value) => value.finalization,
+    })).rejects.toThrow(/source reference|snapshot/i);
+    expect(engine.worker.listWorkerRunsForChild(admitted.child.jobId)[0]?.acceptedResultId).toBeNull();
+    expect(engine.worker.listWorkerEvents(engine.getJob(admitted.child.jobId)?.parentJobId ?? '')
+      .filter((event) => event.kind === 'worker.result_rejected')).toHaveLength(1);
+    expect(engine.proof.listEvidence(admitted.child.jobId)).toHaveLength(0);
+  });
+
+  it('persists malformed output as a rejected candidate and never creates Evidence', async () => {
+    const { admitted } = await setup();
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        return {
+          content: '{"schemaVersion":1,"status":"completed"}',
+          toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 },
+        };
+      },
+    };
+    await expect(runWorker(admitted, adapter)).rejects.toThrow(/summary|result|schema/i);
+    expect(engine.worker.listWorkerEvents(engine.getJob(admitted.child.jobId)?.parentJobId ?? '')
+      .filter((event) => event.kind === 'worker.result_rejected')).toHaveLength(1);
+    expect(engine.worker.listWorkerRunsForChild(admitted.child.jobId)[0]?.acceptedResultId).toBeNull();
+    expect(engine.proof.listEvidence(admitted.child.jobId)).toHaveLength(0);
+  });
+
+  it('does not fall back or accept a result when the pinned provider fails', async () => {
+    const { admitted } = await setup();
+    let calls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        calls += 1;
+        throw new Error('fixture provider unavailable');
+      },
+    };
+    await expect(runWorker(admitted, adapter)).rejects.toThrow(/fixture provider unavailable/i);
+    expect(calls).toBe(1);
+    expect(engine.worker.listWorkerRunsForChild(admitted.child.jobId)).toHaveLength(1);
+    expect(engine.worker.listWorkerRunsForChild(admitted.child.jobId)[0].acceptedResultId).toBeNull();
+    expect(engine.worker.rebuildWorkerProjection(engine.getJob(admitted.child.jobId)?.parentJobId ?? '').acceptedResultIds)
+      .toHaveLength(0);
+  });
+
+  it('prevents cancelled parent authority from creating parent Evidence or changing its Claim', async () => {
+    const { parent, parentLease, snapshot, entry, claim, admitted } = await setup();
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        return {
+          content: JSON.stringify({
+            schemaVersion: 1, status: 'completed', summary: 'The marker is present.',
+            findings: [{
+              findingId: 'marker', statement: 'source.ts declares durable-worker.', uncertainty: 'low',
+              sourceReferences: [{
+                snapshotId: snapshot.id, snapshotEntryId: entry.canonicalIdentity,
+                path: 'source.ts', startLine: 1, endLine: 1, contentHash: entry.contentHash,
+              }],
+            }],
+            unresolvedQuestions: [], uncertainty: { level: 'low', reasons: [] },
+          }),
+          toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 },
+        };
+      },
+    };
+    const child = await runWorker(admitted, adapter);
+    expect(child.value.workerResult.acceptanceState).toBe('accepted');
+    engine.cancelJob({
+      jobId: parent.jobId, reason: 'parent cancelled', producer: 'test', eventIdempotencyKey: 'cancel-parent',
+    });
+    await expect(verifyReadOnlyRepositoryWorkerResult({
+      engine,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation!, fenceToken: parentLease.fenceToken! },
+      workerResultId: child.value.workerResult.workerResultId,
+      producer: 'parent-verifier', idempotencyKey: 'cancelled-parent-verification',
+    })).rejects.toThrow(/authority/i);
+    expect(engine.proof.listEvidence(parent.jobId)).toHaveLength(0);
+    expect(engine.proof.listClaims(parent.jobId)).toContainEqual(expect.objectContaining({
+      claimId: claim.claimId, state: 'unverified',
+    }));
+    expect(engine.worker.getWorkerResult(child.value.workerResult.workerResultId)).toMatchObject({
+      acceptanceState: 'accepted',
+    });
+  });
+
+  it('preserves the accepted candidate and records failed parent Verification when readback becomes stale', async () => {
+    const { parent, parentLease, snapshot, entry, claim, admitted } = await setup();
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        return {
+          content: JSON.stringify({
+            schemaVersion: 1, status: 'completed', summary: 'The marker is present.',
+            findings: [{
+              findingId: 'marker', statement: 'source.ts declares durable-worker.', uncertainty: 'low',
+              sourceReferences: [{
+                snapshotId: snapshot.id, snapshotEntryId: entry.canonicalIdentity,
+                path: 'source.ts', startLine: 1, endLine: 1, contentHash: entry.contentHash,
+              }],
+            }],
+            unresolvedQuestions: [], uncertainty: { level: 'low', reasons: [] },
+          }),
+          toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 },
+        };
+      },
+    };
+    const child = await runWorker(admitted, adapter);
+    await writeFile(path.join(root, 'source.ts'), 'changed after Worker completion\n');
+    await expect(verifyReadOnlyRepositoryWorkerResult({
+      engine,
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation!, fenceToken: parentLease.fenceToken! },
+      workerResultId: child.value.workerResult.workerResultId,
+      producer: 'parent-verifier', idempotencyKey: 'stale-parent-readback',
+    })).rejects.toThrow(/stale|incomplete/i);
+    expect(engine.worker.getWorkerResult(child.value.workerResult.workerResultId)).toMatchObject({
+      acceptanceState: 'accepted',
+    });
+    expect(engine.proof.listEvidence(parent.jobId)).toContainEqual(expect.objectContaining({
+      source: 'repository_readback', verificationResult: 'failed', coverage: 'unknown',
+    }));
+    expect(engine.proof.listClaims(parent.jobId)).toContainEqual(expect.objectContaining({
+      claimId: claim.claimId, state: 'failed',
+    }));
+    expect(engine.proof.getVerdict(parent.jobId)).toBeNull();
+  });
+});

--- a/tests/v4/worker/readOnlyRepositoryWorkerTools.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerTools.test.ts
@@ -3,7 +3,7 @@
  * Licensed under AGPL-3.0. See LICENSE for details.
  */
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
@@ -38,6 +38,8 @@ describe('read-only repository Worker tools', () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-home-'));
     await writeFile(path.join(root, 'AGENTS.md'), 'Read the source before reporting.\n');
     await writeFile(path.join(root, 'source.ts'), 'export const marker = "needle";\n');
+    await mkdir(path.join(root, 'nested directory'), { recursive: true });
+    await writeFile(path.join(root, 'nested directory', 'child.ts'), 'export const child = "needle";\n');
   });
 
   afterEach(async () => {
@@ -144,6 +146,45 @@ describe('read-only repository Worker tools', () => {
       },
       finalize: () => ({ status: 'completed', outcome: 'checked', finishReason: 'stop', evidence: {} }),
     });
+  });
+
+  it('uses canonical snapshot-relative paths instead of the caller working directory', async () => {
+    const { admitted, parent, parentLease } = await assignment();
+    const values = await executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-test' },
+      execute: async (handle) => {
+        const workerRunId = `worker_run_${admitted.assignment.assignmentId.slice('worker_assignment_'.length)}`;
+        engine.worker.bindWorkerRun({
+          parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+          parentGeneration: parentLease.generation!, parentFenceToken: parentLease.fenceToken!,
+          childJobId: handle.jobId, childAttemptId: handle.attemptId,
+          childGeneration: handle.generation, childFenceToken: handle.fenceToken,
+          workerRunId, schemaVersion: 1, assignmentId: admitted.assignment.assignmentId,
+          providerBindingId: admitted.providerBinding.providerBindingId,
+          contextEnvelopeId: admitted.contextEnvelope.contextEnvelopeId,
+          producer: 'test', idempotencyKey: 'canonical-path-run',
+        });
+        const executor = createReadOnlyRepositoryWorkerToolRegistry({ engine, assignmentId: admitted.assignment.assignmentId, workerRunId })
+          .buildExecutor({ cwd: path.dirname(root), paths: resolveAidenPaths({ rootOverride: home }) });
+        return {
+          windowsSeparators: await executor({ id: 'windows-separators', name: 'repository_snapshot_read', arguments: { path: 'nested directory\\child.ts' } }),
+          posixSeparators: await executor({ id: 'posix-separators', name: 'repository_snapshot_read', arguments: { path: 'nested directory/child.ts' } }),
+          escaped: await executor({ id: 'escaped', name: 'repository_snapshot_read', arguments: { path: '../outside.ts' } }),
+          absoluteWindows: await executor({ id: 'absolute-windows', name: 'repository_snapshot_read', arguments: { path: 'C:\\outside.ts' } }),
+          absolutePosix: await executor({ id: 'absolute-posix', name: 'repository_snapshot_read', arguments: { path: '/outside.ts' } }),
+          unc: await executor({ id: 'unc', name: 'repository_snapshot_read', arguments: { path: '\\\\server\\share\\outside.ts' } }),
+        };
+      },
+      finalize: () => ({ status: 'completed', outcome: 'checked', finishReason: 'stop', evidence: {} }),
+    });
+    expect(values.value.windowsSeparators.result).toMatchObject({ path: 'nested directory/child.ts', stale: false });
+    expect(values.value.posixSeparators.result).toMatchObject({ path: 'nested directory/child.ts', stale: false });
+    for (const outcome of [values.value.escaped, values.value.absoluteWindows, values.value.absolutePosix, values.value.unc]) {
+      expect(outcome.error).toMatch(/snapshot|path/i);
+    }
+    expect(db.prepare('SELECT COUNT(*) AS n FROM tool_calls WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 2 });
+    expect(db.prepare('SELECT COUNT(*) AS n FROM side_effect_ledger WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 0 });
   });
 
   it('keeps every generic or mutating capability outside the Worker registry', async () => {

--- a/tests/v4/worker/readOnlyRepositoryWorkerTools.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerTools.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { executeDurableJob } from '../../../core/v4/daemon/jobLifecycle';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import {
+  READ_ONLY_REPOSITORY_WORKER_TOOLS,
+  admitReadOnlyRepositoryWorker,
+  createReadOnlyRepositoryWorkerToolRegistry,
+} from '../../../core/v4/worker/readOnlyRepositoryWorker';
+
+describe('read-only repository Worker tools', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let root: string;
+  let home: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      'INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)',
+    ).run('worker-instance', 1, 'localhost', Date.now(), Date.now(), '4.18.0');
+    engine = createJobEngine({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-tools-'));
+    home = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-home-'));
+    await writeFile(path.join(root, 'AGENTS.md'), 'Read the source before reporting.\n');
+    await writeFile(path.join(root, 'source.ts'), 'export const marker = "needle";\n');
+  });
+
+  afterEach(async () => {
+    db.close();
+    await Promise.all([
+      rm(root, { recursive: true, force: true }),
+      rm(home, { recursive: true, force: true }),
+    ]);
+  });
+
+  async function assignment() {
+    const parent = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'session', workspaceId: root,
+      instanceId: 'worker-instance', idempotencyNamespace: 'parent', idempotencyKey: 'one', goal: 'inspect',
+    });
+    const parentLease = engine.claimAttempt({ attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000 });
+    if (!parentLease.acquired || !parentLease.fenceToken || parentLease.generation === undefined) throw new Error('lease');
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation,
+      fenceToken: parentLease.fenceToken, requestedPath: root, producer: 'test',
+    });
+    const admitted = admitReadOnlyRepositoryWorker({
+      engine, triggerBus: createTriggerBus({ db }),
+      parent: { jobId: parent.jobId, attemptId: parent.attemptId, generation: parentLease.generation, fenceToken: parentLease.fenceToken },
+      idempotencyKey: 'one', goal: 'Inspect the marker.', repositorySnapshotId: snapshot.id,
+      provider: {
+        providerId: 'test', modelId: 'tool-model', providerRuntimeIdentity: 'runtime:test',
+        credentialReference: null, endpointReference: null, supportsToolCalling: true,
+        contextWindow: 8_192, maxOutputTokens: 1_024, selectionReason: 'test binding',
+      },
+    });
+    return { admitted, parent, parentLease, snapshot };
+  }
+
+  it('exposes only three snapshot-bound tools through durable ToolCall execution', async () => {
+    const { admitted, parent, parentLease } = await assignment();
+    const values = await executeDurableJob({
+      engine,
+      ownerId: 'worker-instance',
+      leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-test' },
+      execute: async (handle) => {
+        const workerRunId = `worker_run_${admitted.assignment.assignmentId.slice('worker_assignment_'.length)}`;
+        engine.worker.bindWorkerRun({
+          parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+          parentGeneration: parentLease.generation!, parentFenceToken: parentLease.fenceToken!,
+          childJobId: handle.jobId, childAttemptId: handle.attemptId,
+          childGeneration: handle.generation, childFenceToken: handle.fenceToken,
+          workerRunId, schemaVersion: 1, assignmentId: admitted.assignment.assignmentId,
+          providerBindingId: admitted.providerBinding.providerBindingId,
+          contextEnvelopeId: admitted.contextEnvelope.contextEnvelopeId,
+          producer: 'test', idempotencyKey: 'run',
+        });
+        const registry = createReadOnlyRepositoryWorkerToolRegistry({
+          engine, assignmentId: admitted.assignment.assignmentId, workerRunId,
+        });
+        const executor = registry.buildExecutor({
+          cwd: root, paths: resolveAidenPaths({ rootOverride: home }), sessionId: 'worker-session',
+        });
+        const search = await executor({ id: 'search-one', name: 'repository_snapshot_search', arguments: { query: 'needle' } }, handle.signal);
+        const read = await executor({ id: 'read-one', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } }, handle.signal);
+        const instruction = await executor({ id: 'instruction-one', name: 'repository_instruction_read', arguments: { path: 'AGENTS.md' } }, handle.signal);
+        const shell = await executor({ id: 'shell-one', name: 'shell_exec', arguments: { command: 'echo forbidden' } }, handle.signal);
+        return { names: registry.list(), search, read, instruction, shell };
+      },
+      finalize: () => ({ status: 'completed', outcome: 'inspected', finishReason: 'stop', evidence: { readOnly: true } }),
+    });
+
+    expect(values.value.names).toEqual([...READ_ONLY_REPOSITORY_WORKER_TOOLS]);
+    expect(values.value.search.error).toBeUndefined();
+    expect(values.value.search.result).toMatchObject({ snapshotId: admitted.assignment.repositorySnapshotId, stale: false });
+    expect(values.value.read.result).toMatchObject({ path: 'source.ts', stale: false });
+    expect(values.value.instruction.result).toMatchObject({ path: 'AGENTS.md', stale: false });
+    expect(values.value.shell.error).toMatch(/not registered/i);
+    expect(db.prepare('SELECT COUNT(*) AS n FROM tool_calls WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 3 });
+    expect(db.prepare('SELECT COUNT(*) AS n FROM side_effect_ledger WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 0 });
+  });
+
+  it('rejects path escape and refuses stale snapshot content', async () => {
+    const { admitted, parent, parentLease } = await assignment();
+    await executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-test' },
+      execute: async (handle) => {
+        const workerRunId = `worker_run_${admitted.assignment.assignmentId.slice('worker_assignment_'.length)}`;
+        engine.worker.bindWorkerRun({
+          parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+          parentGeneration: parentLease.generation!, parentFenceToken: parentLease.fenceToken!,
+          childJobId: handle.jobId, childAttemptId: handle.attemptId,
+          childGeneration: handle.generation, childFenceToken: handle.fenceToken,
+          workerRunId, schemaVersion: 1, assignmentId: admitted.assignment.assignmentId,
+          providerBindingId: admitted.providerBinding.providerBindingId,
+          contextEnvelopeId: admitted.contextEnvelope.contextEnvelopeId,
+          producer: 'test', idempotencyKey: 'run',
+        });
+        const executor = createReadOnlyRepositoryWorkerToolRegistry({ engine, assignmentId: admitted.assignment.assignmentId, workerRunId })
+          .buildExecutor({ cwd: root, paths: resolveAidenPaths({ rootOverride: home }) });
+        const escaped = await executor({ id: 'escape', name: 'repository_snapshot_read', arguments: { path: '../outside.txt' } });
+        await writeFile(path.join(root, 'source.ts'), 'changed after snapshot\n');
+        const stale = await executor({ id: 'stale', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } });
+        expect(escaped.error).toMatch(/snapshot|path/i);
+        expect(stale.error).toMatch(/stale/i);
+        return null;
+      },
+      finalize: () => ({ status: 'completed', outcome: 'checked', finishReason: 'stop', evidence: {} }),
+    });
+  });
+
+  it('keeps every generic or mutating capability outside the Worker registry', async () => {
+    const { admitted, parent, parentLease } = await assignment();
+    await executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-test' },
+      execute: async (handle) => {
+        const workerRunId = `worker_run_${admitted.assignment.assignmentId.slice('worker_assignment_'.length)}`;
+        engine.worker.bindWorkerRun({
+          parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+          parentGeneration: parentLease.generation!, parentFenceToken: parentLease.fenceToken!,
+          childJobId: handle.jobId, childAttemptId: handle.attemptId,
+          childGeneration: handle.generation, childFenceToken: handle.fenceToken,
+          workerRunId, schemaVersion: 1, assignmentId: admitted.assignment.assignmentId,
+          providerBindingId: admitted.providerBinding.providerBindingId,
+          contextEnvelopeId: admitted.contextEnvelope.contextEnvelopeId,
+          producer: 'test', idempotencyKey: 'restricted-run',
+        });
+        const registry = createReadOnlyRepositoryWorkerToolRegistry({
+          engine, assignmentId: admitted.assignment.assignmentId, workerRunId,
+        });
+        const executor = registry.buildExecutor({ cwd: root, paths: resolveAidenPaths({ rootOverride: home }) });
+        for (const tool of [
+          'file_read', 'file_write', 'file_patch', 'shell_exec', 'git_status', 'browser_open',
+          'web_search', 'mcp_call', 'plugin_execute', 'send_message', 'clarify', 'memory_search',
+          'skill_run', 'spawn_sub_agent',
+        ]) {
+          const outcome = await executor({ id: `forbidden-${tool}`, name: tool, arguments: {} });
+          expect(outcome.error, tool).toMatch(/not registered/i);
+        }
+        return null;
+      },
+      finalize: () => ({ status: 'completed', outcome: 'checked', finishReason: 'stop', evidence: {} }),
+    });
+    expect(db.prepare('SELECT COUNT(*) AS n FROM tool_calls WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 0 });
+    expect(db.prepare('SELECT COUNT(*) AS n FROM side_effect_ledger WHERE job_id=?').get(admitted.child.jobId)).toEqual({ n: 0 });
+  });
+
+  it('denies every Worker tool when the immutable capability set is missing', async () => {
+    const { admitted, parent, parentLease } = await assignment();
+    db.prepare('UPDATE worker_assignments SET capability_set_id=NULL WHERE assignment_id=?')
+      .run(admitted.assignment.assignmentId);
+    await expect(executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-test' },
+      execute: async (handle) => {
+        const workerRunId = `worker_run_${admitted.assignment.assignmentId.slice('worker_assignment_'.length)}`;
+        engine.worker.bindWorkerRun({
+          parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+          parentGeneration: parentLease.generation!, parentFenceToken: parentLease.fenceToken!,
+          childJobId: handle.jobId, childAttemptId: handle.attemptId,
+          childGeneration: handle.generation, childFenceToken: handle.fenceToken,
+          workerRunId, schemaVersion: 1, assignmentId: admitted.assignment.assignmentId,
+          providerBindingId: admitted.providerBinding.providerBindingId,
+          contextEnvelopeId: admitted.contextEnvelope.contextEnvelopeId,
+          producer: 'test', idempotencyKey: 'missing-capabilities',
+        });
+        return createReadOnlyRepositoryWorkerToolRegistry({
+          engine, assignmentId: admitted.assignment.assignmentId, workerRunId,
+        });
+      },
+      finalize: () => ({ status: 'completed', outcome: 'unexpected', finishReason: 'stop', evidence: {} }),
+    })).rejects.toThrow(/capability/i);
+  });
+});


### PR DESCRIPTION
## Summary

- executes one repository-reading Worker as a durable child Job and Attempt;
- delivers immutable assignments through the existing TriggerBus and dispatcher;
- limits execution to snapshot search, bounded snapshot reads, and repository instruction reads;
- resolves one pinned provider binding with physical-attempt accounting and no fallback;
- validates structured Worker results before recording canonical child Evidence;
- independently rereads cited snapshot content before checking pre-existing parent Claims;
- adds no mutation, shell access, parallelism, nesting, scheduler, lifecycle state, or database migration.

## Validation

- PR2 Worker tests: 18 passed
- Focused Worker/lifecycle/proof/dispatcher compatibility matrix: 258 passed
- Offline integration: 20 passed
- Deterministic Node 22.23.1 suite: 7,441 passed, 48 skipped
- Typecheck passed
- Production build passed
- Package dry run passed
- Scope, secret, attribution, NUL, diff, and process-cleanup checks passed