### PR TITLE
feat(worker): add provider call and budget bridge

### DIFF
--- a/cli/v4/daemonAgentBuilder.ts
+++ b/cli/v4/daemonAgentBuilder.ts
@@ -216,6 +216,11 @@ export function buildDaemonAgentBuilder(
       paths: deps.paths,
     }),
     paths: deps.paths,
+    providerId: binding.providerId,
+    modelId: binding.modelId,
+    providerRuntimeIdentity: binding.providerRuntimeIdentity,
+    credentialReference: binding.credentialReference,
+    endpointReference: binding.endpointReference,
   });
   return builder;
 }

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -1984,6 +1984,126 @@ function applyV37(db: Database.Database): void {
   `);
 }
 
+/** Durable Worker provider-call correlation and parent budget reservations. */
+function applyV38(db: Database.Database): void {
+  addMissingColumns(db, 'worker_provider_bindings', [
+    ['supports_tool_calling', 'INTEGER NOT NULL DEFAULT 1'],
+    ['supports_streaming', 'INTEGER NOT NULL DEFAULT 0'],
+    ['catalog_digest', "TEXT NOT NULL DEFAULT ''"],
+    ['fallback_binding_ids_json', "TEXT NOT NULL DEFAULT '[]'"],
+  ]);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS worker_logical_provider_calls (
+      logical_call_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      worker_run_id TEXT NOT NULL,
+      assignment_id TEXT NOT NULL,
+      provider_binding_id TEXT NOT NULL,
+      child_job_id TEXT NOT NULL,
+      child_attempt_id TEXT NOT NULL,
+      child_generation INTEGER NOT NULL,
+      call_ordinal INTEGER NOT NULL,
+      request_hash TEXT NOT NULL,
+      tool_schema_hash TEXT NOT NULL,
+      provider_id TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      fallback_policy_id TEXT,
+      state TEXT NOT NULL CHECK (state IN (
+        'prepared','attempting','response_received','accepted','downstream_started',
+        'completed','failed','cancelled','unknown'
+      )),
+      accepted_provider_attempt_id TEXT,
+      response_hash TEXT,
+      provider_request_id TEXT,
+      failure_kind TEXT,
+      outcome_known INTEGER NOT NULL DEFAULT 1,
+      response_received_at INTEGER,
+      accepted_at INTEGER,
+      downstream_started_at INTEGER,
+      completed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (worker_run_id) REFERENCES worker_runs(worker_run_id) ON DELETE CASCADE,
+      FOREIGN KEY (assignment_id) REFERENCES worker_assignments(assignment_id) ON DELETE CASCADE,
+      FOREIGN KEY (provider_binding_id) REFERENCES worker_provider_bindings(provider_binding_id),
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (worker_run_id, idempotency_key),
+      UNIQUE (worker_run_id, call_ordinal)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_logical_calls_child
+      ON worker_logical_provider_calls(child_job_id, child_attempt_id, child_generation, call_ordinal);
+
+    CREATE TABLE IF NOT EXISTS worker_provider_tool_links (
+      link_id TEXT PRIMARY KEY,
+      logical_call_id TEXT NOT NULL,
+      worker_run_id TEXT NOT NULL,
+      provider_tool_call_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      arguments_hash TEXT NOT NULL,
+      response_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (logical_call_id) REFERENCES worker_logical_provider_calls(logical_call_id) ON DELETE CASCADE,
+      FOREIGN KEY (worker_run_id) REFERENCES worker_runs(worker_run_id) ON DELETE CASCADE,
+      UNIQUE (worker_run_id, provider_tool_call_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS job_budget_reservations (
+      reservation_id TEXT PRIMARY KEY,
+      idempotency_key TEXT NOT NULL,
+      parent_job_id TEXT NOT NULL,
+      parent_attempt_id TEXT NOT NULL,
+      parent_generation INTEGER NOT NULL,
+      child_job_id TEXT NOT NULL,
+      child_attempt_id TEXT NOT NULL,
+      child_generation INTEGER NOT NULL,
+      worker_run_id TEXT NOT NULL,
+      assignment_id TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN (
+        'reserved','partially_committed','committed','released','exhausted','cancelled','reconciled'
+      )),
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      released_at INTEGER,
+      FOREIGN KEY (parent_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (parent_job_id, idempotency_key),
+      UNIQUE (child_job_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_budget_reservations_parent
+      ON job_budget_reservations(parent_job_id, state, created_at);
+
+    CREATE TABLE IF NOT EXISTS job_budget_reservation_items (
+      reservation_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      reserved_value REAL NOT NULL,
+      committed_value REAL NOT NULL DEFAULT 0,
+      released_value REAL NOT NULL DEFAULT 0,
+      has_unknown_usage INTEGER NOT NULL DEFAULT 0,
+      state TEXT NOT NULL CHECK (state IN ('reserved','partially_committed','committed','released','exhausted','unknown')),
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (reservation_id, kind),
+      FOREIGN KEY (reservation_id) REFERENCES job_budget_reservations(reservation_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS job_budget_reservation_commits (
+      commit_id TEXT PRIMARY KEY,
+      reservation_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      amount REAL,
+      certainty TEXT NOT NULL,
+      source_kind TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (reservation_id) REFERENCES job_budget_reservations(reservation_id) ON DELETE CASCADE,
+      UNIQUE (reservation_id, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_job_budget_reservation_commits_source
+      ON job_budget_reservation_commits(source_kind, source_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -2022,6 +2142,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 35, name: 'durable Git effects and reconciliation', apply: applyV35 },
   { version: 36, name: 'repository understanding and durable coding plans', apply: applyV36 },
   { version: 37, name: 'durable Worker contracts and authority boundaries', apply: applyV37 },
+  { version: 38, name: 'durable Worker provider calls and budget reservations', apply: applyV38 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -2062,7 +2183,9 @@ function validateLatestSchema(db: Database.Database): void {
     'git_effect_operations', 'repository_understanding_indexes', 'repository_understanding_records',
     'repository_understanding_snapshot_records', 'repository_architecture_notes',
     'execution_graph_node_references', 'worker_assignments', 'worker_runs',
-    'worker_provider_bindings', 'worker_context_envelopes', 'worker_results'];
+    'worker_provider_bindings', 'worker_context_envelopes', 'worker_results',
+    'worker_logical_provider_calls', 'worker_provider_tool_links', 'job_budget_reservations',
+    'job_budget_reservation_items', 'job_budget_reservation_commits'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -42,6 +42,10 @@ import {
   type RepositoryUnderstandingAuthority,
 } from '../codebase/repositoryUnderstandingAuthority';
 import { createWorkerAuthority, type WorkerAuthority } from '../worker/workerAuthority';
+import {
+  createWorkerProviderCallAuthority,
+  type WorkerProviderCallAuthority,
+} from '../worker/workerProviderCallAuthority';
 
 export type JobStatus =
   | 'queued' | 'running' | 'waiting' | 'paused' | 'cancelling'
@@ -202,6 +206,7 @@ export interface LeaseResult extends TransitionResult {
 export interface JobEngine {
   readonly graph: ExecutionGraphAuthority;
   readonly worker: WorkerAuthority;
+  readonly workerProviderCalls: WorkerProviderCallAuthority;
   readonly resources: JobResourceAuthority;
   readonly proof: JobProofAuthority;
   readonly projection: JobEventProjectionAuthority;
@@ -2370,10 +2375,26 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       return { duplicate: result.duplicate, sequence: result.jobSequence };
     },
   });
+  const workerProviderCalls = createWorkerProviderCallAuthority(db, (command) => {
+    const attempt = activeFence(
+      command.childAttemptId,
+      command.childGeneration,
+      command.childFenceToken,
+      command.now,
+    );
+    const job = attempt ? getJobRow(command.childJobId) : undefined;
+    return Boolean(
+      attempt
+      && attempt.task_id === command.childJobId
+      && job?.active_attempt_id === command.childAttemptId
+      && !JOB_TERMINAL.has(job.status),
+    );
+  });
 
   return {
     graph,
     worker,
+    workerProviderCalls,
     resources,
     proof,
     projection,

--- a/core/v4/daemon/jobResourceAuthority.ts
+++ b/core/v4/daemon/jobResourceAuthority.ts
@@ -36,6 +36,37 @@ export interface JobBudgetRecord {
   stateVersion: number;
 }
 
+export type JobBudgetReservationState =
+  | 'reserved' | 'partially_committed' | 'committed' | 'released'
+  | 'exhausted' | 'cancelled' | 'reconciled';
+
+export interface JobBudgetReservationItemRecord {
+  kind: JobBudgetKind;
+  reserved: number;
+  committed: number;
+  released: number;
+  hasUnknownUsage: boolean;
+  state: 'reserved' | 'partially_committed' | 'committed' | 'released' | 'exhausted' | 'unknown';
+}
+
+export interface JobBudgetReservationRecord {
+  reservationId: string;
+  idempotencyKey: string;
+  parentJobId: string;
+  parentAttemptId: string;
+  parentGeneration: number;
+  childJobId: string;
+  childAttemptId: string;
+  childGeneration: number;
+  workerRunId: string;
+  assignmentId: string;
+  state: JobBudgetReservationState;
+  items: JobBudgetReservationItemRecord[];
+  createdAt: number;
+  updatedAt: number;
+  releasedAt: number | null;
+}
+
 export interface JobResourceAuthority {
   configure(command: {
     jobId: string;
@@ -56,6 +87,46 @@ export interface JobResourceAuthority {
     enforceLimit?: boolean;
     now?: number;
   }): { applied: boolean; duplicate?: boolean; exhausted?: boolean; remaining: number | null };
+  reserveWorker(command: {
+    reservationId: string;
+    idempotencyKey: string;
+    parentJobId: string;
+    parentAttemptId: string;
+    parentGeneration: number;
+    parentFenceToken: string;
+    childJobId: string;
+    childAttemptId: string;
+    childGeneration: number;
+    workerRunId: string;
+    assignmentId: string;
+    amounts: Partial<Record<JobBudgetKind, number>>;
+    now?: number;
+  }): JobBudgetReservationRecord;
+  getWorkerReservation(reservationId: string): JobBudgetReservationRecord | null;
+  getWorkerReservationForChild(childJobId: string): JobBudgetReservationRecord | null;
+  listWorkerReservations(parentJobId: string): JobBudgetReservationRecord[];
+  available(jobId: string, kind: JobBudgetKind): number | null;
+  commitWorkerUsage(command: {
+    reservationId: string;
+    childAttemptId: string;
+    childGeneration: number;
+    childFenceToken: string;
+    kind: JobBudgetKind;
+    amount: number | null;
+    certainty: BudgetCertainty;
+    sourceKind: 'provider_attempt' | 'tool_call' | 'runtime' | 'reconciliation';
+    sourceId: string;
+    idempotencyKey: string;
+    now?: number;
+  }): { applied: boolean; duplicate?: boolean; exhausted?: boolean; remaining: number };
+  releaseWorker(command: {
+    reservationId: string;
+    childAttemptId: string;
+    childGeneration: number;
+    childFenceToken: string;
+    cancelled?: boolean;
+    now?: number;
+  }): JobBudgetReservationRecord;
   authorize(command: {
     jobId: string;
     kind: 'tool' | 'path' | 'host' | 'application' | 'connection' | 'account' | 'worker' | 'effect';
@@ -99,7 +170,320 @@ function normalizeCapabilities(value: JobCapabilities = {}): Required<JobCapabil
 }
 
 export function createJobResourceAuthority(db: Db): JobResourceAuthority {
+  type ReservationRow = {
+    reservation_id: string; idempotency_key: string; parent_job_id: string;
+    parent_attempt_id: string; parent_generation: number; child_job_id: string;
+    child_attempt_id: string; child_generation: number; worker_run_id: string;
+    assignment_id: string; state: JobBudgetReservationState; created_at: number;
+    updated_at: number; released_at: number | null;
+  };
+  type ItemRow = {
+    kind: JobBudgetKind; reserved_value: number; committed_value: number;
+    released_value: number; has_unknown_usage: number;
+    state: JobBudgetReservationItemRecord['state'];
+  };
+  const getReservation = (reservationId: string): JobBudgetReservationRecord | null => {
+    const row = db.prepare('SELECT * FROM job_budget_reservations WHERE reservation_id=?')
+      .get(reservationId) as ReservationRow | undefined;
+    if (!row) return null;
+    const items = (db.prepare(
+      'SELECT kind,reserved_value,committed_value,released_value,has_unknown_usage,state FROM job_budget_reservation_items WHERE reservation_id=? ORDER BY kind',
+    ).all(reservationId) as ItemRow[]).map((item) => ({
+      kind: item.kind,
+      reserved: item.reserved_value,
+      committed: item.committed_value,
+      released: item.released_value,
+      hasUnknownUsage: item.has_unknown_usage === 1,
+      state: item.state,
+    }));
+    return {
+      reservationId: row.reservation_id,
+      idempotencyKey: row.idempotency_key,
+      parentJobId: row.parent_job_id,
+      parentAttemptId: row.parent_attempt_id,
+      parentGeneration: row.parent_generation,
+      childJobId: row.child_job_id,
+      childAttemptId: row.child_attempt_id,
+      childGeneration: row.child_generation,
+      workerRunId: row.worker_run_id,
+      assignmentId: row.assignment_id,
+      state: row.state,
+      items,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      releasedAt: row.released_at,
+    };
+  };
+
+  const activeAttempt = (jobId: string, attemptId: string, generation: number, fenceToken: string) => (
+    db.prepare(
+      `SELECT r.task_id,r.generation,r.fence_token,r.status,t.active_attempt_id,t.status AS job_status
+         FROM runs r JOIN tasks t ON t.id=r.task_id WHERE r.attempt_id=?`,
+    ).get(attemptId) as {
+      task_id: string; generation: number; fence_token: string | null; status: string;
+      active_attempt_id: string | null; job_status: string;
+    } | undefined
+  );
+  const requireActiveAttempt = (jobId: string, attemptId: string, generation: number, fenceToken: string): void => {
+    const attempt = activeAttempt(jobId, attemptId, generation, fenceToken);
+    if (!attempt || attempt.task_id !== jobId || attempt.generation !== generation
+      || attempt.fence_token !== fenceToken || attempt.active_attempt_id !== attemptId
+      || /^(succeeded|failed|cancelled|timed_out|crashed|unknown)$/u.test(attempt.status)
+      || /^(completed|failed|cancelled|dead_letter)$/u.test(attempt.job_status)) {
+      throw new Error('Stale worker cannot reserve or consume Job budget');
+    }
+  };
+  const requireReleasableAttempt = (jobId: string, attemptId: string, generation: number, fenceToken: string): void => {
+    const attempt = activeAttempt(jobId, attemptId, generation, fenceToken);
+    const terminalAttempt = /^(succeeded|failed|cancelled|timed_out|crashed|unknown)$/u.test(attempt?.status ?? '');
+    const current = attempt?.active_attempt_id === attemptId && !terminalAttempt;
+    const settled = attempt?.active_attempt_id === null && terminalAttempt;
+    if (!attempt || attempt.task_id !== jobId || attempt.generation !== generation
+      || attempt.fence_token !== fenceToken || (!current && !settled)) {
+      throw new Error('Stale worker cannot release Job budget');
+    }
+  };
+
+  const outstandingReserved = (jobId: string, kind: JobBudgetKind): number => {
+    const row = db.prepare(
+      `SELECT COALESCE(SUM(MAX(0,i.reserved_value-i.committed_value-i.released_value)),0) AS amount
+         FROM job_budget_reservations r
+         JOIN job_budget_reservation_items i ON i.reservation_id=r.reservation_id
+        WHERE r.parent_job_id=? AND i.kind=?
+          AND r.state IN ('reserved','partially_committed','committed','exhausted')`,
+    ).get(jobId, kind) as { amount: number };
+    return row.amount;
+  };
+
+  const available = (jobId: string, kind: JobBudgetKind): number | null => {
+    const budget = db.prepare('SELECT limit_value,used_value FROM job_budgets WHERE job_id=? AND kind=?')
+      .get(jobId, kind) as { limit_value: number | null; used_value: number } | undefined;
+    if (!budget || budget.limit_value === null) return null;
+    return Math.max(0, budget.limit_value - budget.used_value - outstandingReserved(jobId, kind));
+  };
+
+  const reserveWorker = db.transaction((command: Parameters<JobResourceAuthority['reserveWorker']>[0]) => {
+    requireActiveAttempt(
+      command.parentJobId, command.parentAttemptId, command.parentGeneration, command.parentFenceToken,
+    );
+    const child = db.prepare(
+      `SELECT t.parent_task_id,t.active_attempt_id,r.generation
+         FROM tasks t JOIN runs r ON r.attempt_id=t.active_attempt_id WHERE t.id=?`,
+    ).get(command.childJobId) as {
+      parent_task_id: string | null; active_attempt_id: string; generation: number;
+    } | undefined;
+    const assignment = db.prepare(
+      'SELECT parent_job_id,child_job_id FROM worker_assignments WHERE assignment_id=?',
+    ).get(command.assignmentId) as { parent_job_id: string; child_job_id: string } | undefined;
+    if (!child || child.parent_task_id !== command.parentJobId
+      || child.active_attempt_id !== command.childAttemptId || child.generation !== command.childGeneration
+      || !assignment || assignment.parent_job_id !== command.parentJobId
+      || assignment.child_job_id !== command.childJobId) {
+      throw new Error('Worker budget reservation lineage is invalid');
+    }
+    const entries = Object.entries(command.amounts) as Array<[JobBudgetKind, number]>;
+    if (entries.length === 0) throw new Error('Worker budget reservation requires at least one resource');
+    for (const [kind, amount] of entries) {
+      if (!Number.isFinite(amount) || amount < 0) throw new Error(`Invalid ${kind} reservation`);
+    }
+    const existingByKey = db.prepare(
+      'SELECT reservation_id FROM job_budget_reservations WHERE parent_job_id=? AND idempotency_key=?',
+    ).get(command.parentJobId, command.idempotencyKey) as { reservation_id: string } | undefined;
+    const existingById = getReservation(command.reservationId);
+    const existing = existingByKey ? getReservation(existingByKey.reservation_id) : existingById;
+    if (existing) {
+      const same = existing.reservationId === command.reservationId
+        && existing.parentAttemptId === command.parentAttemptId
+        && existing.parentGeneration === command.parentGeneration
+        && existing.childJobId === command.childJobId
+        && existing.childAttemptId === command.childAttemptId
+        && existing.childGeneration === command.childGeneration
+        && existing.workerRunId === command.workerRunId
+        && existing.assignmentId === command.assignmentId
+        && JSON.stringify(existing.items.map((item) => [item.kind, item.reserved]))
+          === JSON.stringify(entries.sort(([a], [b]) => a.localeCompare(b)));
+      if (!same) throw new Error('Worker budget reservation idempotency conflict');
+      return existing;
+    }
+    for (const [kind, amount] of entries) {
+      const remaining = available(command.parentJobId, kind);
+      if (remaining !== null && amount > remaining) throw new Error(`Worker ${kind} reservation exceeds parent capacity`);
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO job_budget_reservations (
+         reservation_id,idempotency_key,parent_job_id,parent_attempt_id,parent_generation,
+         child_job_id,child_attempt_id,child_generation,worker_run_id,assignment_id,state,created_at,updated_at
+       ) VALUES (?,?,?,?,?,?,?,?,?,?,'reserved',?,?)`,
+    ).run(
+      command.reservationId, command.idempotencyKey, command.parentJobId, command.parentAttemptId,
+      command.parentGeneration, command.childJobId, command.childAttemptId, command.childGeneration,
+      command.workerRunId, command.assignmentId, now, now,
+    );
+    const insertItem = db.prepare(
+      `INSERT INTO job_budget_reservation_items (
+         reservation_id,kind,reserved_value,committed_value,released_value,has_unknown_usage,state,updated_at
+       ) VALUES (?,?,?,0,0,0,'reserved',?)`,
+    );
+    for (const [kind, amount] of entries) insertItem.run(command.reservationId, kind, amount, now);
+    return getReservation(command.reservationId)!;
+  }).immediate;
+
+  const applyDebit = (input: {
+    jobId: string; attemptId: string; generation: number; kind: JobBudgetKind;
+    amount: number | null; certainty: BudgetCertainty; idempotencyKey: string; now: number;
+  }): boolean => {
+    const existing = db.prepare(
+      'SELECT kind,amount,certainty FROM job_budget_debits WHERE job_id=? AND idempotency_key=?',
+    ).get(input.jobId, input.idempotencyKey) as {
+      kind: JobBudgetKind; amount: number | null; certainty: BudgetCertainty;
+    } | undefined;
+    if (existing) {
+      if (existing.kind !== input.kind || existing.amount !== input.amount || existing.certainty !== input.certainty) {
+        throw new Error('Worker usage debit idempotency conflict');
+      }
+      return false;
+    }
+    const budget = db.prepare('SELECT used_value,has_unknown_usage FROM job_budgets WHERE job_id=? AND kind=?')
+      .get(input.jobId, input.kind) as { used_value: number; has_unknown_usage: number } | undefined;
+    if (!budget) return false;
+    db.prepare(
+      `INSERT INTO job_budget_debits
+         (debit_id,job_id,attempt_id,generation,kind,amount,certainty,idempotency_key,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      `debit_${randomBytes(12).toString('hex')}`, input.jobId, input.attemptId, input.generation,
+      input.kind, input.amount, input.certainty, input.idempotencyKey, input.now,
+    );
+    db.prepare(
+      `UPDATE job_budgets SET used_value=used_value+?,has_unknown_usage=?,state_version=state_version+1,updated_at=?
+        WHERE job_id=? AND kind=?`,
+    ).run(
+      input.amount ?? 0, input.amount === null ? 1 : budget.has_unknown_usage,
+      input.now, input.jobId, input.kind,
+    );
+    return true;
+  };
+
+  const commitWorkerUsage = db.transaction((command: Parameters<JobResourceAuthority['commitWorkerUsage']>[0]) => {
+    const reservation = getReservation(command.reservationId);
+    if (!reservation) throw new Error('Worker budget reservation was not found');
+    requireActiveAttempt(
+      reservation.childJobId, command.childAttemptId, command.childGeneration, command.childFenceToken,
+    );
+    if (reservation.childAttemptId !== command.childAttemptId
+      || reservation.childGeneration !== command.childGeneration) throw new Error('Worker budget reservation Attempt is stale');
+    const prior = db.prepare(
+      'SELECT kind,amount,certainty,source_kind,source_id FROM job_budget_reservation_commits WHERE reservation_id=? AND idempotency_key=?',
+    ).get(command.reservationId, command.idempotencyKey) as {
+      kind: JobBudgetKind; amount: number | null; certainty: BudgetCertainty;
+      source_kind: string; source_id: string;
+    } | undefined;
+    if (prior) {
+      if (prior.kind !== command.kind || prior.amount !== command.amount || prior.certainty !== command.certainty
+        || prior.source_kind !== command.sourceKind || prior.source_id !== command.sourceId) {
+        throw new Error('Worker usage commit idempotency conflict');
+      }
+      const item = reservation.items.find((candidate) => candidate.kind === command.kind)!;
+      return { applied: false, duplicate: true, exhausted: item.state === 'exhausted', remaining: Math.max(0, item.reserved - item.committed - item.released) };
+    }
+    const item = reservation.items.find((candidate) => candidate.kind === command.kind);
+    if (!item) throw new Error(`Worker ${command.kind} usage is outside the reservation`);
+    const amount = command.certainty === 'unknown' ? null : command.amount;
+    if (amount !== null && (!Number.isFinite(amount) || amount < 0)) throw new Error('Worker usage must be non-negative');
+    const parentAttempt = db.prepare(
+      `SELECT r.generation,r.status,t.active_attempt_id,t.status AS job_status
+         FROM runs r JOIN tasks t ON t.id=r.task_id
+        WHERE r.attempt_id=? AND r.task_id=?`,
+    ).get(reservation.parentAttemptId, reservation.parentJobId) as {
+      generation: number; status: string; active_attempt_id: string | null; job_status: string;
+    } | undefined;
+    if (!parentAttempt || parentAttempt.generation !== reservation.parentGeneration
+      || parentAttempt.active_attempt_id !== reservation.parentAttemptId
+      || /^(succeeded|failed|cancelled|timed_out|crashed|unknown)$/u.test(parentAttempt.status)
+      || /^(completed|failed|cancelled|dead_letter)$/u.test(parentAttempt.job_status)) {
+      throw new Error('Parent Worker budget authority is stale');
+    }
+    const now = command.now ?? Date.now();
+    applyDebit({
+      jobId: reservation.childJobId, attemptId: reservation.childAttemptId,
+      generation: reservation.childGeneration, kind: command.kind, amount,
+      certainty: command.certainty, idempotencyKey: command.idempotencyKey, now,
+    });
+    applyDebit({
+      jobId: reservation.parentJobId, attemptId: reservation.parentAttemptId,
+      generation: reservation.parentGeneration, kind: command.kind, amount,
+      certainty: command.certainty, idempotencyKey: `worker-rollup:${reservation.reservationId}:${command.idempotencyKey}`, now,
+    });
+    db.prepare(
+      `INSERT INTO job_budget_reservation_commits
+         (commit_id,reservation_id,kind,amount,certainty,source_kind,source_id,idempotency_key,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      `budget_commit_${randomBytes(12).toString('hex')}`, reservation.reservationId, command.kind,
+      amount, command.certainty, command.sourceKind, command.sourceId, command.idempotencyKey, now,
+    );
+    const nextCommitted = amount === null ? item.reserved : item.committed + amount;
+    const exhausted = amount === null || nextCommitted >= item.reserved;
+    const itemState: JobBudgetReservationItemRecord['state'] = amount === null
+      ? 'unknown' : nextCommitted > item.reserved ? 'exhausted' : exhausted ? 'committed' : 'partially_committed';
+    db.prepare(
+      `UPDATE job_budget_reservation_items
+          SET committed_value=?,has_unknown_usage=?,state=?,updated_at=? WHERE reservation_id=? AND kind=?`,
+    ).run(nextCommitted, amount === null ? 1 : item.hasUnknownUsage ? 1 : 0, itemState, now, reservation.reservationId, command.kind);
+    const all = (db.prepare(
+      'SELECT state FROM job_budget_reservation_items WHERE reservation_id=?',
+    ).all(reservation.reservationId) as Array<{ state: JobBudgetReservationItemRecord['state'] }>).map((row) => row.state);
+    const nextState: JobBudgetReservationState = all.some((state) => state === 'exhausted' || state === 'unknown')
+      ? 'exhausted'
+      : all.every((state) => state === 'committed') ? 'committed' : 'partially_committed';
+    db.prepare('UPDATE job_budget_reservations SET state=?,updated_at=? WHERE reservation_id=?')
+      .run(nextState, now, reservation.reservationId);
+    return { applied: true, exhausted, remaining: Math.max(0, item.reserved - nextCommitted - item.released) };
+  }).immediate;
+
+  const releaseWorker = db.transaction((command: Parameters<JobResourceAuthority['releaseWorker']>[0]) => {
+    const reservation = getReservation(command.reservationId);
+    if (!reservation) throw new Error('Worker budget reservation was not found');
+    if (reservation.childAttemptId !== command.childAttemptId || reservation.childGeneration !== command.childGeneration) {
+      throw new Error('Worker budget reservation Attempt is stale');
+    }
+    if (reservation.state === 'released' || reservation.state === 'cancelled' || reservation.state === 'reconciled') return reservation;
+    requireReleasableAttempt(
+      reservation.childJobId, command.childAttemptId, command.childGeneration, command.childFenceToken,
+    );
+    const now = command.now ?? Date.now();
+    for (const item of reservation.items) {
+      const release = item.hasUnknownUsage ? 0 : Math.max(0, item.reserved - item.committed - item.released);
+      const state: JobBudgetReservationItemRecord['state'] = item.hasUnknownUsage
+        ? 'unknown' : item.state === 'exhausted' ? 'exhausted' : 'released';
+      db.prepare(
+        'UPDATE job_budget_reservation_items SET released_value=released_value+?,state=?,updated_at=? WHERE reservation_id=? AND kind=?',
+      ).run(release, state, now, reservation.reservationId, item.kind);
+    }
+    const state: JobBudgetReservationState = command.cancelled ? 'cancelled' : 'released';
+    db.prepare('UPDATE job_budget_reservations SET state=?,updated_at=?,released_at=? WHERE reservation_id=?')
+      .run(state, now, now, reservation.reservationId);
+    return getReservation(reservation.reservationId)!;
+  }).immediate;
+
   return {
+    reserveWorker,
+    getWorkerReservation: getReservation,
+    getWorkerReservationForChild(childJobId) {
+      const row = db.prepare('SELECT reservation_id FROM job_budget_reservations WHERE child_job_id=?')
+        .get(childJobId) as { reservation_id: string } | undefined;
+      return row ? getReservation(row.reservation_id) : null;
+    },
+    listWorkerReservations(parentJobId) {
+      const rows = db.prepare(
+        'SELECT reservation_id FROM job_budget_reservations WHERE parent_job_id=? ORDER BY created_at,reservation_id',
+      ).all(parentJobId) as Array<{ reservation_id: string }>;
+      return rows.map((row) => getReservation(row.reservation_id)!).filter(Boolean);
+    },
+    available,
+    commitWorkerUsage,
+    releaseWorker,
     configure(command) {
       const now = command.now ?? Date.now();
       db.transaction(() => {

--- a/core/v4/usageLedger.ts
+++ b/core/v4/usageLedger.ts
@@ -56,6 +56,8 @@ export interface ProviderAttemptRecord {
   readonly jobId?: string | null;
   readonly attemptId?: string | null;
   readonly attemptGeneration?: number | null;
+  readonly workerRunId?: string | null;
+  readonly providerBindingId?: string | null;
   readonly entryPoint: string;
   readonly purpose: ProviderAttemptPurpose;
   readonly providerConfigured: string | null;
@@ -69,6 +71,8 @@ export interface ProviderAttemptRecord {
   readonly credentialLabelRedacted: string | null;
   readonly status: ProviderAttemptStatus;
   readonly errorClass: string | null;
+  readonly providerRequestId?: string | null;
+  readonly responseHash?: string | null;
   readonly startedAt: number;
   readonly completedAt: number;
   readonly estimatedInputTokens: number | null;
@@ -169,6 +173,8 @@ interface ProviderAttemptRow {
   job_id: string | null;
   attempt_id: string | null;
   attempt_generation: number | null;
+  worker_run_id: string | null;
+  provider_binding_id: string | null;
   entry_point: string;
   purpose: ProviderAttemptPurpose;
   provider_configured: string | null;
@@ -182,6 +188,8 @@ interface ProviderAttemptRow {
   credential_label_redacted: string | null;
   status: ProviderAttemptStatus;
   error_class: string | null;
+  provider_request_id: string | null;
+  response_hash: string | null;
   started_at: number;
   completed_at: number;
   estimated_input_tokens: number | null;
@@ -218,7 +226,7 @@ interface ProviderAttemptRow {
   loaded_skill_tokens: number | null;
 }
 
-const LEDGER_SCHEMA_VERSION = 3;
+const LEDGER_SCHEMA_VERSION = 4;
 
 const LEDGER_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS provider_attempt_ledger_meta (
@@ -235,6 +243,8 @@ CREATE TABLE IF NOT EXISTS provider_attempts (
   job_id TEXT,
   attempt_id TEXT,
   attempt_generation INTEGER,
+  worker_run_id TEXT,
+  provider_binding_id TEXT,
   entry_point TEXT NOT NULL,
   purpose TEXT NOT NULL,
   provider_configured TEXT,
@@ -248,6 +258,8 @@ CREATE TABLE IF NOT EXISTS provider_attempts (
   credential_label_redacted TEXT,
   status TEXT NOT NULL,
   error_class TEXT,
+  provider_request_id TEXT,
+  response_hash TEXT,
   started_at INTEGER NOT NULL,
   completed_at INTEGER NOT NULL,
   estimated_input_tokens INTEGER,
@@ -301,10 +313,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_attempts_purpose_status
 const INSERT_SQL = `
 INSERT INTO provider_attempts (
   call_id, parent_call_id, session_id, task_id, run_id,
-  job_id, attempt_id, attempt_generation, entry_point, purpose,
+  job_id, attempt_id, attempt_generation, worker_run_id, provider_binding_id, entry_point, purpose,
   provider_configured, provider_actual, model_configured, model_actual,
   api_mode, transport, attempt_index, fallback_index,
-  credential_label_redacted, status, error_class, started_at, completed_at,
+  credential_label_redacted, status, error_class, provider_request_id, response_hash, started_at, completed_at,
   estimated_input_tokens, estimated_output_tokens, estimated_schema_tokens,
   estimated_image_tokens, provider_input_tokens, provider_output_tokens,
   provider_cache_read_tokens, provider_cache_write_tokens,
@@ -318,10 +330,10 @@ INSERT INTO provider_attempts (
   skill_index_tokens, loaded_skill_tokens
 ) VALUES (
   @call_id, @parent_call_id, @session_id, @task_id, @run_id,
-  @job_id, @attempt_id, @attempt_generation, @entry_point, @purpose,
+  @job_id, @attempt_id, @attempt_generation, @worker_run_id, @provider_binding_id, @entry_point, @purpose,
   @provider_configured, @provider_actual, @model_configured, @model_actual,
   @api_mode, @transport, @attempt_index, @fallback_index,
-  @credential_label_redacted, @status, @error_class, @started_at, @completed_at,
+  @credential_label_redacted, @status, @error_class, @provider_request_id, @response_hash, @started_at, @completed_at,
   @estimated_input_tokens, @estimated_output_tokens, @estimated_schema_tokens,
   @estimated_image_tokens, @provider_input_tokens, @provider_output_tokens,
   @provider_cache_read_tokens, @provider_cache_write_tokens,
@@ -544,13 +556,19 @@ function ensureLedgerColumns(db: DatabaseType): void {
     ['job_id', 'TEXT'],
     ['attempt_id', 'TEXT'],
     ['attempt_generation', 'INTEGER'],
+    ['worker_run_id', 'TEXT'],
+    ['provider_binding_id', 'TEXT'],
+    ['provider_request_id', 'TEXT'],
+    ['response_hash', 'TEXT'],
   ];
   for (const [name, sqlType] of additions) {
     if (!existing.has(name)) db.exec(`ALTER TABLE provider_attempts ADD COLUMN ${name} ${sqlType}`);
   }
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_provider_attempts_job_attempt
-      ON provider_attempts(job_id, attempt_id, started_at)
+      ON provider_attempts(job_id, attempt_id, started_at);
+    CREATE INDEX IF NOT EXISTS idx_provider_attempts_worker_call
+      ON provider_attempts(worker_run_id, parent_call_id, started_at)
   `);
 }
 
@@ -620,6 +638,8 @@ function recordToRow(record: ProviderAttemptRecord): ProviderAttemptRow {
     job_id: record.jobId ?? null,
     attempt_id: record.attemptId ?? null,
     attempt_generation: record.attemptGeneration ?? null,
+    worker_run_id: record.workerRunId ?? null,
+    provider_binding_id: record.providerBindingId ?? null,
     entry_point: record.entryPoint,
     purpose: record.purpose,
     provider_configured: record.providerConfigured,
@@ -633,6 +653,8 @@ function recordToRow(record: ProviderAttemptRecord): ProviderAttemptRow {
     credential_label_redacted: record.credentialLabelRedacted,
     status: record.status,
     error_class: record.errorClass,
+    provider_request_id: record.providerRequestId ?? null,
+    response_hash: record.responseHash ?? null,
     started_at: record.startedAt,
     completed_at: record.completedAt,
     estimated_input_tokens: record.estimatedInputTokens,
@@ -680,6 +702,8 @@ function rowToRecord(row: ProviderAttemptRow): ProviderAttemptRecord {
     jobId: row.job_id,
     attemptId: row.attempt_id,
     attemptGeneration: row.attempt_generation,
+    workerRunId: row.worker_run_id,
+    providerBindingId: row.provider_binding_id,
     entryPoint: row.entry_point,
     purpose: row.purpose,
     providerConfigured: row.provider_configured,
@@ -693,6 +717,8 @@ function rowToRecord(row: ProviderAttemptRow): ProviderAttemptRecord {
     credentialLabelRedacted: row.credential_label_redacted,
     status: row.status,
     errorClass: row.error_class,
+    providerRequestId: row.provider_request_id,
+    responseHash: row.response_hash,
     startedAt: row.started_at,
     completedAt: row.completed_at,
     estimatedInputTokens: row.estimated_input_tokens,

--- a/core/v4/worker/readOnlyRepositoryWorker.ts
+++ b/core/v4/worker/readOnlyRepositoryWorker.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { AidenAgent } from '../aidenAgent';
 import type { DurableJobDisposition, DurableJobHandle } from '../daemon/jobLifecycle';
 import type { JobEngine, AdmissionResult } from '../daemon/jobEngine';
+import type { JobBudgetReservationRecord } from '../daemon/jobResourceAuthority';
 import { currentJobExecutionContext } from '../daemon/jobExecutionContext';
 import type { TriggerBus } from '../daemon/triggerBus';
 import type { AidenPaths } from '../paths';
@@ -29,6 +30,7 @@ import {
   type WorkerResultSourceReference,
   type WorkerRunRecord,
 } from './types';
+import { createDurableWorkerProviderBridge, type DurableWorkerProviderBridge } from './workerProviderBridge';
 
 export const READ_ONLY_REPOSITORY_WORKER_TOOLS = Object.freeze([
   'repository_snapshot_search',
@@ -59,9 +61,11 @@ export interface ReadOnlyWorkerProviderSelection {
   credentialReference: string | null;
   endpointReference: string | null;
   supportsToolCalling: boolean;
+  supportsStreaming?: boolean;
   contextWindow: number;
   maxOutputTokens: number;
   selectionReason: string;
+  catalogDigest?: string;
 }
 
 export interface AdmitReadOnlyRepositoryWorkerInput {
@@ -81,6 +85,7 @@ export interface AdmitReadOnlyRepositoryWorkerInput {
   maxModelCalls?: number;
   maxToolCalls?: number;
   maxRuntimeMs?: number;
+  maxExternalCost?: number;
 }
 
 export interface ReadOnlyRepositoryWorkerAdmission {
@@ -88,6 +93,7 @@ export interface ReadOnlyRepositoryWorkerAdmission {
   assignment: WorkerAssignmentRecord;
   providerBinding: WorkerProviderBindingRecord;
   contextEnvelope: WorkerContextEnvelopeRecord;
+  reservation: JobBudgetReservationRecord;
   triggerEvent: { id: number; inserted: boolean };
 }
 
@@ -100,6 +106,11 @@ export interface ReadOnlyRepositoryWorkerToolRegistryInput {
 export interface ResolvedReadOnlyWorkerProvider {
   adapter: ProviderAdapter;
   paths: AidenPaths;
+  providerId: string;
+  modelId: string;
+  providerRuntimeIdentity: string;
+  credentialReference: string | null;
+  endpointReference: string | null;
 }
 
 export type ReadOnlyWorkerProviderResolver = (
@@ -239,6 +250,10 @@ export function admitReadOnlyRepositoryWorker(
     fallbackPolicyId: null,
     contextWindow: input.provider.contextWindow,
     maxOutputTokens: input.provider.maxOutputTokens,
+    supportsToolCalling: input.provider.supportsToolCalling,
+    supportsStreaming: input.provider.supportsStreaming ?? false,
+    catalogDigest: input.provider.catalogDigest ?? capabilitySnapshotHash,
+    fallbackBindingIds: [],
     idempotencyKey: `${input.idempotencyKey}:provider`,
   });
   const contextEnvelope = input.engine.worker.createWorkerContextEnvelope({
@@ -284,6 +299,9 @@ export function admitReadOnlyRepositoryWorker(
         runtime_ms: maxRuntimeMs,
         input_tokens: input.provider.contextWindow * maxModelCalls,
         output_tokens: input.provider.maxOutputTokens * maxModelCalls,
+        reasoning_tokens: input.provider.maxOutputTokens * maxModelCalls,
+        retries: Math.max(0, maxModelCalls - 1),
+        ...(input.maxExternalCost === undefined ? {} : { external_cost: input.maxExternalCost }),
         output_bytes: 512 * 1024,
         effects: 0,
         workers: 0,
@@ -310,6 +328,51 @@ export function admitReadOnlyRepositoryWorker(
     expectedResultSchemaId: READ_ONLY_REPOSITORY_WORKER.expectedResultSchemaId,
     expectedEvidenceSchemaId: READ_ONLY_REPOSITORY_WORKER.expectedEvidenceSchemaId,
     idempotencyKey: input.idempotencyKey,
+  });
+  const predictedWorkerRunId = identity('worker_run', {
+    assignmentId: assignment.assignmentId,
+    childAttemptId: child.attemptId,
+    childGeneration: 1,
+  });
+  const reservationAmounts = {
+    workers: 1,
+    model_calls: maxModelCalls,
+    retries: Math.max(0, maxModelCalls - 1),
+    tool_calls: maxToolCalls,
+    runtime_ms: maxRuntimeMs,
+    input_tokens: input.provider.contextWindow * maxModelCalls,
+    output_tokens: input.provider.maxOutputTokens * maxModelCalls,
+    reasoning_tokens: input.provider.maxOutputTokens * maxModelCalls,
+    output_bytes: 512 * 1024,
+    ...(input.maxExternalCost === undefined ? {} : { external_cost: input.maxExternalCost }),
+  } as const;
+  const reservation = input.engine.resources.reserveWorker({
+    reservationId: identity('worker_budget', requestIdentity),
+    idempotencyKey: `${input.idempotencyKey}:budget`,
+    parentJobId: input.parent.jobId,
+    parentAttemptId: input.parent.attemptId,
+    parentGeneration: input.parent.generation,
+    parentFenceToken: input.parent.fenceToken,
+    childJobId: child.jobId,
+    childAttemptId: child.attemptId,
+    childGeneration: 1,
+    workerRunId: predictedWorkerRunId,
+    assignmentId: assignment.assignmentId,
+    amounts: reservationAmounts,
+  });
+  input.engine.appendJobEvent({
+    jobId: input.parent.jobId,
+    attemptId: input.parent.attemptId,
+    generation: input.parent.generation,
+    type: 'worker.budget_reserved',
+    payload: {
+      assignmentId: assignment.assignmentId,
+      reservationId: reservation.reservationId,
+      childJobId: child.jobId,
+      kinds: reservation.items.map((item) => item.kind),
+    },
+    producer,
+    idempotencyKey: `worker-budget-reserved:${reservation.reservationId}`,
   });
   const triggerEvent = input.triggerBus.insert({
     source: 'manual',
@@ -343,7 +406,7 @@ export function admitReadOnlyRepositoryWorker(
     producer,
     idempotencyKey: `worker-dispatch-enqueued:${assignment.assignmentId}`,
   });
-  return { child, assignment, providerBinding, contextEnvelope, triggerEvent };
+  return { child, assignment, providerBinding, contextEnvelope, reservation, triggerEvent };
 }
 
 function requireString(value: unknown, label: string): string {
@@ -727,8 +790,27 @@ export async function executeReadOnlyRepositoryWorker(
     producer: 'repository-worker-runtime',
     idempotencyKey: `worker-execution-started:${workerRun.workerRunId}`,
   });
+  const reservation = engine.resources.getWorkerReservationForChild(handle.jobId);
+  if (!reservation || reservation.workerRunId !== workerRun.workerRunId
+    || reservation.assignmentId !== assignment.assignmentId
+    || reservation.childAttemptId !== handle.attemptId
+    || reservation.childGeneration !== handle.generation
+    || reservation.state === 'released' || reservation.state === 'cancelled') {
+    throw new Error('Worker provider execution requires an active durable budget reservation');
+  }
+  const executionStartedAt = Date.now();
+  let providerBridge: DurableWorkerProviderBridge | null = null;
+  try {
   const resolved = await input.resolveProvider(binding);
   if (!resolved?.adapter || !resolved.paths) throw new Error('Worker provider binding could not be resolved');
+  if (resolved.providerId !== binding.providerId
+    || resolved.modelId !== binding.modelId
+    || resolved.providerRuntimeIdentity !== binding.providerRuntimeIdentity
+    || resolved.credentialReference !== binding.credentialReference
+    || resolved.endpointReference !== binding.endpointReference) {
+    throw new Error('Resolved Worker provider does not match the immutable provider binding');
+  }
+  if (!binding.supportsToolCalling) throw new Error('Worker provider binding is not tool-call capable');
   const snapshot = engine.repository.getSnapshot(assignment.repositorySnapshotId);
   const workspace = snapshot ? engine.repository.getWorkspace(snapshot.workspaceId) : undefined;
   if (!snapshot || !workspace) throw new Error('Worker repository snapshot is unavailable');
@@ -740,15 +822,22 @@ export async function executeReadOnlyRepositoryWorker(
   if (registry.list().join('\0') !== READ_ONLY_REPOSITORY_WORKER_TOOLS.join('\0')) {
     throw new Error('Worker tool registry does not match the immutable capability set');
   }
+  providerBridge = createDurableWorkerProviderBridge({
+    engine, handle, assignment, workerRun, binding, reservation, adapter: resolved.adapter,
+  });
+  const baseExecutor = registry.buildExecutor({
+    cwd: snapshot.repositoryRoot ?? workspace.canonicalPath,
+    paths: resolved.paths,
+    sessionId: `worker:${assignment.assignmentId}`,
+  });
   const calls = new Map<string, { call: ToolCallRequest; result?: ToolCallResult }>();
   const agent = new AidenAgent({
-    provider: resolved.adapter,
+    provider: providerBridge.adapter,
     tools: registry.getSchemas(undefined, 'daemon'),
-    toolExecutor: registry.buildExecutor({
-      cwd: snapshot.repositoryRoot ?? workspace.canonicalPath,
-      paths: resolved.paths,
-      sessionId: `worker:${assignment.assignmentId}`,
-    }),
+    toolExecutor: async (call, signal, onActivity) => {
+      providerBridge!.linkToolCall(call);
+      return baseExecutor(call, signal, onActivity);
+    },
     maxTurns: 8,
     iterationBudgetInjection: false,
     providerId: binding.providerId,
@@ -759,6 +848,18 @@ export async function executeReadOnlyRepositoryWorker(
       if (phase === 'after') item.result = result;
       calls.set(call.id, item);
       if (phase === 'after') {
+        engine.resources.commitWorkerUsage({
+          reservationId: reservation.reservationId,
+          childAttemptId: handle.attemptId,
+          childGeneration: handle.generation,
+          childFenceToken: handle.fenceToken,
+          kind: 'tool_calls',
+          amount: 1,
+          certainty: 'confirmed',
+          sourceKind: 'tool_call',
+          sourceId: call.id,
+          idempotencyKey: `tool-call:${call.id}`,
+        });
         engine.appendJobEvent({
           jobId: handle.jobId,
           attemptId: handle.attemptId,
@@ -772,6 +873,7 @@ export async function executeReadOnlyRepositoryWorker(
     },
   });
   const startedAt = Date.now();
+  const modelCalls = reservation.items.find((item) => item.kind === 'model_calls')?.reserved ?? 0;
   const agentResult = await runWithProviderUsageContext({
     sessionId: `worker:${assignment.assignmentId}`,
     taskId: handle.jobId,
@@ -788,6 +890,8 @@ export async function executeReadOnlyRepositoryWorker(
     coreSchemaCount: READ_ONLY_REPOSITORY_WORKER_TOOLS.length,
     selectedProfile: 'repository-read-worker',
     selectedMode: 'economy',
+    workerRunId: workerRun.workerRunId,
+    providerBindingId: binding.providerBindingId,
   }, () => agent.runConversation([
     { role: 'system', content: workerSystemPrompt() },
     {
@@ -812,6 +916,12 @@ export async function executeReadOnlyRepositoryWorker(
     purpose: 'primary',
     selectedMode: 'economy',
     selectedProfile: 'repository-read-worker',
+    providerAttemptBudgets: [{
+      label: `worker:${workerRun.workerRunId}`,
+      maxAttempts: modelCalls,
+      usedAttempts: 0,
+      usedEstimatedTokens: 0,
+    }],
     signal: handle.signal,
   }));
   if (agentResult.finishReason === 'interrupted') throw new Error('Worker execution was cancelled');
@@ -984,6 +1094,40 @@ export async function executeReadOnlyRepositoryWorker(
     finalization,
     totalTokens: agentResult.totalUsage.inputTokens + agentResult.totalUsage.outputTokens,
   };
+  } finally {
+    providerBridge?.completeAcceptedCalls();
+    try {
+      engine.resources.commitWorkerUsage({
+        reservationId: reservation.reservationId,
+        childAttemptId: handle.attemptId,
+        childGeneration: handle.generation,
+        childFenceToken: handle.fenceToken,
+        kind: 'runtime_ms',
+        amount: Math.max(0, Date.now() - executionStartedAt),
+        certainty: 'confirmed',
+        sourceKind: 'runtime',
+        sourceId: `${handle.attemptId}:${handle.generation}`,
+        idempotencyKey: `runtime:${handle.attemptId}:${handle.generation}`,
+      });
+    } finally {
+      const released = engine.resources.releaseWorker({
+        reservationId: reservation.reservationId,
+        childAttemptId: handle.attemptId,
+        childGeneration: handle.generation,
+        childFenceToken: handle.fenceToken,
+        cancelled: handle.signal.aborted,
+      });
+      engine.appendJobEvent({
+        jobId: handle.jobId,
+        attemptId: handle.attemptId,
+        generation: handle.generation,
+        type: 'worker.budget_released',
+        payload: { reservationId: reservation.reservationId, state: released.state },
+        producer: 'repository-worker-runtime',
+        idempotencyKey: `worker-budget-released:${reservation.reservationId}`,
+      });
+    }
+  }
 }
 
 export async function verifyReadOnlyRepositoryWorkerResult(

--- a/core/v4/worker/types.ts
+++ b/core/v4/worker/types.ts
@@ -68,8 +68,53 @@ export interface WorkerProviderBindingRecord {
   readonly fallbackPolicyId: string | null;
   readonly contextWindow: number;
   readonly maxOutputTokens: number;
+  readonly supportsToolCalling: boolean;
+  readonly supportsStreaming: boolean;
+  readonly catalogDigest: string;
+  readonly fallbackBindingIds: readonly string[];
   readonly bindingHash: string;
   readonly createdAt: WorkerTimestamp;
+}
+
+export type WorkerLogicalProviderCallState =
+  | 'prepared'
+  | 'attempting'
+  | 'response_received'
+  | 'accepted'
+  | 'downstream_started'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'unknown';
+
+export interface WorkerLogicalProviderCallRecord {
+  readonly logicalCallId: string;
+  readonly schemaVersion: 1;
+  readonly idempotencyKey: string;
+  readonly workerRunId: string;
+  readonly assignmentId: string;
+  readonly providerBindingId: string;
+  readonly childJobId: string;
+  readonly childAttemptId: string;
+  readonly childGeneration: number;
+  readonly callOrdinal: number;
+  readonly requestHash: string;
+  readonly toolSchemaHash: string;
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly fallbackPolicyId: string | null;
+  readonly state: WorkerLogicalProviderCallState;
+  readonly acceptedProviderAttemptId: string | null;
+  readonly responseHash: string | null;
+  readonly providerRequestId: string | null;
+  readonly failureKind: string | null;
+  readonly outcomeKnown: boolean;
+  readonly responseReceivedAt: number | null;
+  readonly acceptedAt: number | null;
+  readonly downstreamStartedAt: number | null;
+  readonly completedAt: number | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
 }
 
 export interface WorkerContextEnvelopeRecord {

--- a/core/v4/worker/workerAuthority.ts
+++ b/core/v4/worker/workerAuthority.ts
@@ -74,7 +74,12 @@ interface WorkerAuthorityDeps {
 }
 
 type ProviderBindingCommand = ParentAuthorityCommand & Omit<WorkerProviderBindingRecord,
-  'bindingHash' | 'createdAt'>;
+  'bindingHash' | 'createdAt' | 'supportsToolCalling' | 'supportsStreaming' | 'catalogDigest' | 'fallbackBindingIds'> & {
+    supportsToolCalling?: boolean;
+    supportsStreaming?: boolean;
+    catalogDigest?: string;
+    fallbackBindingIds?: readonly string[];
+  };
 
 type ContextEnvelopeCommand = ParentAuthorityCommand & Omit<WorkerContextEnvelopeRecord,
   'contentDigest' | 'createdAt'>;
@@ -153,7 +158,9 @@ type BindingRow = {
   provider_binding_id: string; schema_version: number; provider_id: string; model_id: string;
   provider_runtime_identity: string; credential_reference: string | null; endpoint_reference: string | null;
   capability_snapshot_hash: string; selection_reason: string; fallback_policy_id: string | null;
-  context_window: number; max_output_tokens: number; binding_hash: string; created_at: number;
+  context_window: number; max_output_tokens: number; supports_tool_calling: number;
+  supports_streaming: number; catalog_digest: string; fallback_binding_ids_json: string;
+  binding_hash: string; created_at: number;
 };
 
 type ContextRow = {
@@ -213,7 +220,10 @@ function mapBinding(row: BindingRow): WorkerProviderBindingRecord {
     credentialReference: row.credential_reference, endpointReference: row.endpoint_reference,
     capabilitySnapshotHash: row.capability_snapshot_hash, selectionReason: row.selection_reason,
     fallbackPolicyId: row.fallback_policy_id, contextWindow: row.context_window,
-    maxOutputTokens: row.max_output_tokens, bindingHash: row.binding_hash, createdAt: row.created_at,
+    maxOutputTokens: row.max_output_tokens, supportsToolCalling: row.supports_tool_calling === 1,
+    supportsStreaming: row.supports_streaming === 1, catalogDigest: row.catalog_digest,
+    fallbackBindingIds: array(row.fallback_binding_ids_json),
+    bindingHash: row.binding_hash, createdAt: row.created_at,
   };
 }
 
@@ -508,6 +518,20 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
       assertString(value, label, 512);
     }
     assertHash(command.capabilitySnapshotHash, 'Capability snapshot hash');
+    const supportsToolCalling = command.supportsToolCalling ?? true;
+    const supportsStreaming = command.supportsStreaming ?? false;
+    const catalogDigest = command.catalogDigest ?? command.capabilitySnapshotHash;
+    const fallbackBindingIds = [...(command.fallbackBindingIds ?? [])];
+    assertHash(catalogDigest, 'Provider catalog digest');
+    assertStringList(fallbackBindingIds, 'Fallback provider binding references');
+    if (fallbackBindingIds.includes(command.providerBindingId)) {
+      throw new WorkerAuthorityError('invalid_contract', 'Provider binding cannot fall back to itself');
+    }
+    for (const fallbackBindingId of fallbackBindingIds) {
+      if (!getBinding(fallbackBindingId)) {
+        throw new WorkerAuthorityError('reference_mismatch', 'Fallback provider binding is not registered');
+      }
+    }
     assertString(command.selectionReason, 'Selection reason', 2_048);
     if (!Number.isSafeInteger(command.contextWindow) || command.contextWindow < 1
       || !Number.isSafeInteger(command.maxOutputTokens) || command.maxOutputTokens < 1) {
@@ -519,7 +543,8 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
       credentialReference: command.credentialReference, endpointReference: command.endpointReference,
       capabilitySnapshotHash: command.capabilitySnapshotHash, selectionReason: command.selectionReason,
       fallbackPolicyId: command.fallbackPolicyId, contextWindow: command.contextWindow,
-      maxOutputTokens: command.maxOutputTokens,
+      maxOutputTokens: command.maxOutputTokens, supportsToolCalling, supportsStreaming,
+      catalogDigest, fallbackBindingIds,
     });
     const existing = getBinding(command.providerBindingId);
     if (existing) {
@@ -532,13 +557,15 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
       `INSERT INTO worker_provider_bindings
          (provider_binding_id,schema_version,provider_id,model_id,provider_runtime_identity,
           credential_reference,endpoint_reference,capability_snapshot_hash,selection_reason,
-          fallback_policy_id,context_window,max_output_tokens,binding_hash,created_at)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          fallback_policy_id,context_window,max_output_tokens,supports_tool_calling,supports_streaming,
+          catalog_digest,fallback_binding_ids_json,binding_hash,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     ).run(
       command.providerBindingId, 1, command.providerId, command.modelId, command.providerRuntimeIdentity,
       command.credentialReference, command.endpointReference, command.capabilitySnapshotHash,
       command.selectionReason, command.fallbackPolicyId, command.contextWindow,
-      command.maxOutputTokens, bindingHash, now,
+      command.maxOutputTokens, supportsToolCalling ? 1 : 0, supportsStreaming ? 1 : 0,
+      catalogDigest, JSON.stringify(fallbackBindingIds), bindingHash, now,
     );
     append(command, runId, 'worker.provider_binding_created', {
       providerBindingId: command.providerBindingId, bindingHash,

--- a/core/v4/worker/workerProviderBridge.ts
+++ b/core/v4/worker/workerProviderBridge.ts
@@ -1,0 +1,349 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { ProviderAdapter, ProviderCallInput, ProviderCallOutput, StreamEvent } from '../../../providers/v4/types';
+import {
+  computeProviderRequestHash,
+  computeProviderResponseHash,
+  computeProviderToolSchemaHash,
+  currentProviderAttemptLedger,
+  extractProviderRequestId,
+} from '../../../providers/v4/providerAttemptAccounting';
+import type { ProviderAttemptRecord } from '../usageLedger';
+import type { DurableJobHandle } from '../daemon/jobLifecycle';
+import type { JobEngine } from '../daemon/jobEngine';
+import type { JobBudgetKind, JobBudgetReservationRecord } from '../daemon/jobResourceAuthority';
+import { computeWorkerDigest, type WorkerAssignmentRecord, type WorkerProviderBindingRecord, type WorkerRunRecord } from './types';
+
+export interface DurableWorkerProviderBridge {
+  adapter: ProviderAdapter;
+  linkToolCall(call: { id: string; name: string; arguments: unknown }): void;
+  completeAcceptedCalls(): void;
+}
+
+interface BridgeOptions {
+  engine: JobEngine;
+  handle: DurableJobHandle;
+  assignment: WorkerAssignmentRecord;
+  workerRun: WorkerRunRecord;
+  binding: WorkerProviderBindingRecord;
+  reservation: JobBudgetReservationRecord;
+  adapter: ProviderAdapter;
+}
+
+function authority(options: BridgeOptions) {
+  return {
+    childJobId: options.handle.jobId,
+    childAttemptId: options.handle.attemptId,
+    childGeneration: options.handle.generation,
+    childFenceToken: options.handle.fenceToken,
+  };
+}
+
+function event(options: BridgeOptions, type: string, payload: Record<string, unknown>, idempotencyKey: string): void {
+  const result = options.engine.appendJobEvent({
+    jobId: options.handle.jobId,
+    attemptId: options.handle.attemptId,
+    generation: options.handle.generation,
+    type,
+    payload,
+    producer: 'repository-worker-provider-bridge',
+    idempotencyKey,
+  });
+  if (!result.applied && !result.duplicate) throw new Error(`Worker provider event rejected: ${result.conflict ?? 'unknown'}`);
+}
+
+function knownZero(attempt: ProviderAttemptRecord): boolean {
+  return attempt.status === 'failed_before_send'
+    || attempt.errorClass === 'rate_limit'
+    || attempt.errorClass === 'authentication'
+    || attempt.errorClass === 'context_overflow'
+    || attempt.errorClass === 'request_size_limit';
+}
+
+function usageValue(attempt: ProviderAttemptRecord, kind: JobBudgetKind): number | null {
+  if (knownZero(attempt)) return 0;
+  if (kind === 'input_tokens') return attempt.providerInputTokens;
+  if (kind === 'output_tokens') return attempt.providerOutputTokens;
+  if (kind === 'reasoning_tokens') return attempt.providerReasoningTokens;
+  if (kind === 'external_cost') return attempt.costStatus === 'unknown' ? null : attempt.costAmount;
+  if (kind === 'output_bytes') return attempt.responseBytes;
+  return null;
+}
+
+function failureOutcome(attempts: readonly ProviderAttemptRecord[], error: unknown): {
+  kind: string; known: boolean; cancelled: boolean;
+} {
+  const cancelled = error instanceof Error && error.name === 'AbortError';
+  if (cancelled) return { kind: 'cancelled', known: false, cancelled: true };
+  const missingAcceptance = error instanceof Error && /returned without|not linked|response/i.test(error.message);
+  const ambiguous = missingAcceptance || attempts.some((attempt) => (
+    attempt.status === 'success'
+    ||
+    attempt.status === 'failed_after_send' || attempt.status === 'timeout' || attempt.status === 'interrupted'
+  ));
+  const finalClass = attempts.length > 0 ? attempts[attempts.length - 1]?.errorClass : undefined;
+  return {
+    kind: finalClass && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(finalClass) ? finalClass : 'provider_failure',
+    known: !ambiguous,
+    cancelled: false,
+  };
+}
+
+export function createDurableWorkerProviderBridge(options: BridgeOptions): DurableWorkerProviderBridge {
+  let activeLogicalCallId: string | null = null;
+
+  const reservationItem = (kind: JobBudgetKind) => options.engine.resources
+    .getWorkerReservation(options.reservation.reservationId)?.items.find((item) => item.kind === kind);
+
+  const commit = (
+    logicalCallId: string,
+    attempt: ProviderAttemptRecord,
+    kind: JobBudgetKind,
+    amount: number | null,
+    idempotencyKey: string,
+  ): void => {
+    if (!reservationItem(kind)) return;
+    const result = options.engine.resources.commitWorkerUsage({
+      reservationId: options.reservation.reservationId,
+      ...authority(options),
+      kind,
+      amount,
+      certainty: amount === null ? 'unknown' : 'confirmed',
+      sourceKind: 'provider_attempt',
+      sourceId: attempt.callId,
+      idempotencyKey,
+    });
+    event(options, 'worker.budget_commit_recorded', {
+      reservationId: options.reservation.reservationId,
+      logicalCallId,
+      providerAttemptId: attempt.callId,
+      kind,
+      amountKnown: amount !== null,
+      applied: result.applied,
+      exhausted: result.exhausted === true,
+    }, `worker-budget-commit:${options.reservation.reservationId}:${idempotencyKey}`);
+  };
+
+  const accountAttempts = (logicalCallId: string, attempts: readonly ProviderAttemptRecord[]): void => {
+    attempts.forEach((attempt, index) => {
+      commit(
+        logicalCallId,
+        attempt,
+        'model_calls',
+        1,
+        index === 0 ? `model-call:${logicalCallId}` : `provider-attempt:${attempt.callId}:model-call`,
+      );
+      if (attempt.purpose === 'retry' || attempt.purpose === 'fallback') {
+        commit(logicalCallId, attempt, 'retries', 1, `provider-attempt:${attempt.callId}:retry`);
+      }
+      for (const kind of ['input_tokens', 'output_tokens', 'reasoning_tokens', 'external_cost', 'output_bytes'] as const) {
+        commit(logicalCallId, attempt, kind, usageValue(attempt, kind), `provider-attempt:${attempt.callId}:${kind}`);
+      }
+    });
+  };
+
+  const physicalAttempts = (logicalCallId: string): readonly ProviderAttemptRecord[] => {
+    const ledger = currentProviderAttemptLedger();
+    if (!ledger) throw new Error('Worker provider attempt ledger is unavailable');
+    const attempts = ledger.query({ parentCallId: logicalCallId });
+    for (const attempt of attempts) {
+      if (attempt.workerRunId !== options.workerRun.workerRunId
+        || attempt.providerBindingId !== options.binding.providerBindingId
+        || attempt.jobId !== options.handle.jobId
+        || attempt.attemptId !== options.handle.attemptId
+        || attempt.attemptGeneration !== options.handle.generation) {
+        throw new Error('Physical ProviderAttempt is not bound to the active Worker call');
+      }
+      const allowed = [options.binding, ...options.binding.fallbackBindingIds.map((id) => options.engine.worker.getWorkerProviderBinding(id))]
+        .filter((item): item is WorkerProviderBindingRecord => item !== null);
+      if (!allowed.some((item) => item.providerId === attempt.providerActual && item.modelId === attempt.modelActual)) {
+        throw new Error('Physical ProviderAttempt used an unapproved provider binding');
+      }
+    }
+    return attempts;
+  };
+
+  const completeActive = (): void => {
+    if (!activeLogicalCallId) return;
+    const call = options.engine.workerProviderCalls.get(activeLogicalCallId);
+    if (call?.state === 'accepted' || call?.state === 'downstream_started') {
+      options.engine.workerProviderCalls.complete({ ...authority(options), logicalCallId: activeLogicalCallId });
+      event(options, 'worker.logical_call_completed', {
+        logicalCallId: activeLogicalCallId,
+        workerRunId: options.workerRun.workerRunId,
+      }, `worker-logical-call-completed:${activeLogicalCallId}`);
+    }
+    activeLogicalCallId = null;
+  };
+
+  const runCall = async (input: ProviderCallInput, stream: boolean): Promise<ProviderCallOutput | StreamEvent[]> => {
+    completeActive();
+    const logicalCallId = input.usageContext?.logicalCallId;
+    if (!logicalCallId) throw new Error('Worker provider call is missing a logical identity');
+    const ordinal = options.engine.workerProviderCalls.listForWorkerRun(options.workerRun.workerRunId).length + 1;
+    const requestHash = computeProviderRequestHash(input);
+    const toolSchemaHash = computeProviderToolSchemaHash(input);
+    const prepared = options.engine.workerProviderCalls.prepare({
+      ...authority(options),
+      logicalCallId,
+      idempotencyKey: `worker-provider-call:${options.workerRun.workerRunId}:${ordinal}`,
+      workerRunId: options.workerRun.workerRunId,
+      assignmentId: options.assignment.assignmentId,
+      providerBindingId: options.binding.providerBindingId,
+      callOrdinal: ordinal,
+      requestHash,
+      toolSchemaHash,
+    });
+    const modelBudget = reservationItem('model_calls');
+    if (!modelBudget || modelBudget.hasUnknownUsage
+      || modelBudget.committed + modelBudget.released >= modelBudget.reserved) {
+      options.engine.workerProviderCalls.fail({
+        ...authority(options), logicalCallId, failureKind: 'budget_exhausted', outcomeKnown: true,
+      });
+      event(options, 'worker.provider_attempt_failed', {
+        logicalCallId,
+        failureKind: 'budget_exhausted',
+        outcomeKnown: true,
+      }, `worker-provider-failed:${logicalCallId}`);
+      throw new Error('Worker model-call budget exhausted before provider send');
+    }
+    options.engine.workerProviderCalls.markAttempting({ ...authority(options), logicalCallId });
+    event(options, 'worker.logical_call_prepared', {
+      logicalCallId,
+      workerRunId: options.workerRun.workerRunId,
+      providerBindingId: options.binding.providerBindingId,
+      callOrdinal: prepared.callOrdinal,
+      requestHash,
+      toolSchemaHash,
+    }, `worker-logical-call-prepared:${logicalCallId}`);
+    const forwarded: ProviderCallInput = {
+      ...input,
+      stream,
+      usageContext: {
+        ...input.usageContext,
+        logicalCallId,
+        jobId: options.handle.jobId,
+        attemptId: options.handle.attemptId,
+        attemptGeneration: options.handle.generation,
+        workerRunId: options.workerRun.workerRunId,
+        providerBindingId: options.binding.providerBindingId,
+        providerConfigured: options.binding.providerId,
+        modelConfigured: options.binding.modelId,
+      },
+    };
+    try {
+      let output: ProviderCallOutput;
+      let events: StreamEvent[] | null = null;
+      if (stream) {
+        events = [];
+        if (typeof options.adapter.callStream === 'function') {
+          for await (const item of options.adapter.callStream(forwarded)) {
+            events.push(item);
+          }
+          let done: Extract<StreamEvent, { type: 'done' }> | undefined;
+          for (let index = events.length - 1; index >= 0; index -= 1) {
+            const candidate = events[index];
+            if (candidate?.type === 'done') { done = candidate; break; }
+          }
+          if (!done) throw new Error('Worker provider stream closed without a terminal response');
+          output = done.output;
+        } else {
+          output = await options.adapter.call(forwarded);
+          events.push({ type: 'done', output });
+        }
+      } else {
+        output = await options.adapter.call(forwarded);
+      }
+      const attempts = physicalAttempts(logicalCallId);
+      if (attempts.length === 0) throw new Error('Worker provider returned without a physical ProviderAttempt record');
+      const responseHash = computeProviderResponseHash(output);
+      let acceptedAttempt: ProviderAttemptRecord | undefined;
+      for (let index = attempts.length - 1; index >= 0; index -= 1) {
+        const candidate = attempts[index];
+        if (candidate?.status === 'success' && candidate.responseHash === responseHash) {
+          acceptedAttempt = candidate;
+          break;
+        }
+      }
+      if (!acceptedAttempt) throw new Error('Worker provider response is not linked to a successful physical attempt');
+      accountAttempts(logicalCallId, attempts);
+      options.engine.workerProviderCalls.recordResponseReceived({
+        ...authority(options),
+        logicalCallId,
+        providerAttemptId: acceptedAttempt.callId,
+        responseHash,
+        providerRequestId: acceptedAttempt.providerRequestId ?? extractProviderRequestId(output),
+      });
+      event(options, 'worker.provider_response_received', {
+        logicalCallId,
+        providerAttemptId: acceptedAttempt.callId,
+        responseHash,
+      }, `worker-provider-response-received:${logicalCallId}`);
+      options.engine.workerProviderCalls.acceptResponse({
+        ...authority(options), logicalCallId, providerAttemptId: acceptedAttempt.callId, responseHash,
+      });
+      event(options, 'worker.provider_response_accepted', {
+        logicalCallId,
+        providerAttemptId: acceptedAttempt.callId,
+        responseHash,
+      }, `worker-provider-response-accepted:${logicalCallId}`);
+      if (output.toolCalls.length > 0) {
+        options.engine.workerProviderCalls.markDownstreamStarted({ ...authority(options), logicalCallId });
+        event(options, 'worker.provider_downstream_started', {
+          logicalCallId,
+          toolCallCount: output.toolCalls.length,
+        }, `worker-provider-downstream-started:${logicalCallId}`);
+      }
+      activeLogicalCallId = logicalCallId;
+      return events ?? output;
+    } catch (error) {
+      const attempts = currentProviderAttemptLedger()?.query({ parentCallId: logicalCallId }) ?? [];
+      if (attempts.length > 0) accountAttempts(logicalCallId, attempts);
+      const call = options.engine.workerProviderCalls.get(logicalCallId);
+      if (call && call.state !== 'accepted' && call.state !== 'downstream_started' && call.state !== 'completed') {
+        const failure = failureOutcome(attempts, error);
+        options.engine.workerProviderCalls.fail({
+          ...authority(options), logicalCallId, failureKind: failure.kind,
+          outcomeKnown: failure.known, cancelled: failure.cancelled,
+        });
+        event(options, failure.known ? 'worker.provider_attempt_failed' : 'worker.logical_call_unknown', {
+          logicalCallId,
+          failureKind: failure.kind,
+          outcomeKnown: failure.known,
+        }, `worker-provider-failed:${logicalCallId}`);
+      }
+      throw error;
+    }
+  };
+
+  const adapter: ProviderAdapter = {
+    apiMode: options.adapter.apiMode,
+    async call(input) {
+      return runCall(input, false) as Promise<ProviderCallOutput>;
+    },
+    ...(options.adapter.callStream ? {
+      async *callStream(input: ProviderCallInput): AsyncGenerator<StreamEvent, void, void> {
+        const events = await runCall(input, true) as StreamEvent[];
+        for (const item of events) yield item;
+      },
+    } : {}),
+  };
+
+  return {
+    adapter,
+    linkToolCall(call) {
+      if (!activeLogicalCallId) throw new Error('Worker tool call has no accepted provider response');
+      options.engine.workerProviderCalls.linkToolCall({
+        ...authority(options),
+        logicalCallId: activeLogicalCallId,
+        providerToolCallId: call.id,
+        toolName: call.name,
+        argumentsHash: computeWorkerDigest(call.arguments),
+      });
+    },
+    completeAcceptedCalls: completeActive,
+  };
+}

--- a/core/v4/worker/workerProviderCallAuthority.ts
+++ b/core/v4/worker/workerProviderCallAuthority.ts
@@ -1,0 +1,369 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { Db } from '../daemon/db/connection';
+import type { WorkerLogicalProviderCallRecord, WorkerLogicalProviderCallState } from './types';
+
+const HASH = /^[a-f0-9]{64}$/u;
+const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u;
+const TERMINAL = new Set<WorkerLogicalProviderCallState>(['completed', 'failed', 'cancelled', 'unknown']);
+
+export class WorkerProviderCallError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = 'WorkerProviderCallError';
+  }
+}
+
+interface AuthorityCommand {
+  childJobId: string;
+  childAttemptId: string;
+  childGeneration: number;
+  childFenceToken: string;
+  now?: number;
+}
+
+export interface PrepareWorkerProviderCallCommand extends AuthorityCommand {
+  logicalCallId: string;
+  idempotencyKey: string;
+  workerRunId: string;
+  assignmentId: string;
+  providerBindingId: string;
+  callOrdinal: number;
+  requestHash: string;
+  toolSchemaHash: string;
+}
+
+export interface WorkerProviderCallAuthority {
+  prepare(command: PrepareWorkerProviderCallCommand): WorkerLogicalProviderCallRecord;
+  markAttempting(command: AuthorityCommand & { logicalCallId: string }): WorkerLogicalProviderCallRecord;
+  recordResponseReceived(command: AuthorityCommand & {
+    logicalCallId: string;
+    providerAttemptId: string;
+    responseHash: string;
+    providerRequestId?: string | null;
+  }): WorkerLogicalProviderCallRecord;
+  acceptResponse(command: AuthorityCommand & {
+    logicalCallId: string;
+    providerAttemptId: string;
+    responseHash: string;
+  }): WorkerLogicalProviderCallRecord;
+  markDownstreamStarted(command: AuthorityCommand & { logicalCallId: string }): WorkerLogicalProviderCallRecord;
+  linkToolCall(command: AuthorityCommand & {
+    logicalCallId: string;
+    providerToolCallId: string;
+    toolName: string;
+    argumentsHash: string;
+  }): { applied: boolean; duplicate?: boolean };
+  complete(command: AuthorityCommand & { logicalCallId: string }): WorkerLogicalProviderCallRecord;
+  fail(command: AuthorityCommand & {
+    logicalCallId: string;
+    failureKind: string;
+    outcomeKnown: boolean;
+    cancelled?: boolean;
+  }): WorkerLogicalProviderCallRecord;
+  get(logicalCallId: string): WorkerLogicalProviderCallRecord | null;
+  listForWorkerRun(workerRunId: string): WorkerLogicalProviderCallRecord[];
+}
+
+type Row = {
+  logical_call_id: string; schema_version: number; idempotency_key: string;
+  worker_run_id: string; assignment_id: string; provider_binding_id: string;
+  child_job_id: string; child_attempt_id: string; child_generation: number;
+  call_ordinal: number; request_hash: string; tool_schema_hash: string;
+  provider_id: string; model_id: string; fallback_policy_id: string | null;
+  state: WorkerLogicalProviderCallState; accepted_provider_attempt_id: string | null;
+  response_hash: string | null; provider_request_id: string | null; failure_kind: string | null;
+  outcome_known: number; response_received_at: number | null; accepted_at: number | null;
+  downstream_started_at: number | null; completed_at: number | null;
+  created_at: number; updated_at: number;
+};
+
+function mapRow(row: Row): WorkerLogicalProviderCallRecord {
+  return {
+    logicalCallId: row.logical_call_id,
+    schemaVersion: 1,
+    idempotencyKey: row.idempotency_key,
+    workerRunId: row.worker_run_id,
+    assignmentId: row.assignment_id,
+    providerBindingId: row.provider_binding_id,
+    childJobId: row.child_job_id,
+    childAttemptId: row.child_attempt_id,
+    childGeneration: row.child_generation,
+    callOrdinal: row.call_ordinal,
+    requestHash: row.request_hash,
+    toolSchemaHash: row.tool_schema_hash,
+    providerId: row.provider_id,
+    modelId: row.model_id,
+    fallbackPolicyId: row.fallback_policy_id,
+    state: row.state,
+    acceptedProviderAttemptId: row.accepted_provider_attempt_id,
+    responseHash: row.response_hash,
+    providerRequestId: row.provider_request_id,
+    failureKind: row.failure_kind,
+    outcomeKnown: row.outcome_known === 1,
+    responseReceivedAt: row.response_received_at,
+    acceptedAt: row.accepted_at,
+    downstreamStartedAt: row.downstream_started_at,
+    completedAt: row.completed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function safeId(value: string, label: string): void {
+  if (!ID.test(value)) throw new WorkerProviderCallError('invalid_contract', `${label} is invalid`);
+}
+
+function safeHash(value: string, label: string): void {
+  if (!HASH.test(value)) throw new WorkerProviderCallError('invalid_contract', `${label} is invalid`);
+}
+
+function safeRequestId(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  if (!ID.test(value) || /(?:token|secret|bearer|api[_-]?key)/iu.test(value)) {
+    throw new WorkerProviderCallError('invalid_contract', 'Provider request identity is invalid');
+  }
+  return value;
+}
+
+export function createWorkerProviderCallAuthority(
+  db: Db,
+  validateActiveFence: (command: AuthorityCommand) => boolean,
+): WorkerProviderCallAuthority {
+  const get = (logicalCallId: string): WorkerLogicalProviderCallRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_logical_provider_calls WHERE logical_call_id=?')
+      .get(logicalCallId) as Row | undefined;
+    return row ? mapRow(row) : null;
+  };
+
+  const requireAuthority = (command: AuthorityCommand): void => {
+    if (!validateActiveFence(command)) {
+      throw new WorkerProviderCallError('stale_authority', 'Worker provider call authority is no longer active');
+    }
+  };
+
+  const requireCall = (command: AuthorityCommand & { logicalCallId: string }): WorkerLogicalProviderCallRecord => {
+    requireAuthority(command);
+    const call = get(command.logicalCallId);
+    if (!call || call.childJobId !== command.childJobId || call.childAttemptId !== command.childAttemptId
+      || call.childGeneration !== command.childGeneration) {
+      throw new WorkerProviderCallError('lineage_mismatch', 'Logical provider call does not match the active Worker Attempt');
+    }
+    return call;
+  };
+
+  const prepare = db.transaction((command: PrepareWorkerProviderCallCommand): WorkerLogicalProviderCallRecord => {
+    requireAuthority(command);
+    for (const [value, label] of [
+      [command.logicalCallId, 'Logical call identity'], [command.workerRunId, 'WorkerRun identity'],
+      [command.assignmentId, 'Assignment identity'], [command.providerBindingId, 'Provider binding identity'],
+    ] as const) safeId(value, label);
+    safeHash(command.requestHash, 'Provider request hash');
+    safeHash(command.toolSchemaHash, 'Tool schema hash');
+    if (!Number.isSafeInteger(command.callOrdinal) || command.callOrdinal < 1) {
+      throw new WorkerProviderCallError('invalid_contract', 'Logical call ordinal is invalid');
+    }
+    const run = db.prepare(
+      `SELECT wr.assignment_id,wr.provider_binding_id,wr.child_job_id,wr.child_attempt_id,wr.child_generation,
+              wa.provider_binding_id AS assignment_binding_id
+         FROM worker_runs wr JOIN worker_assignments wa ON wa.assignment_id=wr.assignment_id
+        WHERE wr.worker_run_id=?`,
+    ).get(command.workerRunId) as {
+      assignment_id: string; provider_binding_id: string; child_job_id: string;
+      child_attempt_id: string; child_generation: number; assignment_binding_id: string;
+    } | undefined;
+    const binding = db.prepare(
+      'SELECT provider_id,model_id,fallback_policy_id FROM worker_provider_bindings WHERE provider_binding_id=?',
+    ).get(command.providerBindingId) as {
+      provider_id: string; model_id: string; fallback_policy_id: string | null;
+    } | undefined;
+    if (!run || !binding || run.assignment_id !== command.assignmentId
+      || run.provider_binding_id !== command.providerBindingId
+      || run.assignment_binding_id !== command.providerBindingId
+      || run.child_job_id !== command.childJobId
+      || run.child_attempt_id !== command.childAttemptId
+      || run.child_generation !== command.childGeneration) {
+      throw new WorkerProviderCallError('lineage_mismatch', 'Logical provider call lineage is invalid');
+    }
+    const existingByKey = db.prepare(
+      'SELECT * FROM worker_logical_provider_calls WHERE worker_run_id=? AND idempotency_key=?',
+    ).get(command.workerRunId, command.idempotencyKey) as Row | undefined;
+    const existingById = db.prepare('SELECT * FROM worker_logical_provider_calls WHERE logical_call_id=?')
+      .get(command.logicalCallId) as Row | undefined;
+    const existing = existingByKey ?? existingById;
+    if (existing) {
+      const record = mapRow(existing);
+      if (record.logicalCallId !== command.logicalCallId || record.workerRunId !== command.workerRunId
+        || record.assignmentId !== command.assignmentId || record.providerBindingId !== command.providerBindingId
+        || record.callOrdinal !== command.callOrdinal || record.requestHash !== command.requestHash
+        || record.toolSchemaHash !== command.toolSchemaHash) {
+        throw new WorkerProviderCallError('idempotency_conflict', 'Logical provider call identity has conflicting input');
+      }
+      return record;
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO worker_logical_provider_calls (
+         logical_call_id,schema_version,idempotency_key,worker_run_id,assignment_id,provider_binding_id,
+         child_job_id,child_attempt_id,child_generation,call_ordinal,request_hash,tool_schema_hash,
+         provider_id,model_id,fallback_policy_id,state,outcome_known,created_at,updated_at
+       ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'prepared',1,?,?)`,
+    ).run(
+      command.logicalCallId, 1, command.idempotencyKey, command.workerRunId, command.assignmentId,
+      command.providerBindingId, command.childJobId, command.childAttemptId, command.childGeneration,
+      command.callOrdinal, command.requestHash, command.toolSchemaHash, binding.provider_id,
+      binding.model_id, binding.fallback_policy_id, now, now,
+    );
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  const markAttempting = db.transaction((command: AuthorityCommand & { logicalCallId: string }) => {
+    const call = requireCall(command);
+    if (call.state === 'attempting') return call;
+    if (call.state !== 'prepared') throw new WorkerProviderCallError('invalid_transition', 'Logical call cannot begin another attempt');
+    db.prepare("UPDATE worker_logical_provider_calls SET state='attempting',updated_at=? WHERE logical_call_id=?")
+      .run(command.now ?? Date.now(), command.logicalCallId);
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  const recordResponseReceived = db.transaction((command: AuthorityCommand & {
+    logicalCallId: string; providerAttemptId: string; responseHash: string; providerRequestId?: string | null;
+  }) => {
+    const call = requireCall(command);
+    safeId(command.providerAttemptId, 'ProviderAttempt identity');
+    safeHash(command.responseHash, 'Provider response hash');
+    const providerRequestId = safeRequestId(command.providerRequestId);
+    if (call.responseHash !== null || call.acceptedProviderAttemptId !== null) {
+      if (call.responseHash === command.responseHash && call.acceptedProviderAttemptId === command.providerAttemptId) return call;
+      throw new WorkerProviderCallError('response_conflict', 'A competing provider response cannot replace the received response');
+    }
+    if (call.state !== 'attempting') throw new WorkerProviderCallError('invalid_transition', 'Provider response arrived outside an active attempt');
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_logical_provider_calls
+          SET state='response_received',accepted_provider_attempt_id=?,response_hash=?,provider_request_id=?,
+              response_received_at=?,updated_at=? WHERE logical_call_id=?`,
+    ).run(command.providerAttemptId, command.responseHash, providerRequestId, now, now, command.logicalCallId);
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  const acceptResponse = db.transaction((command: AuthorityCommand & {
+    logicalCallId: string; providerAttemptId: string; responseHash: string;
+  }) => {
+    const call = requireCall(command);
+    safeId(command.providerAttemptId, 'ProviderAttempt identity');
+    safeHash(command.responseHash, 'Provider response hash');
+    if (call.state === 'accepted' || call.state === 'downstream_started' || call.state === 'completed') {
+      if (call.acceptedProviderAttemptId === command.providerAttemptId && call.responseHash === command.responseHash) return call;
+      throw new WorkerProviderCallError('response_conflict', 'A competing provider response cannot replace the accepted response');
+    }
+    if (call.state !== 'response_received' || call.acceptedProviderAttemptId !== command.providerAttemptId
+      || call.responseHash !== command.responseHash) {
+      throw new WorkerProviderCallError('invalid_transition', 'Provider response must be durably received before acceptance');
+    }
+    const now = command.now ?? Date.now();
+    db.prepare("UPDATE worker_logical_provider_calls SET state='accepted',accepted_at=?,updated_at=? WHERE logical_call_id=?")
+      .run(now, now, command.logicalCallId);
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  const markDownstreamStarted = db.transaction((command: AuthorityCommand & { logicalCallId: string }) => {
+    const call = requireCall(command);
+    if (call.state === 'downstream_started' || call.state === 'completed') return call;
+    if (call.state !== 'accepted') throw new WorkerProviderCallError('invalid_transition', 'Downstream work requires an accepted provider response');
+    const now = command.now ?? Date.now();
+    db.prepare("UPDATE worker_logical_provider_calls SET state='downstream_started',downstream_started_at=?,updated_at=? WHERE logical_call_id=?")
+      .run(now, now, command.logicalCallId);
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  const complete = db.transaction((command: AuthorityCommand & { logicalCallId: string }) => {
+    const call = requireCall(command);
+    if (call.state === 'completed') return call;
+    if (call.state !== 'accepted' && call.state !== 'downstream_started') {
+      throw new WorkerProviderCallError('invalid_transition', 'Only an accepted provider call can complete');
+    }
+    const now = command.now ?? Date.now();
+    db.prepare("UPDATE worker_logical_provider_calls SET state='completed',completed_at=?,updated_at=? WHERE logical_call_id=?")
+      .run(now, now, command.logicalCallId);
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  const linkToolCall = db.transaction((command: AuthorityCommand & {
+    logicalCallId: string; providerToolCallId: string; toolName: string; argumentsHash: string;
+  }) => {
+    const call = requireCall(command);
+    safeId(command.providerToolCallId, 'Provider tool-call identity');
+    safeId(command.toolName, 'Tool name');
+    safeHash(command.argumentsHash, 'Tool arguments hash');
+    if ((call.state !== 'accepted' && call.state !== 'downstream_started') || !call.responseHash) {
+      throw new WorkerProviderCallError('invalid_transition', 'Tool dispatch requires an accepted provider response');
+    }
+    const existing = db.prepare(
+      'SELECT logical_call_id,tool_name,arguments_hash,response_hash FROM worker_provider_tool_links WHERE worker_run_id=? AND provider_tool_call_id=?',
+    ).get(call.workerRunId, command.providerToolCallId) as {
+      logical_call_id: string; tool_name: string; arguments_hash: string; response_hash: string;
+    } | undefined;
+    if (existing) {
+      if (existing.logical_call_id !== call.logicalCallId || existing.tool_name !== command.toolName
+        || existing.arguments_hash !== command.argumentsHash || existing.response_hash !== call.responseHash) {
+        throw new WorkerProviderCallError('tool_call_conflict', 'Provider tool-call identity has conflicting arguments');
+      }
+      return { applied: false, duplicate: true };
+    }
+    const linkId = `worker_tool_link_${createHash('sha256')
+      .update(`${call.workerRunId}\0${command.providerToolCallId}`)
+      .digest('hex').slice(0, 32)}`;
+    db.prepare(
+      `INSERT INTO worker_provider_tool_links
+         (link_id,logical_call_id,worker_run_id,provider_tool_call_id,tool_name,arguments_hash,response_hash,created_at)
+       VALUES (?,?,?,?,?,?,?,?)`,
+    ).run(
+      linkId, call.logicalCallId, call.workerRunId, command.providerToolCallId,
+      command.toolName, command.argumentsHash, call.responseHash, command.now ?? Date.now(),
+    );
+    return { applied: true };
+  }).immediate;
+
+  const fail = db.transaction((command: AuthorityCommand & {
+    logicalCallId: string; failureKind: string; outcomeKnown: boolean; cancelled?: boolean;
+  }) => {
+    const call = requireCall(command);
+    if (TERMINAL.has(call.state)) return call;
+    if (call.state === 'accepted' || call.state === 'downstream_started') {
+      throw new WorkerProviderCallError('accepted_response', 'Accepted provider work cannot be replaced by a failure');
+    }
+    if (!ID.test(command.failureKind)) throw new WorkerProviderCallError('invalid_contract', 'Provider failure kind is invalid');
+    const state: WorkerLogicalProviderCallState = command.cancelled
+      ? 'cancelled'
+      : command.outcomeKnown ? 'failed' : 'unknown';
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_logical_provider_calls SET state=?,failure_kind=?,outcome_known=?,completed_at=?,updated_at=?
+        WHERE logical_call_id=?`,
+    ).run(state, command.failureKind, command.outcomeKnown ? 1 : 0, now, now, command.logicalCallId);
+    return get(command.logicalCallId)!;
+  }).immediate;
+
+  return {
+    prepare,
+    markAttempting,
+    recordResponseReceived,
+    acceptResponse,
+    markDownstreamStarted,
+    linkToolCall,
+    complete,
+    fail,
+    get,
+    listForWorkerRun(workerRunId) {
+      return (db.prepare(
+        'SELECT * FROM worker_logical_provider_calls WHERE worker_run_id=? ORDER BY call_ordinal,created_at,logical_call_id',
+      ).all(workerRunId) as Row[]).map(mapRow);
+    },
+  };
+}

--- a/providers/v4/providerAttemptAccounting.ts
+++ b/providers/v4/providerAttemptAccounting.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import {
@@ -163,6 +163,8 @@ export function beginPhysicalProviderAttempt(
       jobId: context?.jobId ?? context?.taskId ?? null,
       attemptId: context?.attemptId ?? null,
       attemptGeneration: context?.attemptGeneration ?? null,
+      workerRunId: context?.workerRunId ?? null,
+      providerBindingId: context?.providerBindingId ?? null,
       entryPoint: context?.entryPoint ?? 'unknown',
       purpose: effectivePurpose(context, metadata.attemptIndex, metadata.fallbackIndex ?? 0),
       providerConfigured: context?.providerConfigured ?? metadata.providerActual,
@@ -176,6 +178,8 @@ export function beginPhysicalProviderAttempt(
       credentialLabelRedacted: context?.credentialLabelRedacted ?? 'configured',
       status,
       errorClass: classifyAttemptError(error),
+      providerRequestId: output ? extractProviderRequestId(output) : null,
+      responseHash: output ? computeProviderResponseHash(output) : null,
       startedAt,
       completedAt: Date.now(),
       estimatedInputTokens: estimates.input,
@@ -269,6 +273,57 @@ function claimAttemptBudgets(
 
 export function byteLength(value: string): number {
   return Buffer.byteLength(value, 'utf8');
+}
+
+function canonical(value: unknown): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonical(item)]));
+  }
+  return String(value);
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(canonical(value))).digest('hex');
+}
+
+export function computeProviderRequestHash(input: ProviderCallInput): string {
+  return digest({
+    messages: input.messages,
+    tools: input.tools,
+    maxTokens: input.maxTokens,
+    temperature: input.temperature,
+    stream: input.stream === true,
+    extraBody: input.extraBody,
+  });
+}
+
+export function computeProviderToolSchemaHash(input: ProviderCallInput): string {
+  return digest(input.tools);
+}
+
+export function computeProviderResponseHash(output: ProviderCallOutput): string {
+  return digest({
+    content: output.content,
+    toolCalls: output.toolCalls,
+    finishReason: output.finishReason,
+    usage: output.usage,
+  });
+}
+
+export function extractProviderRequestId(output: ProviderCallOutput): string | null {
+  if (!output.raw || typeof output.raw !== 'object' || Array.isArray(output.raw)) return null;
+  const raw = output.raw as Record<string, unknown>;
+  for (const key of ['requestId', 'request_id', 'id']) {
+    const value = raw[key];
+    if (typeof value === 'string' && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(value)) return value;
+  }
+  return null;
 }
 
 function estimateRequest(input: ProviderCallInput): {

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -323,6 +323,8 @@ export interface ProviderCallUsageContext {
   jobId?: string | null;
   attemptId?: string | null;
   attemptGeneration?: number | null;
+  workerRunId?: string | null;
+  providerBindingId?: string | null;
   entryPoint?: string;
   purpose?: import('../../core/v4/usageLedger').ProviderAttemptPurpose;
   providerConfigured?: string | null;

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,13 +31,13 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(37);
+    expect(LATEST_SCHEMA_VERSION).toBe(38);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 37 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: 38 });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
       { name: 'repository_change_intents' }, { name: 'repository_change_records' },
     ]);
@@ -53,7 +53,7 @@ describe('repository snapshot migration v32', () => {
       ]);
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('repository_architecture_notes','execution_graph_node_references') ORDER BY name").all())
       .toEqual([{ name: 'execution_graph_node_references' }, { name: 'repository_architecture_notes' }]);
-    expect(runMigrations(db)).toEqual({ from: 37, to: 37 });
+    expect(runMigrations(db)).toEqual({ from: 38, to: 38 });
   });
 
   it('adds validation records to a v33 database without changing repository history', () => {
@@ -77,7 +77,7 @@ describe('repository snapshot migration v32', () => {
       (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence)
       VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
 
-    expect(runMigrations(db)).toEqual({ from: 33, to: 37 });
+    expect(runMigrations(db)).toEqual({ from: 33, to: 38 });
     expect(db.prepare('SELECT id,status FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued' });
     expect(db.prepare('SELECT attempt_id,status FROM runs WHERE attempt_id=?').get('attempt'))
       .toEqual({ attempt_id: 'attempt', status: 'queued' });

--- a/tests/v4/providers/providerAttemptAccounting.test.ts
+++ b/tests/v4/providers/providerAttemptAccounting.test.ts
@@ -37,6 +37,8 @@ function input() {
       sessionId: 'session-1',
       taskId: 'task-1',
       runId: 'run-1',
+      workerRunId: 'worker-run-1',
+      providerBindingId: 'provider-binding-1',
       entryPoint: 'cli',
       providerConfigured: 'groq',
       modelConfigured: 'llama-3.3-70b-versatile',
@@ -49,6 +51,7 @@ function input() {
 describe('physical provider-attempt accounting', () => {
   it('records a successful adapter attempt with provider usage', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      id: 'provider-request-1',
       choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
       usage: {
         prompt_tokens: 11,
@@ -78,7 +81,11 @@ describe('physical provider-attempt accounting', () => {
       providerOutputTokens: 4,
       providerReasoningTokens: 2,
       usageSource: 'provider_reported',
+      workerRunId: 'worker-run-1',
+      providerBindingId: 'provider-binding-1',
+      providerRequestId: 'provider-request-1',
     });
+    expect(record.responseHash).toMatch(/^[a-f0-9]{64}$/u);
   });
 
   it('records each adapter retry as a distinct physical attempt', async () => {

--- a/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
@@ -16,15 +16,29 @@ import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 import { createRunStore } from '../../../core/v4/daemon/runStore';
 import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
 import { resolveAidenPaths } from '../../../core/v4/paths';
+import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
 import {
   admitReadOnlyRepositoryWorker,
   verifyReadOnlyRepositoryWorkerResult,
 } from '../../../core/v4/worker/readOnlyRepositoryWorker';
 import type { ProviderAdapter } from '../../../providers/v4/types';
+import {
+  beginPhysicalProviderAttempt,
+  createLogicalProviderCallId,
+  setProviderAttemptLedger,
+} from '../../../providers/v4/providerAttemptAccounting';
 
 describe('read-only repository Worker durable dispatcher path', () => {
   const cleanup: string[] = [];
+  const databases: Database.Database[] = [];
+  let ledger: ProviderAttemptLedger | null = null;
   afterEach(async () => {
+    setProviderAttemptLedger(null);
+    ledger?.close();
+    ledger = null;
+    for (const database of databases.splice(0)) {
+      if (database.open) database.close();
+    }
     await Promise.all(cleanup.splice(0).map((item) => rm(item, { recursive: true, force: true })));
   });
 
@@ -36,8 +50,11 @@ describe('read-only repository Worker durable dispatcher path', () => {
     await writeFile(path.join(root, 'source.ts'), sourceBytes);
     const dbPath = path.join(home, 'worker-e2e.db');
     const db = new Database(dbPath);
+    databases.push(db);
     db.pragma('foreign_keys = ON');
     runMigrations(db);
+    ledger = new ProviderAttemptLedger(path.join(home, 'provider-usage.db'));
+    setProviderAttemptLedger(ledger);
     db.prepare(
       'INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version) VALUES (?,?,?,?,?,?)',
     ).run('worker-instance', 1, 'localhost', Date.now(), Date.now(), '4.18.0');
@@ -84,16 +101,24 @@ describe('read-only repository Worker durable dispatcher path', () => {
     let calls = 0;
     const adapter: ProviderAdapter = {
       apiMode: 'chat_completions',
-      async call() {
+      async call(input) {
         calls += 1;
+        const lifecycle = beginPhysicalProviderAttempt(input, {
+          providerActual: 'fixture', modelActual: 'fixture-model', apiMode: 'chat_completions',
+          transport: 'fixture', attemptIndex: calls - 1,
+          logicalCallId: input.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+          requestBytes: JSON.stringify(input.messages).length,
+        });
         if (calls === 1) {
-          return {
+          const output = {
             content: null,
             toolCalls: [{ id: 'read', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } }],
             finishReason: 'tool_use', usage: { inputTokens: 10, outputTokens: 5 },
-          };
+          } as const;
+          lifecycle.success(output, JSON.stringify(output).length);
+          return output;
         }
-        return {
+        const output = {
           content: JSON.stringify({
             schemaVersion: 1, status: 'completed', summary: 'The value is dispatcher-worker.',
             findings: [{
@@ -106,7 +131,9 @@ describe('read-only repository Worker durable dispatcher path', () => {
             unresolvedQuestions: [], uncertainty: { level: 'low', reasons: [] },
           }),
           toolCalls: [], finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5 },
-        };
+        } as const;
+        lifecycle.success(output, JSON.stringify(output).length);
+        return output;
       },
     };
     let normalBuilderCalls = 0;
@@ -117,7 +144,15 @@ describe('read-only repository Worker durable dispatcher path', () => {
     builder.resolveReadOnlyWorkerProvider = async (binding) => {
       expect(binding.providerId).toBe('fixture');
       expect(binding.modelId).toBe('fixture-model');
-      return { adapter, paths: resolveAidenPaths({ rootOverride: home }) };
+      return {
+        adapter,
+        paths: resolveAidenPaths({ rootOverride: home }),
+        providerId: binding.providerId,
+        modelId: binding.modelId,
+        providerRuntimeIdentity: binding.providerRuntimeIdentity,
+        credentialReference: binding.credentialReference,
+        endpointReference: binding.endpointReference,
+      };
     };
     const runner = createRealAgentRunner({
       db, runStore, jobEngine: engine, agentBuilder: builder,
@@ -158,6 +193,7 @@ describe('read-only repository Worker durable dispatcher path', () => {
     db.close();
 
     const reopenedDb = new Database(dbPath);
+    databases.push(reopenedDb);
     reopenedDb.pragma('foreign_keys = ON');
     const reopened = createJobEngine({ db: reopenedDb });
     expect(reopened.worker.getWorkerAssignment(admission.assignment.assignmentId)).toMatchObject({

--- a/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
@@ -20,12 +20,14 @@ import {
   executeReadOnlyRepositoryWorker,
   verifyReadOnlyRepositoryWorkerResult,
 } from '../../../core/v4/worker/readOnlyRepositoryWorker';
+import { createDurableWorkerProviderBridge } from '../../../core/v4/worker/workerProviderBridge';
 import {
   beginPhysicalProviderAttempt,
   createLogicalProviderCallId,
   setProviderAttemptLedger,
 } from '../../../providers/v4/providerAttemptAccounting';
 import type { ProviderAdapter, ProviderCallInput, ProviderCallOutput } from '../../../providers/v4/types';
+import { ProviderRateLimitError } from '../../../providers/v4/errors';
 
 describe('read-only repository Worker runtime', () => {
   let db: Database.Database;
@@ -62,11 +64,19 @@ describe('read-only repository Worker runtime', () => {
     ]);
   });
 
-  async function setup() {
+  async function setup(maxModelCalls = 4) {
     const parent = engine.submitJob({
       entryPoint: 'test', source: 'test', sessionId: 'parent-session', workspaceId: root,
       instanceId: 'worker-instance', idempotencyNamespace: 'worker-parent', idempotencyKey: 'one',
       goal: 'Verify the durable Worker marker.',
+    });
+    engine.resources.configure({
+      jobId: parent.jobId,
+      budgets: {
+        workers: 1, model_calls: 10, retries: 4, tool_calls: 20, runtime_ms: 300_000,
+        input_tokens: 100_000, output_tokens: 40_000, reasoning_tokens: 40_000,
+        output_bytes: 2_000_000,
+      },
     });
     const parentLease = engine.claimAttempt({ attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000 });
     if (!parentLease.acquired || !parentLease.fenceToken || parentLease.generation === undefined) throw new Error('parent lease');
@@ -100,20 +110,93 @@ describe('read-only repository Worker runtime', () => {
         credentialReference: null, endpointReference: null, supportsToolCalling: true,
         contextWindow: 8_192, maxOutputTokens: 2_048, selectionReason: 'deterministic test provider',
       },
+      maxModelCalls,
     });
     return { parent, parentLease, snapshot, entry, claim, admitted };
+  }
+
+  function resolvedProvider(adapter: ProviderAdapter) {
+    return {
+      adapter,
+      paths: resolveAidenPaths({ rootOverride: home }),
+      providerId: 'fixture',
+      modelId: 'fixture-tool-model',
+      providerRuntimeIdentity: 'runtime:fixture',
+      credentialReference: null,
+      endpointReference: null,
+    };
+  }
+
+  function directBridge(admitted: Awaited<ReturnType<typeof setup>>['admitted'], adapter: ProviderAdapter) {
+    const controller = new AbortController();
+    const lease = engine.claimAttempt({
+      attemptId: admitted.child.attemptId, ownerId: 'worker-instance', ttlMs: 60_000,
+    });
+    if (!lease.acquired || !lease.fenceToken || lease.generation === undefined) throw new Error('worker lease');
+    const handle = {
+      jobId: admitted.child.jobId,
+      attemptId: admitted.child.attemptId,
+      runId: admitted.child.runId,
+      generation: lease.generation,
+      fenceToken: lease.fenceToken,
+      signal: controller.signal,
+      pauseAtBoundary() {},
+      resumeAttempt() {},
+    };
+    const workerRun = engine.worker.bindWorkerRunFromAssignment({
+      childJobId: handle.jobId,
+      childAttemptId: handle.attemptId,
+      childGeneration: handle.generation,
+      childFenceToken: handle.fenceToken,
+      workerRunId: admitted.reservation.workerRunId,
+      schemaVersion: 1,
+      assignmentId: admitted.assignment.assignmentId,
+      providerBindingId: admitted.providerBinding.providerBindingId,
+      contextEnvelopeId: admitted.contextEnvelope.contextEnvelopeId,
+      producer: 'test',
+      idempotencyKey: `worker-run:${handle.attemptId}:${handle.generation}`,
+    });
+    return createDurableWorkerProviderBridge({
+      engine,
+      handle,
+      assignment: admitted.assignment,
+      workerRun,
+      binding: admitted.providerBinding,
+      reservation: admitted.reservation,
+      adapter,
+    });
   }
 
   async function runWorker(
     admitted: Awaited<ReturnType<typeof setup>>['admitted'],
     adapter: ProviderAdapter,
   ) {
+    let attemptIndex = 0;
+    const accounted: ProviderAdapter = {
+      apiMode: adapter.apiMode,
+      async call(providerInput) {
+        const lifecycle = beginPhysicalProviderAttempt(providerInput, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: adapter.apiMode,
+          transport: 'fixture', attemptIndex: attemptIndex++,
+          logicalCallId: providerInput.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+          requestBytes: JSON.stringify(providerInput.messages).length,
+        });
+        try {
+          const output = await adapter.call(providerInput);
+          lifecycle.success(output, JSON.stringify(output).length);
+          return output;
+        } catch (error) {
+          lifecycle.failure(error, { sent: true });
+          throw error;
+        }
+      },
+    };
     return executeDurableJob({
       engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
       admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
       execute: (handle) => executeReadOnlyRepositoryWorker({
         engine, handle, assignmentId: admitted.assignment.assignmentId,
-        resolveProvider: async () => ({ adapter, paths: resolveAidenPaths({ rootOverride: home }) }),
+        resolveProvider: async () => resolvedProvider(accounted),
       }),
       finalize: (value) => value.finalization,
     });
@@ -172,7 +255,7 @@ describe('read-only repository Worker runtime', () => {
       admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
       execute: (handle) => executeReadOnlyRepositoryWorker({
         engine, handle, assignmentId: admitted.assignment.assignmentId,
-        resolveProvider: async () => ({ adapter, paths: resolveAidenPaths({ rootOverride: home }) }),
+        resolveProvider: async () => resolvedProvider(adapter),
       }),
       finalize: (value) => value.finalization,
     });
@@ -217,6 +300,16 @@ describe('read-only repository Worker runtime', () => {
     expect(inputs).toHaveLength(2);
     expect(new Set(ledger.query({ jobId: admitted.child.jobId }).map((record) => `${record.providerActual}/${record.modelActual}`)))
       .toEqual(new Set(['fixture/fixture-tool-model']));
+    expect(engine.workerProviderCalls.listForWorkerRun(childExecution.value.workerRun.workerRunId))
+      .toMatchObject([
+        { callOrdinal: 1, state: 'completed', acceptedProviderAttemptId: expect.any(String) },
+        { callOrdinal: 2, state: 'completed', acceptedProviderAttemptId: expect.any(String) },
+      ]);
+    expect(db.prepare('SELECT COUNT(*) AS n FROM worker_provider_tool_links WHERE worker_run_id=?')
+      .get(childExecution.value.workerRun.workerRunId)).toEqual({ n: 3 });
+    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)).toMatchObject({ state: 'released' });
+    expect(engine.resources.getBudgets(parent.jobId).find((budget) => budget.kind === 'model_calls')?.used).toBe(2);
+    expect(engine.resources.getBudgets(parent.jobId).find((budget) => budget.kind === 'tool_calls')?.used).toBe(3);
     expect(JSON.stringify(inputs[0].messages)).not.toContain(parentLease.fenceToken!);
     expect(JSON.stringify(inputs[0].messages)).not.toContain(process.env.PATH ?? '<unset>');
     expect(inputs[0].tools.map((tool) => tool.name).sort()).toEqual([
@@ -254,7 +347,24 @@ describe('read-only repository Worker runtime', () => {
       admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
       execute: (handle) => executeReadOnlyRepositoryWorker({
         engine, handle, assignmentId: admitted.assignment.assignmentId,
-        resolveProvider: async () => ({ adapter, paths: resolveAidenPaths({ rootOverride: home }) }),
+        resolveProvider: async () => {
+          let attemptIndex = 0;
+          const accounted: ProviderAdapter = {
+            apiMode: adapter.apiMode,
+            async call(providerInput) {
+              const lifecycle = beginPhysicalProviderAttempt(providerInput, {
+                providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: adapter.apiMode,
+                transport: 'fixture', attemptIndex: attemptIndex++,
+                logicalCallId: providerInput.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+                requestBytes: JSON.stringify(providerInput.messages).length,
+              });
+              const output = await adapter.call(providerInput);
+              lifecycle.success(output, JSON.stringify(output).length);
+              return output;
+            },
+          };
+          return resolvedProvider(accounted);
+        },
       }),
       finalize: (value) => value.finalization,
     })).rejects.toThrow(/source reference|snapshot/i);
@@ -298,6 +408,233 @@ describe('read-only repository Worker runtime', () => {
     expect(engine.worker.listWorkerRunsForChild(admitted.child.jobId)[0].acceptedResultId).toBeNull();
     expect(engine.worker.rebuildWorkerProjection(engine.getJob(admitted.child.jobId)?.parentJobId ?? '').acceptedResultIds)
       .toHaveLength(0);
+  });
+
+  it('blocks a resolved provider identity that differs from the immutable binding', async () => {
+    const { admitted } = await setup();
+    let calls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        calls += 1;
+        throw new Error('must not send');
+      },
+    };
+    await expect(executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
+      execute: (handle) => executeReadOnlyRepositoryWorker({
+        engine, handle, assignmentId: admitted.assignment.assignmentId,
+        resolveProvider: async () => ({ ...resolvedProvider(adapter), modelId: 'unapproved-model' }),
+      }),
+      finalize: (value) => value.finalization,
+    })).rejects.toThrow(/immutable provider binding/i);
+    expect(calls).toBe(0);
+    expect(ledger.query({ jobId: admitted.child.jobId })).toHaveLength(0);
+  });
+
+  it('accepts a terminal streamed response before exposing its first buffered event', async () => {
+    const { admitted } = await setup();
+    const output: ProviderCallOutput = {
+      content: 'stream complete', toolCalls: [], finishReason: 'stop',
+      usage: { inputTokens: 6, outputTokens: 3 },
+    };
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() { throw new Error('plain call must not run'); },
+      async *callStream(input) {
+        const lifecycle = beginPhysicalProviderAttempt(input, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+          transport: 'fixture-stream', attemptIndex: 0,
+          logicalCallId: input.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+          requestBytes: JSON.stringify(input.messages).length,
+        });
+        yield { type: 'delta' as const, content: 'stream ' };
+        lifecycle.success(output, JSON.stringify(output).length);
+        yield { type: 'done' as const, output };
+      },
+    };
+    const bridge = directBridge(admitted, adapter);
+    const logicalCallId = 'logical_stream_acceptance';
+    const stream = bridge.adapter.callStream!({
+      messages: [{ role: 'user', content: 'inspect' }], tools: [], stream: true,
+      usageContext: { logicalCallId },
+    });
+    const first = await stream.next();
+    expect(first.value).toEqual({ type: 'delta', content: 'stream ' });
+    expect(engine.workerProviderCalls.get(logicalCallId)).toMatchObject({
+      state: 'accepted', responseHash: expect.any(String), acceptedProviderAttemptId: expect.any(String),
+    });
+    expect((await stream.next()).value).toMatchObject({ type: 'done' });
+    bridge.completeAcceptedCalls();
+    expect(engine.workerProviderCalls.get(logicalCallId)?.state).toBe('completed');
+  });
+
+  it('records a partial ambiguous stream as unknown without a second physical attempt', async () => {
+    const { admitted } = await setup();
+    let calls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() { throw new Error('plain call must not run'); },
+      async *callStream(input) {
+        calls += 1;
+        const lifecycle = beginPhysicalProviderAttempt(input, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+          transport: 'fixture-stream', attemptIndex: 0,
+          logicalCallId: input.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+          requestBytes: JSON.stringify(input.messages).length,
+        });
+        yield { type: 'delta' as const, content: 'partial' };
+        const error = new Error('stream interrupted after response bytes');
+        lifecycle.failure(error, { sent: true, status: 'interrupted' });
+        throw error;
+      },
+    };
+    const bridge = directBridge(admitted, adapter);
+    const logicalCallId = 'logical_stream_unknown';
+    const consume = async () => {
+      for await (const _event of bridge.adapter.callStream!({
+        messages: [{ role: 'user', content: 'inspect' }], tools: [], stream: true,
+        usageContext: { logicalCallId },
+      })) { /* buffered until a terminal provider response */ }
+    };
+    await expect(consume()).rejects.toThrow(/stream interrupted/i);
+    expect(calls).toBe(1);
+    expect(ledger.query({ parentCallId: logicalCallId })).toHaveLength(1);
+    expect(engine.workerProviderCalls.get(logicalCallId)).toMatchObject({ state: 'unknown', outcomeKnown: false });
+  });
+
+  it('settles a bridge-level budget denial before transport send', async () => {
+    const { admitted } = await setup(1);
+    db.prepare(
+      'UPDATE job_budget_reservation_items SET committed_value=reserved_value,state=? WHERE reservation_id=? AND kind=?',
+    ).run('committed', admitted.reservation.reservationId, 'model_calls');
+    let calls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call() {
+        calls += 1;
+        throw new Error('must not send');
+      },
+    };
+    const bridge = directBridge(admitted, adapter);
+    const logicalCallId = 'logical_budget_denied';
+    await expect(bridge.adapter.call({
+      messages: [{ role: 'user', content: 'inspect' }], tools: [],
+      usageContext: { logicalCallId },
+    })).rejects.toThrow(/budget exhausted before provider send/i);
+    expect(calls).toBe(0);
+    expect(ledger.query({ parentCallId: logicalCallId })).toHaveLength(0);
+    expect(engine.workerProviderCalls.get(logicalCallId)).toMatchObject({
+      state: 'failed', failureKind: 'budget_exhausted', outcomeKnown: true,
+    });
+  });
+
+  it('accounts a safe pre-response fallback as two physical attempts under one logical call', async () => {
+    const { admitted, snapshot, entry } = await setup();
+    let logicalCalls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call(providerInput) {
+        logicalCalls += 1;
+        const logicalCallId = providerInput.usageContext?.logicalCallId ?? createLogicalProviderCallId();
+        if (logicalCalls === 1) {
+          const primary = beginPhysicalProviderAttempt(providerInput, {
+            providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+            transport: 'fixture', attemptIndex: 0, fallbackIndex: 0, logicalCallId,
+            requestBytes: JSON.stringify(providerInput.messages).length,
+          });
+          primary.failure(new ProviderRateLimitError('fixture'), { sent: true });
+          const fallback = beginPhysicalProviderAttempt(providerInput, {
+            providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+            transport: 'fixture', attemptIndex: 1, fallbackIndex: 1, logicalCallId,
+            requestBytes: JSON.stringify(providerInput.messages).length,
+          });
+          const output: ProviderCallOutput = {
+            content: null,
+            toolCalls: [{ id: 'read-fallback', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } }],
+            finishReason: 'tool_use', usage: { inputTokens: 12, outputTokens: 4 },
+          };
+          fallback.success(output, JSON.stringify(output).length);
+          return output;
+        }
+        const finalAttempt = beginPhysicalProviderAttempt(providerInput, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+          transport: 'fixture', attemptIndex: 0, fallbackIndex: 0, logicalCallId,
+          requestBytes: JSON.stringify(providerInput.messages).length,
+        });
+        const output: ProviderCallOutput = {
+          content: JSON.stringify({
+            schemaVersion: 1, status: 'completed', summary: 'The marker is present.',
+            findings: [{
+              findingId: 'marker', statement: 'source.ts declares durable-worker.', uncertainty: 'low',
+              sourceReferences: [{
+                snapshotId: snapshot.id, snapshotEntryId: entry.canonicalIdentity,
+                path: 'source.ts', startLine: 1, endLine: 1, contentHash: entry.contentHash,
+              }],
+            }],
+            unresolvedQuestions: [], uncertainty: { level: 'low', reasons: [] },
+          }),
+          toolCalls: [], finishReason: 'stop', usage: { inputTokens: 14, outputTokens: 6 },
+        };
+        finalAttempt.success(output, JSON.stringify(output).length);
+        return output;
+      },
+    };
+    const result = await executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
+      execute: (handle) => executeReadOnlyRepositoryWorker({
+        engine, handle, assignmentId: admitted.assignment.assignmentId,
+        resolveProvider: async () => resolvedProvider(adapter),
+      }),
+      finalize: (value) => value.finalization,
+    });
+    const attempts = ledger.query({ jobId: admitted.child.jobId });
+    expect(attempts.map((item) => [item.purpose, item.status])).toEqual([
+      ['primary', 'provider_error'], ['fallback', 'success'], ['primary', 'success'],
+    ]);
+    expect(engine.workerProviderCalls.listForWorkerRun(result.value.workerRun.workerRunId)).toHaveLength(2);
+    expect(engine.resources.getBudgets(result.value.workerRun.childJobId).find((item) => item.kind === 'model_calls')?.used).toBe(3);
+    expect(engine.resources.getBudgets(result.value.workerRun.childJobId).find((item) => item.kind === 'retries')?.used).toBe(1);
+  });
+
+  it('blocks the next logical call before send when the physical model-call reservation is exhausted', async () => {
+    const { admitted } = await setup(1);
+    let calls = 0;
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call(providerInput) {
+        calls += 1;
+        const lifecycle = beginPhysicalProviderAttempt(providerInput, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+          transport: 'fixture', attemptIndex: 0,
+          logicalCallId: providerInput.usageContext?.logicalCallId ?? createLogicalProviderCallId(),
+          requestBytes: JSON.stringify(providerInput.messages).length,
+        });
+        const output: ProviderCallOutput = {
+          content: null,
+          toolCalls: [{ id: 'read-once', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } }],
+          finishReason: 'tool_use', usage: { inputTokens: 10, outputTokens: 4 },
+        };
+        lifecycle.success(output, JSON.stringify(output).length);
+        return output;
+      },
+    };
+    await expect(executeDurableJob({
+      engine, ownerId: 'worker-instance', leaseTtlMs: 60_000,
+      admission: { existing: { ...admitted.child, reused: true }, source: 'worker-dispatch' },
+      execute: (handle) => executeReadOnlyRepositoryWorker({
+        engine, handle, assignmentId: admitted.assignment.assignmentId,
+        resolveProvider: async () => resolvedProvider(adapter),
+      }),
+      finalize: (value) => value.finalization,
+    })).rejects.toThrow(/model-call budget exhausted/i);
+    expect(calls).toBe(1);
+    expect(ledger.query({ jobId: admitted.child.jobId })).toHaveLength(1);
+    expect(engine.workerProviderCalls.listForWorkerRun(admitted.reservation.workerRunId))
+      .toMatchObject([{ callOrdinal: 1, state: 'completed' }]);
+    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)?.state).toBe('released');
   });
 
   it('prevents cancelled parent authority from creating parent Evidence or changing its Claim', async () => {

--- a/tests/v4/worker/workerAuthority.test.ts
+++ b/tests/v4/worker/workerAuthority.test.ts
@@ -163,6 +163,40 @@ describe('WorkerAuthority', () => {
     ]);
   });
 
+  it('freezes provider capabilities, catalog identity, and ordered fallback references in the binding hash', () => {
+    const current = make();
+    current.engine.worker.createWorkerProviderBinding({
+      ...current.parentAuthority,
+      providerBindingId: 'provider_fallback_one', schemaVersion: 1,
+      providerId: 'groq', modelId: 'fallback-model', providerRuntimeIdentity: 'runtime:fallback',
+      credentialReference: 'credential:fallback', endpointReference: 'endpoint:fallback',
+      capabilitySnapshotHash: 'c'.repeat(64), selectionReason: 'fallback policy', fallbackPolicyId: null,
+      contextWindow: 16_384, maxOutputTokens: 2_048, producer: 'test', idempotencyKey: 'provider-fallback', now: 19,
+    });
+    const command = {
+      ...current.parentAuthority,
+      providerBindingId: 'provider_immutable', schemaVersion: 1 as const,
+      providerId: 'custom_openai', modelId: 'custom-default', providerRuntimeIdentity: 'runtime:custom',
+      credentialReference: 'credential:custom', endpointReference: 'endpoint:configured',
+      capabilitySnapshotHash: 'a'.repeat(64), selectionReason: 'runtime policy', fallbackPolicyId: 'fallback-policy-one',
+      contextWindow: 32_768, maxOutputTokens: 4_096, supportsToolCalling: true,
+      supportsStreaming: true, catalogDigest: 'b'.repeat(64), fallbackBindingIds: ['provider_fallback_one'],
+      producer: 'test', idempotencyKey: 'provider-immutable', now: 20,
+    };
+    const first = current.engine.worker.createWorkerProviderBinding(command);
+    expect(first).toMatchObject({
+      supportsToolCalling: true,
+      supportsStreaming: true,
+      catalogDigest: 'b'.repeat(64),
+      fallbackBindingIds: ['provider_fallback_one'],
+    });
+    expect(current.engine.worker.createWorkerProviderBinding(command)).toEqual(first);
+    expect(() => current.engine.worker.createWorkerProviderBinding({
+      ...command, modelId: 'model-selected-by-output',
+    })).toThrowError(expect.objectContaining({ code: 'immutable_conflict' }));
+    expect(JSON.stringify(first)).not.toContain('secret');
+  });
+
   it.each(['env', 'environment', 'conversationHistory', 'messages', 'fenceToken'])(
     'rejects context envelope ambient field %s',
     (field) => {

--- a/tests/v4/worker/workerBudgetReservation.test.ts
+++ b/tests/v4/worker/workerBudgetReservation.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createAssignment, createWorkerFixture, type WorkerFixture } from './fixture';
+
+describe('Worker JobResource reservations', () => {
+  let fixture: WorkerFixture | undefined;
+  afterEach(() => fixture?.db.close());
+
+  function setup() {
+    const current = fixture = createWorkerFixture();
+    const records = createAssignment(current);
+    current.engine.resources.configure({
+      jobId: current.parent.jobId,
+      budgets: { model_calls: 5, input_tokens: 100, external_cost: 10 },
+    });
+    current.engine.resources.configure({
+      jobId: current.child.jobId,
+      budgets: { model_calls: 3, input_tokens: 50, external_cost: 5 },
+    });
+    const command = {
+      reservationId: 'worker_budget_one',
+      idempotencyKey: 'worker-budget-one',
+      ...current.parentAuthority,
+      childJobId: current.child.jobId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      workerRunId: 'worker_run_reserved',
+      assignmentId: records.assignment.assignmentId,
+      amounts: { model_calls: 3, input_tokens: 50, external_cost: 5 },
+      now: 30,
+    };
+    return { current, records, command };
+  }
+
+  it('atomically reserves finite parent capacity and replays an identical request', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    expect(reservation).toMatchObject({
+      reservationId: command.reservationId,
+      parentJobId: current.parent.jobId,
+      childJobId: current.child.jobId,
+      childAttemptId: current.child.attemptId,
+      state: 'reserved',
+    });
+    expect(current.engine.resources.available(current.parent.jobId, 'model_calls')).toBe(2);
+    expect(current.engine.resources.reserveWorker(command)).toEqual(reservation);
+    expect(() => current.engine.resources.reserveWorker({
+      ...command, amounts: { ...command.amounts, model_calls: 4 },
+    })).toThrow(/idempotency conflict/i);
+  });
+
+  it('rejects reservations beyond parent capacity and stale parent authority', () => {
+    const { current, command } = setup();
+    expect(() => current.engine.resources.reserveWorker({
+      ...command, amounts: { model_calls: 6 },
+    })).toThrow(/exceeds parent capacity/i);
+    expect(() => current.engine.resources.reserveWorker({
+      ...command, reservationId: 'worker_budget_stale', idempotencyKey: 'worker-budget-stale',
+      parentFenceToken: 'stale-fence',
+    })).toThrow(/stale worker/i);
+    expect(current.engine.resources.listWorkerReservations(current.parent.jobId)).toEqual([]);
+  });
+
+  it('serializes competing child reservations so parent capacity cannot be oversubscribed', () => {
+    const { current, command } = setup();
+    const secondChild = current.engine.submitJob({
+      entryPoint: 'worker', source: 'worker', sessionId: 'worker-session', instanceId: 'worker-instance',
+      idempotencyNamespace: 'worker-child', idempotencyKey: 'child-two', goal: 'inspect another repository view',
+      parentJobId: current.parent.jobId,
+      childContract: {
+        required: true, workerId: 'repository-reader', capabilities: ['repository_snapshot_read'],
+        allowedResources: { repository: 'snapshot' }, budget: { modelCalls: 1 },
+      },
+    });
+    const secondLease = current.engine.claimAttempt({
+      attemptId: secondChild.attemptId, ownerId: 'child-owner-two', ttlMs: 60_000, now: 10,
+    });
+    const secondFixture: WorkerFixture = {
+      ...current,
+      child: secondChild,
+      childAuthority: {
+        childJobId: secondChild.jobId,
+        childAttemptId: secondChild.attemptId,
+        childGeneration: secondLease.generation!,
+        childFenceToken: secondLease.fenceToken!,
+      },
+    };
+    const second = createAssignment(secondFixture, 'two');
+    current.engine.resources.reserveWorker(command);
+    expect(() => current.engine.resources.reserveWorker({
+      ...command,
+      reservationId: 'worker_budget_two',
+      idempotencyKey: 'worker-budget-two',
+      childJobId: secondChild.jobId,
+      childAttemptId: secondChild.attemptId,
+      childGeneration: secondLease.generation!,
+      workerRunId: 'worker_run_reserved_two',
+      assignmentId: second.assignment.assignmentId,
+      amounts: { model_calls: 3 },
+    })).toThrow(/exceeds parent capacity/i);
+    expect(current.engine.resources.available(current.parent.jobId, 'model_calls')).toBe(2);
+  });
+
+  it('commits child usage and parent roll-up exactly once, then releases only unused capacity', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    const commit = {
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      kind: 'model_calls' as const,
+      amount: 1,
+      certainty: 'confirmed' as const,
+      sourceKind: 'provider_attempt' as const,
+      sourceId: 'physical_one',
+      idempotencyKey: 'physical-one:model',
+      now: 31,
+    };
+    expect(current.engine.resources.commitWorkerUsage(commit)).toMatchObject({ applied: true, remaining: 2 });
+    expect(current.engine.resources.commitWorkerUsage(commit)).toMatchObject({ applied: false, duplicate: true, remaining: 2 });
+    expect(current.engine.resources.getBudgets(current.child.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(1);
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(1);
+    expect(current.db.prepare(
+      "SELECT COUNT(*) AS n FROM job_budget_debits WHERE kind='model_calls'",
+    ).get()).toEqual({ n: 2 });
+
+    const released = current.engine.resources.releaseWorker({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      now: 32,
+    });
+    expect(released.state).toBe('released');
+    expect(released.items.find((item) => item.kind === 'model_calls')).toMatchObject({
+      committed: 1, released: 2,
+    });
+    expect(current.engine.resources.available(current.parent.jobId, 'model_calls')).toBe(4);
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(1);
+    expect(current.engine.resources.releaseWorker({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+    })).toEqual(released);
+  });
+
+  it('preserves unknown usage and cost instead of treating either as zero', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    expect(current.engine.resources.commitWorkerUsage({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      kind: 'external_cost', amount: null, certainty: 'unknown',
+      sourceKind: 'provider_attempt', sourceId: 'physical_unknown',
+      idempotencyKey: 'physical-unknown:cost', now: 31,
+    })).toMatchObject({ applied: true, exhausted: true, remaining: 0 });
+    expect(current.engine.resources.getWorkerReservation(reservation.reservationId)?.items
+      .find((item) => item.kind === 'external_cost')).toMatchObject({
+      hasUnknownUsage: true, state: 'unknown', released: 0,
+    });
+    expect(current.engine.resources.getBudgets(current.child.jobId).find((item) => item.kind === 'external_cost'))
+      .toMatchObject({ used: 0, hasUnknownUsage: true });
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'external_cost'))
+      .toMatchObject({ used: 0, hasUnknownUsage: true });
+  });
+
+  it('releases unused capacity after persist-first child cancellation', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    expect(current.engine.cancelJob({
+      jobId: current.child.jobId,
+      reason: 'operator_cancelled',
+      producer: 'test',
+      eventIdempotencyKey: 'cancel-worker-child',
+    })).toMatchObject({ applied: true });
+    const released = current.engine.resources.releaseWorker({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      cancelled: true,
+    });
+    expect(released.state).toBe('cancelled');
+    expect(released.items.find((item) => item.kind === 'model_calls')).toMatchObject({
+      committed: 0, released: 3, state: 'released',
+    });
+    expect(current.engine.resources.available(current.parent.jobId, 'model_calls')).toBe(5);
+  });
+
+  it('records accepted overage and prohibits further capacity without erasing usage', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    expect(current.engine.resources.commitWorkerUsage({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      kind: 'model_calls', amount: 4, certainty: 'confirmed',
+      sourceKind: 'reconciliation', sourceId: 'accepted-overage',
+      idempotencyKey: 'accepted-overage:model', now: 31,
+    })).toMatchObject({ applied: true, exhausted: true, remaining: 0 });
+    expect(current.engine.resources.getBudgets(current.child.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(4);
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(4);
+    expect(current.engine.resources.getWorkerReservation(reservation.reservationId)?.state).toBe('exhausted');
+  });
+
+  it('rejects usage roll-up after the parent Attempt loses active authority', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    current.db.prepare('UPDATE tasks SET active_attempt_id=NULL WHERE id=?').run(current.parent.jobId);
+    expect(() => current.engine.resources.commitWorkerUsage({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      kind: 'model_calls', amount: 1, certainty: 'confirmed',
+      sourceKind: 'provider_attempt', sourceId: 'stale-parent', idempotencyKey: 'stale-parent:model',
+    })).toThrow(/parent worker budget authority is stale/i);
+    expect(current.engine.resources.getBudgets(current.child.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(0);
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(0);
+  });
+});

--- a/tests/v4/worker/workerMigration.test.ts
+++ b/tests/v4/worker/workerMigration.test.ts
@@ -29,11 +29,35 @@ describe('Worker persistence migration', () => {
       })();
     }
     const before = new Set(tables());
-    expect(runMigrations(db)).toEqual({ from: 36, to: 37 });
-    expect(LATEST_SCHEMA_VERSION).toBe(37);
+    const migration = MIGRATIONS_FOR_TESTS.find((entry) => entry.version === 37)!;
+    db.transaction(() => {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,37,1)').run();
+    })();
     expect(tables().filter((table) => !before.has(table))).toEqual([
       'worker_assignments', 'worker_context_envelopes', 'worker_provider_bindings', 'worker_results', 'worker_runs',
     ]);
+  });
+
+  it('upgrades v37 additively with provider-call and reservation records', () => {
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= 37)) {
+      db.transaction(() => {
+        if (migration.apply) migration.apply(db);
+        else db.exec(migration.sql ?? '');
+        db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)').run(migration.version, 1);
+      })();
+    }
+    const before = new Set(tables());
+    expect(runMigrations(db)).toEqual({ from: 37, to: 38 });
+    expect(LATEST_SCHEMA_VERSION).toBe(38);
+    expect(tables().filter((table) => !before.has(table))).toEqual([
+      'job_budget_reservation_commits', 'job_budget_reservation_items', 'job_budget_reservations',
+      'worker_logical_provider_calls', 'worker_provider_tool_links',
+    ]);
+    expect(columns('worker_provider_bindings')).toEqual(expect.arrayContaining([
+      'supports_tool_calling', 'supports_streaming', 'catalog_digest', 'fallback_binding_ids_json',
+    ]));
   });
 
   it('keeps WorkerRun as a relation without lifecycle, lease, fence, cancellation, or budget authority', () => {
@@ -77,14 +101,14 @@ describe('Worker persistence migration', () => {
       idempotencyNamespace: 'fixture', idempotencyKey: 'job', goal: 'legacy job',
     });
 
-    expect(runMigrations(db)).toEqual({ from: 36, to: 37 });
+    expect(runMigrations(db)).toEqual({ from: 36, to: 38 });
     const engine = createJobEngine({ db });
     expect(engine.getJob(before.jobId)?.goal).toBe('legacy job');
     expect(engine.worker.listWorkerRunsForParent(before.jobId)).toEqual([]);
   });
 
-  it('is idempotent when v37 is already installed', () => {
-    expect(runMigrations(db)).toEqual({ from: 0, to: 37 });
-    expect(runMigrations(db)).toEqual({ from: 37, to: 37 });
+  it('is idempotent when v38 is already installed', () => {
+    expect(runMigrations(db)).toEqual({ from: 0, to: 38 });
+    expect(runMigrations(db)).toEqual({ from: 38, to: 38 });
   });
 });

--- a/tests/v4/worker/workerProviderCallAuthority.test.ts
+++ b/tests/v4/worker/workerProviderCallAuthority.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { bindRun, createWorkerFixture, type WorkerFixture } from './fixture';
+
+describe('Worker logical provider-call authority', () => {
+  let fixture: WorkerFixture | undefined;
+  const make = () => (fixture = createWorkerFixture());
+  afterEach(() => fixture?.db.close());
+
+  function prepared() {
+    const current = make();
+    const records = bindRun(current);
+    const command = {
+      ...current.childAuthority,
+      logicalCallId: 'logical_worker_one',
+      idempotencyKey: 'logical-one',
+      workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      callOrdinal: 1,
+      requestHash: 'c'.repeat(64),
+      toolSchemaHash: 'd'.repeat(64),
+      now: 30,
+    };
+    return { current, records, command, call: current.engine.workerProviderCalls.prepare(command) };
+  }
+
+  it('persists the exact WorkerRun, child generation, binding, and request hashes before send', () => {
+    const { current, records, command, call } = prepared();
+    expect(call).toMatchObject({
+      logicalCallId: command.logicalCallId,
+      workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      childJobId: current.child.jobId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      requestHash: command.requestHash,
+      toolSchemaHash: command.toolSchemaHash,
+      state: 'prepared',
+    });
+    expect(current.engine.workerProviderCalls.prepare(command)).toEqual(call);
+    expect(() => current.engine.workerProviderCalls.prepare({ ...command, requestHash: 'e'.repeat(64) }))
+      .toThrowError(expect.objectContaining({ code: 'idempotency_conflict' }));
+  });
+
+  it('durably receives then accepts one physical response before linking downstream tools', () => {
+    const { current, command } = prepared();
+    current.engine.workerProviderCalls.markAttempting(command);
+    const received = current.engine.workerProviderCalls.recordResponseReceived({
+      ...command,
+      providerAttemptId: 'physical_attempt_one',
+      responseHash: 'e'.repeat(64),
+      providerRequestId: 'request_one',
+      now: 31,
+    });
+    expect(received).toMatchObject({
+      state: 'response_received', acceptedProviderAttemptId: 'physical_attempt_one',
+      responseHash: 'e'.repeat(64), providerRequestId: 'request_one',
+    });
+    const accepted = current.engine.workerProviderCalls.acceptResponse({
+      ...command, providerAttemptId: 'physical_attempt_one', responseHash: 'e'.repeat(64), now: 32,
+    });
+    expect(accepted.state).toBe('accepted');
+    expect(current.engine.workerProviderCalls.markDownstreamStarted(command).state).toBe('downstream_started');
+    expect(current.engine.workerProviderCalls.linkToolCall({
+      ...command,
+      providerToolCallId: 'provider_tool_one',
+      toolName: 'repository_snapshot_read',
+      argumentsHash: 'f'.repeat(64),
+    })).toEqual({ applied: true });
+    expect(current.engine.workerProviderCalls.linkToolCall({
+      ...command,
+      providerToolCallId: 'provider_tool_one',
+      toolName: 'repository_snapshot_read',
+      argumentsHash: 'f'.repeat(64),
+    })).toMatchObject({ applied: false, duplicate: true });
+    expect(() => current.engine.workerProviderCalls.linkToolCall({
+      ...command,
+      providerToolCallId: 'provider_tool_one',
+      toolName: 'repository_snapshot_read',
+      argumentsHash: 'a'.repeat(64),
+    })).toThrowError(expect.objectContaining({ code: 'tool_call_conflict' }));
+  });
+
+  it('allows only the first accepted physical response and rejects a conflicting duplicate', () => {
+    const { current, command } = prepared();
+    current.engine.workerProviderCalls.markAttempting(command);
+    current.engine.workerProviderCalls.recordResponseReceived({
+      ...command, providerAttemptId: 'physical_attempt_one', responseHash: 'e'.repeat(64),
+    });
+    current.engine.workerProviderCalls.acceptResponse({
+      ...command, providerAttemptId: 'physical_attempt_one', responseHash: 'e'.repeat(64),
+    });
+    expect(current.engine.workerProviderCalls.acceptResponse({
+      ...command, providerAttemptId: 'physical_attempt_one', responseHash: 'e'.repeat(64),
+    }).state).toBe('accepted');
+    expect(() => current.engine.workerProviderCalls.recordResponseReceived({
+      ...command, providerAttemptId: 'physical_attempt_two', responseHash: 'a'.repeat(64),
+    })).toThrowError(expect.objectContaining({ code: 'response_conflict' }));
+    expect(() => current.engine.workerProviderCalls.fail({
+      ...command, failureKind: 'late_failure', outcomeKnown: true,
+    })).toThrowError(expect.objectContaining({ code: 'accepted_response' }));
+  });
+
+  it('records ambiguous post-send failure as unknown and blocks stale generations', () => {
+    const { current, command } = prepared();
+    current.engine.workerProviderCalls.markAttempting(command);
+    expect(current.engine.workerProviderCalls.fail({
+      ...command, failureKind: 'transport_unknown', outcomeKnown: false,
+    })).toMatchObject({ state: 'unknown', outcomeKnown: false, failureKind: 'transport_unknown' });
+    expect(current.engine.workerProviderCalls.listForWorkerRun(command.workerRunId)).toHaveLength(1);
+
+    const next = { ...command, logicalCallId: 'logical_worker_two', idempotencyKey: 'logical-two', callOrdinal: 2 };
+    current.engine.cancelJob({
+      jobId: current.child.jobId, reason: 'cancelled', producer: 'test', eventIdempotencyKey: 'cancel-child',
+    });
+    expect(() => current.engine.workerProviderCalls.prepare(next))
+      .toThrowError(expect.objectContaining({ code: 'stale_authority' }));
+  });
+
+  it('stores hashes and identifiers without raw prompts, responses, credentials, or fence tokens', () => {
+    const { current, command } = prepared();
+    current.engine.workerProviderCalls.markAttempting(command);
+    current.engine.workerProviderCalls.recordResponseReceived({
+      ...command, providerAttemptId: 'physical_attempt_one', responseHash: 'e'.repeat(64),
+    });
+    const raw = JSON.stringify(current.db.prepare('SELECT * FROM worker_logical_provider_calls').all());
+    expect(raw).not.toContain('messages');
+    expect(raw).not.toContain('authorization');
+    expect(raw).not.toContain(current.childAuthority.childFenceToken);
+    expect(raw).not.toContain('raw response');
+  });
+});


### PR DESCRIPTION
## Summary

- freezes the read-only Worker provider/model capability binding and ordered approved fallback references;
- adds durable logical provider-call identity above physical ProviderAttempt records;
- persists request hashes, response receipt, and response acceptance before downstream Worker execution;
- gates retry and fallback after acceptance, downstream dispatch, cancellation, stale authority, or unknown outcome;
- reserves parent resources before Worker execution, commits canonical child usage, rolls usage up once, and releases unused capacity;
- adds additive migration v38 while preserving v37 data and legacy ProviderAttempt readability.

## Scope

- retains a single read-only repository Worker;
- retains JobEngine, ProviderAttemptLedger, JobResourceAuthority, TriggerBus, ExecutionGraphAuthority, and JobProofAuthority ownership;
- adds no parallel or nested Workers, mutation capability, recovery redesign, user interface changes, or legacy subagent migration;
- keeps package version 4.18.0.

## Validation

- focused Worker/provider/resource matrix: 110 passed;
- broader lifecycle, dispatcher, proof, fallback, streaming, migration, and subagent matrix: 213 passed;
- offline integration matrix: 24 passed;
- CI-equivalent deterministic suite: 7,463 passed, 48 skipped;
- typecheck passed;
- production build passed;
- package dry run passed for aiden-runtime@4.18.0;
- diff, binary-content, secret, attribution, scope, and duplicate-authority checks passed.