### PR TITLE
feat(worker): add recovery and reconciliation

### DIFF
--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -2104,6 +2104,90 @@ function applyV38(db: Database.Database): void {
   `);
 }
 
+/** Worker provider interruption and restart reconciliation metadata. */
+function applyV39(db: Database.Database): void {
+  addMissingColumns(db, 'worker_logical_provider_calls', [
+    ['reconciliation_state', "TEXT NOT NULL DEFAULT 'not_required'"],
+    ['outcome_knowledge', "TEXT NOT NULL DEFAULT 'no_request_started'"],
+    ['retry_safety', "TEXT NOT NULL DEFAULT 'not_applicable'"],
+    ['interruption_kind', 'TEXT'],
+    ['cancellation_requested_at', 'INTEGER'],
+    ['timeout_requested_at', 'INTEGER'],
+    ['authority_lost_at', 'INTEGER'],
+    ['stale_response_rejected_at', 'INTEGER'],
+    ['late_response_observed_at', 'INTEGER'],
+    ['reconciliation_started_at', 'INTEGER'],
+    ['reconciled_at', 'INTEGER'],
+    ['reconciliation_reason', 'TEXT'],
+    ['reconciliation_version', 'INTEGER NOT NULL DEFAULT 0'],
+    ['recovery_predecessor_logical_call_id', 'TEXT'],
+  ]);
+  addMissingColumns(db, 'job_budget_reservations', [
+    ['reconciliation_state', "TEXT NOT NULL DEFAULT 'not_required'"],
+    ['reconciliation_reason', 'TEXT'],
+    ['unknown_spend_pending', 'INTEGER NOT NULL DEFAULT 0'],
+    ['last_reconciled_at', 'INTEGER'],
+    ['settlement_blocked_at', 'INTEGER'],
+  ]);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_worker_logical_calls_reconciliation
+      ON worker_logical_provider_calls(reconciliation_state, logical_call_id);
+    CREATE INDEX IF NOT EXISTS idx_worker_budget_reconciliation
+      ON job_budget_reservations(reconciliation_state, updated_at, reservation_id);
+
+    CREATE TABLE IF NOT EXISTS worker_provider_call_reconciliations (
+      reconciliation_id TEXT PRIMARY KEY,
+      logical_call_id TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      worker_run_id TEXT NOT NULL,
+      child_job_id TEXT NOT NULL,
+      child_attempt_id TEXT NOT NULL,
+      child_generation INTEGER NOT NULL,
+      outcome_knowledge TEXT NOT NULL,
+      retry_safety TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      physical_attempt_ids_json TEXT NOT NULL DEFAULT '[]',
+      unknown_spend INTEGER NOT NULL DEFAULT 0,
+      unsettled_downstream INTEGER NOT NULL DEFAULT 0,
+      state TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      FOREIGN KEY (logical_call_id) REFERENCES worker_logical_provider_calls(logical_call_id) ON DELETE CASCADE,
+      UNIQUE (logical_call_id, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_provider_reconciliations_pending
+      ON worker_provider_call_reconciliations(state, created_at, reconciliation_id);
+
+    CREATE TABLE IF NOT EXISTS worker_provider_late_responses (
+      late_response_id TEXT PRIMARY KEY,
+      logical_call_id TEXT NOT NULL,
+      provider_attempt_id TEXT NOT NULL,
+      response_hash TEXT NOT NULL,
+      provider_request_id TEXT,
+      reason TEXT NOT NULL,
+      observed_at INTEGER NOT NULL,
+      FOREIGN KEY (logical_call_id) REFERENCES worker_logical_provider_calls(logical_call_id) ON DELETE CASCADE,
+      UNIQUE (logical_call_id, provider_attempt_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS job_budget_reservation_reconciliations (
+      reconciliation_id TEXT PRIMARY KEY,
+      reservation_id TEXT NOT NULL,
+      logical_call_id TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      outcome_knowledge TEXT NOT NULL,
+      retry_safety TEXT NOT NULL,
+      unknown_spend INTEGER NOT NULL DEFAULT 0,
+      safe_to_release INTEGER NOT NULL DEFAULT 0,
+      reason TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (reservation_id) REFERENCES job_budget_reservations(reservation_id) ON DELETE CASCADE,
+      FOREIGN KEY (logical_call_id) REFERENCES worker_logical_provider_calls(logical_call_id) ON DELETE CASCADE,
+      UNIQUE (reservation_id, idempotency_key)
+    );
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -2143,6 +2227,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 36, name: 'repository understanding and durable coding plans', apply: applyV36 },
   { version: 37, name: 'durable Worker contracts and authority boundaries', apply: applyV37 },
   { version: 38, name: 'durable Worker provider calls and budget reservations', apply: applyV38 },
+  { version: 39, name: 'Worker provider restart and reconciliation', apply: applyV39 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -2185,7 +2270,9 @@ function validateLatestSchema(db: Database.Database): void {
     'execution_graph_node_references', 'worker_assignments', 'worker_runs',
     'worker_provider_bindings', 'worker_context_envelopes', 'worker_results',
     'worker_logical_provider_calls', 'worker_provider_tool_links', 'job_budget_reservations',
-    'job_budget_reservation_items', 'job_budget_reservation_commits'];
+    'job_budget_reservation_items', 'job_budget_reservation_commits',
+    'worker_provider_call_reconciliations', 'worker_provider_late_responses',
+    'job_budget_reservation_reconciliations'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -431,12 +431,25 @@ export interface JobEngine {
     instanceId: string;
     producer: string;
     maxCrashes: number;
+    reconcileWorkerAttempt?: (input: {
+      childJobId: string;
+      childAttemptId: string;
+      childGeneration: number;
+      now: number;
+    }) => WorkerAttemptReconciliationSummary;
   }): Array<{
     jobId: string;
     expiredAttemptId: string;
     recoveryAttemptId?: string;
     decision: 'retry' | 'ask_user' | 'dead_letter';
+    workerReconciliation?: WorkerAttemptReconciliationSummary;
   }>;
+}
+
+export interface WorkerAttemptReconciliationSummary {
+  calls: number;
+  retrySafety: 'safe' | 'unsafe' | 'blocked_unknown' | 'not_applicable';
+  outcomeKnowledge: string[];
 }
 
 export interface CreateJobEngineOptions {
@@ -708,6 +721,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     ) return null;
     return attempt;
   };
+  let workerProviderCalls!: WorkerProviderCallAuthority;
 
   const existingEvent = (jobId: string, key: string): { id: number; job_sequence: number } | undefined => db.prepare(
     'SELECT id, job_sequence FROM run_events WHERE job_id = ? AND idempotency_key = ?',
@@ -1292,6 +1306,18 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     const attempt = job.active_attempt_id ? getAttemptRow(job.active_attempt_id) : undefined;
     if (!attempt) return { applied: false, conflict: 'not_found' };
     const now = command.now ?? Date.now();
+    if (!ATTEMPT_TERMINAL.has(attempt.status) && attempt.fence_token) {
+      workerProviderCalls.recordInterruptionForAttempt({
+        childJobId: job.id,
+        childAttemptId: attempt.attempt_id,
+        childGeneration: attempt.generation,
+        childFenceToken: attempt.fence_token,
+        kind: 'cancellation',
+        reason: command.reason,
+        idempotencyKey: `worker-cancel:${command.eventIdempotencyKey}`,
+        now,
+      });
+    }
     if (!ATTEMPT_TERMINAL.has(attempt.status)) {
       const attemptChanged = db.prepare(
         `UPDATE runs
@@ -2116,11 +2142,15 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     instanceId: string;
     producer: string;
     maxCrashes: number;
+    reconcileWorkerAttempt?: (input: {
+      childJobId: string; childAttemptId: string; childGeneration: number; now: number;
+    }) => WorkerAttemptReconciliationSummary;
   }): {
     jobId: string;
     expiredAttemptId: string;
     recoveryAttemptId?: string;
     decision: 'retry' | 'ask_user' | 'dead_letter';
+    workerReconciliation?: WorkerAttemptReconciliationSummary;
   } | null => {
     const attempt = getAttemptRow(command.attemptId);
     if (
@@ -2143,10 +2173,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     ).get(attempt.attempt_id, attempt.generation) !== undefined;
     const crashRow = db.prepare('SELECT crash_count FROM tasks WHERE id = ?').get(job.id) as { crash_count: number };
     const crashCount = crashRow.crash_count + 1;
-    const decision: 'retry' | 'ask_user' | 'dead_letter' = ambiguous
-      ? 'ask_user'
-      : crashCount >= Math.max(1, command.maxCrashes) ? 'dead_letter' : 'retry';
-    const attemptStatus = ambiguous ? 'unknown' : 'crashed';
+    let attemptStatus: 'unknown' | 'crashed' = ambiguous ? 'unknown' : 'crashed';
     const attemptVersion = attempt.state_version + 1;
     const cleared = db.prepare(
       `UPDATE runs
@@ -2202,13 +2229,71 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         });
       }
     }
+    const workerReconciliation = command.reconcileWorkerAttempt
+      ? command.reconcileWorkerAttempt({
+        childJobId: job.id,
+        childAttemptId: attempt.attempt_id,
+        childGeneration: attempt.generation,
+        now: command.now,
+      })
+      : (() => {
+        const calls = workerProviderCalls.markAuthorityLostForAttempt({
+          childJobId: job.id,
+          childAttemptId: attempt.attempt_id,
+          childGeneration: attempt.generation,
+          kind: 'lease_expired',
+          reason: 'attempt_lease_expired',
+          idempotencyKey: `worker-authority-lost:${attempt.attempt_id}:${attempt.generation}`,
+          now: command.now,
+        });
+        const reconciled = calls.map((call) => workerProviderCalls.reconcile({
+          logicalCallId: call.logicalCallId,
+          workerRunId: call.workerRunId,
+          childJobId: call.childJobId,
+          childAttemptId: call.childAttemptId,
+          childGeneration: call.childGeneration,
+          physicalAttempts: [],
+          unknownSpend: call.state === 'attempting',
+          reason: 'attempt_lease_expired',
+          idempotencyKey: `worker-reconcile:${call.logicalCallId}:${call.childGeneration}`,
+          now: command.now,
+        }));
+        const retrySafety = reconciled.some((entry) => entry.retrySafety === 'blocked_unknown')
+          ? 'blocked_unknown'
+          : reconciled.some((entry) => entry.retrySafety === 'unsafe')
+            ? 'unsafe'
+            : reconciled.some((entry) => entry.retrySafety === 'safe')
+              ? 'safe'
+              : 'not_applicable';
+        return {
+          calls: reconciled.length,
+          retrySafety,
+          outcomeKnowledge: reconciled.map((entry) => entry.outcomeKnowledge),
+        } satisfies WorkerAttemptReconciliationSummary;
+      })();
+    const workerBlocksRetry = workerReconciliation.retrySafety === 'blocked_unknown'
+      || workerReconciliation.retrySafety === 'unsafe';
+    if (workerBlocksRetry && attemptStatus !== 'unknown') {
+      db.prepare(
+        `UPDATE runs SET status = 'unknown', finish_reason = 'worker_provider_outcome_unknown'
+          WHERE attempt_id = ? AND generation = ? AND state_version = ?`,
+      ).run(attempt.attempt_id, attempt.generation, attemptVersion);
+      attemptStatus = 'unknown';
+    }
+    const decision: 'retry' | 'ask_user' | 'dead_letter' = ambiguous || workerBlocksRetry
+      ? 'ask_user'
+      : crashCount >= Math.max(1, command.maxCrashes) ? 'dead_letter' : 'retry';
+    const recoveryReason = ambiguous
+      ? 'unknown_side_effect'
+      : workerBlocksRetry ? 'worker_provider_outcome_unknown' : 'lease_expired';
+
     appendEvent({
       jobId: job.id,
       runId: attempt.id,
       attemptId: attempt.attempt_id,
       generation: attempt.generation,
       type: `attempt.${attemptStatus}`,
-      payload: { reason: ambiguous ? 'unknown_side_effect' : 'lease_expired' },
+      payload: { reason: recoveryReason, workerReconciliation },
       producer: command.producer,
       idempotencyKey: `attempt-recovered:${attempt.attempt_id}:${attempt.generation}`,
     });
@@ -2227,7 +2312,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         jobStatus,
         crashCount,
         decision === 'ask_user' ? 'user_required' : 'dead_letter',
-        ambiguous ? 'unknown_side_effect' : 'crash_loop',
+        decision === 'ask_user' ? recoveryReason : 'crash_loop',
         jobStatus,
         command.now,
         jobStatus,
@@ -2246,7 +2331,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
         producer: command.producer,
         idempotencyKey: `job-recovery:${job.id}:${attempt.generation}`,
       });
-      return { jobId: job.id, expiredAttemptId: attempt.attempt_id, decision };
+      return { jobId: job.id, expiredAttemptId: attempt.attempt_id, decision, workerReconciliation };
     }
 
     const max = db.prepare(
@@ -2301,7 +2386,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       producer: command.producer,
       idempotencyKey: `attempt-created:${recoveryAttemptId}`,
     });
-    return { jobId: job.id, expiredAttemptId: attempt.attempt_id, recoveryAttemptId, decision };
+    return { jobId: job.id, expiredAttemptId: attempt.attempt_id, recoveryAttemptId, decision, workerReconciliation };
   }).immediate;
 
   const repository = createRepositorySnapshotAuthority({
@@ -2375,7 +2460,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       return { duplicate: result.duplicate, sequence: result.jobSequence };
     },
   });
-  const workerProviderCalls = createWorkerProviderCallAuthority(db, (command) => {
+  workerProviderCalls = createWorkerProviderCallAuthority(db, (command) => {
     const attempt = activeFence(
       command.childAttemptId,
       command.childGeneration,
@@ -2389,6 +2474,21 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
       && job?.active_attempt_id === command.childAttemptId
       && !JOB_TERMINAL.has(job.status),
     );
+  }, ({ call, type, payload, idempotencyKey }) => {
+    const attempt = getAttemptRow(call.childAttemptId);
+    if (!attempt || attempt.task_id !== call.childJobId || attempt.generation !== call.childGeneration) {
+      throw new Error('Worker provider reconciliation event lineage is invalid');
+    }
+    appendEvent({
+      jobId: call.childJobId,
+      runId: attempt.id,
+      attemptId: call.childAttemptId,
+      generation: call.childGeneration,
+      type,
+      payload,
+      producer: 'worker-provider-reconciliation',
+      idempotencyKey,
+    });
   });
 
   return {

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -556,8 +556,25 @@ export async function executeDurableJob<T>(
     if (runtimeBudget?.limit !== null && runtimeBudget !== undefined) {
       const remaining = Math.max(0, runtimeBudget.limit - runtimeBudget.used);
       runtimeBudgetTimer = setTimeout(() => {
-        runtimeBudgetExpired = true;
-        leaseAbort.abort(new DurableJobBudgetExceededError('runtime_ms', handle));
+        try {
+          options.engine.workerProviderCalls.recordInterruptionForAttempt({
+            childJobId: handle.jobId,
+            childAttemptId: handle.attemptId,
+            childGeneration: handle.generation,
+            childFenceToken: handle.fenceToken,
+            kind: 'timeout',
+            reason: 'runtime_budget_exceeded',
+            idempotencyKey: `worker-timeout:${handle.attemptId}:${handle.generation}`,
+          });
+          runtimeBudgetExpired = true;
+          leaseAbort.abort(new DurableJobBudgetExceededError('runtime_ms', handle));
+        } catch (error) {
+          leaseLost = new DurableJobAuthorityLostError(
+            `Durable Worker timeout intent could not be persisted: ${error instanceof Error ? error.message : 'unknown'}`,
+            handle,
+          );
+          leaseAbort.abort(leaseLost);
+        }
       }, remaining);
       runtimeBudgetTimer.unref?.();
     }

--- a/core/v4/daemon/jobRecoverySweep.ts
+++ b/core/v4/daemon/jobRecoverySweep.ts
@@ -6,6 +6,11 @@
 import type { JobEngine } from './jobEngine';
 import type { TriggerBus } from './triggerBus';
 import { reconcileFilesystemEffectSync } from '../effectReconciliation';
+import { currentProviderAttemptLedger } from '../../../providers/v4/providerAttemptAccounting';
+import {
+  reconcileWorkerProviderAttempt,
+  sweepWorkerProviderReconciliation,
+} from '../worker/workerProviderReconciliation';
 
 export interface DurableRecoverySweepResult {
   expired: number;
@@ -30,11 +35,24 @@ export function sweepDurableJobRecovery(input: {
   maxCrashes?: number;
   now?: number;
 }): DurableRecoverySweepResult {
+  const providerLedger = currentProviderAttemptLedger();
   const decisions = input.jobEngine.recoverExpiredAttempts({
     now: input.now,
     instanceId: input.instanceId,
     producer: input.producer,
     maxCrashes: input.maxCrashes ?? 3,
+    reconcileWorkerAttempt: ({ childJobId, childAttemptId, childGeneration, now }) =>
+      reconcileWorkerProviderAttempt({
+        engine: input.jobEngine,
+        ledger: providerLedger,
+        childJobId,
+        childAttemptId,
+        childGeneration,
+        ownerId: input.instanceId,
+        producer: input.producer,
+        reason: 'attempt_lease_expired',
+        now,
+      }),
   });
   const result: DurableRecoverySweepResult = {
     expired: decisions.length,
@@ -44,10 +62,20 @@ export function sweepDurableJobRecovery(input: {
     enqueued: 0,
     reconciled: 0,
   };
+  const workerSweep = sweepWorkerProviderReconciliation({
+    engine: input.jobEngine,
+    ledger: providerLedger,
+    ownerId: input.instanceId,
+    producer: input.producer,
+    now: input.now,
+  });
+  result.reconciled += workerSweep.reconciled;
 
   for (const decision of decisions.filter((item) => item.decision === 'ask_user')) {
     const job = input.jobEngine.getJob(decision.jobId);
     if (!job) continue;
+    const workerRequiresResolution = decision.workerReconciliation?.retrySafety === 'blocked_unknown'
+      || decision.workerReconciliation?.retrySafety === 'unsafe';
     const effects = input.jobEngine.listEffectsRequiringReconciliation(job.id);
     for (const effect of effects) {
       const reconciliation = reconcileFilesystemEffectSync(effect);
@@ -61,7 +89,7 @@ export function sweepDurableJobRecovery(input: {
       });
       if (recorded.applied) result.reconciled += 1;
     }
-    if (input.jobEngine.listEffectsRequiringReconciliation(job.id).length === 0) {
+    if (!workerRequiresResolution && input.jobEngine.listEffectsRequiringReconciliation(job.id).length === 0) {
       input.jobEngine.createRecoveryAttempt({
         jobId: job.id,
         recoveryOfAttemptId: decision.expiredAttemptId,

--- a/core/v4/daemon/jobResourceAuthority.ts
+++ b/core/v4/daemon/jobResourceAuthority.ts
@@ -65,6 +65,11 @@ export interface JobBudgetReservationRecord {
   createdAt: number;
   updatedAt: number;
   releasedAt: number | null;
+  reconciliationState: 'not_required' | 'pending' | 'reconciled' | 'blocked_unknown';
+  reconciliationReason: string | null;
+  unknownSpendPending: boolean;
+  lastReconciledAt: number | null;
+  settlementBlockedAt: number | null;
 }
 
 export interface JobResourceAuthority {
@@ -127,6 +132,27 @@ export interface JobResourceAuthority {
     cancelled?: boolean;
     now?: number;
   }): JobBudgetReservationRecord;
+  reconcileWorkerUsage(command: {
+    reservationId: string;
+    logicalCallId: string;
+    kind: JobBudgetKind;
+    amount: number | null;
+    certainty: BudgetCertainty;
+    providerAttemptId: string;
+    idempotencyKey: string;
+    now?: number;
+  }): { applied: boolean; duplicate?: boolean; repaired?: boolean; exhausted?: boolean; remaining: number };
+  reconcileWorkerReservation(command: {
+    reservationId: string;
+    logicalCallId: string;
+    outcomeKnowledge: string;
+    retrySafety: 'safe' | 'unsafe' | 'blocked_unknown' | 'not_applicable';
+    unknownSpend: boolean;
+    safeToRelease: boolean;
+    reason: string;
+    idempotencyKey: string;
+    now?: number;
+  }): JobBudgetReservationRecord;
   authorize(command: {
     jobId: string;
     kind: 'tool' | 'path' | 'host' | 'application' | 'connection' | 'account' | 'worker' | 'effect';
@@ -176,6 +202,9 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
     child_attempt_id: string; child_generation: number; worker_run_id: string;
     assignment_id: string; state: JobBudgetReservationState; created_at: number;
     updated_at: number; released_at: number | null;
+    reconciliation_state: JobBudgetReservationRecord['reconciliationState'];
+    reconciliation_reason: string | null; unknown_spend_pending: number;
+    last_reconciled_at: number | null; settlement_blocked_at: number | null;
   };
   type ItemRow = {
     kind: JobBudgetKind; reserved_value: number; committed_value: number;
@@ -212,6 +241,11 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       releasedAt: row.released_at,
+      reconciliationState: row.reconciliation_state,
+      reconciliationReason: row.reconciliation_reason,
+      unknownSpendPending: row.unknown_spend_pending === 1,
+      lastReconciledAt: row.last_reconciled_at,
+      settlementBlockedAt: row.settlement_blocked_at,
     };
   };
 
@@ -442,6 +476,183 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
     return { applied: true, exhausted, remaining: Math.max(0, item.reserved - nextCommitted - item.released) };
   }).immediate;
 
+  const requireReconciliationLineage = (
+    reservation: JobBudgetReservationRecord,
+    logicalCallId: string,
+  ): void => {
+    const call = db.prepare(
+      `SELECT worker_run_id,assignment_id,child_job_id,child_attempt_id,child_generation
+         FROM worker_logical_provider_calls WHERE logical_call_id=?`,
+    ).get(logicalCallId) as {
+      worker_run_id: string; assignment_id: string; child_job_id: string;
+      child_attempt_id: string; child_generation: number;
+    } | undefined;
+    if (!call || call.worker_run_id !== reservation.workerRunId || call.assignment_id !== reservation.assignmentId
+      || call.child_job_id !== reservation.childJobId || call.child_attempt_id !== reservation.childAttemptId
+      || call.child_generation !== reservation.childGeneration) {
+      throw new Error('Worker budget reconciliation lineage is invalid');
+    }
+  };
+
+  const refreshReservationItem = (
+    reservation: JobBudgetReservationRecord,
+    kind: JobBudgetKind,
+    now: number,
+  ): { exhausted: boolean; remaining: number } => {
+    const item = getReservation(reservation.reservationId)?.items.find((candidate) => candidate.kind === kind);
+    if (!item) throw new Error(`Worker ${kind} usage is outside the reservation`);
+    const sums = db.prepare(
+      `SELECT COALESCE(SUM(CASE WHEN amount IS NULL THEN 0 ELSE amount END),0) AS known,
+              MAX(CASE WHEN amount IS NULL OR certainty='unknown' THEN 1 ELSE 0 END) AS unknown
+         FROM job_budget_reservation_commits WHERE reservation_id=? AND kind=?`,
+    ).get(reservation.reservationId, kind) as { known: number; unknown: number | null };
+    const unknown = (sums.unknown ?? 0) === 1;
+    const committed = unknown ? Math.max(item.reserved, sums.known) : sums.known;
+    const exhausted = unknown || committed >= item.reserved;
+    const state: JobBudgetReservationItemRecord['state'] = unknown
+      ? 'unknown' : committed > item.reserved ? 'exhausted' : exhausted ? 'committed' : 'partially_committed';
+    db.prepare(
+      `UPDATE job_budget_reservation_items
+          SET committed_value=?,has_unknown_usage=?,state=?,updated_at=? WHERE reservation_id=? AND kind=?`,
+    ).run(committed, unknown ? 1 : item.hasUnknownUsage ? 1 : 0, state, now, reservation.reservationId, kind);
+    const states = db.prepare('SELECT state FROM job_budget_reservation_items WHERE reservation_id=?')
+      .all(reservation.reservationId) as Array<{ state: JobBudgetReservationItemRecord['state'] }>;
+    const reservationState: JobBudgetReservationState = states.some((row) => row.state === 'unknown' || row.state === 'exhausted')
+      ? 'exhausted' : states.every((row) => row.state === 'committed') ? 'committed' : 'partially_committed';
+    db.prepare('UPDATE job_budget_reservations SET state=?,updated_at=? WHERE reservation_id=?')
+      .run(reservationState, now, reservation.reservationId);
+    return { exhausted, remaining: Math.max(0, item.reserved - committed - item.released) };
+  };
+
+  const reconcileWorkerUsage = db.transaction((command: Parameters<JobResourceAuthority['reconcileWorkerUsage']>[0]) => {
+    const reservation = getReservation(command.reservationId);
+    if (!reservation) throw new Error('Worker budget reservation was not found');
+    requireReconciliationLineage(reservation, command.logicalCallId);
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.providerAttemptId)) {
+      throw new Error('ProviderAttempt reconciliation identity is invalid');
+    }
+    const item = reservation.items.find((candidate) => candidate.kind === command.kind);
+    if (!item) throw new Error(`Worker ${command.kind} usage is outside the reservation`);
+    const amount = command.certainty === 'unknown' ? null : command.amount;
+    if (amount !== null && (!Number.isFinite(amount) || amount < 0)) throw new Error('Worker usage must be non-negative');
+    const prior = db.prepare(
+      `SELECT kind,amount,certainty,source_kind,source_id FROM job_budget_reservation_commits
+        WHERE reservation_id=? AND idempotency_key=?`,
+    ).get(command.reservationId, command.idempotencyKey) as {
+      kind: JobBudgetKind; amount: number | null; certainty: BudgetCertainty;
+      source_kind: string; source_id: string;
+    } | undefined;
+    if (prior && (prior.kind !== command.kind || prior.amount !== amount || prior.certainty !== command.certainty
+      || prior.source_kind !== 'provider_attempt' || prior.source_id !== command.providerAttemptId)) {
+      throw new Error('Worker usage reconciliation idempotency conflict');
+    }
+    const now = command.now ?? Date.now();
+    const childApplied = applyDebit({
+      jobId: reservation.childJobId, attemptId: reservation.childAttemptId,
+      generation: reservation.childGeneration, kind: command.kind, amount,
+      certainty: command.certainty, idempotencyKey: command.idempotencyKey, now,
+    });
+    const parentApplied = applyDebit({
+      jobId: reservation.parentJobId, attemptId: reservation.parentAttemptId,
+      generation: reservation.parentGeneration, kind: command.kind, amount,
+      certainty: command.certainty,
+      idempotencyKey: `worker-rollup:${reservation.reservationId}:${command.idempotencyKey}`,
+      now,
+    });
+    if (!prior) {
+      db.prepare(
+        `INSERT INTO job_budget_reservation_commits
+           (commit_id,reservation_id,kind,amount,certainty,source_kind,source_id,idempotency_key,created_at)
+         VALUES (?,?,?,?,?,'provider_attempt',?,?,?)`,
+      ).run(
+        `budget_commit_${randomBytes(12).toString('hex')}`, reservation.reservationId,
+        command.kind, amount, command.certainty, command.providerAttemptId, command.idempotencyKey, now,
+      );
+    }
+    const refreshed = refreshReservationItem(reservation, command.kind, now);
+    const repaired = Boolean(prior && (childApplied || parentApplied));
+    return {
+      applied: !prior || repaired,
+      ...(prior && !repaired ? { duplicate: true } : {}),
+      ...(repaired ? { repaired: true } : {}),
+      ...refreshed,
+    };
+  }).immediate;
+
+  const reconcileWorkerReservation = db.transaction((
+    command: Parameters<JobResourceAuthority['reconcileWorkerReservation']>[0],
+  ) => {
+    const reservation = getReservation(command.reservationId);
+    if (!reservation) throw new Error('Worker budget reservation was not found');
+    requireReconciliationLineage(reservation, command.logicalCallId);
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.reason)
+      || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.idempotencyKey)) {
+      throw new Error('Worker reservation reconciliation contract is invalid');
+    }
+    const existing = db.prepare(
+      `SELECT logical_call_id,outcome_knowledge,retry_safety,unknown_spend,safe_to_release,reason
+         FROM job_budget_reservation_reconciliations WHERE reservation_id=? AND idempotency_key=?`,
+    ).get(command.reservationId, command.idempotencyKey) as {
+      logical_call_id: string; outcome_knowledge: string; retry_safety: string;
+      unknown_spend: number; safe_to_release: number; reason: string;
+    } | undefined;
+    if (existing) {
+      const same = existing.logical_call_id === command.logicalCallId
+        && existing.outcome_knowledge === command.outcomeKnowledge
+        && existing.retry_safety === command.retrySafety
+        && existing.unknown_spend === (command.unknownSpend ? 1 : 0)
+        && existing.safe_to_release === (command.safeToRelease ? 1 : 0)
+        && existing.reason === command.reason;
+      if (!same) throw new Error('Worker reservation reconciliation idempotency conflict');
+      return getReservation(command.reservationId)!;
+    }
+    const now = command.now ?? Date.now();
+    const reconciliationId = `budget_reconcile_${randomBytes(12).toString('hex')}`;
+    db.prepare(
+      `INSERT INTO job_budget_reservation_reconciliations
+         (reconciliation_id,reservation_id,logical_call_id,idempotency_key,outcome_knowledge,
+          retry_safety,unknown_spend,safe_to_release,reason,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      reconciliationId, command.reservationId, command.logicalCallId, command.idempotencyKey,
+      command.outcomeKnowledge, command.retrySafety, command.unknownSpend ? 1 : 0,
+      command.safeToRelease ? 1 : 0, command.reason, now,
+    );
+    if (command.unknownSpend) {
+      db.prepare(
+        `UPDATE job_budget_reservations
+            SET reconciliation_state='blocked_unknown',reconciliation_reason=?,unknown_spend_pending=1,
+                last_reconciled_at=?,settlement_blocked_at=COALESCE(settlement_blocked_at,?),updated_at=?
+          WHERE reservation_id=?`,
+      ).run(command.reason, now, now, now, command.reservationId);
+      return getReservation(command.reservationId)!;
+    }
+    if (command.safeToRelease) {
+      for (const candidate of reservation.items) {
+        const release = candidate.hasUnknownUsage ? 0 : Math.max(0, candidate.reserved - candidate.committed - candidate.released);
+        const state: JobBudgetReservationItemRecord['state'] = candidate.hasUnknownUsage
+          ? 'unknown' : candidate.state === 'exhausted' ? 'exhausted' : 'released';
+        db.prepare(
+          `UPDATE job_budget_reservation_items SET released_value=released_value+?,state=?,updated_at=?
+            WHERE reservation_id=? AND kind=?`,
+        ).run(release, state, now, command.reservationId, candidate.kind);
+      }
+      db.prepare(
+        `UPDATE job_budget_reservations
+            SET state='reconciled',reconciliation_state='reconciled',reconciliation_reason=?,
+                unknown_spend_pending=0,last_reconciled_at=?,released_at=COALESCE(released_at,?),updated_at=?
+          WHERE reservation_id=?`,
+      ).run(command.reason, now, now, now, command.reservationId);
+    } else {
+      db.prepare(
+        `UPDATE job_budget_reservations
+            SET reconciliation_state='pending',reconciliation_reason=?,last_reconciled_at=?,updated_at=?
+          WHERE reservation_id=?`,
+      ).run(command.reason, now, now, command.reservationId);
+    }
+    return getReservation(command.reservationId)!;
+  }).immediate;
+
   const releaseWorker = db.transaction((command: Parameters<JobResourceAuthority['releaseWorker']>[0]) => {
     const reservation = getReservation(command.reservationId);
     if (!reservation) throw new Error('Worker budget reservation was not found');
@@ -453,10 +664,19 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
       reservation.childJobId, command.childAttemptId, command.childGeneration, command.childFenceToken,
     );
     const now = command.now ?? Date.now();
+    if (reservation.unknownSpendPending || reservation.items.some((item) => item.hasUnknownUsage)) {
+      db.prepare(
+        `UPDATE job_budget_reservations
+            SET reconciliation_state='blocked_unknown',unknown_spend_pending=1,
+                reconciliation_reason=COALESCE(reconciliation_reason,'unknown_spend'),
+                settlement_blocked_at=COALESCE(settlement_blocked_at,?),updated_at=?
+          WHERE reservation_id=?`,
+      ).run(now, now, reservation.reservationId);
+      return getReservation(reservation.reservationId)!;
+    }
     for (const item of reservation.items) {
-      const release = item.hasUnknownUsage ? 0 : Math.max(0, item.reserved - item.committed - item.released);
-      const state: JobBudgetReservationItemRecord['state'] = item.hasUnknownUsage
-        ? 'unknown' : item.state === 'exhausted' ? 'exhausted' : 'released';
+      const release = Math.max(0, item.reserved - item.committed - item.released);
+      const state: JobBudgetReservationItemRecord['state'] = item.state === 'exhausted' ? 'exhausted' : 'released';
       db.prepare(
         'UPDATE job_budget_reservation_items SET released_value=released_value+?,state=?,updated_at=? WHERE reservation_id=? AND kind=?',
       ).run(release, state, now, reservation.reservationId, item.kind);
@@ -484,6 +704,8 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
     available,
     commitWorkerUsage,
     releaseWorker,
+    reconcileWorkerUsage,
+    reconcileWorkerReservation,
     configure(command) {
       const now = command.now ?? Date.now();
       db.transaction(() => {

--- a/core/v4/worker/types.ts
+++ b/core/v4/worker/types.ts
@@ -87,6 +87,38 @@ export type WorkerLogicalProviderCallState =
   | 'cancelled'
   | 'unknown';
 
+export type WorkerProviderCallReconciliationState =
+  | 'not_required'
+  | 'pending'
+  | 'inspecting'
+  | 'reconciled'
+  | 'blocked_unknown'
+  | 'superseded'
+  | 'terminal';
+
+export type WorkerProviderCallOutcomeKnowledge =
+  | 'no_request_started'
+  | 'request_started_no_response_proven'
+  | 'response_received'
+  | 'response_accepted'
+  | 'downstream_started'
+  | 'provider_failed_known'
+  | 'provider_cancelled_known'
+  | 'provider_timed_out_known'
+  | 'outcome_unknown';
+
+export type WorkerProviderCallRetrySafety =
+  | 'safe'
+  | 'unsafe'
+  | 'blocked_unknown'
+  | 'not_applicable';
+
+export type WorkerProviderCallInterruptionKind =
+  | 'cancellation'
+  | 'timeout'
+  | 'lease_expired'
+  | 'authority_lost';
+
 export interface WorkerLogicalProviderCallRecord {
   readonly logicalCallId: string;
   readonly schemaVersion: 1;
@@ -109,12 +141,42 @@ export interface WorkerLogicalProviderCallRecord {
   readonly providerRequestId: string | null;
   readonly failureKind: string | null;
   readonly outcomeKnown: boolean;
+  readonly reconciliationState: WorkerProviderCallReconciliationState;
+  readonly outcomeKnowledge: WorkerProviderCallOutcomeKnowledge;
+  readonly retrySafety: WorkerProviderCallRetrySafety;
+  readonly interruptionKind: WorkerProviderCallInterruptionKind | null;
+  readonly cancellationRequestedAt: number | null;
+  readonly timeoutRequestedAt: number | null;
+  readonly authorityLostAt: number | null;
+  readonly staleResponseRejectedAt: number | null;
+  readonly lateResponseObservedAt: number | null;
+  readonly reconciliationStartedAt: number | null;
+  readonly reconciledAt: number | null;
+  readonly reconciliationReason: string | null;
+  readonly reconciliationVersion: number;
+  readonly recoveryPredecessorLogicalCallId: string | null;
   readonly responseReceivedAt: number | null;
   readonly acceptedAt: number | null;
   readonly downstreamStartedAt: number | null;
   readonly completedAt: number | null;
   readonly createdAt: number;
   readonly updatedAt: number;
+}
+
+export interface WorkerProviderCallReconciliationResult {
+  readonly logicalCallId: string;
+  readonly workerRunId: string;
+  readonly childJobId: string;
+  readonly childAttemptId: string;
+  readonly childGeneration: number;
+  readonly reconciliationState: WorkerProviderCallReconciliationState;
+  readonly outcomeKnowledge: WorkerProviderCallOutcomeKnowledge;
+  readonly retrySafety: WorkerProviderCallRetrySafety;
+  readonly reason: string;
+  readonly physicalAttemptIds: readonly string[];
+  readonly unknownSpend: boolean;
+  readonly unsettledDownstream: boolean;
+  readonly reconciledAt: number | null;
 }
 
 export interface WorkerContextEnvelopeRecord {

--- a/core/v4/worker/workerProviderBridge.ts
+++ b/core/v4/worker/workerProviderBridge.ts
@@ -16,6 +16,9 @@ import type { DurableJobHandle } from '../daemon/jobLifecycle';
 import type { JobEngine } from '../daemon/jobEngine';
 import type { JobBudgetKind, JobBudgetReservationRecord } from '../daemon/jobResourceAuthority';
 import { computeWorkerDigest, type WorkerAssignmentRecord, type WorkerProviderBindingRecord, type WorkerRunRecord } from './types';
+import { workerProviderUsageFacts } from './workerProviderUsage';
+import { reconcileWorkerProviderCall } from './workerProviderReconciliation';
+import { WorkerProviderCallError } from './workerProviderCallAuthority';
 
 export interface DurableWorkerProviderBridge {
   adapter: ProviderAdapter;
@@ -55,24 +58,6 @@ function event(options: BridgeOptions, type: string, payload: Record<string, unk
   if (!result.applied && !result.duplicate) throw new Error(`Worker provider event rejected: ${result.conflict ?? 'unknown'}`);
 }
 
-function knownZero(attempt: ProviderAttemptRecord): boolean {
-  return attempt.status === 'failed_before_send'
-    || attempt.errorClass === 'rate_limit'
-    || attempt.errorClass === 'authentication'
-    || attempt.errorClass === 'context_overflow'
-    || attempt.errorClass === 'request_size_limit';
-}
-
-function usageValue(attempt: ProviderAttemptRecord, kind: JobBudgetKind): number | null {
-  if (knownZero(attempt)) return 0;
-  if (kind === 'input_tokens') return attempt.providerInputTokens;
-  if (kind === 'output_tokens') return attempt.providerOutputTokens;
-  if (kind === 'reasoning_tokens') return attempt.providerReasoningTokens;
-  if (kind === 'external_cost') return attempt.costStatus === 'unknown' ? null : attempt.costAmount;
-  if (kind === 'output_bytes') return attempt.responseBytes;
-  return null;
-}
-
 function failureOutcome(attempts: readonly ProviderAttemptRecord[], error: unknown): {
   kind: string; known: boolean; cancelled: boolean;
 } {
@@ -106,41 +91,46 @@ export function createDurableWorkerProviderBridge(options: BridgeOptions): Durab
     idempotencyKey: string,
   ): void => {
     if (!reservationItem(kind)) return;
-    const result = options.engine.resources.commitWorkerUsage({
-      reservationId: options.reservation.reservationId,
-      ...authority(options),
-      kind,
-      amount,
-      certainty: amount === null ? 'unknown' : 'confirmed',
-      sourceKind: 'provider_attempt',
-      sourceId: attempt.callId,
-      idempotencyKey,
-    });
-    event(options, 'worker.budget_commit_recorded', {
-      reservationId: options.reservation.reservationId,
-      logicalCallId,
-      providerAttemptId: attempt.callId,
-      kind,
-      amountKnown: amount !== null,
-      applied: result.applied,
-      exhausted: result.exhausted === true,
-    }, `worker-budget-commit:${options.reservation.reservationId}:${idempotencyKey}`);
+    try {
+      const result = options.engine.resources.commitWorkerUsage({
+        reservationId: options.reservation.reservationId,
+        ...authority(options),
+        kind,
+        amount,
+        certainty: amount === null ? 'unknown' : 'confirmed',
+        sourceKind: 'provider_attempt',
+        sourceId: attempt.callId,
+        idempotencyKey,
+      });
+      event(options, 'worker.budget_commit_recorded', {
+        reservationId: options.reservation.reservationId,
+        logicalCallId,
+        providerAttemptId: attempt.callId,
+        kind,
+        amountKnown: amount !== null,
+        applied: result.applied,
+        exhausted: result.exhausted === true,
+      }, `worker-budget-commit:${options.reservation.reservationId}:${idempotencyKey}`);
+    } catch (error) {
+      if (!(error instanceof Error) || !/^(?:Stale worker cannot reserve or consume Job budget|Worker budget reservation Attempt is stale|Parent Worker budget authority is stale)$/iu.test(error.message)) {
+        throw error;
+      }
+      options.engine.resources.reconcileWorkerUsage({
+        reservationId: options.reservation.reservationId,
+        logicalCallId,
+        kind,
+        amount,
+        certainty: amount === null ? 'unknown' : 'confirmed',
+        providerAttemptId: attempt.callId,
+        idempotencyKey,
+      });
+    }
   };
 
   const accountAttempts = (logicalCallId: string, attempts: readonly ProviderAttemptRecord[]): void => {
     attempts.forEach((attempt, index) => {
-      commit(
-        logicalCallId,
-        attempt,
-        'model_calls',
-        1,
-        index === 0 ? `model-call:${logicalCallId}` : `provider-attempt:${attempt.callId}:model-call`,
-      );
-      if (attempt.purpose === 'retry' || attempt.purpose === 'fallback') {
-        commit(logicalCallId, attempt, 'retries', 1, `provider-attempt:${attempt.callId}:retry`);
-      }
-      for (const kind of ['input_tokens', 'output_tokens', 'reasoning_tokens', 'external_cost', 'output_bytes'] as const) {
-        commit(logicalCallId, attempt, kind, usageValue(attempt, kind), `provider-attempt:${attempt.callId}:${kind}`);
+      for (const fact of workerProviderUsageFacts(logicalCallId, attempt, index)) {
+        commit(logicalCallId, attempt, fact.kind, fact.amount, fact.idempotencyKey);
       }
     });
   };
@@ -270,13 +260,42 @@ export function createDurableWorkerProviderBridge(options: BridgeOptions): Durab
       }
       if (!acceptedAttempt) throw new Error('Worker provider response is not linked to a successful physical attempt');
       accountAttempts(logicalCallId, attempts);
-      options.engine.workerProviderCalls.recordResponseReceived({
-        ...authority(options),
-        logicalCallId,
-        providerAttemptId: acceptedAttempt.callId,
-        responseHash,
-        providerRequestId: acceptedAttempt.providerRequestId ?? extractProviderRequestId(output),
-      });
+      const providerRequestId = acceptedAttempt.providerRequestId ?? extractProviderRequestId(output);
+      try {
+        options.engine.workerProviderCalls.recordResponseReceived({
+          ...authority(options),
+          logicalCallId,
+          providerAttemptId: acceptedAttempt.callId,
+          responseHash,
+          providerRequestId,
+        });
+      } catch (error) {
+        if (!(error instanceof WorkerProviderCallError)
+          || !['stale_authority', 'interrupted', 'authority_lost'].includes(error.code)) throw error;
+        const call = options.engine.workerProviderCalls.get(logicalCallId);
+        if (!call) throw error;
+        options.engine.workerProviderCalls.rejectLateResponse({
+          logicalCallId,
+          workerRunId: call.workerRunId,
+          childJobId: call.childJobId,
+          childAttemptId: call.childAttemptId,
+          childGeneration: call.childGeneration,
+          providerAttemptId: acceptedAttempt.callId,
+          responseHash,
+          providerRequestId,
+          reason: 'response_after_authority_loss',
+          idempotencyKey: `worker-late-response:${logicalCallId}:${acceptedAttempt.callId}`,
+        });
+        reconcileWorkerProviderCall({
+          engine: options.engine,
+          ledger: currentProviderAttemptLedger(),
+          call: options.engine.workerProviderCalls.get(logicalCallId)!,
+          ownerId: 'provider-bridge',
+          producer: 'repository-worker-provider-bridge',
+          reason: 'late_response',
+        });
+        throw error;
+      }
       event(options, 'worker.provider_response_received', {
         logicalCallId,
         providerAttemptId: acceptedAttempt.callId,
@@ -303,7 +322,17 @@ export function createDurableWorkerProviderBridge(options: BridgeOptions): Durab
       const attempts = currentProviderAttemptLedger()?.query({ parentCallId: logicalCallId }) ?? [];
       if (attempts.length > 0) accountAttempts(logicalCallId, attempts);
       const call = options.engine.workerProviderCalls.get(logicalCallId);
-      if (call && call.state !== 'accepted' && call.state !== 'downstream_started' && call.state !== 'completed') {
+      if (call && (call.interruptionKind !== null || call.authorityLostAt !== null)
+        && ['not_required', 'pending', 'inspecting'].includes(call.reconciliationState)) {
+        reconcileWorkerProviderCall({
+          engine: options.engine,
+          ledger: currentProviderAttemptLedger(),
+          call,
+          ownerId: 'provider-bridge',
+          producer: 'repository-worker-provider-bridge',
+          reason: call.interruptionKind ?? 'authority_lost',
+        });
+      } else if (call && call.state !== 'accepted' && call.state !== 'downstream_started' && call.state !== 'completed') {
         const failure = failureOutcome(attempts, error);
         options.engine.workerProviderCalls.fail({
           ...authority(options), logicalCallId, failureKind: failure.kind,

--- a/core/v4/worker/workerProviderCallAuthority.ts
+++ b/core/v4/worker/workerProviderCallAuthority.ts
@@ -6,7 +6,15 @@
 import { createHash } from 'node:crypto';
 
 import type { Db } from '../daemon/db/connection';
-import type { WorkerLogicalProviderCallRecord, WorkerLogicalProviderCallState } from './types';
+import type {
+  WorkerLogicalProviderCallRecord,
+  WorkerLogicalProviderCallState,
+  WorkerProviderCallInterruptionKind,
+  WorkerProviderCallOutcomeKnowledge,
+  WorkerProviderCallReconciliationResult,
+  WorkerProviderCallReconciliationState,
+  WorkerProviderCallRetrySafety,
+} from './types';
 
 const HASH = /^[a-f0-9]{64}$/u;
 const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u;
@@ -38,6 +46,27 @@ export interface PrepareWorkerProviderCallCommand extends AuthorityCommand {
   toolSchemaHash: string;
 }
 
+export interface WorkerProviderPhysicalAttemptFact {
+  providerAttemptId: string;
+  status: string;
+  responseHash?: string | null;
+  providerRequestId?: string | null;
+  noResponseProven?: boolean;
+  usageKnown?: boolean;
+  costKnown?: boolean;
+}
+
+interface ReconciliationLineageCommand {
+  logicalCallId: string;
+  workerRunId: string;
+  childJobId: string;
+  childAttemptId: string;
+  childGeneration: number;
+  idempotencyKey: string;
+  reason: string;
+  now?: number;
+}
+
 export interface WorkerProviderCallAuthority {
   prepare(command: PrepareWorkerProviderCallCommand): WorkerLogicalProviderCallRecord;
   markAttempting(command: AuthorityCommand & { logicalCallId: string }): WorkerLogicalProviderCallRecord;
@@ -66,6 +95,44 @@ export interface WorkerProviderCallAuthority {
     outcomeKnown: boolean;
     cancelled?: boolean;
   }): WorkerLogicalProviderCallRecord;
+  recordCancellationIntent(command: AuthorityCommand & {
+    logicalCallId: string;
+    reason: string;
+    idempotencyKey: string;
+  }): WorkerLogicalProviderCallRecord;
+  recordTimeoutIntent(command: AuthorityCommand & {
+    logicalCallId: string;
+    reason: string;
+    idempotencyKey: string;
+  }): WorkerLogicalProviderCallRecord;
+  recordInterruptionForAttempt(command: AuthorityCommand & {
+    kind: 'cancellation' | 'timeout';
+    reason: string;
+    idempotencyKey: string;
+  }): WorkerLogicalProviderCallRecord[];
+  markAuthorityLost(command: ReconciliationLineageCommand & {
+    kind: 'lease_expired' | 'authority_lost';
+  }): WorkerLogicalProviderCallRecord;
+  markAuthorityLostForAttempt(command: {
+    childJobId: string;
+    childAttemptId: string;
+    childGeneration: number;
+    kind: 'lease_expired' | 'authority_lost';
+    reason: string;
+    idempotencyKey: string;
+    now?: number;
+  }): WorkerLogicalProviderCallRecord[];
+  rejectLateResponse(command: ReconciliationLineageCommand & {
+    providerAttemptId: string;
+    responseHash: string;
+    providerRequestId?: string | null;
+  }): { applied: boolean; duplicate?: boolean; call: WorkerLogicalProviderCallRecord };
+  reconcile(command: ReconciliationLineageCommand & {
+    physicalAttempts: readonly WorkerProviderPhysicalAttemptFact[];
+    unknownSpend?: boolean;
+  }): WorkerProviderCallReconciliationResult;
+  listPendingReconciliation(input?: { limit?: number; afterLogicalCallId?: string }): WorkerLogicalProviderCallRecord[];
+  listForAttempt(childAttemptId: string, childGeneration: number): WorkerLogicalProviderCallRecord[];
   get(logicalCallId: string): WorkerLogicalProviderCallRecord | null;
   listForWorkerRun(workerRunId: string): WorkerLogicalProviderCallRecord[];
 }
@@ -80,6 +147,15 @@ type Row = {
   response_hash: string | null; provider_request_id: string | null; failure_kind: string | null;
   outcome_known: number; response_received_at: number | null; accepted_at: number | null;
   downstream_started_at: number | null; completed_at: number | null;
+  reconciliation_state: WorkerProviderCallReconciliationState;
+  outcome_knowledge: WorkerProviderCallOutcomeKnowledge;
+  retry_safety: WorkerProviderCallRetrySafety;
+  interruption_kind: WorkerProviderCallInterruptionKind | null;
+  cancellation_requested_at: number | null; timeout_requested_at: number | null;
+  authority_lost_at: number | null; stale_response_rejected_at: number | null;
+  late_response_observed_at: number | null; reconciliation_started_at: number | null;
+  reconciled_at: number | null; reconciliation_reason: string | null;
+  reconciliation_version: number; recovery_predecessor_logical_call_id: string | null;
   created_at: number; updated_at: number;
 };
 
@@ -106,6 +182,20 @@ function mapRow(row: Row): WorkerLogicalProviderCallRecord {
     providerRequestId: row.provider_request_id,
     failureKind: row.failure_kind,
     outcomeKnown: row.outcome_known === 1,
+    reconciliationState: row.reconciliation_state,
+    outcomeKnowledge: row.outcome_knowledge,
+    retrySafety: row.retry_safety,
+    interruptionKind: row.interruption_kind,
+    cancellationRequestedAt: row.cancellation_requested_at,
+    timeoutRequestedAt: row.timeout_requested_at,
+    authorityLostAt: row.authority_lost_at,
+    staleResponseRejectedAt: row.stale_response_rejected_at,
+    lateResponseObservedAt: row.late_response_observed_at,
+    reconciliationStartedAt: row.reconciliation_started_at,
+    reconciledAt: row.reconciled_at,
+    reconciliationReason: row.reconciliation_reason,
+    reconciliationVersion: row.reconciliation_version,
+    recoveryPredecessorLogicalCallId: row.recovery_predecessor_logical_call_id,
     responseReceivedAt: row.response_received_at,
     acceptedAt: row.accepted_at,
     downstreamStartedAt: row.downstream_started_at,
@@ -113,6 +203,51 @@ function mapRow(row: Row): WorkerLogicalProviderCallRecord {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+export function classifyWorkerProviderCall(
+  call: WorkerLogicalProviderCallRecord,
+  physicalAttempts: readonly WorkerProviderPhysicalAttemptFact[],
+): Pick<WorkerProviderCallReconciliationResult, 'outcomeKnowledge' | 'retrySafety' | 'unknownSpend'> {
+  if (call.state === 'downstream_started') {
+    return { outcomeKnowledge: 'downstream_started', retrySafety: 'unsafe', unknownSpend: false };
+  }
+  if (call.state === 'accepted' || call.state === 'completed') {
+    return { outcomeKnowledge: 'response_accepted', retrySafety: 'unsafe', unknownSpend: false };
+  }
+  if (call.state === 'response_received') {
+    return { outcomeKnowledge: 'response_received', retrySafety: 'unsafe', unknownSpend: false };
+  }
+  if (call.cancellationRequestedAt !== null || call.state === 'cancelled') {
+    if (call.state === 'prepared' && physicalAttempts.length === 0) {
+      return { outcomeKnowledge: 'no_request_started', retrySafety: 'unsafe', unknownSpend: false };
+    }
+    const known = call.outcomeKnown && physicalAttempts.every((attempt) => attempt.status === 'interrupted');
+    return known
+      ? { outcomeKnowledge: 'provider_cancelled_known', retrySafety: 'unsafe', unknownSpend: false }
+      : { outcomeKnowledge: 'outcome_unknown', retrySafety: 'blocked_unknown', unknownSpend: call.state !== 'prepared' };
+  }
+  if (call.state === 'failed' && call.outcomeKnown) {
+    const timeout = call.interruptionKind === 'timeout' || /timeout/iu.test(call.failureKind ?? '');
+    return {
+      outcomeKnowledge: timeout ? 'provider_timed_out_known' : 'provider_failed_known',
+      retrySafety: 'safe',
+      unknownSpend: false,
+    };
+  }
+  if (call.state === 'unknown' || physicalAttempts.some((attempt) => !attempt.noResponseProven
+    && !['success', 'failed_before_send', 'validation_error'].includes(attempt.status))) {
+    return { outcomeKnowledge: 'outcome_unknown', retrySafety: 'blocked_unknown', unknownSpend: true };
+  }
+  if (call.state === 'prepared' && physicalAttempts.length === 0) {
+    return { outcomeKnowledge: 'no_request_started', retrySafety: 'safe', unknownSpend: false };
+  }
+  if (physicalAttempts.length > 0 && physicalAttempts.every((attempt) => (
+    attempt.noResponseProven === true || attempt.status === 'failed_before_send' || attempt.status === 'validation_error'
+  ))) {
+    return { outcomeKnowledge: 'provider_failed_known', retrySafety: 'safe', unknownSpend: false };
+  }
+  return { outcomeKnowledge: 'outcome_unknown', retrySafety: 'blocked_unknown', unknownSpend: true };
 }
 
 function safeId(value: string, label: string): void {
@@ -134,6 +269,13 @@ function safeRequestId(value: string | null | undefined): string | null {
 export function createWorkerProviderCallAuthority(
   db: Db,
   validateActiveFence: (command: AuthorityCommand) => boolean,
+  appendEvent?: (input: {
+    call: WorkerLogicalProviderCallRecord;
+    type: string;
+    payload: Record<string, unknown>;
+    idempotencyKey: string;
+    now: number;
+  }) => void,
 ): WorkerProviderCallAuthority {
   const get = (logicalCallId: string): WorkerLogicalProviderCallRecord | null => {
     const row = db.prepare('SELECT * FROM worker_logical_provider_calls WHERE logical_call_id=?')
@@ -155,6 +297,39 @@ export function createWorkerProviderCallAuthority(
       throw new WorkerProviderCallError('lineage_mismatch', 'Logical provider call does not match the active Worker Attempt');
     }
     return call;
+  };
+
+  const requireLineage = (command: ReconciliationLineageCommand): WorkerLogicalProviderCallRecord => {
+    const call = get(command.logicalCallId);
+    if (!call || call.workerRunId !== command.workerRunId || call.childJobId !== command.childJobId
+      || call.childAttemptId !== command.childAttemptId || call.childGeneration !== command.childGeneration) {
+      throw new WorkerProviderCallError('lineage_mismatch', 'Logical provider reconciliation lineage is invalid');
+    }
+    safeId(command.idempotencyKey, 'Reconciliation idempotency key');
+    safeId(command.reason, 'Reconciliation reason');
+    return call;
+  };
+
+  const emit = (
+    call: WorkerLogicalProviderCallRecord,
+    type: string,
+    payload: Record<string, unknown>,
+    idempotencyKey: string,
+    now: number,
+  ): void => appendEvent?.({ call, type, payload, idempotencyKey, now });
+
+  const authorityStillActive = (call: WorkerLogicalProviderCallRecord, now: number): boolean => {
+    const row = db.prepare(
+      `SELECT r.status,r.lease_expires_at,t.active_attempt_id,t.status AS job_status
+         FROM runs r JOIN tasks t ON t.id=r.task_id
+        WHERE r.attempt_id=? AND r.task_id=? AND r.generation=?`,
+    ).get(call.childAttemptId, call.childJobId, call.childGeneration) as {
+      status: string; lease_expires_at: number | null; active_attempt_id: string | null; job_status: string;
+    } | undefined;
+    return Boolean(row && row.active_attempt_id === call.childAttemptId
+      && !/^(succeeded|failed|cancelled|timed_out|crashed|unknown|interrupted)$/u.test(row.status)
+      && !/^(completed|failed|cancelled|dead_letter)$/u.test(row.job_status)
+      && (row.lease_expires_at === null || row.lease_expires_at > now));
   };
 
   const prepare = db.transaction((command: PrepareWorkerProviderCallCommand): WorkerLogicalProviderCallRecord => {
@@ -207,17 +382,29 @@ export function createWorkerProviderCallAuthority(
       return record;
     }
     const now = command.now ?? Date.now();
+    const recovery = db.prepare('SELECT recovery_of_attempt_id FROM runs WHERE attempt_id=?')
+      .get(command.childAttemptId) as { recovery_of_attempt_id: string | null } | undefined;
+    const predecessor = recovery?.recovery_of_attempt_id
+      ? db.prepare(
+        `SELECT logical_call_id FROM worker_logical_provider_calls
+          WHERE child_job_id=? AND child_attempt_id=? AND call_ordinal=?
+          ORDER BY created_at DESC,logical_call_id DESC LIMIT 1`,
+      ).get(command.childJobId, recovery.recovery_of_attempt_id, command.callOrdinal) as {
+        logical_call_id: string;
+      } | undefined
+      : undefined;
     db.prepare(
       `INSERT INTO worker_logical_provider_calls (
          logical_call_id,schema_version,idempotency_key,worker_run_id,assignment_id,provider_binding_id,
          child_job_id,child_attempt_id,child_generation,call_ordinal,request_hash,tool_schema_hash,
-         provider_id,model_id,fallback_policy_id,state,outcome_known,created_at,updated_at
-       ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'prepared',1,?,?)`,
+         provider_id,model_id,fallback_policy_id,state,outcome_known,recovery_predecessor_logical_call_id,
+         created_at,updated_at
+       ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'prepared',1,?,?,?)`,
     ).run(
       command.logicalCallId, 1, command.idempotencyKey, command.workerRunId, command.assignmentId,
       command.providerBindingId, command.childJobId, command.childAttemptId, command.childGeneration,
       command.callOrdinal, command.requestHash, command.toolSchemaHash, binding.provider_id,
-      binding.model_id, binding.fallback_policy_id, now, now,
+      binding.model_id, binding.fallback_policy_id, predecessor?.logical_call_id ?? null, now, now,
     );
     return get(command.logicalCallId)!;
   }).immediate;
@@ -238,6 +425,9 @@ export function createWorkerProviderCallAuthority(
     safeId(command.providerAttemptId, 'ProviderAttempt identity');
     safeHash(command.responseHash, 'Provider response hash');
     const providerRequestId = safeRequestId(command.providerRequestId);
+    if (call.cancellationRequestedAt !== null || call.timeoutRequestedAt !== null || call.authorityLostAt !== null) {
+      throw new WorkerProviderCallError('interrupted', 'Interrupted provider output cannot be received authoritatively');
+    }
     if (call.responseHash !== null || call.acceptedProviderAttemptId !== null) {
       if (call.responseHash === command.responseHash && call.acceptedProviderAttemptId === command.providerAttemptId) return call;
       throw new WorkerProviderCallError('response_conflict', 'A competing provider response cannot replace the received response');
@@ -258,6 +448,9 @@ export function createWorkerProviderCallAuthority(
     const call = requireCall(command);
     safeId(command.providerAttemptId, 'ProviderAttempt identity');
     safeHash(command.responseHash, 'Provider response hash');
+    if (call.cancellationRequestedAt !== null || call.timeoutRequestedAt !== null || call.authorityLostAt !== null) {
+      throw new WorkerProviderCallError('interrupted', 'Interrupted provider output cannot be accepted');
+    }
     if (call.state === 'accepted' || call.state === 'downstream_started' || call.state === 'completed') {
       if (call.acceptedProviderAttemptId === command.providerAttemptId && call.responseHash === command.responseHash) return call;
       throw new WorkerProviderCallError('response_conflict', 'A competing provider response cannot replace the accepted response');
@@ -350,6 +543,229 @@ export function createWorkerProviderCallAuthority(
     return get(command.logicalCallId)!;
   }).immediate;
 
+  const recordInterruption = db.transaction((command: AuthorityCommand & {
+    logicalCallId: string; kind: 'cancellation' | 'timeout'; reason: string; idempotencyKey: string;
+  }) => {
+    const call = requireCall(command);
+    safeId(command.reason, 'Interruption reason');
+    safeId(command.idempotencyKey, 'Interruption idempotency key');
+    const existingAt = command.kind === 'cancellation'
+      ? call.cancellationRequestedAt
+      : call.timeoutRequestedAt;
+    if (existingAt !== null) return call;
+    const now = command.now ?? Date.now();
+    const outcome = call.state === 'prepared'
+      ? 'no_request_started'
+      : call.state === 'response_received'
+        ? 'response_received'
+        : call.state === 'accepted'
+          ? 'response_accepted'
+          : call.state === 'downstream_started' || call.state === 'completed'
+            ? 'downstream_started'
+            : 'outcome_unknown';
+    const retrySafety = outcome === 'no_request_started' && command.kind === 'timeout' ? 'safe'
+      : outcome === 'outcome_unknown' ? 'blocked_unknown' : 'unsafe';
+    const timestampColumn = command.kind === 'cancellation'
+      ? 'cancellation_requested_at'
+      : 'timeout_requested_at';
+    db.prepare(
+      `UPDATE worker_logical_provider_calls
+          SET interruption_kind=?,${timestampColumn}=?,reconciliation_state='pending',
+              outcome_knowledge=?,retry_safety=?,reconciliation_reason=?,
+              reconciliation_version=reconciliation_version+1,updated_at=?
+        WHERE logical_call_id=?`,
+    ).run(command.kind, now, outcome, retrySafety, command.reason, now, command.logicalCallId);
+    const updated = get(command.logicalCallId)!;
+    emit(updated, command.kind === 'cancellation'
+      ? 'worker.provider_cancellation_requested'
+      : 'worker.provider_timeout_requested', {
+      logicalCallId: updated.logicalCallId,
+      workerRunId: updated.workerRunId,
+      reason: command.reason,
+      outcomeKnowledge: updated.outcomeKnowledge,
+      retrySafety: updated.retrySafety,
+    }, command.idempotencyKey, now);
+    return updated;
+  }).immediate;
+
+  const markAuthorityLost = db.transaction((command: ReconciliationLineageCommand & {
+    kind: 'lease_expired' | 'authority_lost';
+  }) => {
+    const call = requireLineage(command);
+    const now = command.now ?? Date.now();
+    if (authorityStillActive(call, now)) {
+      throw new WorkerProviderCallError('authority_active', 'Active Worker provider authority cannot be marked lost');
+    }
+    if (call.authorityLostAt !== null) return call;
+    const classification = classifyWorkerProviderCall(call, []);
+    db.prepare(
+      `UPDATE worker_logical_provider_calls
+          SET interruption_kind=COALESCE(interruption_kind,?),authority_lost_at=?,
+              reconciliation_state='pending',outcome_knowledge=?,retry_safety=?,
+              reconciliation_reason=?,reconciliation_version=reconciliation_version+1,updated_at=?
+        WHERE logical_call_id=?`,
+    ).run(
+      command.kind, now, classification.outcomeKnowledge, classification.retrySafety,
+      command.reason, now, call.logicalCallId,
+    );
+    const updated = get(call.logicalCallId)!;
+    emit(updated, 'worker.provider_authority_lost', {
+      logicalCallId: updated.logicalCallId,
+      workerRunId: updated.workerRunId,
+      reason: command.reason,
+      outcomeKnowledge: updated.outcomeKnowledge,
+      retrySafety: updated.retrySafety,
+    }, command.idempotencyKey, now);
+    return updated;
+  }).immediate;
+
+  const rejectLateResponse = db.transaction((command: ReconciliationLineageCommand & {
+    providerAttemptId: string; responseHash: string; providerRequestId?: string | null;
+  }) => {
+    const call = requireLineage(command);
+    const now = command.now ?? Date.now();
+    safeId(command.providerAttemptId, 'ProviderAttempt identity');
+    safeHash(command.responseHash, 'Late provider response hash');
+    const providerRequestId = safeRequestId(command.providerRequestId);
+    if (authorityStillActive(call, now) && call.cancellationRequestedAt === null
+      && call.timeoutRequestedAt === null && call.authorityLostAt === null) {
+      throw new WorkerProviderCallError('authority_active', 'Current provider output must use the acceptance path');
+    }
+    const existing = db.prepare(
+      `SELECT response_hash,provider_request_id,reason FROM worker_provider_late_responses
+        WHERE logical_call_id=? AND provider_attempt_id=?`,
+    ).get(call.logicalCallId, command.providerAttemptId) as {
+      response_hash: string; provider_request_id: string | null; reason: string;
+    } | undefined;
+    if (existing) {
+      if (existing.response_hash !== command.responseHash || existing.provider_request_id !== providerRequestId
+        || existing.reason !== command.reason) {
+        throw new WorkerProviderCallError('late_response_conflict', 'Conflicting late provider response was rejected');
+      }
+      return { applied: false, duplicate: true, call: get(call.logicalCallId)! };
+    }
+    const lateResponseId = `worker_late_${createHash('sha256')
+      .update(`${call.logicalCallId}\0${command.providerAttemptId}`)
+      .digest('hex').slice(0, 32)}`;
+    db.prepare(
+      `INSERT INTO worker_provider_late_responses
+         (late_response_id,logical_call_id,provider_attempt_id,response_hash,provider_request_id,reason,observed_at)
+       VALUES (?,?,?,?,?,?,?)`,
+    ).run(
+      lateResponseId, call.logicalCallId, command.providerAttemptId,
+      command.responseHash, providerRequestId, command.reason, now,
+    );
+    db.prepare(
+      `UPDATE worker_logical_provider_calls
+          SET late_response_observed_at=?,stale_response_rejected_at=?,reconciliation_state='pending',
+              retry_safety='unsafe',reconciliation_reason=?,
+              reconciliation_version=reconciliation_version+1,updated_at=?
+        WHERE logical_call_id=?`,
+    ).run(now, now, command.reason, now, call.logicalCallId);
+    const updated = get(call.logicalCallId)!;
+    emit(updated, 'worker.provider_late_response_rejected', {
+      logicalCallId: updated.logicalCallId,
+      workerRunId: updated.workerRunId,
+      providerAttemptId: command.providerAttemptId,
+      responseHash: command.responseHash,
+      reason: command.reason,
+    }, command.idempotencyKey, now);
+    return { applied: true, call: updated };
+  }).immediate;
+
+  const reconcile = db.transaction((command: ReconciliationLineageCommand & {
+    physicalAttempts: readonly WorkerProviderPhysicalAttemptFact[]; unknownSpend?: boolean;
+  }): WorkerProviderCallReconciliationResult => {
+    const call = requireLineage(command);
+    const now = command.now ?? Date.now();
+    const physicalAttemptIds = [...new Set(command.physicalAttempts.map((attempt) => {
+      safeId(attempt.providerAttemptId, 'ProviderAttempt identity');
+      return attempt.providerAttemptId;
+    }))].sort();
+    const classification = classifyWorkerProviderCall(call, command.physicalAttempts);
+    const unknownSpend = command.unknownSpend ?? (
+      classification.unknownSpend
+      || command.physicalAttempts.some((attempt) => attempt.usageKnown === false || attempt.costKnown === false)
+    );
+    const unsettledDownstream = db.prepare(
+      `SELECT 1 FROM worker_provider_tool_links link
+         LEFT JOIN tool_calls tc ON tc.tool_call_id=link.provider_tool_call_id
+        WHERE link.logical_call_id=?
+          AND (tc.tool_call_id IS NULL OR tc.state NOT IN ('completed','failed','cancelled','unknown')) LIMIT 1`,
+    ).get(call.logicalCallId) !== undefined;
+    const state: WorkerProviderCallReconciliationState = classification.retrySafety === 'blocked_unknown'
+      ? 'blocked_unknown' : 'reconciled';
+    const existing = db.prepare(
+      'SELECT * FROM worker_provider_call_reconciliations WHERE logical_call_id=? AND idempotency_key=?',
+    ).get(call.logicalCallId, command.idempotencyKey) as {
+      worker_run_id: string; child_job_id: string; child_attempt_id: string; child_generation: number;
+      outcome_knowledge: WorkerProviderCallOutcomeKnowledge; retry_safety: WorkerProviderCallRetrySafety;
+      reason: string; physical_attempt_ids_json: string; unknown_spend: number;
+      unsettled_downstream: number; state: WorkerProviderCallReconciliationState; completed_at: number | null;
+    } | undefined;
+    const result = (): WorkerProviderCallReconciliationResult => ({
+      logicalCallId: call.logicalCallId,
+      workerRunId: call.workerRunId,
+      childJobId: call.childJobId,
+      childAttemptId: call.childAttemptId,
+      childGeneration: call.childGeneration,
+      reconciliationState: state,
+      outcomeKnowledge: classification.outcomeKnowledge,
+      retrySafety: classification.retrySafety,
+      reason: command.reason,
+      physicalAttemptIds,
+      unknownSpend,
+      unsettledDownstream,
+      reconciledAt: now,
+    });
+    if (existing) {
+      const same = existing.worker_run_id === call.workerRunId && existing.child_job_id === call.childJobId
+        && existing.child_attempt_id === call.childAttemptId && existing.child_generation === call.childGeneration
+        && existing.outcome_knowledge === classification.outcomeKnowledge
+        && existing.retry_safety === classification.retrySafety && existing.reason === command.reason
+        && existing.physical_attempt_ids_json === JSON.stringify(physicalAttemptIds)
+        && existing.unknown_spend === (unknownSpend ? 1 : 0)
+        && existing.unsettled_downstream === (unsettledDownstream ? 1 : 0);
+      if (!same) throw new WorkerProviderCallError('reconciliation_conflict', 'Provider reconciliation identity has conflicting facts');
+      return { ...result(), reconciliationState: existing.state, reconciledAt: existing.completed_at };
+    }
+    const reconciliationId = `worker_reconcile_${createHash('sha256')
+      .update(`${call.logicalCallId}\0${command.idempotencyKey}`)
+      .digest('hex').slice(0, 32)}`;
+    db.prepare(
+      `INSERT INTO worker_provider_call_reconciliations
+         (reconciliation_id,logical_call_id,idempotency_key,worker_run_id,child_job_id,child_attempt_id,
+          child_generation,outcome_knowledge,retry_safety,reason,physical_attempt_ids_json,
+          unknown_spend,unsettled_downstream,state,created_at,completed_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).run(
+      reconciliationId, call.logicalCallId, command.idempotencyKey, call.workerRunId,
+      call.childJobId, call.childAttemptId, call.childGeneration, classification.outcomeKnowledge,
+      classification.retrySafety, command.reason, JSON.stringify(physicalAttemptIds), unknownSpend ? 1 : 0,
+      unsettledDownstream ? 1 : 0, state, now, now,
+    );
+    db.prepare(
+      `UPDATE worker_logical_provider_calls
+          SET reconciliation_state=?,outcome_knowledge=?,retry_safety=?,
+              reconciliation_started_at=COALESCE(reconciliation_started_at,?),reconciled_at=?,
+              reconciliation_reason=?,reconciliation_version=reconciliation_version+1,updated_at=?
+        WHERE logical_call_id=?`,
+    ).run(
+      state, classification.outcomeKnowledge, classification.retrySafety,
+      now, now, command.reason, now, call.logicalCallId,
+    );
+    const updated = get(call.logicalCallId)!;
+    emit(updated, 'worker.provider_reconciliation_completed', {
+      logicalCallId: updated.logicalCallId,
+      workerRunId: updated.workerRunId,
+      outcomeKnowledge: classification.outcomeKnowledge,
+      retrySafety: classification.retrySafety,
+      unknownSpend,
+      reason: command.reason,
+    }, command.idempotencyKey, now);
+    return result();
+  }).immediate;
+
   return {
     prepare,
     markAttempting,
@@ -359,6 +775,50 @@ export function createWorkerProviderCallAuthority(
     linkToolCall,
     complete,
     fail,
+    recordCancellationIntent(command) {
+      return recordInterruption({ ...command, kind: 'cancellation' });
+    },
+    recordTimeoutIntent(command) {
+      return recordInterruption({ ...command, kind: 'timeout' });
+    },
+    recordInterruptionForAttempt(command) {
+      return db.transaction(() => (db.prepare(
+        `SELECT logical_call_id FROM worker_logical_provider_calls
+          WHERE child_job_id=? AND child_attempt_id=? AND child_generation=?
+            AND state NOT IN ('completed','failed','cancelled','unknown')
+          ORDER BY call_ordinal,logical_call_id`,
+      ).all(command.childJobId, command.childAttemptId, command.childGeneration) as Array<{ logical_call_id: string }>)
+        .map((row) => recordInterruption({ ...command, logicalCallId: row.logical_call_id })))
+        .immediate();
+    },
+    markAuthorityLost,
+    markAuthorityLostForAttempt(command) {
+      return db.transaction(() => (db.prepare(
+        `SELECT logical_call_id,worker_run_id FROM worker_logical_provider_calls
+          WHERE child_job_id=? AND child_attempt_id=? AND child_generation=?
+          ORDER BY call_ordinal,logical_call_id`,
+      ).all(command.childJobId, command.childAttemptId, command.childGeneration) as Array<{
+        logical_call_id: string; worker_run_id: string;
+      }>).map((row) => markAuthorityLost({
+        ...command, logicalCallId: row.logical_call_id, workerRunId: row.worker_run_id,
+      }))).immediate();
+    },
+    rejectLateResponse,
+    reconcile,
+    listPendingReconciliation(input = {}) {
+      const limit = Math.max(1, Math.min(input.limit ?? 100, 1_000));
+      return (db.prepare(
+        `SELECT * FROM worker_logical_provider_calls
+          WHERE logical_call_id>? AND reconciliation_state IN ('not_required','pending','inspecting')
+          ORDER BY logical_call_id LIMIT ?`,
+      ).all(input.afterLogicalCallId ?? '', limit) as Row[]).map(mapRow);
+    },
+    listForAttempt(childAttemptId, childGeneration) {
+      return (db.prepare(
+        `SELECT * FROM worker_logical_provider_calls
+          WHERE child_attempt_id=? AND child_generation=? ORDER BY call_ordinal,logical_call_id`,
+      ).all(childAttemptId, childGeneration) as Row[]).map(mapRow);
+    },
     get,
     listForWorkerRun(workerRunId) {
       return (db.prepare(

--- a/core/v4/worker/workerProviderReconciliation.ts
+++ b/core/v4/worker/workerProviderReconciliation.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { JobEngine, WorkerAttemptReconciliationSummary } from '../daemon/jobEngine';
+import type { ProviderAttemptLedger, ProviderAttemptRecord } from '../usageLedger';
+import type {
+  WorkerLogicalProviderCallRecord,
+  WorkerProviderCallReconciliationResult,
+} from './types';
+import type { WorkerProviderPhysicalAttemptFact } from './workerProviderCallAuthority';
+import { workerProviderUsageFacts } from './workerProviderUsage';
+
+export interface WorkerProviderRecoverySummary {
+  inspected: number;
+  reconciled: number;
+  safe: number;
+  unsafe: number;
+  blockedUnknown: number;
+  usageFacts: number;
+  reservationsSettled: number;
+  results: WorkerProviderCallReconciliationResult[];
+}
+
+function physicalFact(attempt: ProviderAttemptRecord): WorkerProviderPhysicalAttemptFact {
+  const knownNoResponse = attempt.status === 'failed_before_send' || attempt.status === 'validation_error'
+    || ['rate_limit', 'authentication', 'context_overflow', 'request_size_limit'].includes(attempt.errorClass ?? '');
+  const usageKnown = knownNoResponse || attempt.providerInputTokens !== null
+    || attempt.providerOutputTokens !== null || attempt.providerReasoningTokens !== null;
+  return {
+    providerAttemptId: attempt.callId,
+    status: attempt.status,
+    responseHash: attempt.responseHash,
+    providerRequestId: attempt.providerRequestId,
+    noResponseProven: knownNoResponse,
+    usageKnown,
+    costKnown: knownNoResponse || attempt.costStatus !== 'unknown',
+  };
+}
+
+function exactAttempts(
+  call: WorkerLogicalProviderCallRecord,
+  ledger: ProviderAttemptLedger | null,
+): readonly ProviderAttemptRecord[] {
+  if (!ledger) return [];
+  const attempts = ledger.query({ parentCallId: call.logicalCallId });
+  for (const attempt of attempts) {
+    if (attempt.workerRunId !== call.workerRunId || attempt.jobId !== call.childJobId
+      || attempt.attemptId !== call.childAttemptId || attempt.attemptGeneration !== call.childGeneration
+      || attempt.providerBindingId !== call.providerBindingId) {
+      throw new Error('ProviderAttempt reconciliation lineage is invalid');
+    }
+  }
+  return attempts;
+}
+
+function attemptIsCurrent(engine: JobEngine, call: WorkerLogicalProviderCallRecord, now: number): boolean {
+  const attempt = engine.getAttempt(call.childAttemptId);
+  const job = engine.getJob(call.childJobId);
+  return Boolean(attempt && job && attempt.generation === call.childGeneration
+    && job.activeAttemptId === call.childAttemptId
+    && !/^(succeeded|completed|failed|cancelled|timed_out|crashed|unknown|interrupted)$/u.test(attempt.status)
+    && (attempt.leaseExpiresAt === null || attempt.leaseExpiresAt > now));
+}
+
+export function reconcileWorkerProviderCall(input: {
+  engine: JobEngine;
+  ledger: ProviderAttemptLedger | null;
+  call: WorkerLogicalProviderCallRecord;
+  ownerId: string;
+  producer: string;
+  reason: string;
+  now?: number;
+}): { result: WorkerProviderCallReconciliationResult; usageFacts: number; reservationSettled: boolean } {
+  const now = input.now ?? Date.now();
+  let call = input.call;
+  const terminalCall = ['completed', 'failed', 'cancelled', 'unknown'].includes(call.state);
+  if (!terminalCall && !attemptIsCurrent(input.engine, call, now) && call.authorityLostAt === null) {
+    call = input.engine.workerProviderCalls.markAuthorityLost({
+      logicalCallId: call.logicalCallId,
+      workerRunId: call.workerRunId,
+      childJobId: call.childJobId,
+      childAttemptId: call.childAttemptId,
+      childGeneration: call.childGeneration,
+      kind: 'authority_lost',
+      reason: input.reason,
+      idempotencyKey: `worker-authority-lost:${call.logicalCallId}:${call.childGeneration}`,
+      now,
+    });
+  }
+  const attempts = exactAttempts(call, input.ledger);
+  const facts = attempts.map(physicalFact);
+  const result = input.engine.workerProviderCalls.reconcile({
+    logicalCallId: call.logicalCallId,
+    workerRunId: call.workerRunId,
+    childJobId: call.childJobId,
+    childAttemptId: call.childAttemptId,
+    childGeneration: call.childGeneration,
+    idempotencyKey: `worker-reconcile:${call.logicalCallId}:${call.childGeneration}`,
+    reason: input.reason,
+    physicalAttempts: facts,
+    now,
+  });
+  const reservation = input.engine.resources.getWorkerReservationForChild(call.childJobId);
+  let usageFacts = 0;
+  if (reservation && reservation.workerRunId === call.workerRunId) {
+    attempts.forEach((attempt, index) => {
+      for (const fact of workerProviderUsageFacts(call.logicalCallId, attempt, index)) {
+        if (!reservation.items.some((item) => item.kind === fact.kind)) continue;
+        const settled = input.engine.resources.reconcileWorkerUsage({
+          reservationId: reservation.reservationId,
+          logicalCallId: call.logicalCallId,
+          kind: fact.kind,
+          amount: fact.amount,
+          certainty: fact.amount === null ? 'unknown' : 'confirmed',
+          providerAttemptId: attempt.callId,
+          idempotencyKey: fact.idempotencyKey,
+          now,
+        });
+        if (settled.applied || settled.repaired) usageFacts += 1;
+      }
+    });
+    const safeToRelease = !result.unknownSpend && !result.unsettledDownstream
+      && result.outcomeKnowledge !== 'downstream_started';
+    input.engine.resources.reconcileWorkerReservation({
+      reservationId: reservation.reservationId,
+      logicalCallId: call.logicalCallId,
+      outcomeKnowledge: result.outcomeKnowledge,
+      retrySafety: result.retrySafety,
+      unknownSpend: result.unknownSpend,
+      safeToRelease,
+      reason: input.reason,
+      idempotencyKey: `worker-reservation-reconcile:${call.logicalCallId}:${call.childGeneration}`,
+      now,
+    });
+    input.engine.appendJobEvent({
+      jobId: call.childJobId,
+      attemptId: call.childAttemptId,
+      generation: call.childGeneration,
+      type: 'worker.provider_reservation_reconciled',
+      payload: {
+        logicalCallId: call.logicalCallId,
+        reservationId: reservation.reservationId,
+        unknownSpend: result.unknownSpend,
+        safelyReleased: safeToRelease,
+      },
+      producer: input.producer,
+      idempotencyKey: `worker-provider-reservation-reconciled:${call.logicalCallId}:${call.childGeneration}`,
+    });
+  }
+  return { result, usageFacts, reservationSettled: reservation !== null };
+}
+
+export function reconcileWorkerProviderAttempt(input: {
+  engine: JobEngine;
+  ledger: ProviderAttemptLedger | null;
+  childJobId: string;
+  childAttemptId: string;
+  childGeneration: number;
+  ownerId: string;
+  producer: string;
+  reason: string;
+  now?: number;
+}): WorkerAttemptReconciliationSummary {
+  const results = input.engine.workerProviderCalls
+    .listForAttempt(input.childAttemptId, input.childGeneration)
+    .filter((call) => call.childJobId === input.childJobId)
+    .map((call) => reconcileWorkerProviderCall({ ...input, call }).result);
+  const retrySafety = results.some((entry) => entry.retrySafety === 'blocked_unknown')
+    ? 'blocked_unknown'
+    : results.some((entry) => entry.retrySafety === 'unsafe')
+      ? 'unsafe'
+      : results.some((entry) => entry.retrySafety === 'safe')
+        ? 'safe'
+        : 'not_applicable';
+  return {
+    calls: results.length,
+    retrySafety,
+    outcomeKnowledge: results.map((entry) => entry.outcomeKnowledge),
+  };
+}
+
+export function sweepWorkerProviderReconciliation(input: {
+  engine: JobEngine;
+  ledger: ProviderAttemptLedger | null;
+  ownerId: string;
+  producer: string;
+  limit?: number;
+  now?: number;
+}): WorkerProviderRecoverySummary {
+  const now = input.now ?? Date.now();
+  const summary: WorkerProviderRecoverySummary = {
+    inspected: 0,
+    reconciled: 0,
+    safe: 0,
+    unsafe: 0,
+    blockedUnknown: 0,
+    usageFacts: 0,
+    reservationsSettled: 0,
+    results: [],
+  };
+  const limit = Math.max(1, Math.min(input.limit ?? 100, 1_000));
+  let afterLogicalCallId = '';
+  let scanned = 0;
+  while (summary.inspected < limit && scanned < 1_000) {
+    const batch = input.engine.workerProviderCalls.listPendingReconciliation({
+      limit: Math.min(100, 1_000 - scanned),
+      afterLogicalCallId,
+    });
+    if (batch.length === 0) break;
+    scanned += batch.length;
+    afterLogicalCallId = batch[batch.length - 1]!.logicalCallId;
+    for (const call of batch) {
+      if (summary.inspected >= limit) break;
+      if (attemptIsCurrent(input.engine, call, now)) continue;
+      summary.inspected += 1;
+      const reconciled = reconcileWorkerProviderCall({
+        ...input,
+        call,
+        reason: call.interruptionKind ?? 'restart',
+        now,
+      });
+      summary.reconciled += 1;
+      summary.usageFacts += reconciled.usageFacts;
+      if (reconciled.reservationSettled) summary.reservationsSettled += 1;
+      if (reconciled.result.retrySafety === 'safe') summary.safe += 1;
+      else if (reconciled.result.retrySafety === 'blocked_unknown') summary.blockedUnknown += 1;
+      else summary.unsafe += 1;
+      summary.results.push(reconciled.result);
+    }
+  }
+  return summary;
+}

--- a/core/v4/worker/workerProviderUsage.ts
+++ b/core/v4/worker/workerProviderUsage.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { JobBudgetKind } from '../daemon/jobResourceAuthority';
+import type { ProviderAttemptRecord } from '../usageLedger';
+
+export interface WorkerProviderUsageFact {
+  kind: JobBudgetKind;
+  amount: number | null;
+  idempotencyKey: string;
+}
+
+function knownZero(attempt: ProviderAttemptRecord): boolean {
+  return attempt.status === 'failed_before_send'
+    || attempt.errorClass === 'rate_limit'
+    || attempt.errorClass === 'authentication'
+    || attempt.errorClass === 'context_overflow'
+    || attempt.errorClass === 'request_size_limit';
+}
+
+export function workerProviderUsageValue(
+  attempt: ProviderAttemptRecord,
+  kind: JobBudgetKind,
+): number | null {
+  if (knownZero(attempt)) return 0;
+  if (kind === 'input_tokens') return attempt.providerInputTokens;
+  if (kind === 'output_tokens') return attempt.providerOutputTokens;
+  if (kind === 'reasoning_tokens') return attempt.providerReasoningTokens;
+  if (kind === 'external_cost') {
+    if (attempt.costStatus === 'unknown') return null;
+    return attempt.costStatus === 'included' ? 0 : attempt.costAmount;
+  }
+  if (kind === 'output_bytes') return attempt.responseBytes;
+  return null;
+}
+
+export function workerProviderUsageFacts(
+  logicalCallId: string,
+  attempt: ProviderAttemptRecord,
+  index: number,
+): WorkerProviderUsageFact[] {
+  const facts: WorkerProviderUsageFact[] = [{
+    kind: 'model_calls',
+    amount: 1,
+    idempotencyKey: index === 0
+      ? `model-call:${logicalCallId}`
+      : `provider-attempt:${attempt.callId}:model-call`,
+  }];
+  if (attempt.purpose === 'retry' || attempt.purpose === 'fallback') {
+    facts.push({ kind: 'retries', amount: 1, idempotencyKey: `provider-attempt:${attempt.callId}:retry` });
+  }
+  for (const kind of ['input_tokens', 'output_tokens', 'reasoning_tokens', 'external_cost', 'output_bytes'] as const) {
+    facts.push({
+      kind,
+      amount: workerProviderUsageValue(attempt, kind),
+      idempotencyKey: `provider-attempt:${attempt.callId}:${kind}`,
+    });
+  }
+  return facts;
+}

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,13 +31,13 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(38);
+    expect(LATEST_SCHEMA_VERSION).toBe(39);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 38 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: 39 });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
       { name: 'repository_change_intents' }, { name: 'repository_change_records' },
     ]);
@@ -53,7 +53,7 @@ describe('repository snapshot migration v32', () => {
       ]);
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('repository_architecture_notes','execution_graph_node_references') ORDER BY name").all())
       .toEqual([{ name: 'execution_graph_node_references' }, { name: 'repository_architecture_notes' }]);
-    expect(runMigrations(db)).toEqual({ from: 38, to: 38 });
+    expect(runMigrations(db)).toEqual({ from: 39, to: 39 });
   });
 
   it('adds validation records to a v33 database without changing repository history', () => {
@@ -77,7 +77,7 @@ describe('repository snapshot migration v32', () => {
       (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence)
       VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
 
-    expect(runMigrations(db)).toEqual({ from: 33, to: 38 });
+    expect(runMigrations(db)).toEqual({ from: 33, to: 39 });
     expect(db.prepare('SELECT id,status FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued' });
     expect(db.prepare('SELECT attempt_id,status FROM runs WHERE attempt_id=?').get('attempt'))
       .toEqual({ attempt_id: 'attempt', status: 'queued' });

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -3,7 +3,7 @@
  * Licensed under AGPL-3.0. See LICENSE for details.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
 
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
@@ -201,6 +201,13 @@ describe('executeDurableJob', () => {
   });
 
   it('expires a durable runtime budget while execution is waiting and records actual elapsed use', async () => {
+    let intentPersisted = false;
+    let persistedBeforeAbort = false;
+    const interruption = vi.spyOn(engine.workerProviderCalls, 'recordInterruptionForAttempt')
+      .mockImplementation(() => {
+        intentPersisted = true;
+        return [];
+      });
     const execution = executeDurableJob({
       engine,
       ownerId: 'instance_lifecycle',
@@ -211,7 +218,10 @@ describe('executeDurableJob', () => {
         goal: 'wait beyond budget', resourcePolicy: { budgets: { runtime_ms: 5 } },
       },
       execute: async (handle) => new Promise<string>((resolve) => {
-        handle.signal.addEventListener('abort', () => resolve('aborted'), { once: true });
+        handle.signal.addEventListener('abort', () => {
+          persistedBeforeAbort = intentPersisted;
+          resolve('aborted');
+        }, { once: true });
       }),
       finalize: () => ({ status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {} }),
     });
@@ -223,6 +233,12 @@ describe('executeDurableJob', () => {
       { kind: 'runtime_ms', limit: 5, hasUnknownUsage: false },
     ]);
     expect(engine.resources.getBudgets(job.id)[0]!.used).toBeGreaterThanOrEqual(5);
+    expect(interruption).toHaveBeenCalledWith(expect.objectContaining({
+      childJobId: job.id,
+      kind: 'timeout',
+      reason: 'runtime_budget_exceeded',
+    }));
+    expect(persistedBeforeAbort).toBe(true);
   });
 
   it('adopts an already admitted Job without creating a parallel lifecycle', async () => {

--- a/tests/v4/worker/fixture.ts
+++ b/tests/v4/worker/fixture.ts
@@ -21,12 +21,12 @@ export interface WorkerFixture {
   childAuthority: { childJobId: string; childAttemptId: string; childGeneration: number; childFenceToken: string };
 }
 
-export function createWorkerFixture(): WorkerFixture {
-  const db = new Database(':memory:');
+export function createWorkerFixture(databasePath = ':memory:'): WorkerFixture {
+  const db = new Database(databasePath);
   db.pragma('foreign_keys = ON');
   runMigrations(db);
   db.prepare(
-    `INSERT INTO daemon_instances
+    `INSERT OR IGNORE INTO daemon_instances
        (instance_id, pid, hostname, started_at, last_heartbeat, version)
      VALUES ('worker-instance', 1, 'localhost', 1, 1, '4.18.0')`,
   ).run();

--- a/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
@@ -307,7 +307,9 @@ describe('read-only repository Worker runtime', () => {
       ]);
     expect(db.prepare('SELECT COUNT(*) AS n FROM worker_provider_tool_links WHERE worker_run_id=?')
       .get(childExecution.value.workerRun.workerRunId)).toEqual({ n: 3 });
-    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)).toMatchObject({ state: 'released' });
+    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)).toMatchObject({
+      state: 'exhausted', reconciliationState: 'blocked_unknown', unknownSpendPending: true,
+    });
     expect(engine.resources.getBudgets(parent.jobId).find((budget) => budget.kind === 'model_calls')?.used).toBe(2);
     expect(engine.resources.getBudgets(parent.jobId).find((budget) => budget.kind === 'tool_calls')?.used).toBe(3);
     expect(JSON.stringify(inputs[0].messages)).not.toContain(parentLease.fenceToken!);
@@ -504,6 +506,57 @@ describe('read-only repository Worker runtime', () => {
     expect(engine.workerProviderCalls.get(logicalCallId)).toMatchObject({ state: 'unknown', outcomeKnown: false });
   });
 
+  it('rejects and accounts a provider response that arrives after durable cancellation', async () => {
+    const { admitted } = await setup();
+    const logicalCallId = 'logical_late_after_cancel';
+    const adapter: ProviderAdapter = {
+      apiMode: 'chat_completions',
+      async call(input) {
+        const lifecycle = beginPhysicalProviderAttempt(input, {
+          providerActual: 'fixture', modelActual: 'fixture-tool-model', apiMode: 'chat_completions',
+          transport: 'fixture-late', attemptIndex: 0, logicalCallId,
+          requestBytes: JSON.stringify(input.messages).length,
+        });
+        const output: ProviderCallOutput = {
+          content: 'late result',
+          toolCalls: [{ id: 'late-tool', name: 'repository_snapshot_read', arguments: { path: 'source.ts' } }],
+          finishReason: 'tool_use', usage: { inputTokens: 8, outputTokens: 4 },
+        };
+        expect(engine.cancelJob({
+          jobId: admitted.child.jobId,
+          reason: 'operator_cancelled',
+          producer: 'test',
+          eventIdempotencyKey: 'cancel-late-worker',
+        })).toMatchObject({ applied: true });
+        lifecycle.success(output, JSON.stringify(output).length);
+        return output;
+      },
+    };
+    const bridge = directBridge(admitted, adapter);
+    await expect(bridge.adapter.call({
+      messages: [{ role: 'user', content: 'inspect' }], tools: [], usageContext: { logicalCallId },
+    })).rejects.toMatchObject({ code: 'stale_authority' });
+    expect(engine.workerProviderCalls.get(logicalCallId)).toMatchObject({
+      state: 'attempting',
+      interruptionKind: 'cancellation',
+      retrySafety: 'blocked_unknown',
+      reconciliationState: 'blocked_unknown',
+      staleResponseRejectedAt: expect.any(Number),
+    });
+    expect(db.prepare(
+      'SELECT provider_attempt_id,response_hash FROM worker_provider_late_responses WHERE logical_call_id=?',
+    ).get(logicalCallId)).toMatchObject({
+      provider_attempt_id: expect.any(String), response_hash: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    });
+    expect(db.prepare('SELECT COUNT(*) AS n FROM worker_provider_tool_links WHERE logical_call_id=?')
+      .get(logicalCallId)).toEqual({ n: 0 });
+    expect(engine.resources.getBudgets(admitted.child.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(1);
+    expect(engine.resources.getBudgets(admitted.child.jobId).find((item) => item.kind === 'input_tokens')?.used).toBe(8);
+    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)).toMatchObject({
+      reconciliationState: 'blocked_unknown', unknownSpendPending: true,
+    });
+  });
+
   it('settles a bridge-level budget denial before transport send', async () => {
     const { admitted } = await setup(1);
     db.prepare(
@@ -634,7 +687,9 @@ describe('read-only repository Worker runtime', () => {
     expect(ledger.query({ jobId: admitted.child.jobId })).toHaveLength(1);
     expect(engine.workerProviderCalls.listForWorkerRun(admitted.reservation.workerRunId))
       .toMatchObject([{ callOrdinal: 1, state: 'completed' }]);
-    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)?.state).toBe('released');
+    expect(engine.resources.getWorkerReservation(admitted.reservation.reservationId)).toMatchObject({
+      state: 'exhausted', reconciliationState: 'blocked_unknown', unknownSpendPending: true,
+    });
   });
 
   it('prevents cancelled parent authority from creating parent Evidence or changing its Claim', async () => {

--- a/tests/v4/worker/workerBudgetReservation.test.ts
+++ b/tests/v4/worker/workerBudgetReservation.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createAssignment, createWorkerFixture, type WorkerFixture } from './fixture';
+import { bindRun, createAssignment, createWorkerFixture, type WorkerFixture } from './fixture';
 
 describe('Worker JobResource reservations', () => {
   let fixture: WorkerFixture | undefined;
@@ -13,7 +13,7 @@ describe('Worker JobResource reservations', () => {
 
   function setup() {
     const current = fixture = createWorkerFixture();
-    const records = createAssignment(current);
+    const records = bindRun(current);
     current.engine.resources.configure({
       jobId: current.parent.jobId,
       budgets: { model_calls: 5, input_tokens: 100, external_cost: 10 },
@@ -29,7 +29,7 @@ describe('Worker JobResource reservations', () => {
       childJobId: current.child.jobId,
       childAttemptId: current.child.attemptId,
       childGeneration: current.childAuthority.childGeneration,
-      workerRunId: 'worker_run_reserved',
+      workerRunId: records.run.workerRunId,
       assignmentId: records.assignment.assignmentId,
       amounts: { model_calls: 3, input_tokens: 50, external_cost: 5 },
       now: 30,
@@ -227,5 +227,90 @@ describe('Worker JobResource reservations', () => {
     })).toThrow(/parent worker budget authority is stale/i);
     expect(current.engine.resources.getBudgets(current.child.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(0);
     expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(0);
+  });
+
+  it('repairs a missing parent roll-up exactly once after reopen-style reconciliation', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    const logicalCallId = 'logical_repair_one';
+    current.engine.workerProviderCalls.prepare({
+      ...current.childAuthority,
+      logicalCallId,
+      idempotencyKey: 'logical-repair-one',
+      workerRunId: command.workerRunId,
+      assignmentId: command.assignmentId,
+      providerBindingId: 'worker_provider_one',
+      callOrdinal: 1,
+      requestHash: 'c'.repeat(64),
+      toolSchemaHash: 'd'.repeat(64),
+      now: 30,
+    });
+    current.engine.resources.commitWorkerUsage({
+      reservationId: reservation.reservationId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      childFenceToken: current.childAuthority.childFenceToken,
+      kind: 'model_calls', amount: 1, certainty: 'confirmed',
+      sourceKind: 'provider_attempt', sourceId: 'physical_repair',
+      idempotencyKey: 'physical-repair:model', now: 31,
+    });
+    current.db.prepare(
+      `DELETE FROM job_budget_debits
+        WHERE job_id=? AND idempotency_key=?`,
+    ).run(current.parent.jobId, `worker-rollup:${reservation.reservationId}:physical-repair:model`);
+    current.db.prepare(
+      `UPDATE job_budgets SET used_value=0 WHERE job_id=? AND kind='model_calls'`,
+    ).run(current.parent.jobId);
+
+    expect(current.engine.resources.reconcileWorkerUsage({
+      reservationId: reservation.reservationId,
+      logicalCallId,
+      kind: 'model_calls', amount: 1, certainty: 'confirmed',
+      providerAttemptId: 'physical_repair',
+      idempotencyKey: 'physical-repair:model', now: 32,
+    })).toMatchObject({ applied: true, repaired: true });
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(1);
+    expect(current.engine.resources.reconcileWorkerUsage({
+      reservationId: reservation.reservationId,
+      logicalCallId,
+      kind: 'model_calls', amount: 1, certainty: 'confirmed',
+      providerAttemptId: 'physical_repair',
+      idempotencyKey: 'physical-repair:model', now: 33,
+    })).toMatchObject({ applied: false, duplicate: true });
+    expect(current.engine.resources.getBudgets(current.parent.jobId).find((item) => item.kind === 'model_calls')?.used).toBe(1);
+  });
+
+  it('retains reservation capacity while provider spend remains unknown', () => {
+    const { current, command } = setup();
+    const reservation = current.engine.resources.reserveWorker(command);
+    const logicalCallId = 'logical_unknown_spend';
+    current.engine.workerProviderCalls.prepare({
+      ...current.childAuthority,
+      logicalCallId,
+      idempotencyKey: 'logical-unknown-spend',
+      workerRunId: command.workerRunId,
+      assignmentId: command.assignmentId,
+      providerBindingId: 'worker_provider_one',
+      callOrdinal: 1,
+      requestHash: 'c'.repeat(64),
+      toolSchemaHash: 'd'.repeat(64),
+      now: 30,
+    });
+    const blocked = current.engine.resources.reconcileWorkerReservation({
+      reservationId: reservation.reservationId,
+      logicalCallId,
+      outcomeKnowledge: 'outcome_unknown',
+      retrySafety: 'blocked_unknown',
+      unknownSpend: true,
+      safeToRelease: false,
+      reason: 'provider_outcome_unknown',
+      idempotencyKey: 'reservation-unknown-spend',
+      now: 31,
+    });
+    expect(blocked).toMatchObject({
+      state: 'reserved', reconciliationState: 'blocked_unknown', unknownSpendPending: true,
+    });
+    expect(blocked.items.find((item) => item.kind === 'model_calls')).toMatchObject({ released: 0 });
+    expect(current.engine.resources.available(current.parent.jobId, 'model_calls')).toBe(2);
   });
 });

--- a/tests/v4/worker/workerMigration.test.ts
+++ b/tests/v4/worker/workerMigration.test.ts
@@ -49,8 +49,12 @@ describe('Worker persistence migration', () => {
       })();
     }
     const before = new Set(tables());
-    expect(runMigrations(db)).toEqual({ from: 37, to: 38 });
-    expect(LATEST_SCHEMA_VERSION).toBe(38);
+    const migration = MIGRATIONS_FOR_TESTS.find((entry) => entry.version === 38)!;
+    db.transaction(() => {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,38,1)').run();
+    })();
     expect(tables().filter((table) => !before.has(table))).toEqual([
       'job_budget_reservation_commits', 'job_budget_reservation_items', 'job_budget_reservations',
       'worker_logical_provider_calls', 'worker_provider_tool_links',
@@ -58,6 +62,45 @@ describe('Worker persistence migration', () => {
     expect(columns('worker_provider_bindings')).toEqual(expect.arrayContaining([
       'supports_tool_calling', 'supports_streaming', 'catalog_digest', 'fallback_binding_ids_json',
     ]));
+  });
+
+  it('upgrades v38 additively with reconciliation facts and keeps existing rows readable', () => {
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= 38)) {
+      db.transaction(() => {
+        if (migration.apply) migration.apply(db);
+        else db.exec(migration.sql ?? '');
+        db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)').run(migration.version, 1);
+      })();
+    }
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO worker_logical_provider_calls (
+         logical_call_id,schema_version,idempotency_key,worker_run_id,assignment_id,provider_binding_id,
+         child_job_id,child_attempt_id,child_generation,call_ordinal,request_hash,tool_schema_hash,
+         provider_id,model_id,state,outcome_known,created_at,updated_at
+       ) VALUES ('logical_existing',1,'existing','run','assignment','binding','job','attempt',1,1,?,?,
+                 'provider','model','prepared',0,1,1)`,
+    ).run('a'.repeat(64), 'b'.repeat(64));
+    db.pragma('foreign_keys = ON');
+    const before = new Set(tables());
+    expect(runMigrations(db)).toEqual({ from: 38, to: 39 });
+    expect(LATEST_SCHEMA_VERSION).toBe(39);
+    expect(tables().filter((table) => !before.has(table))).toEqual([
+      'job_budget_reservation_reconciliations',
+      'worker_provider_call_reconciliations',
+      'worker_provider_late_responses',
+    ]);
+    expect(columns('worker_logical_provider_calls')).toEqual(expect.arrayContaining([
+      'reconciliation_state', 'outcome_knowledge', 'retry_safety', 'interruption_kind',
+      'cancellation_requested_at', 'timeout_requested_at', 'authority_lost_at',
+      'stale_response_rejected_at', 'late_response_observed_at', 'reconciled_at',
+    ]));
+    expect(db.prepare(
+      `SELECT reconciliation_state,outcome_knowledge,retry_safety
+         FROM worker_logical_provider_calls WHERE logical_call_id='logical_existing'`,
+    ).get()).toEqual({
+      reconciliation_state: 'not_required', outcome_knowledge: 'no_request_started', retry_safety: 'not_applicable',
+    });
   });
 
   it('keeps WorkerRun as a relation without lifecycle, lease, fence, cancellation, or budget authority', () => {
@@ -101,14 +144,14 @@ describe('Worker persistence migration', () => {
       idempotencyNamespace: 'fixture', idempotencyKey: 'job', goal: 'legacy job',
     });
 
-    expect(runMigrations(db)).toEqual({ from: 36, to: 38 });
+    expect(runMigrations(db)).toEqual({ from: 36, to: 39 });
     const engine = createJobEngine({ db });
     expect(engine.getJob(before.jobId)?.goal).toBe('legacy job');
     expect(engine.worker.listWorkerRunsForParent(before.jobId)).toEqual([]);
   });
 
-  it('is idempotent when v38 is already installed', () => {
-    expect(runMigrations(db)).toEqual({ from: 0, to: 38 });
-    expect(runMigrations(db)).toEqual({ from: 38, to: 38 });
+  it('is idempotent when v39 is already installed', () => {
+    expect(runMigrations(db)).toEqual({ from: 0, to: 39 });
+    expect(runMigrations(db)).toEqual({ from: 39, to: 39 });
   });
 });

--- a/tests/v4/worker/workerProviderCallAuthority.test.ts
+++ b/tests/v4/worker/workerProviderCallAuthority.test.ts
@@ -136,4 +136,150 @@ describe('Worker logical provider-call authority', () => {
     expect(raw).not.toContain(current.childAuthority.childFenceToken);
     expect(raw).not.toContain('raw response');
   });
+
+  it('persists cancellation intent before rejecting a late response', () => {
+    const { current, command } = prepared();
+    current.engine.workerProviderCalls.markAttempting(command);
+    const cancelled = current.engine.workerProviderCalls.recordCancellationIntent({
+      ...command,
+      reason: 'job_cancelled',
+      idempotencyKey: 'cancel-logical-one',
+      now: 31,
+    });
+    expect(cancelled).toMatchObject({
+      interruptionKind: 'cancellation',
+      cancellationRequestedAt: 31,
+      retrySafety: 'blocked_unknown',
+    });
+    expect(() => current.engine.workerProviderCalls.recordResponseReceived({
+      ...command,
+      providerAttemptId: 'physical_attempt_late',
+      responseHash: 'e'.repeat(64),
+      providerRequestId: 'request_late',
+      now: 32,
+    })).toThrowError(expect.objectContaining({ code: 'interrupted' }));
+    const rejected = current.engine.workerProviderCalls.rejectLateResponse({
+      logicalCallId: command.logicalCallId,
+      workerRunId: command.workerRunId,
+      childJobId: command.childJobId,
+      childAttemptId: command.childAttemptId,
+      childGeneration: command.childGeneration,
+      providerAttemptId: 'physical_attempt_late',
+      responseHash: 'e'.repeat(64),
+      providerRequestId: 'request_late',
+      reason: 'response_after_cancellation',
+      idempotencyKey: 'late-logical-one',
+      now: 32,
+    });
+    expect(rejected.call).toMatchObject({
+      lateResponseObservedAt: 32,
+      staleResponseRejectedAt: 32,
+    });
+    expect(current.engine.workerProviderCalls.rejectLateResponse({
+      logicalCallId: command.logicalCallId,
+      workerRunId: command.workerRunId,
+      childJobId: command.childJobId,
+      childAttemptId: command.childAttemptId,
+      childGeneration: command.childGeneration,
+      providerAttemptId: 'physical_attempt_late',
+      responseHash: 'e'.repeat(64),
+      providerRequestId: 'request_late',
+      reason: 'response_after_cancellation',
+      idempotencyKey: 'late-logical-one',
+      now: 33,
+    })).toMatchObject({ applied: false, duplicate: true });
+    expect(() => current.engine.workerProviderCalls.rejectLateResponse({
+      logicalCallId: command.logicalCallId,
+      workerRunId: command.workerRunId,
+      childJobId: command.childJobId,
+      childAttemptId: command.childAttemptId,
+      childGeneration: command.childGeneration,
+      providerAttemptId: 'physical_attempt_late',
+      responseHash: 'a'.repeat(64),
+      providerRequestId: 'request_late',
+      reason: 'response_after_cancellation',
+      idempotencyKey: 'late-logical-one',
+      now: 34,
+    })).toThrowError(expect.objectContaining({ code: 'late_response_conflict' }));
+  });
+
+  it('classifies restart recovery from canonical physical-attempt facts', () => {
+    const { current, command } = prepared();
+    const safe = current.engine.workerProviderCalls.markAuthorityLost({
+      logicalCallId: command.logicalCallId,
+      workerRunId: command.workerRunId,
+      childJobId: command.childJobId,
+      childAttemptId: command.childAttemptId,
+      childGeneration: command.childGeneration,
+      kind: 'lease_expired',
+      reason: 'restart',
+      idempotencyKey: 'authority-lost-prepared',
+      now: 60_011,
+    });
+    expect(safe.retrySafety).toBe('safe');
+    expect(current.engine.workerProviderCalls.reconcile({
+      logicalCallId: command.logicalCallId,
+      workerRunId: command.workerRunId,
+      childJobId: command.childJobId,
+      childAttemptId: command.childAttemptId,
+      childGeneration: command.childGeneration,
+      physicalAttempts: [],
+      reason: 'restart',
+      idempotencyKey: 'reconcile-prepared',
+      now: 60_012,
+    })).toMatchObject({ outcomeKnowledge: 'no_request_started', retrySafety: 'safe' });
+
+    current.db.close();
+    const second = prepared();
+    second.current.engine.workerProviderCalls.markAttempting(second.command);
+    second.current.engine.workerProviderCalls.markAuthorityLost({
+      logicalCallId: second.command.logicalCallId,
+      workerRunId: second.command.workerRunId,
+      childJobId: second.command.childJobId,
+      childAttemptId: second.command.childAttemptId,
+      childGeneration: second.command.childGeneration,
+      kind: 'lease_expired',
+      reason: 'restart',
+      idempotencyKey: 'authority-lost-attempting',
+      now: 60_011,
+    });
+    expect(second.current.engine.workerProviderCalls.reconcile({
+      logicalCallId: second.command.logicalCallId,
+      workerRunId: second.command.workerRunId,
+      childJobId: second.command.childJobId,
+      childAttemptId: second.command.childAttemptId,
+      childGeneration: second.command.childGeneration,
+      physicalAttempts: [{ providerAttemptId: 'physical_unknown', status: 'attempting' }],
+      unknownSpend: true,
+      reason: 'restart',
+      idempotencyKey: 'reconcile-attempting',
+      now: 60_012,
+    })).toMatchObject({ outcomeKnowledge: 'outcome_unknown', retrySafety: 'blocked_unknown' });
+  });
+
+  it('distinguishes a pre-send timeout from an ambiguous in-flight timeout', () => {
+    const first = prepared();
+    expect(first.current.engine.workerProviderCalls.recordTimeoutIntent({
+      ...first.command,
+      reason: 'runtime_budget_exceeded',
+      idempotencyKey: 'timeout-before-send',
+      now: 31,
+    })).toMatchObject({
+      interruptionKind: 'timeout', timeoutRequestedAt: 31,
+      outcomeKnowledge: 'no_request_started', retrySafety: 'safe',
+    });
+    first.current.db.close();
+
+    const second = prepared();
+    second.current.engine.workerProviderCalls.markAttempting(second.command);
+    expect(second.current.engine.workerProviderCalls.recordTimeoutIntent({
+      ...second.command,
+      reason: 'runtime_budget_exceeded',
+      idempotencyKey: 'timeout-in-flight',
+      now: 31,
+    })).toMatchObject({
+      interruptionKind: 'timeout', timeoutRequestedAt: 31,
+      outcomeKnowledge: 'outcome_unknown', retrySafety: 'blocked_unknown',
+    });
+  });
 });

--- a/tests/v4/worker/workerRecoveryReconciliation.test.ts
+++ b/tests/v4/worker/workerRecoveryReconciliation.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { sweepDurableJobRecovery } from '../../../core/v4/daemon/jobRecoverySweep';
+import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { bindRun, createWorkerFixture, type WorkerFixture } from './fixture';
+
+describe('Worker provider recovery reconciliation', () => {
+  let fixture: WorkerFixture | undefined;
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    if (fixture?.db.open) fixture.db.close();
+    fixture = undefined;
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function prepare(state: 'prepared' | 'attempting') {
+    const current = fixture = createWorkerFixture();
+    const records = bindRun(current);
+    const command = {
+      ...current.childAuthority,
+      logicalCallId: `logical_recovery_${state}`,
+      idempotencyKey: `logical-recovery-${state}`,
+      workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      callOrdinal: 1,
+      requestHash: 'c'.repeat(64),
+      toolSchemaHash: 'd'.repeat(64),
+      now: 30,
+    };
+    current.engine.workerProviderCalls.prepare(command);
+    if (state === 'attempting') current.engine.workerProviderCalls.markAttempting(command);
+    current.db.prepare('UPDATE runs SET lease_expires_at=? WHERE attempt_id=?')
+      .run(40, current.child.attemptId);
+    return { current, command, records };
+  }
+
+  it('allows JobEngine to replace a no-send call only after the old Attempt is fenced', () => {
+    const { current, command, records } = prepare('prepared');
+    const [decision] = current.engine.recoverExpiredAttempts({
+      now: 41,
+      instanceId: 'worker-instance',
+      producer: 'test',
+      maxCrashes: 3,
+    });
+    expect(decision).toMatchObject({
+      jobId: current.child.jobId,
+      expiredAttemptId: current.child.attemptId,
+      decision: 'retry',
+      workerReconciliation: {
+        calls: 1,
+        retrySafety: 'safe',
+        outcomeKnowledge: ['no_request_started'],
+      },
+    });
+    expect(decision?.recoveryAttemptId).not.toBe(current.child.attemptId);
+    expect(current.engine.getAttempt(current.child.attemptId)).toMatchObject({
+      status: 'crashed', fenceToken: current.childAuthority.childFenceToken, leaseOwner: null,
+    });
+    expect(current.engine.workerProviderCalls.get(command.logicalCallId)).toMatchObject({
+      authorityLostAt: 41,
+      retrySafety: 'safe',
+      reconciliationState: 'reconciled',
+    });
+    const nextLease = current.engine.claimAttempt({
+      attemptId: decision!.recoveryAttemptId!, ownerId: 'child-owner-next', ttlMs: 60_000, now: 42,
+    });
+    const nextRun = current.engine.worker.bindWorkerRunFromAssignment({
+      childJobId: current.child.jobId,
+      childAttemptId: decision!.recoveryAttemptId!,
+      childGeneration: nextLease.generation!,
+      childFenceToken: nextLease.fenceToken!,
+      workerRunId: 'worker_run_recovery_next',
+      schemaVersion: 1,
+      assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      contextEnvelopeId: records.contextEnvelope.contextEnvelopeId,
+      producer: 'test',
+      idempotencyKey: 'worker-run-recovery-next',
+      now: 43,
+    });
+    expect(current.engine.workerProviderCalls.prepare({
+      childJobId: current.child.jobId,
+      childAttemptId: decision!.recoveryAttemptId!,
+      childGeneration: nextLease.generation!,
+      childFenceToken: nextLease.fenceToken!,
+      logicalCallId: 'logical_recovery_replacement',
+      idempotencyKey: 'logical-recovery-replacement',
+      workerRunId: nextRun.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      callOrdinal: 1,
+      requestHash: 'e'.repeat(64),
+      toolSchemaHash: 'd'.repeat(64),
+      now: 44,
+    })).toMatchObject({ recoveryPredecessorLogicalCallId: command.logicalCallId });
+  });
+
+  it('blocks automatic replacement when a sent request has unknown outcome and spend', () => {
+    const { current, command } = prepare('attempting');
+    const [decision] = current.engine.recoverExpiredAttempts({
+      now: 41,
+      instanceId: 'worker-instance',
+      producer: 'test',
+      maxCrashes: 3,
+    });
+    expect(decision).toMatchObject({
+      jobId: current.child.jobId,
+      expiredAttemptId: current.child.attemptId,
+      decision: 'ask_user',
+      workerReconciliation: {
+        calls: 1,
+        retrySafety: 'blocked_unknown',
+        outcomeKnowledge: ['outcome_unknown'],
+      },
+    });
+    expect(decision?.recoveryAttemptId).toBeUndefined();
+    expect(current.engine.getJob(current.child.jobId)).toMatchObject({
+      status: 'blocked', activeAttemptId: null,
+    });
+    expect(current.engine.getAttempt(current.child.attemptId)).toMatchObject({ status: 'unknown' });
+    expect(current.engine.workerProviderCalls.get(command.logicalCallId)).toMatchObject({
+      authorityLostAt: 41,
+      retrySafety: 'blocked_unknown',
+      outcomeKnowledge: 'outcome_unknown',
+      reconciliationState: 'blocked_unknown',
+    });
+  });
+
+  it('persists cancellation intent through JobEngine before terminal Attempt settlement', () => {
+    const { current, command } = prepare('attempting');
+    expect(current.engine.cancelJob({
+      jobId: current.child.jobId,
+      reason: 'operator_cancelled',
+      producer: 'test',
+      eventIdempotencyKey: 'cancel-worker-recovery',
+      now: 31,
+    })).toMatchObject({ applied: true });
+    expect(current.engine.workerProviderCalls.get(command.logicalCallId)).toMatchObject({
+      interruptionKind: 'cancellation',
+      cancellationRequestedAt: 31,
+      reconciliationState: 'pending',
+    });
+    const events = current.engine.listEvents(current.child.jobId);
+    const intent = events.findIndex((event) => event.type === 'worker.provider_cancellation_requested');
+    const cancelled = events.findIndex((event) => event.type === 'attempt.cancelled');
+    expect(intent).toBeGreaterThanOrEqual(0);
+    expect(cancelled).toBeGreaterThan(intent);
+  });
+
+  it('keeps unknown provider spend reserved and does not enqueue a replacement on restart', () => {
+    const { current, command, records } = prepare('attempting');
+    current.engine.resources.configure({
+      jobId: current.parent.jobId,
+      budgets: { model_calls: 2, input_tokens: 100, output_tokens: 100 },
+    });
+    current.engine.resources.configure({
+      jobId: current.child.jobId,
+      budgets: { model_calls: 1, input_tokens: 50, output_tokens: 50 },
+    });
+    const reservation = current.engine.resources.reserveWorker({
+      reservationId: 'worker_recovery_reservation',
+      idempotencyKey: 'worker-recovery-reservation',
+      ...current.parentAuthority,
+      childJobId: current.child.jobId,
+      childAttemptId: current.child.attemptId,
+      childGeneration: current.childAuthority.childGeneration,
+      workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      amounts: { model_calls: 1, input_tokens: 50, output_tokens: 50 },
+      now: 31,
+    });
+    const result = sweepDurableJobRecovery({
+      jobEngine: current.engine,
+      triggerBus: createTriggerBus({ db: current.db }),
+      instanceId: 'worker-instance',
+      producer: 'test',
+      now: 41,
+    });
+    expect(result).toMatchObject({ expired: 1, retried: 0, needsUser: 1, enqueued: 0 });
+    expect(current.engine.resources.getWorkerReservation(reservation.reservationId)).toMatchObject({
+      state: 'reserved', reconciliationState: 'blocked_unknown', unknownSpendPending: true,
+    });
+    expect(current.engine.workerProviderCalls.get(command.logicalCallId)).toMatchObject({
+      outcomeKnowledge: 'outcome_unknown', retrySafety: 'blocked_unknown',
+    });
+    expect(current.engine.getJob(current.child.jobId)).toMatchObject({ status: 'blocked', activeAttemptId: null });
+  });
+
+  it('reopens v39 state and repeats reconciliation without duplicate events or replacement attempts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'aiden-worker-recovery-'));
+    tempDirs.push(root);
+    const first = fixture = createWorkerFixture(join(root, 'jobs.db'));
+    const records = bindRun(first);
+    const command = {
+      ...first.childAuthority,
+      logicalCallId: 'logical_reopen_unknown',
+      idempotencyKey: 'logical-reopen-unknown',
+      workerRunId: records.run.workerRunId,
+      assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId,
+      callOrdinal: 1,
+      requestHash: 'c'.repeat(64),
+      toolSchemaHash: 'd'.repeat(64),
+      now: 30,
+    };
+    first.engine.workerProviderCalls.prepare(command);
+    first.engine.workerProviderCalls.markAttempting(command);
+    first.db.prepare('UPDATE runs SET lease_expires_at=40 WHERE attempt_id=?').run(first.child.attemptId);
+    first.db.close();
+
+    const reopenedDb = new Database(join(root, 'jobs.db'));
+    reopenedDb.pragma('foreign_keys = ON');
+    fixture = { ...first, db: reopenedDb, engine: createJobEngine({ db: reopenedDb }) };
+    const [decision] = fixture.engine.recoverExpiredAttempts({
+      now: 41, instanceId: 'worker-instance', producer: 'test', maxCrashes: 3,
+    });
+    expect(decision).toMatchObject({ decision: 'ask_user' });
+    expect(fixture.engine.recoverExpiredAttempts({
+      now: 42, instanceId: 'worker-instance', producer: 'test', maxCrashes: 3,
+    })).toEqual([]);
+    expect(fixture.engine.listAttempts(first.child.jobId)).toHaveLength(1);
+    expect(reopenedDb.prepare(
+      'SELECT COUNT(*) AS n FROM worker_provider_call_reconciliations WHERE logical_call_id=?',
+    ).get(command.logicalCallId)).toEqual({ n: 1 });
+    expect(fixture.engine.listEvents(first.child.jobId)
+      .filter((event) => event.type === 'worker.provider_reconciliation_completed')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- persists Worker provider cancellation and timeout intent before physical interruption;
- reconciles interrupted logical provider calls across restart and expired Attempt leases;
- fences stale and late provider responses before Worker consumption;
- classifies no-send, known-failure, accepted, downstream-started and unknown outcomes for safe recovery;
- repairs usage commits and parent roll-ups idempotently;
- releases unused reservation capacity only when settlement is known, retaining unknown spend;
- adds additive schema migration v39 and restart/reopen coverage.

## Authority boundaries

- JobEngine remains the Job and Attempt recovery-decision owner;
- WorkerProviderCallAuthority owns logical-call and late-response reconciliation facts;
- ProviderAttemptLedger remains the physical-attempt owner;
- JobResourceAuthority remains the reservation and budget owner;
- existing cancellation, queue, graph, evidence and proof authorities remain unchanged;
- no parallel or nested Workers, mutation, UI changes or new lifecycle authority are included.

## Validation

- focused Worker PR1-PR4 matrix passed;
- recovery and process arbitration passed;
- 7,440 deterministic tests passed, 39 skipped;
- 33 offline integration tests passed, 4 skipped;
- 44 serial PTY tests passed;
- typecheck and production build passed;
- package dry run, diff, NUL, secret, attribution, scope, duplicate-authority and process-cleanup checks passed.