### PR TITLE
feat(worker): add bounded parallel read-only execution

### DIFF
--- a/core/v4/daemon/bootstrap.ts
+++ b/core/v4/daemon/bootstrap.ts
@@ -970,13 +970,13 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
         db,
         ownerId:       tracker.instanceId,
         instanceId:    tracker.instanceId,
-        workerCount:   1,                   // Q-P5-1(a)
+        workerCount:   4,
         runnerFactory,
         initialRunnerKind: opts.agentBuilder ? 'real' : 'placeholder',
         log,
       });
       dispatcher.start();
-      log('info', `[dispatcher] active workerCount=1 runner=${opts.agentBuilder ? 'real' : 'placeholder'}`);
+      log('info', `[dispatcher] active workerCount=4 runner=${opts.agentBuilder ? 'real' : 'placeholder'}`);
       const runDurableRecoverySweep = (): void => {
         if (dispatcher?.runnerKind() !== 'real') return;
         try {

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -2188,6 +2188,99 @@ function applyV39(db: Database.Database): void {
   `);
 }
 
+/** Bounded parallel read-only Worker group projections and provider slots. */
+function applyV40(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS worker_groups (
+      group_id TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL DEFAULT 1,
+      idempotency_key TEXT NOT NULL,
+      parent_job_id TEXT NOT NULL,
+      parent_attempt_id TEXT NOT NULL,
+      parent_generation INTEGER NOT NULL,
+      parent_fence_digest TEXT NOT NULL,
+      policy TEXT NOT NULL CHECK(policy IN ('require_all','allow_partial')),
+      state TEXT NOT NULL CHECK(state IN ('admitting','active','cancelling','timed_out','settling','settled','blocked_unknown')),
+      requested_member_count INTEGER NOT NULL CHECK(requested_member_count BETWEEN 1 AND 4),
+      admitted_member_count INTEGER NOT NULL DEFAULT 0,
+      settled_member_count INTEGER NOT NULL DEFAULT 0,
+      successful_member_count INTEGER NOT NULL DEFAULT 0,
+      failed_member_count INTEGER NOT NULL DEFAULT 0,
+      unknown_member_count INTEGER NOT NULL DEFAULT 0,
+      cancelled_member_count INTEGER NOT NULL DEFAULT 0,
+      input_hash TEXT NOT NULL,
+      aggregate_hash TEXT,
+      created_at INTEGER NOT NULL,
+      cancellation_requested_at INTEGER,
+      timeout_requested_at INTEGER,
+      settled_at INTEGER,
+      settlement_version INTEGER NOT NULL DEFAULT 0,
+      settlement_reason TEXT,
+      FOREIGN KEY (parent_job_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      UNIQUE (parent_job_id, parent_attempt_id, parent_generation, idempotency_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_groups_pending
+      ON worker_groups(state, created_at, group_id);
+    CREATE INDEX IF NOT EXISTS idx_worker_groups_parent
+      ON worker_groups(parent_job_id, parent_attempt_id, parent_generation, state, group_id);
+
+    CREATE TABLE IF NOT EXISTS worker_group_members (
+      group_id TEXT NOT NULL,
+      member_id TEXT PRIMARY KEY,
+      ordinal INTEGER NOT NULL CHECK(ordinal BETWEEN 1 AND 4),
+      requested_provider_id TEXT NOT NULL,
+      assignment_id TEXT,
+      child_job_id TEXT,
+      child_attempt_id TEXT,
+      child_generation INTEGER,
+      provider_binding_id TEXT,
+      outcome TEXT NOT NULL DEFAULT 'pending' CHECK(outcome IN ('pending','admitted','verified','rejected','failed','unknown','blocked','cancelled','timed_out')),
+      worker_result_id TEXT,
+      result_hash TEXT,
+      joined_at INTEGER,
+      settlement_reason TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (group_id) REFERENCES worker_groups(group_id) ON DELETE CASCADE,
+      FOREIGN KEY (assignment_id) REFERENCES worker_assignments(assignment_id) ON DELETE RESTRICT,
+      FOREIGN KEY (child_job_id) REFERENCES tasks(id) ON DELETE RESTRICT,
+      FOREIGN KEY (worker_result_id) REFERENCES worker_results(worker_result_id) ON DELETE RESTRICT,
+      UNIQUE (group_id, ordinal),
+      UNIQUE (group_id, assignment_id),
+      UNIQUE (child_job_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_group_members_group
+      ON worker_group_members(group_id, ordinal, member_id);
+    CREATE INDEX IF NOT EXISTS idx_worker_group_members_unsettled
+      ON worker_group_members(outcome, updated_at, member_id);
+
+    CREATE TABLE IF NOT EXISTS worker_provider_concurrency_reservations (
+      provider_slot_id TEXT PRIMARY KEY,
+      idempotency_key TEXT NOT NULL,
+      group_id TEXT NOT NULL,
+      member_id TEXT NOT NULL,
+      parent_job_id TEXT NOT NULL,
+      parent_attempt_id TEXT NOT NULL,
+      parent_generation INTEGER NOT NULL,
+      provider_id TEXT NOT NULL,
+      limit_value INTEGER NOT NULL CHECK(limit_value BETWEEN 1 AND 1024),
+      state TEXT NOT NULL CHECK(state IN ('reserved','released','blocked_unknown')),
+      created_at INTEGER NOT NULL,
+      released_at INTEGER,
+      blocked_at INTEGER,
+      settlement_reason TEXT,
+      FOREIGN KEY (group_id) REFERENCES worker_groups(group_id) ON DELETE CASCADE,
+      FOREIGN KEY (member_id) REFERENCES worker_group_members(member_id) ON DELETE CASCADE,
+      UNIQUE (parent_job_id, idempotency_key),
+      UNIQUE (member_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worker_provider_slots_capacity
+      ON worker_provider_concurrency_reservations(provider_id, state, created_at, provider_slot_id);
+    CREATE INDEX IF NOT EXISTS idx_worker_provider_slots_group
+      ON worker_provider_concurrency_reservations(group_id, state, member_id);
+  `);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -2228,6 +2321,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 37, name: 'durable Worker contracts and authority boundaries', apply: applyV37 },
   { version: 38, name: 'durable Worker provider calls and budget reservations', apply: applyV38 },
   { version: 39, name: 'Worker provider restart and reconciliation', apply: applyV39 },
+  { version: 40, name: 'bounded parallel read-only Worker groups', apply: applyV40 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;
@@ -2272,7 +2366,8 @@ function validateLatestSchema(db: Database.Database): void {
     'worker_logical_provider_calls', 'worker_provider_tool_links', 'job_budget_reservations',
     'job_budget_reservation_items', 'job_budget_reservation_commits',
     'worker_provider_call_reconciliations', 'worker_provider_late_responses',
-    'job_budget_reservation_reconciliations'];
+    'job_budget_reservation_reconciliations', 'worker_groups', 'worker_group_members',
+    'worker_provider_concurrency_reservations'];
   const missing = required.filter((table) => !tableExists(db, table));
   if (missing.length > 0) throw new Error(`Database schema is incomplete at version ${LATEST_SCHEMA_VERSION}: missing ${missing.join(', ')}`);
   if (!tableExists(db, 'job_event_cursors')) {

--- a/core/v4/daemon/jobControlAuthority.ts
+++ b/core/v4/daemon/jobControlAuthority.ts
@@ -8,6 +8,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import type { Db } from './db/connection';
 import type { JobEngine } from './jobEngine';
 import { createJobWaitAuthority, type JobWaitAuthority } from './jobWaitAuthority';
+import { reconcileInterruptedReadOnlyRepositoryWorkerGroups } from '../worker/workerParallel';
 
 export type DurableInputKind =
   | 'message' | 'steering' | 'control' | 'approval_decision' | 'credential'
@@ -833,6 +834,11 @@ export function createJobControlAuthority(options: CreateJobControlAuthorityOpti
                 });
                 if (cancelled.applied || cancelled.duplicate) attemptIds.push(childAttemptId);
               }
+              reconcileInterruptedReadOnlyRepositoryWorkerGroups({
+                engine: jobEngine,
+                parentJobId: command.jobId,
+                producer: command.source,
+              });
             }
           }
           const now = command.now ?? Date.now();

--- a/core/v4/daemon/jobEngine.ts
+++ b/core/v4/daemon/jobEngine.ts
@@ -721,6 +721,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     ) return null;
     return attempt;
   };
+  let worker!: WorkerAuthority;
   let workerProviderCalls!: WorkerProviderCallAuthority;
 
   const existingEvent = (jobId: string, key: string): { id: number; job_sequence: number } | undefined => db.prepare(
@@ -1307,6 +1308,17 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     if (!attempt) return { applied: false, conflict: 'not_found' };
     const now = command.now ?? Date.now();
     if (!ATTEMPT_TERMINAL.has(attempt.status) && attempt.fence_token) {
+      worker.requestWorkerGroupInterruptionForParent({
+        parentJobId: job.id,
+        parentAttemptId: attempt.attempt_id,
+        parentGeneration: attempt.generation,
+        parentFenceToken: attempt.fence_token,
+        kind: 'cancellation',
+        reason: command.reason,
+        producer: command.producer,
+        idempotencyKey: `worker-groups:${command.eventIdempotencyKey}`,
+        now,
+      });
       workerProviderCalls.recordInterruptionForAttempt({
         childJobId: job.id,
         childAttemptId: attempt.attempt_id,
@@ -2427,7 +2439,7 @@ export function createJobEngine(opts: CreateJobEngineOptions): JobEngine {
     getAttempt(attemptId) { const row = getAttemptRow(attemptId); return row ? mapAttempt(row) : null; },
     appendJobEvent: appendJobEventTx,
   });
-  const worker = createWorkerAuthority({
+  worker = createWorkerAuthority({
     db,
     graph,
     validateActiveFence(command) {

--- a/core/v4/daemon/jobRecoverySweep.ts
+++ b/core/v4/daemon/jobRecoverySweep.ts
@@ -11,6 +11,10 @@ import {
   reconcileWorkerProviderAttempt,
   sweepWorkerProviderReconciliation,
 } from '../worker/workerProviderReconciliation';
+import {
+  projectReadOnlyRepositoryWorkerGroups,
+  reconcileInterruptedReadOnlyRepositoryWorkerGroups,
+} from '../worker/workerParallel';
 
 export interface DurableRecoverySweepResult {
   expired: number;
@@ -70,6 +74,19 @@ export function sweepDurableJobRecovery(input: {
     now: input.now,
   });
   result.reconciled += workerSweep.reconciled;
+  const interruptedParents = new Set(
+    input.jobEngine.worker.listWorkerGroupsPendingSettlement({ limit: 1_000 })
+      .filter((group) => group.state === 'cancelling' || group.state === 'timed_out')
+      .map((group) => group.parentJobId),
+  );
+  for (const parentJobId of interruptedParents) {
+    result.reconciled += reconcileInterruptedReadOnlyRepositoryWorkerGroups({
+      engine: input.jobEngine,
+      parentJobId,
+      producer: input.producer,
+    }).settled;
+  }
+  projectReadOnlyRepositoryWorkerGroups({ engine: input.jobEngine, limit: 100 });
 
   for (const decision of decisions.filter((item) => item.decision === 'ask_user')) {
     const job = input.jobEngine.getJob(decision.jobId);

--- a/core/v4/daemon/jobResourceAuthority.ts
+++ b/core/v4/daemon/jobResourceAuthority.ts
@@ -72,6 +72,23 @@ export interface JobBudgetReservationRecord {
   settlementBlockedAt: number | null;
 }
 
+export interface WorkerProviderConcurrencyReservationRecord {
+  providerSlotId: string;
+  idempotencyKey: string;
+  groupId: string;
+  memberId: string;
+  parentJobId: string;
+  parentAttemptId: string;
+  parentGeneration: number;
+  providerId: string;
+  limit: number;
+  state: 'reserved' | 'released' | 'blocked_unknown';
+  createdAt: number;
+  releasedAt: number | null;
+  blockedAt: number | null;
+  settlementReason: string | null;
+}
+
 export interface JobResourceAuthority {
   configure(command: {
     jobId: string;
@@ -153,6 +170,29 @@ export interface JobResourceAuthority {
     idempotencyKey: string;
     now?: number;
   }): JobBudgetReservationRecord;
+  reserveWorkerProviderConcurrency(command: {
+    providerSlotId: string;
+    idempotencyKey: string;
+    groupId: string;
+    memberId: string;
+    parentJobId: string;
+    parentAttemptId: string;
+    parentGeneration: number;
+    parentFenceToken: string;
+    providerId: string;
+    limit: number;
+    now?: number;
+  }): WorkerProviderConcurrencyReservationRecord;
+  settleWorkerProviderConcurrency(command: {
+    providerSlotId: string;
+    unknown: boolean;
+    safeToRelease: boolean;
+    reason: string;
+    now?: number;
+  }): WorkerProviderConcurrencyReservationRecord;
+  getWorkerProviderConcurrency(providerSlotId: string): WorkerProviderConcurrencyReservationRecord | null;
+  getWorkerProviderConcurrencyForMember(memberId: string): WorkerProviderConcurrencyReservationRecord | null;
+  listWorkerProviderConcurrencyForGroup(groupId: string): WorkerProviderConcurrencyReservationRecord[];
   authorize(command: {
     jobId: string;
     kind: 'tool' | 'path' | 'host' | 'application' | 'connection' | 'account' | 'worker' | 'effect';
@@ -210,6 +250,25 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
     kind: JobBudgetKind; reserved_value: number; committed_value: number;
     released_value: number; has_unknown_usage: number;
     state: JobBudgetReservationItemRecord['state'];
+  };
+  type ProviderSlotRow = {
+    provider_slot_id: string; idempotency_key: string; group_id: string; member_id: string;
+    parent_job_id: string; parent_attempt_id: string; parent_generation: number; provider_id: string;
+    limit_value: number; state: WorkerProviderConcurrencyReservationRecord['state']; created_at: number;
+    released_at: number | null; blocked_at: number | null; settlement_reason: string | null;
+  };
+  const mapProviderSlot = (row: ProviderSlotRow): WorkerProviderConcurrencyReservationRecord => ({
+    providerSlotId: row.provider_slot_id, idempotencyKey: row.idempotency_key,
+    groupId: row.group_id, memberId: row.member_id, parentJobId: row.parent_job_id,
+    parentAttemptId: row.parent_attempt_id, parentGeneration: row.parent_generation,
+    providerId: row.provider_id, limit: row.limit_value, state: row.state,
+    createdAt: row.created_at, releasedAt: row.released_at, blockedAt: row.blocked_at,
+    settlementReason: row.settlement_reason,
+  });
+  const getProviderSlot = (providerSlotId: string): WorkerProviderConcurrencyReservationRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_provider_concurrency_reservations WHERE provider_slot_id=?')
+      .get(providerSlotId) as ProviderSlotRow | undefined;
+    return row ? mapProviderSlot(row) : null;
   };
   const getReservation = (reservationId: string): JobBudgetReservationRecord | null => {
     const row = db.prepare('SELECT * FROM job_budget_reservations WHERE reservation_id=?')
@@ -687,6 +746,93 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
     return getReservation(reservation.reservationId)!;
   }).immediate;
 
+  const reserveWorkerProviderConcurrency = db.transaction((
+    command: Parameters<JobResourceAuthority['reserveWorkerProviderConcurrency']>[0],
+  ): WorkerProviderConcurrencyReservationRecord => {
+    requireActiveAttempt(
+      command.parentJobId, command.parentAttemptId, command.parentGeneration, command.parentFenceToken,
+    );
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.providerSlotId)
+      || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.idempotencyKey)
+      || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.providerId)
+      || !Number.isSafeInteger(command.limit) || command.limit < 1 || command.limit > 1_024) {
+      throw new Error('Worker provider concurrency reservation contract is invalid');
+    }
+    const lineage = db.prepare(
+      `SELECT g.parent_job_id,g.parent_attempt_id,g.parent_generation,m.requested_provider_id
+         FROM worker_groups g JOIN worker_group_members m ON m.group_id=g.group_id
+        WHERE g.group_id=? AND m.member_id=?`,
+    ).get(command.groupId, command.memberId) as {
+      parent_job_id: string; parent_attempt_id: string; parent_generation: number; requested_provider_id: string;
+    } | undefined;
+    if (!lineage || lineage.parent_job_id !== command.parentJobId
+      || lineage.parent_attempt_id !== command.parentAttemptId
+      || lineage.parent_generation !== command.parentGeneration
+      || lineage.requested_provider_id !== command.providerId) {
+      throw new Error('Worker provider concurrency lineage is invalid');
+    }
+    const existingByKey = db.prepare(
+      'SELECT * FROM worker_provider_concurrency_reservations WHERE parent_job_id=? AND idempotency_key=?',
+    ).get(command.parentJobId, command.idempotencyKey) as ProviderSlotRow | undefined;
+    const existingById = getProviderSlot(command.providerSlotId);
+    const existing = existingByKey ? mapProviderSlot(existingByKey) : existingById;
+    if (existing) {
+      const same = existing.providerSlotId === command.providerSlotId && existing.groupId === command.groupId
+        && existing.memberId === command.memberId && existing.providerId === command.providerId
+        && existing.limit === command.limit && existing.parentAttemptId === command.parentAttemptId
+        && existing.parentGeneration === command.parentGeneration;
+      if (!same) throw new Error('Worker provider concurrency idempotency conflict');
+      return existing;
+    }
+    const capacity = db.prepare(
+      `SELECT COUNT(*) AS count,MIN(limit_value) AS active_limit
+         FROM worker_provider_concurrency_reservations
+        WHERE provider_id=? AND state IN ('reserved','blocked_unknown')`,
+    ).get(command.providerId) as { count: number; active_limit: number | null };
+    const effectiveLimit = Math.min(command.limit, capacity.active_limit ?? command.limit);
+    if (capacity.count >= effectiveLimit) {
+      throw new Error(`Worker provider concurrency limit exceeded for ${command.providerId}`);
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `INSERT INTO worker_provider_concurrency_reservations
+         (provider_slot_id,idempotency_key,group_id,member_id,parent_job_id,parent_attempt_id,
+          parent_generation,provider_id,limit_value,state,created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,'reserved',?)`,
+    ).run(
+      command.providerSlotId, command.idempotencyKey, command.groupId, command.memberId,
+      command.parentJobId, command.parentAttemptId, command.parentGeneration,
+      command.providerId, command.limit, now,
+    );
+    return getProviderSlot(command.providerSlotId)!;
+  }).immediate;
+
+  const settleWorkerProviderConcurrency = db.transaction((
+    command: Parameters<JobResourceAuthority['settleWorkerProviderConcurrency']>[0],
+  ): WorkerProviderConcurrencyReservationRecord => {
+    const slot = getProviderSlot(command.providerSlotId);
+    if (!slot) throw new Error('Worker provider concurrency reservation was not found');
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u.test(command.reason)) {
+      throw new Error('Worker provider concurrency settlement reason is invalid');
+    }
+    const target = command.unknown ? 'blocked_unknown' : command.safeToRelease ? 'released' : 'reserved';
+    if (slot.state !== 'reserved') {
+      if (slot.state !== target || slot.settlementReason !== command.reason) {
+        throw new Error('Worker provider concurrency settlement conflict');
+      }
+      return slot;
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_provider_concurrency_reservations
+          SET state=?,released_at=?,blocked_at=?,settlement_reason=? WHERE provider_slot_id=?`,
+    ).run(
+      target, target === 'released' ? now : null, target === 'blocked_unknown' ? now : null,
+      command.reason, command.providerSlotId,
+    );
+    return getProviderSlot(command.providerSlotId)!;
+  }).immediate;
+
   return {
     reserveWorker,
     getWorkerReservation: getReservation,
@@ -706,6 +852,19 @@ export function createJobResourceAuthority(db: Db): JobResourceAuthority {
     releaseWorker,
     reconcileWorkerUsage,
     reconcileWorkerReservation,
+    reserveWorkerProviderConcurrency,
+    settleWorkerProviderConcurrency,
+    getWorkerProviderConcurrency: getProviderSlot,
+    getWorkerProviderConcurrencyForMember(memberId) {
+      const row = db.prepare('SELECT * FROM worker_provider_concurrency_reservations WHERE member_id=?')
+        .get(memberId) as ProviderSlotRow | undefined;
+      return row ? mapProviderSlot(row) : null;
+    },
+    listWorkerProviderConcurrencyForGroup(groupId) {
+      return (db.prepare(
+        'SELECT * FROM worker_provider_concurrency_reservations WHERE group_id=? ORDER BY member_id',
+      ).all(groupId) as ProviderSlotRow[]).map(mapProviderSlot);
+    },
     configure(command) {
       const now = command.now ?? Date.now();
       db.transaction(() => {

--- a/core/v4/worker/readOnlyRepositoryWorker.ts
+++ b/core/v4/worker/readOnlyRepositoryWorker.ts
@@ -86,6 +86,11 @@ export interface AdmitReadOnlyRepositoryWorkerInput {
   maxToolCalls?: number;
   maxRuntimeMs?: number;
   maxExternalCost?: number;
+  group?: {
+    groupId: string;
+    memberId: string;
+    ordinal: number;
+  };
 }
 
 export interface ReadOnlyRepositoryWorkerAdmission {
@@ -202,7 +207,9 @@ export function admitReadOnlyRepositoryWorker(
       && candidate.parentAttemptId === input.parent.attemptId
       && candidate.parentGeneration === input.parent.generation
       && !TERMINAL_JOB.has(input.engine.getJob(candidate.childJobId)?.status ?? 'unknown'));
-  if (activeOther) throw new Error('Only one active read-only repository Worker is permitted for a parent Attempt');
+  if (activeOther && input.group === undefined) {
+    throw new Error('Only one active read-only repository Worker is permitted for a parent Attempt');
+  }
 
   const providerBindingId = identity('worker_provider', requestIdentity);
   const contextEnvelopeId = identity('worker_context', requestIdentity);
@@ -360,6 +367,19 @@ export function admitReadOnlyRepositoryWorker(
     assignmentId: assignment.assignmentId,
     amounts: reservationAmounts,
   });
+  if (input.group) {
+    input.engine.worker.bindWorkerGroupMember({
+      ...authority,
+      groupId: input.group.groupId,
+      memberId: input.group.memberId,
+      assignmentId: assignment.assignmentId,
+      childJobId: child.jobId,
+      childAttemptId: child.attemptId,
+      childGeneration: 1,
+      providerBindingId: providerBinding.providerBindingId,
+      idempotencyKey: `${input.idempotencyKey}:group-member`,
+    });
+  }
   input.engine.appendJobEvent({
     jobId: input.parent.jobId,
     attemptId: input.parent.attemptId,

--- a/core/v4/worker/types.ts
+++ b/core/v4/worker/types.ts
@@ -179,6 +179,103 @@ export interface WorkerProviderCallReconciliationResult {
   readonly reconciledAt: number | null;
 }
 
+export type WorkerGroupPolicy = 'require_all' | 'allow_partial';
+
+export type WorkerGroupState =
+  | 'admitting'
+  | 'active'
+  | 'cancelling'
+  | 'timed_out'
+  | 'settling'
+  | 'settled'
+  | 'blocked_unknown';
+
+export type WorkerGroupMemberOutcome =
+  | 'pending'
+  | 'admitted'
+  | 'verified'
+  | 'rejected'
+  | 'failed'
+  | 'unknown'
+  | 'blocked'
+  | 'cancelled'
+  | 'timed_out';
+
+export interface WorkerGroupRecord {
+  readonly groupId: WorkerId;
+  readonly schemaVersion: 1;
+  readonly idempotencyKey: string;
+  readonly parentJobId: string;
+  readonly parentAttemptId: string;
+  readonly parentGeneration: number;
+  readonly parentFenceDigest: string;
+  readonly policy: WorkerGroupPolicy;
+  readonly state: WorkerGroupState;
+  readonly requestedMemberCount: number;
+  readonly admittedMemberCount: number;
+  readonly settledMemberCount: number;
+  readonly successfulMemberCount: number;
+  readonly failedMemberCount: number;
+  readonly unknownMemberCount: number;
+  readonly cancelledMemberCount: number;
+  readonly inputHash: string;
+  readonly aggregateHash: string | null;
+  readonly createdAt: number;
+  readonly cancellationRequestedAt: number | null;
+  readonly timeoutRequestedAt: number | null;
+  readonly settledAt: number | null;
+  readonly settlementVersion: number;
+  readonly settlementReason: string | null;
+}
+
+export interface WorkerGroupMemberRecord {
+  readonly groupId: WorkerId;
+  readonly memberId: WorkerId;
+  readonly ordinal: number;
+  readonly requestedProviderId: string;
+  readonly assignmentId: string | null;
+  readonly childJobId: string | null;
+  readonly childAttemptId: string | null;
+  readonly childGeneration: number | null;
+  readonly providerBindingId: string | null;
+  readonly outcome: WorkerGroupMemberOutcome;
+  readonly workerResultId: string | null;
+  readonly resultHash: string | null;
+  readonly joinedAt: number | null;
+  readonly settlementReason: string | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+export interface WorkerGroupAggregateMember {
+  readonly ordinal: number;
+  readonly memberId: string;
+  readonly assignmentId: string | null;
+  readonly childJobId: string | null;
+  readonly outcome: WorkerGroupMemberOutcome;
+  readonly workerResultId?: string | null;
+  readonly resultHash?: string | null;
+}
+
+export interface WorkerGroupAggregate {
+  readonly groupId: string;
+  readonly policy: WorkerGroupPolicy;
+  readonly outcome: 'verified' | 'partial' | 'failed' | 'unknown';
+  readonly counts: {
+    readonly total: number;
+    readonly verified: number;
+    readonly rejected: number;
+    readonly failed: number;
+    readonly unknown: number;
+    readonly blocked: number;
+    readonly cancelled: number;
+    readonly timedOut: number;
+    readonly pending: number;
+  };
+  readonly members: readonly WorkerGroupAggregateMember[];
+  readonly aggregateHash: string;
+}
+
 export interface WorkerContextEnvelopeRecord {
   readonly contextEnvelopeId: WorkerId;
   readonly schemaVersion: 1;
@@ -289,7 +386,13 @@ export type WorkerEventKind =
   | 'worker.run_bound'
   | 'worker.result_received'
   | 'worker.result_accepted'
-  | 'worker.result_rejected';
+  | 'worker.result_rejected'
+  | 'worker.group_created'
+  | 'worker.group_member_bound'
+  | 'worker.group_admission_completed'
+  | 'worker.group_member_settled'
+  | 'worker.group_interruption_requested'
+  | 'worker.group_settled';
 
 export type WorkerReferenceKind = 'worker_assignment' | 'worker_run' | 'child_attempt' | 'worker_result';
 

--- a/core/v4/worker/workerAuthority.ts
+++ b/core/v4/worker/workerAuthority.ts
@@ -14,6 +14,11 @@ import {
   type WorkerContextEnvelopeRecord,
   type WorkerEventKind,
   type WorkerEventRecord,
+  type WorkerGroupMemberOutcome,
+  type WorkerGroupMemberRecord,
+  type WorkerGroupPolicy,
+  type WorkerGroupRecord,
+  type WorkerGroupState,
   type WorkerProjection,
   type WorkerProviderBindingRecord,
   type WorkerResultPayloadV1,
@@ -116,6 +121,39 @@ interface RecordResultFromRunCommand extends ChildAuthorityCommand {
   now?: number;
 }
 
+interface CreateWorkerGroupCommand extends ParentAuthorityCommand {
+  groupId: string;
+  schemaVersion: 1;
+  policy: WorkerGroupPolicy;
+  members: ReadonlyArray<{ memberId: string; ordinal: number; requestedProviderId: string }>;
+}
+
+interface BindWorkerGroupMemberCommand extends ParentAuthorityCommand {
+  groupId: string;
+  memberId: string;
+  assignmentId: string;
+  childJobId: string;
+  childAttemptId: string;
+  childGeneration: number;
+  providerBindingId: string;
+}
+
+interface SettleWorkerGroupMemberCommand extends ParentAuthorityCommand {
+  groupId: string;
+  memberId: string;
+  outcome: Exclude<WorkerGroupMemberOutcome, 'pending' | 'admitted'>;
+  workerResultId?: string | null;
+  resultHash?: string | null;
+  reason: string;
+}
+
+interface SettleWorkerGroupCommand extends ParentAuthorityCommand {
+  groupId: string;
+  state: 'settled' | 'blocked_unknown';
+  aggregateHash: string;
+  reason: string;
+}
+
 export interface WorkerAuthority {
   createWorkerProviderBinding(command: ProviderBindingCommand): WorkerProviderBindingRecord;
   createWorkerContextEnvelope(command: ContextEnvelopeCommand): WorkerContextEnvelopeRecord;
@@ -124,6 +162,45 @@ export interface WorkerAuthority {
   bindWorkerRunFromAssignment(command: BindRunFromAssignmentCommand): WorkerRunRecord;
   recordWorkerResult(command: RecordResultCommand): WorkerResultRecord;
   recordWorkerResultFromRun(command: RecordResultFromRunCommand): WorkerResultRecord;
+  createWorkerGroup(command: CreateWorkerGroupCommand): WorkerGroupRecord;
+  bindWorkerGroupMember(command: BindWorkerGroupMemberCommand): WorkerGroupMemberRecord;
+  completeWorkerGroupAdmission(command: ParentAuthorityCommand & { groupId: string }): WorkerGroupRecord;
+  settleWorkerGroupMember(command: SettleWorkerGroupMemberCommand): WorkerGroupMemberRecord;
+  reconcileWorkerGroupMember(command: {
+    groupId: string;
+    memberId: string;
+    outcome: Exclude<WorkerGroupMemberOutcome, 'pending' | 'admitted' | 'verified'>;
+    reason: string;
+    producer: string;
+    idempotencyKey: string;
+    now?: number;
+  }): WorkerGroupMemberRecord;
+  requestWorkerGroupInterruption(command: ParentAuthorityCommand & {
+    groupId: string;
+    kind: 'cancellation' | 'timeout';
+    reason: string;
+  }): WorkerGroupRecord;
+  requestWorkerGroupInterruptionForParent(command: ParentAuthorityCommand & {
+    kind: 'cancellation' | 'timeout';
+    reason: string;
+  }): number;
+  settleWorkerGroup(command: SettleWorkerGroupCommand): WorkerGroupRecord;
+  reconcileWorkerGroup(command: {
+    groupId: string;
+    state: 'settled' | 'blocked_unknown';
+    aggregateHash: string;
+    reason: string;
+    producer: string;
+    idempotencyKey: string;
+    now?: number;
+  }): WorkerGroupRecord;
+  getWorkerGroup(groupId: string): WorkerGroupRecord | null;
+  getWorkerGroupMember(memberId: string): WorkerGroupMemberRecord | null;
+  getWorkerGroupMemberForAssignment(assignmentId: string): WorkerGroupMemberRecord | null;
+  getWorkerGroupForAssignment(assignmentId: string): WorkerGroupRecord | null;
+  listWorkerGroupMembers(groupId: string): WorkerGroupMemberRecord[];
+  listWorkerGroupsForParent(parentJobId: string): WorkerGroupRecord[];
+  listWorkerGroupsPendingSettlement(input?: { limit?: number; afterGroupId?: string }): WorkerGroupRecord[];
   getWorkerAssignment(id: string): WorkerAssignmentRecord | null;
   getWorkerRun(id: string): WorkerRunRecord | null;
   getWorkerProviderBinding(id: string): WorkerProviderBindingRecord | null;
@@ -152,6 +229,25 @@ type RunRow = {
   child_job_id: string; child_attempt_id: string; child_generation: number;
   execution_graph_node_id: string | null; provider_binding_id: string; context_envelope_id: string;
   accepted_result_id: string | null; created_at: number;
+};
+
+type GroupRow = {
+  group_id: string; schema_version: number; idempotency_key: string;
+  parent_job_id: string; parent_attempt_id: string; parent_generation: number; parent_fence_digest: string;
+  policy: WorkerGroupPolicy; state: WorkerGroupState; requested_member_count: number;
+  admitted_member_count: number; settled_member_count: number; successful_member_count: number;
+  failed_member_count: number; unknown_member_count: number; cancelled_member_count: number;
+  input_hash: string; aggregate_hash: string | null; created_at: number;
+  cancellation_requested_at: number | null; timeout_requested_at: number | null;
+  settled_at: number | null; settlement_version: number; settlement_reason: string | null;
+};
+
+type GroupMemberRow = {
+  group_id: string; member_id: string; ordinal: number; requested_provider_id: string;
+  assignment_id: string | null; child_job_id: string | null; child_attempt_id: string | null;
+  child_generation: number | null; provider_binding_id: string | null; outcome: WorkerGroupMemberOutcome;
+  worker_result_id: string | null; result_hash: string | null; joined_at: number | null;
+  settlement_reason: string | null; created_at: number; updated_at: number;
 };
 
 type BindingRow = {
@@ -252,6 +348,34 @@ function mapResult(row: ResultRow): WorkerResultRecord {
     acceptanceState: row.acceptance_state, rejectionCode: row.rejection_code,
     rejectionReason: row.rejection_reason, createdAt: row.created_at,
     acceptedAt: row.accepted_at, rejectedAt: row.rejected_at,
+  };
+}
+
+function mapGroup(row: GroupRow): WorkerGroupRecord {
+  return {
+    groupId: row.group_id, schemaVersion: 1, idempotencyKey: row.idempotency_key,
+    parentJobId: row.parent_job_id, parentAttemptId: row.parent_attempt_id,
+    parentGeneration: row.parent_generation, parentFenceDigest: row.parent_fence_digest,
+    policy: row.policy, state: row.state, requestedMemberCount: row.requested_member_count,
+    admittedMemberCount: row.admitted_member_count, settledMemberCount: row.settled_member_count,
+    successfulMemberCount: row.successful_member_count, failedMemberCount: row.failed_member_count,
+    unknownMemberCount: row.unknown_member_count, cancelledMemberCount: row.cancelled_member_count,
+    inputHash: row.input_hash, aggregateHash: row.aggregate_hash, createdAt: row.created_at,
+    cancellationRequestedAt: row.cancellation_requested_at, timeoutRequestedAt: row.timeout_requested_at,
+    settledAt: row.settled_at, settlementVersion: row.settlement_version,
+    settlementReason: row.settlement_reason,
+  };
+}
+
+function mapGroupMember(row: GroupMemberRow): WorkerGroupMemberRecord {
+  return {
+    groupId: row.group_id, memberId: row.member_id, ordinal: row.ordinal,
+    requestedProviderId: row.requested_provider_id, assignmentId: row.assignment_id,
+    childJobId: row.child_job_id, childAttemptId: row.child_attempt_id,
+    childGeneration: row.child_generation, providerBindingId: row.provider_binding_id,
+    outcome: row.outcome, workerResultId: row.worker_result_id, resultHash: row.result_hash,
+    joinedAt: row.joined_at, settlementReason: row.settlement_reason,
+    createdAt: row.created_at, updatedAt: row.updated_at,
   };
 }
 
@@ -449,6 +573,14 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
   const getResult = (id: string): WorkerResultRecord | null => {
     const row = db.prepare('SELECT * FROM worker_results WHERE worker_result_id=?').get(id) as ResultRow | undefined;
     return row ? mapResult(row) : null;
+  };
+  const getGroup = (id: string): WorkerGroupRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_groups WHERE group_id=?').get(id) as GroupRow | undefined;
+    return row ? mapGroup(row) : null;
+  };
+  const getGroupMember = (id: string): WorkerGroupMemberRecord | null => {
+    const row = db.prepare('SELECT * FROM worker_group_members WHERE member_id=?').get(id) as GroupMemberRow | undefined;
+    return row ? mapGroupMember(row) : null;
   };
 
   const parentFence = (command: ParentAuthorityCommand): { runId: number } => {
@@ -917,6 +1049,368 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
     return getResult(command.workerResultId)!;
   }).immediate;
 
+  const refreshGroupCounts = (groupId: string, now: number): WorkerGroupRecord => {
+    const counts = db.prepare(
+      `SELECT COUNT(*) AS total,
+              SUM(CASE WHEN assignment_id IS NOT NULL THEN 1 ELSE 0 END) AS admitted,
+              SUM(CASE WHEN outcome NOT IN ('pending','admitted') THEN 1 ELSE 0 END) AS settled,
+              SUM(CASE WHEN outcome='verified' THEN 1 ELSE 0 END) AS successful,
+              SUM(CASE WHEN outcome IN ('rejected','failed','blocked','timed_out') THEN 1 ELSE 0 END) AS failed,
+              SUM(CASE WHEN outcome='unknown' THEN 1 ELSE 0 END) AS unknown_count,
+              SUM(CASE WHEN outcome='cancelled' THEN 1 ELSE 0 END) AS cancelled
+         FROM worker_group_members WHERE group_id=?`,
+    ).get(groupId) as {
+      total: number; admitted: number | null; settled: number | null; successful: number | null;
+      failed: number | null; unknown_count: number | null; cancelled: number | null;
+    };
+    db.prepare(
+      `UPDATE worker_groups
+          SET admitted_member_count=?,settled_member_count=?,successful_member_count=?,
+              failed_member_count=?,unknown_member_count=?,cancelled_member_count=?,
+              state=CASE WHEN state='admitting' AND ?=requested_member_count THEN 'active' ELSE state END
+        WHERE group_id=?`,
+    ).run(
+      counts.admitted ?? 0, counts.settled ?? 0, counts.successful ?? 0,
+      counts.failed ?? 0, counts.unknown_count ?? 0, counts.cancelled ?? 0,
+      counts.admitted ?? 0, groupId,
+    );
+    const group = getGroup(groupId);
+    if (!group) throw new WorkerAuthorityError('not_found', 'Worker group was not found');
+    void now;
+    return group;
+  };
+
+  const createGroup = db.transaction((command: CreateWorkerGroupCommand): WorkerGroupRecord => {
+    assertId(command.groupId, 'Worker group identity');
+    assertId(command.idempotencyKey, 'Worker group idempotency key');
+    if (command.schemaVersion !== 1 || !['require_all', 'allow_partial'].includes(command.policy)) {
+      throw new WorkerAuthorityError('invalid_contract', 'Worker group contract is invalid');
+    }
+    if (command.members.length < 1 || command.members.length > 4) {
+      throw new WorkerAuthorityError('limit_exceeded', 'Worker group size exceeds the maximum of 4');
+    }
+    const memberIds = new Set<string>();
+    const ordinals = new Set<number>();
+    for (const member of command.members) {
+      assertId(member.memberId, 'Worker group member identity');
+      assertString(member.requestedProviderId, 'Worker group provider identity', 192);
+      if (!Number.isSafeInteger(member.ordinal) || member.ordinal < 1 || member.ordinal > 4
+        || memberIds.has(member.memberId) || ordinals.has(member.ordinal)) {
+        throw new WorkerAuthorityError('invalid_contract', 'Worker group member identity or ordinal is invalid');
+      }
+      memberIds.add(member.memberId);
+      ordinals.add(member.ordinal);
+    }
+    const inputHash = computeWorkerDigest({
+      groupId: command.groupId, parentJobId: command.parentJobId,
+      parentAttemptId: command.parentAttemptId, parentGeneration: command.parentGeneration,
+      policy: command.policy,
+      members: [...command.members].sort((a, b) => a.ordinal - b.ordinal || a.memberId.localeCompare(b.memberId)),
+    });
+    const existing = db.prepare(
+      `SELECT * FROM worker_groups
+        WHERE parent_job_id=? AND parent_attempt_id=? AND parent_generation=? AND idempotency_key=?`,
+    ).get(
+      command.parentJobId, command.parentAttemptId, command.parentGeneration, command.idempotencyKey,
+    ) as GroupRow | undefined;
+    if (existing) {
+      if (existing.group_id !== command.groupId || existing.input_hash !== inputHash) {
+        throw new WorkerAuthorityError('idempotency_conflict', 'Worker group idempotency key has different input');
+      }
+      return mapGroup(existing);
+    }
+    if (getGroup(command.groupId)) throw new WorkerAuthorityError('immutable_conflict', 'Worker group identity already exists');
+    const { runId } = parentFence(command);
+    const now = command.now ?? Date.now();
+    const parentFenceDigest = createHash('sha256').update(command.parentFenceToken).digest('hex');
+    db.prepare(
+      `INSERT INTO worker_groups
+         (group_id,schema_version,idempotency_key,parent_job_id,parent_attempt_id,parent_generation,
+          parent_fence_digest,policy,state,requested_member_count,input_hash,created_at)
+       VALUES (?,?,?,?,?,?,?,?,'admitting',?,?,?)`,
+    ).run(
+      command.groupId, 1, command.idempotencyKey, command.parentJobId, command.parentAttemptId,
+      command.parentGeneration, parentFenceDigest, command.policy, command.members.length, inputHash, now,
+    );
+    const insert = db.prepare(
+      `INSERT INTO worker_group_members
+         (group_id,member_id,ordinal,requested_provider_id,outcome,created_at,updated_at)
+       VALUES (?,?,?,?,'pending',?,?)`,
+    );
+    for (const member of command.members) {
+      insert.run(command.groupId, member.memberId, member.ordinal, member.requestedProviderId, now, now);
+    }
+    append(command, runId, 'worker.group_created', {
+      groupId: command.groupId, policy: command.policy, memberCount: command.members.length,
+    }, `group-created:${command.groupId}`);
+    return getGroup(command.groupId)!;
+  }).immediate;
+
+  const bindGroupMember = db.transaction((command: BindWorkerGroupMemberCommand): WorkerGroupMemberRecord => {
+    const { runId } = parentFence(command);
+    const group = getGroup(command.groupId);
+    const member = getGroupMember(command.memberId);
+    const assignment = getAssignment(command.assignmentId);
+    const binding = getBinding(command.providerBindingId);
+    if (!group || !member || member.groupId !== group.groupId
+      || group.parentJobId !== command.parentJobId || group.parentAttemptId !== command.parentAttemptId
+      || group.parentGeneration !== command.parentGeneration || !assignment
+      || assignment.parentJobId !== command.parentJobId || assignment.parentAttemptId !== command.parentAttemptId
+      || assignment.parentGeneration !== command.parentGeneration || assignment.childJobId !== command.childJobId
+      || assignment.providerBindingId !== command.providerBindingId || !binding
+      || binding.providerId !== member.requestedProviderId) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Worker group member lineage is invalid');
+    }
+    const same = member.assignmentId === command.assignmentId && member.childJobId === command.childJobId
+      && member.childAttemptId === command.childAttemptId && member.childGeneration === command.childGeneration
+      && member.providerBindingId === command.providerBindingId;
+    if (member.assignmentId !== null) {
+      if (!same) throw new WorkerAuthorityError('immutable_conflict', 'Worker group member binding is immutable');
+      return member;
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_group_members
+          SET assignment_id=?,child_job_id=?,child_attempt_id=?,child_generation=?,provider_binding_id=?,
+              outcome='admitted',updated_at=? WHERE member_id=? AND group_id=? AND assignment_id IS NULL`,
+    ).run(
+      command.assignmentId, command.childJobId, command.childAttemptId, command.childGeneration,
+      command.providerBindingId, now, command.memberId, command.groupId,
+    );
+    refreshGroupCounts(command.groupId, now);
+    append(command, runId, 'worker.group_member_bound', {
+      groupId: command.groupId, memberId: command.memberId, ordinal: member.ordinal,
+      assignmentId: command.assignmentId, childJobId: command.childJobId,
+    }, `group-member-bound:${command.memberId}`);
+    return getGroupMember(command.memberId)!;
+  }).immediate;
+
+  const settleGroupMember = db.transaction((command: SettleWorkerGroupMemberCommand): WorkerGroupMemberRecord => {
+    const { runId } = parentFence(command);
+    assertString(command.reason, 'Worker group settlement reason', 192);
+    const group = getGroup(command.groupId);
+    const member = getGroupMember(command.memberId);
+    if (!group || !member || member.groupId !== group.groupId
+      || group.parentJobId !== command.parentJobId || group.parentAttemptId !== command.parentAttemptId
+      || group.parentGeneration !== command.parentGeneration) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Worker group settlement lineage is invalid');
+    }
+    const resultId = command.workerResultId ?? null;
+    const resultHash = command.resultHash ?? null;
+    if (command.outcome === 'verified') {
+      const result = resultId ? getResult(resultId) : null;
+      const verification = result ? db.prepare(
+        `SELECT 1 FROM run_events
+          WHERE job_id=? AND attempt_id=? AND generation=?
+            AND kind='worker.parent_verification_completed'
+            AND json_extract(payload,'$.workerResultId')=? LIMIT 1`,
+      ).get(
+        command.parentJobId, command.parentAttemptId, command.parentGeneration, result.workerResultId,
+      ) : undefined;
+      if (!result || result.acceptanceState !== 'accepted' || result.assignmentId !== member.assignmentId
+        || result.resultHash !== resultHash || !verification) {
+        throw new WorkerAuthorityError(
+          'verification_required',
+          'Verified group member requires an independently verified exact Worker result',
+        );
+      }
+    }
+    if (!['pending', 'admitted'].includes(member.outcome)) {
+      const same = member.outcome === command.outcome && member.workerResultId === resultId
+        && member.resultHash === resultHash && member.settlementReason === command.reason;
+      if (!same) throw new WorkerAuthorityError('final_result_conflict', 'Worker group member result cannot be replaced');
+      return member;
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_group_members SET outcome=?,worker_result_id=?,result_hash=?,joined_at=?,
+              settlement_reason=?,updated_at=? WHERE member_id=? AND group_id=?`,
+    ).run(command.outcome, resultId, resultHash, now, command.reason, now, command.memberId, command.groupId);
+    refreshGroupCounts(command.groupId, now);
+    append(command, runId, 'worker.group_member_settled', {
+      groupId: command.groupId, memberId: command.memberId, outcome: command.outcome,
+      workerResultId: resultId, resultHash,
+    }, `group-member-settled:${command.memberId}`);
+    return getGroupMember(command.memberId)!;
+  }).immediate;
+
+  const completeGroupAdmission = db.transaction((
+    command: ParentAuthorityCommand & { groupId: string },
+  ): WorkerGroupRecord => {
+    const { runId } = parentFence(command);
+    const group = refreshGroupCounts(command.groupId, command.now ?? Date.now());
+    if (group.parentJobId !== command.parentJobId || group.parentAttemptId !== command.parentAttemptId
+      || group.parentGeneration !== command.parentGeneration) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Worker group admission lineage is invalid');
+    }
+    if (group.state !== 'admitting') return group;
+    const unresolved = db.prepare(
+      `SELECT COUNT(*) AS count FROM worker_group_members
+        WHERE group_id=? AND assignment_id IS NULL AND outcome='pending'`,
+    ).get(command.groupId) as { count: number };
+    if (unresolved.count !== 0) {
+      throw new WorkerAuthorityError('incomplete_group', 'Worker group admission has unresolved members');
+    }
+    db.prepare("UPDATE worker_groups SET state='active',settlement_version=settlement_version+1 WHERE group_id=?")
+      .run(command.groupId);
+    append(command, runId, 'worker.group_admission_completed', {
+      groupId: command.groupId,
+      admittedMemberCount: group.admittedMemberCount,
+      rejectedMemberCount: group.requestedMemberCount - group.admittedMemberCount,
+    }, `group-admission-completed:${command.groupId}`);
+    return getGroup(command.groupId)!;
+  }).immediate;
+
+  const groupProjectionRun = (group: WorkerGroupRecord): number => {
+    const row = db.prepare(
+      'SELECT id FROM runs WHERE task_id=? AND attempt_id=? AND generation=?',
+    ).get(group.parentJobId, group.parentAttemptId, group.parentGeneration) as { id: number } | undefined;
+    if (!row) throw new WorkerAuthorityError('lineage_mismatch', 'Worker group parent Attempt is unavailable');
+    return row.id;
+  };
+
+  const appendGroupProjection = (
+    group: WorkerGroupRecord,
+    runId: number,
+    producer: string,
+    idempotencyKey: string,
+    kind: WorkerEventKind,
+    payload: Record<string, unknown>,
+  ): void => {
+    deps.appendOrderedEvent({
+      jobId: group.parentJobId,
+      runId,
+      attemptId: group.parentAttemptId,
+      generation: group.parentGeneration,
+      kind,
+      payload,
+      producer,
+      idempotencyKey,
+    });
+  };
+
+  const reconcileGroupMember = db.transaction((command: Parameters<WorkerAuthority['reconcileWorkerGroupMember']>[0]) => {
+    assertString(command.reason, 'Worker group reconciliation reason', 192);
+    const group = getGroup(command.groupId);
+    const member = getGroupMember(command.memberId);
+    if (!group || !member || member.groupId !== group.groupId) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Worker group reconciliation lineage is invalid');
+    }
+    if (!['pending', 'admitted'].includes(member.outcome)) {
+      if (member.outcome !== command.outcome || member.settlementReason !== command.reason) {
+        throw new WorkerAuthorityError('final_result_conflict', 'Worker group member result cannot be replaced');
+      }
+      return member;
+    }
+    const child = member.childJobId ? db.prepare('SELECT status FROM tasks WHERE id=?')
+      .get(member.childJobId) as { status: string } | undefined : undefined;
+    const canonical = command.outcome === 'rejected'
+      ? member.childJobId === null && member.assignmentId === null
+      : command.outcome === 'timed_out'
+        ? group.timeoutRequestedAt !== null && child?.status === 'cancelled'
+        : command.outcome === 'cancelled'
+          ? child?.status === 'cancelled'
+          : command.outcome === 'failed'
+            ? ['failed', 'crashed', 'dead_letter'].includes(child?.status ?? '')
+            : command.outcome === 'blocked'
+              ? child?.status === 'blocked'
+              : command.outcome === 'unknown' && child?.status === 'unknown';
+    if (!canonical) {
+      throw new WorkerAuthorityError('verification_required', 'Worker group projection does not match canonical child state');
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_group_members SET outcome=?,joined_at=?,settlement_reason=?,updated_at=?
+        WHERE group_id=? AND member_id=? AND outcome IN ('pending','admitted')`,
+    ).run(command.outcome, now, command.reason, now, group.groupId, member.memberId);
+    refreshGroupCounts(group.groupId, now);
+    appendGroupProjection(
+      group, groupProjectionRun(group), command.producer, command.idempotencyKey,
+      'worker.group_member_settled',
+      { groupId: group.groupId, memberId: member.memberId, outcome: command.outcome },
+    );
+    return getGroupMember(member.memberId)!;
+  }).immediate;
+
+  const requestGroupInterruption = db.transaction((command: ParentAuthorityCommand & {
+    groupId: string; kind: 'cancellation' | 'timeout'; reason: string;
+  }): WorkerGroupRecord => {
+    const { runId } = parentFence(command);
+    const group = getGroup(command.groupId);
+    if (!group || group.parentJobId !== command.parentJobId || group.parentAttemptId !== command.parentAttemptId
+      || group.parentGeneration !== command.parentGeneration) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Worker group interruption lineage is invalid');
+    }
+    const timestamp = command.kind === 'cancellation' ? group.cancellationRequestedAt : group.timeoutRequestedAt;
+    if (timestamp !== null) return group;
+    const now = command.now ?? Date.now();
+    const column = command.kind === 'cancellation' ? 'cancellation_requested_at' : 'timeout_requested_at';
+    const state = command.kind === 'cancellation' ? 'cancelling' : 'timed_out';
+    db.prepare(
+      `UPDATE worker_groups SET ${column}=?,state=?,settlement_reason=?,settlement_version=settlement_version+1
+        WHERE group_id=?`,
+    ).run(now, state, command.reason, command.groupId);
+    append(command, runId, 'worker.group_interruption_requested', {
+      groupId: command.groupId, kind: command.kind, reason: command.reason,
+    }, `group-${command.kind}-requested:${command.groupId}`);
+    return getGroup(command.groupId)!;
+  }).immediate;
+
+  const settleGroup = db.transaction((command: SettleWorkerGroupCommand): WorkerGroupRecord => {
+    const { runId } = parentFence(command);
+    assertHash(command.aggregateHash, 'Worker group aggregate hash');
+    assertString(command.reason, 'Worker group settlement reason', 192);
+    const group = refreshGroupCounts(command.groupId, command.now ?? Date.now());
+    if (group.parentJobId !== command.parentJobId || group.parentAttemptId !== command.parentAttemptId
+      || group.parentGeneration !== command.parentGeneration) {
+      throw new WorkerAuthorityError('lineage_mismatch', 'Worker group settlement lineage is invalid');
+    }
+    if (group.state === 'settled' || group.state === 'blocked_unknown') {
+      if (group.state !== command.state || group.aggregateHash !== command.aggregateHash) {
+        throw new WorkerAuthorityError('final_result_conflict', 'Worker group aggregate cannot be replaced');
+      }
+      return group;
+    }
+    if (group.settledMemberCount !== group.requestedMemberCount) {
+      throw new WorkerAuthorityError('incomplete_group', 'Worker group cannot settle before every member is represented');
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_groups SET state=?,aggregate_hash=?,settled_at=?,settlement_reason=?,
+              settlement_version=settlement_version+1 WHERE group_id=?`,
+    ).run(command.state, command.aggregateHash, now, command.reason, command.groupId);
+    append(command, runId, 'worker.group_settled', {
+      groupId: command.groupId, state: command.state, aggregateHash: command.aggregateHash,
+    }, `group-settled:${command.groupId}`);
+    return getGroup(command.groupId)!;
+  }).immediate;
+
+  const reconcileGroup = db.transaction((command: Parameters<WorkerAuthority['reconcileWorkerGroup']>[0]) => {
+    assertHash(command.aggregateHash, 'Worker group aggregate hash');
+    assertString(command.reason, 'Worker group reconciliation reason', 192);
+    const group = refreshGroupCounts(command.groupId, command.now ?? Date.now());
+    if (group.state === 'settled' || group.state === 'blocked_unknown') {
+      if (group.state !== command.state || group.aggregateHash !== command.aggregateHash) {
+        throw new WorkerAuthorityError('final_result_conflict', 'Worker group aggregate cannot be replaced');
+      }
+      return group;
+    }
+    if (group.settledMemberCount !== group.requestedMemberCount) {
+      throw new WorkerAuthorityError('incomplete_group', 'Worker group cannot settle before every member is represented');
+    }
+    const now = command.now ?? Date.now();
+    db.prepare(
+      `UPDATE worker_groups SET state=?,aggregate_hash=?,settled_at=?,settlement_reason=?,
+              settlement_version=settlement_version+1 WHERE group_id=?`,
+    ).run(command.state, command.aggregateHash, now, command.reason, group.groupId);
+    appendGroupProjection(
+      group, groupProjectionRun(group), command.producer, command.idempotencyKey,
+      'worker.group_settled',
+      { groupId: group.groupId, state: command.state, aggregateHash: command.aggregateHash },
+    );
+    return getGroup(group.groupId)!;
+  }).immediate;
+
   const listEvents = (parentJobId: string): WorkerEventRecord[] => (
     db.prepare(
       `SELECT job_sequence,kind,payload,ts FROM run_events
@@ -963,6 +1457,64 @@ export function createWorkerAuthority(deps: WorkerAuthorityDeps): WorkerAuthorit
         assignmentId: command.assignmentId,
         payload: command.payload,
       });
+    },
+    createWorkerGroup: createGroup,
+    bindWorkerGroupMember: bindGroupMember,
+    completeWorkerGroupAdmission: completeGroupAdmission,
+    settleWorkerGroupMember: settleGroupMember,
+    reconcileWorkerGroupMember: reconcileGroupMember,
+    requestWorkerGroupInterruption: requestGroupInterruption,
+    requestWorkerGroupInterruptionForParent(command) {
+      return db.transaction(() => {
+        const groups = (db.prepare(
+          `SELECT * FROM worker_groups
+            WHERE parent_job_id=? AND parent_attempt_id=? AND parent_generation=?
+              AND state NOT IN ('settled','blocked_unknown')
+            ORDER BY created_at,group_id`,
+        ).all(command.parentJobId, command.parentAttemptId, command.parentGeneration) as GroupRow[]).map(mapGroup);
+        for (const group of groups) {
+          requestGroupInterruption({
+            ...command,
+            groupId: group.groupId,
+            idempotencyKey: `${command.idempotencyKey}:${group.groupId}`,
+          });
+        }
+        return groups.length;
+      }).immediate();
+    },
+    settleWorkerGroup: settleGroup,
+    reconcileWorkerGroup: reconcileGroup,
+    getWorkerGroup: getGroup,
+    getWorkerGroupMember: getGroupMember,
+    getWorkerGroupMemberForAssignment(assignmentId) {
+      const row = db.prepare('SELECT * FROM worker_group_members WHERE assignment_id=?')
+        .get(assignmentId) as GroupMemberRow | undefined;
+      return row ? mapGroupMember(row) : null;
+    },
+    getWorkerGroupForAssignment(assignmentId) {
+      const row = db.prepare(
+        `SELECT g.* FROM worker_groups g JOIN worker_group_members m ON m.group_id=g.group_id
+          WHERE m.assignment_id=?`,
+      ).get(assignmentId) as GroupRow | undefined;
+      return row ? mapGroup(row) : null;
+    },
+    listWorkerGroupMembers(groupId) {
+      return (db.prepare(
+        'SELECT * FROM worker_group_members WHERE group_id=? ORDER BY ordinal,member_id',
+      ).all(groupId) as GroupMemberRow[]).map(mapGroupMember);
+    },
+    listWorkerGroupsForParent(parentJobId) {
+      return (db.prepare(
+        'SELECT * FROM worker_groups WHERE parent_job_id=? ORDER BY created_at,group_id',
+      ).all(parentJobId) as GroupRow[]).map(mapGroup);
+    },
+    listWorkerGroupsPendingSettlement(input = {}) {
+      const limit = Math.max(1, Math.min(input.limit ?? 100, 1_000));
+      return (db.prepare(
+        `SELECT * FROM worker_groups
+          WHERE group_id>? AND state NOT IN ('settled','blocked_unknown')
+          ORDER BY group_id LIMIT ?`,
+      ).all(input.afterGroupId ?? '', limit) as GroupRow[]).map(mapGroup);
     },
     getWorkerAssignment: getAssignment,
     getWorkerRun: getRun,

--- a/core/v4/worker/workerParallel.ts
+++ b/core/v4/worker/workerParallel.ts
@@ -1,0 +1,524 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import type { JobEngine } from '../daemon/jobEngine';
+import type { TriggerBus } from '../daemon/triggerBus';
+import {
+  admitReadOnlyRepositoryWorker,
+  verifyReadOnlyRepositoryWorkerResult,
+  type AdmitReadOnlyRepositoryWorkerInput,
+  type ReadOnlyRepositoryWorkerAdmission,
+  type ReadOnlyWorkerParentAuthority,
+  type ReadOnlyWorkerProviderSelection,
+} from './readOnlyRepositoryWorker';
+import {
+  computeWorkerDigest,
+  type WorkerGroupAggregate,
+  type WorkerGroupAggregateMember,
+  type WorkerGroupMemberOutcome,
+  type WorkerGroupPolicy,
+  type WorkerGroupRecord,
+} from './types';
+
+export const DEFAULT_READ_ONLY_WORKER_GROUP_SIZE = 2;
+export const MAX_READ_ONLY_WORKER_GROUP_SIZE = 4;
+export const DEFAULT_WORKER_PROVIDER_CONCURRENCY = 2;
+
+export function normalizeReadOnlyWorkerGroupSize(
+  requested?: number,
+  restrictions: { depth?: number; mutation?: boolean } = {},
+): number {
+  if ((restrictions.depth ?? 0) !== 0) throw new Error('Nested Worker admission is forbidden');
+  if (restrictions.mutation === true) throw new Error('Worker mutation is forbidden');
+  const size = requested ?? DEFAULT_READ_ONLY_WORKER_GROUP_SIZE;
+  if (!Number.isSafeInteger(size) || size < 1) throw new Error('Worker group size must be a positive integer');
+  if (size > MAX_READ_ONLY_WORKER_GROUP_SIZE) {
+    throw new Error(`Worker group size exceeds the maximum of ${MAX_READ_ONLY_WORKER_GROUP_SIZE}`);
+  }
+  return size;
+}
+
+export function buildWorkerGroupAggregate(
+  groupId: string,
+  policy: WorkerGroupPolicy,
+  inputMembers: readonly WorkerGroupAggregateMember[],
+): WorkerGroupAggregate {
+  const members = inputMembers.map((member) => ({
+    ordinal: member.ordinal,
+    memberId: member.memberId,
+    assignmentId: member.assignmentId ?? null,
+    childJobId: member.childJobId ?? null,
+    outcome: member.outcome,
+    workerResultId: member.workerResultId ?? null,
+    resultHash: member.resultHash ?? null,
+  })).sort((left, right) => left.ordinal - right.ordinal || left.memberId.localeCompare(right.memberId));
+  const count = (outcome: WorkerGroupMemberOutcome): number => members.filter((item) => item.outcome === outcome).length;
+  const counts = {
+    total: members.length,
+    verified: count('verified'),
+    rejected: count('rejected'),
+    failed: count('failed'),
+    unknown: count('unknown'),
+    blocked: count('blocked'),
+    cancelled: count('cancelled'),
+    timedOut: count('timed_out'),
+    pending: count('pending') + count('admitted'),
+  };
+  const allVerified = counts.total > 0 && counts.verified === counts.total;
+  const uncertain = counts.unknown > 0 || counts.pending > 0;
+  const outcome: WorkerGroupAggregate['outcome'] = allVerified
+    ? 'verified'
+    : policy === 'allow_partial' && counts.verified > 0
+      ? 'partial'
+      : uncertain ? 'unknown' : 'failed';
+  const unsigned = { groupId, policy, outcome, counts, members };
+  return { ...unsigned, aggregateHash: computeWorkerDigest(unsigned) };
+}
+
+export interface ReadOnlyWorkerGroupMemberInput {
+  goal: string;
+  provider: ReadOnlyWorkerProviderSelection;
+  boundedParentNote?: string | null;
+  planStepIds?: readonly string[];
+  claimIds?: readonly string[];
+  sourceReferenceIds?: readonly string[];
+  instructionReferenceIds?: readonly string[];
+  maxModelCalls?: number;
+  maxToolCalls?: number;
+  maxRuntimeMs?: number;
+  maxExternalCost?: number;
+  providerConcurrencyLimit?: number;
+}
+
+export interface AdmitReadOnlyRepositoryWorkerGroupInput {
+  engine: JobEngine;
+  triggerBus: TriggerBus;
+  parent: ReadOnlyWorkerParentAuthority;
+  idempotencyKey: string;
+  policy: WorkerGroupPolicy;
+  repositorySnapshotId: string;
+  members?: readonly ReadOnlyWorkerGroupMemberInput[];
+  memberTemplate?: ReadOnlyWorkerGroupMemberInput;
+  memberCount?: number;
+  parentConcurrencyLimit?: number;
+  providerConcurrencyLimit?: number;
+  producer?: string;
+  depth?: number;
+  mutation?: boolean;
+}
+
+export interface ReadOnlyRepositoryWorkerGroupAdmission {
+  group: WorkerGroupRecord;
+  admissions: ReadonlyArray<{ memberId: string; ordinal: number; admission: ReadOnlyRepositoryWorkerAdmission }>;
+  failures: ReadonlyArray<{ memberId: string; ordinal: number; error: string }>;
+}
+
+function identity(prefix: string, value: unknown): string {
+  return `${prefix}_${computeWorkerDigest(value).slice(0, 32)}`;
+}
+
+function groupMembers(input: AdmitReadOnlyRepositoryWorkerGroupInput): readonly ReadOnlyWorkerGroupMemberInput[] {
+  if (input.members) {
+    normalizeReadOnlyWorkerGroupSize(input.members.length, { depth: input.depth, mutation: input.mutation });
+    return input.members;
+  }
+  if (!input.memberTemplate) throw new Error('Worker group requires members or a member template');
+  const size = normalizeReadOnlyWorkerGroupSize(input.memberCount, { depth: input.depth, mutation: input.mutation });
+  return Array.from({ length: size }, () => input.memberTemplate!);
+}
+
+function ensureParentConcurrency(
+  input: AdmitReadOnlyRepositoryWorkerGroupInput,
+  memberCount: number,
+  existingGroup: boolean,
+): number {
+  const requested = input.parentConcurrencyLimit ?? DEFAULT_READ_ONLY_WORKER_GROUP_SIZE;
+  if (!Number.isSafeInteger(requested) || requested < 1 || requested > MAX_READ_ONLY_WORKER_GROUP_SIZE) {
+    throw new Error('Parent Worker concurrency limit must be between 1 and 4');
+  }
+  if (memberCount > requested) throw new Error('Worker group exceeds the parent concurrency limit');
+  const existing = input.engine.resources.getBudgets(input.parent.jobId).find((budget) => budget.kind === 'workers');
+  if (!existing || existing.limit === null) {
+    input.engine.resources.configure({ jobId: input.parent.jobId, budgets: { workers: requested } });
+  }
+  else if (!existingGroup && existing.limit !== null
+    && memberCount > input.engine.resources.available(input.parent.jobId, 'workers')!) {
+    throw new Error('Worker group exceeds available parent Worker capacity');
+  }
+  return requested;
+}
+
+export function admitReadOnlyRepositoryWorkerGroup(
+  input: AdmitReadOnlyRepositoryWorkerGroupInput,
+): ReadOnlyRepositoryWorkerGroupAdmission {
+  const members = groupMembers(input);
+  const providerLimits = members.map((member) => (
+    member.providerConcurrencyLimit ?? input.providerConcurrencyLimit ?? DEFAULT_WORKER_PROVIDER_CONCURRENCY
+  ));
+  if (providerLimits.some((limit) => !Number.isSafeInteger(limit) || limit < 1
+    || limit > MAX_READ_ONLY_WORKER_GROUP_SIZE)) {
+    throw new Error('Worker provider concurrency limit must be between 1 and 4');
+  }
+  const producer = input.producer ?? 'repository-worker-group-admission';
+  const requestIdentity = {
+    parentJobId: input.parent.jobId, parentAttemptId: input.parent.attemptId,
+    parentGeneration: input.parent.generation, idempotencyKey: input.idempotencyKey,
+  };
+  const groupId = identity('worker_group', requestIdentity);
+  ensureParentConcurrency(input, members.length, input.engine.worker.getWorkerGroup(groupId) !== null);
+  const memberSpecs = members.map((member, index) => ({
+    memberId: identity('worker_member', { groupId, ordinal: index + 1 }),
+    ordinal: index + 1,
+    requestedProviderId: member.provider.providerId,
+  }));
+  let group = input.engine.worker.createWorkerGroup({
+    parentJobId: input.parent.jobId, parentAttemptId: input.parent.attemptId,
+    parentGeneration: input.parent.generation, parentFenceToken: input.parent.fenceToken,
+    producer, idempotencyKey: input.idempotencyKey, groupId, schemaVersion: 1,
+    policy: input.policy, members: memberSpecs,
+  });
+  const admissions: Array<{ memberId: string; ordinal: number; admission: ReadOnlyRepositoryWorkerAdmission }> = [];
+  const failures: Array<{ memberId: string; ordinal: number; error: string }> = [];
+  for (const [index, member] of members.entries()) {
+    const spec = memberSpecs[index]!;
+    const providerLimit = providerLimits[index]!;
+    const slotId = identity('worker_provider_slot', { groupId, memberId: spec.memberId });
+    let slotReserved = false;
+    try {
+      input.engine.resources.reserveWorkerProviderConcurrency({
+        providerSlotId: slotId, idempotencyKey: `${input.idempotencyKey}:provider-slot:${spec.ordinal}`,
+        groupId, memberId: spec.memberId, parentJobId: input.parent.jobId,
+        parentAttemptId: input.parent.attemptId, parentGeneration: input.parent.generation,
+        parentFenceToken: input.parent.fenceToken, providerId: member.provider.providerId,
+        limit: providerLimit,
+      });
+      slotReserved = true;
+      const admissionInput: AdmitReadOnlyRepositoryWorkerInput = {
+        engine: input.engine, triggerBus: input.triggerBus, parent: input.parent,
+        idempotencyKey: `${input.idempotencyKey}:member:${spec.ordinal}`,
+        goal: member.goal, repositorySnapshotId: input.repositorySnapshotId,
+        provider: member.provider, producer,
+        ...(member.boundedParentNote === undefined ? {} : { boundedParentNote: member.boundedParentNote }),
+        ...(member.planStepIds === undefined ? {} : { planStepIds: member.planStepIds }),
+        ...(member.claimIds === undefined ? {} : { claimIds: member.claimIds }),
+        ...(member.sourceReferenceIds === undefined ? {} : { sourceReferenceIds: member.sourceReferenceIds }),
+        ...(member.instructionReferenceIds === undefined ? {} : { instructionReferenceIds: member.instructionReferenceIds }),
+        ...(member.maxModelCalls === undefined ? {} : { maxModelCalls: member.maxModelCalls }),
+        ...(member.maxToolCalls === undefined ? {} : { maxToolCalls: member.maxToolCalls }),
+        ...(member.maxRuntimeMs === undefined ? {} : { maxRuntimeMs: member.maxRuntimeMs }),
+        ...(member.maxExternalCost === undefined ? {} : { maxExternalCost: member.maxExternalCost }),
+        group: { groupId, memberId: spec.memberId, ordinal: spec.ordinal },
+      };
+      admissions.push({ memberId: spec.memberId, ordinal: spec.ordinal, admission: admitReadOnlyRepositoryWorker(admissionInput) });
+    } catch (error) {
+      const current = input.engine.worker.getWorkerGroupMember(spec.memberId);
+      const unknown = current?.assignmentId !== null && current?.assignmentId !== undefined;
+      if (slotReserved) {
+        input.engine.resources.settleWorkerProviderConcurrency({
+          providerSlotId: slotId, unknown, safeToRelease: !unknown,
+          reason: unknown ? 'admission_outcome_unknown' : 'admission_rejected_before_dispatch',
+        });
+      }
+      if (current?.childJobId) {
+        input.engine.cancelJob({
+          jobId: current.childJobId, reason: 'worker_group_admission_failed', producer,
+          eventIdempotencyKey: `worker-group-admission-failed:${spec.memberId}`,
+        });
+      }
+      input.engine.worker.settleWorkerGroupMember({
+        parentJobId: input.parent.jobId, parentAttemptId: input.parent.attemptId,
+        parentGeneration: input.parent.generation, parentFenceToken: input.parent.fenceToken,
+        producer, idempotencyKey: `worker-group-admission-rejected:${spec.memberId}`,
+        groupId, memberId: spec.memberId, outcome: unknown ? 'unknown' : 'rejected',
+        reason: unknown ? 'admission_outcome_unknown' : 'admission_rejected',
+      });
+      failures.push({
+        memberId: spec.memberId, ordinal: spec.ordinal,
+        error: error instanceof Error ? error.message : 'Worker group admission failed',
+      });
+    }
+  }
+  group = input.engine.worker.completeWorkerGroupAdmission({
+    parentJobId: input.parent.jobId, parentAttemptId: input.parent.attemptId,
+    parentGeneration: input.parent.generation, parentFenceToken: input.parent.fenceToken,
+    producer, idempotencyKey: `${input.idempotencyKey}:admission-completed`, groupId,
+  });
+  return { group, admissions, failures };
+}
+
+function groupParent(group: WorkerGroupRecord, engine: JobEngine): ReadOnlyWorkerParentAuthority {
+  const attempt = engine.getAttempt(group.parentAttemptId);
+  if (!attempt?.fenceToken || attempt.generation !== group.parentGeneration) {
+    throw new Error('Worker group parent authority is unavailable');
+  }
+  return {
+    jobId: group.parentJobId, attemptId: group.parentAttemptId,
+    generation: group.parentGeneration, fenceToken: attempt.fenceToken,
+  };
+}
+
+function terminalOutcome(status: string | undefined): Exclude<WorkerGroupMemberOutcome, 'pending' | 'admitted' | 'verified'> | null {
+  if (status === 'failed' || status === 'dead_letter' || status === 'crashed') return 'failed';
+  if (status === 'cancelled') return 'cancelled';
+  if (status === 'blocked') return 'blocked';
+  if (status === 'unknown') return 'unknown';
+  return null;
+}
+
+export async function joinReadOnlyRepositoryWorkerGroup(input: {
+  engine: JobEngine;
+  groupId: string;
+  producer?: string;
+}): Promise<WorkerGroupAggregate> {
+  const group = input.engine.worker.getWorkerGroup(input.groupId);
+  if (!group) throw new Error('Worker group was not found');
+  const parent = groupParent(group, input.engine);
+  const producer = input.producer ?? 'repository-worker-group-join';
+  for (const member of input.engine.worker.listWorkerGroupMembers(group.groupId)) {
+    if (!['pending', 'admitted'].includes(member.outcome)) continue;
+    let outcome: Exclude<WorkerGroupMemberOutcome, 'pending' | 'admitted'> | null = null;
+    let workerResultId: string | null = null;
+    let resultHash: string | null = null;
+    let reason = 'member_not_terminal';
+    if (!member.assignmentId || !member.childJobId) {
+      outcome = 'rejected';
+      reason = 'member_not_admitted';
+    } else {
+      const runs = input.engine.worker.listWorkerRunsForChild(member.childJobId);
+      const accepted = runs.map((run) => run.acceptedResultId
+        ? input.engine.worker.getWorkerResult(run.acceptedResultId) : null).find(Boolean) ?? null;
+      if (accepted?.acceptanceState === 'accepted' && accepted.status === 'completed') {
+        workerResultId = accepted.workerResultId;
+        resultHash = accepted.resultHash;
+        try {
+          await verifyReadOnlyRepositoryWorkerResult({
+            engine: input.engine, parent, workerResultId: accepted.workerResultId,
+            producer, idempotencyKey: `worker-group-verify:${group.groupId}:${member.memberId}`,
+          });
+          outcome = 'verified';
+          reason = 'independently_verified';
+        } catch {
+          outcome = 'rejected';
+          reason = 'parent_verification_failed';
+        }
+      } else if (accepted) {
+        workerResultId = accepted.workerResultId;
+        resultHash = accepted.resultHash;
+        outcome = accepted.status === 'cancelled' ? 'cancelled'
+          : accepted.status === 'timed_out' ? 'timed_out'
+            : accepted.status === 'blocked' ? 'blocked'
+              : accepted.status === 'failed' ? 'failed' : 'unknown';
+        reason = `worker_result_${accepted.status}`;
+      } else {
+        outcome = terminalOutcome(input.engine.getJob(member.childJobId)?.status);
+        reason = outcome ? `child_job_${outcome}` : reason;
+      }
+    }
+    if (outcome) {
+      input.engine.worker.settleWorkerGroupMember({
+        parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+        parentGeneration: parent.generation, parentFenceToken: parent.fenceToken,
+        producer, idempotencyKey: `worker-group-member-join:${member.memberId}`,
+        groupId: group.groupId, memberId: member.memberId, outcome,
+        workerResultId, resultHash, reason,
+      });
+      const slot = input.engine.resources.getWorkerProviderConcurrencyForMember(member.memberId);
+      if (slot) {
+        const calls = member.childAttemptId && member.childGeneration !== null
+          ? input.engine.workerProviderCalls.listForAttempt(member.childAttemptId, member.childGeneration) : [];
+        const unknown = calls.some((call) => call.retrySafety === 'blocked_unknown'
+          || call.outcomeKnowledge === 'outcome_unknown');
+        input.engine.resources.settleWorkerProviderConcurrency({
+          providerSlotId: slot.providerSlotId, unknown, safeToRelease: !unknown,
+          reason: unknown ? 'provider_outcome_unknown' : 'member_settled',
+        });
+      }
+    }
+  }
+  const currentMembers = input.engine.worker.listWorkerGroupMembers(group.groupId);
+  const aggregate = buildWorkerGroupAggregate(group.groupId, group.policy, currentMembers);
+  if (aggregate.counts.pending === 0) {
+    input.engine.worker.settleWorkerGroup({
+      parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+      parentGeneration: parent.generation, parentFenceToken: parent.fenceToken,
+      producer, idempotencyKey: `worker-group-settle:${group.groupId}`,
+      groupId: group.groupId, state: aggregate.outcome === 'unknown' ? 'blocked_unknown' : 'settled',
+      aggregateHash: aggregate.aggregateHash, reason: `aggregate_${aggregate.outcome}`,
+    });
+  }
+  return aggregate;
+}
+
+export function fanOutReadOnlyRepositoryWorkerGroup(input: {
+  engine: JobEngine;
+  groupId: string;
+  kind: 'cancellation' | 'timeout';
+  reason: string;
+  producer?: string;
+  interruptAttempt?: (attemptId: string, reason: string) => void;
+}): { interrupted: number; group: WorkerGroupRecord } {
+  const group = input.engine.worker.getWorkerGroup(input.groupId);
+  if (!group) throw new Error('Worker group was not found');
+  const parent = groupParent(group, input.engine);
+  const producer = input.producer ?? 'repository-worker-group-control';
+  input.engine.worker.requestWorkerGroupInterruption({
+    parentJobId: parent.jobId, parentAttemptId: parent.attemptId,
+    parentGeneration: parent.generation, parentFenceToken: parent.fenceToken,
+    producer, idempotencyKey: `worker-group-${input.kind}:${group.groupId}`,
+    groupId: group.groupId, kind: input.kind, reason: input.reason,
+  });
+  const attemptIds: string[] = [];
+  for (const member of input.engine.worker.listWorkerGroupMembers(group.groupId)) {
+    if (!member.childJobId || !member.childAttemptId || member.childGeneration === null) continue;
+    const attempt = input.engine.getAttempt(member.childAttemptId);
+    if (!attempt?.fenceToken || attempt.generation !== member.childGeneration) continue;
+    if (input.kind === 'timeout') {
+      input.engine.workerProviderCalls.recordInterruptionForAttempt({
+        childJobId: member.childJobId, childAttemptId: member.childAttemptId,
+        childGeneration: member.childGeneration, childFenceToken: attempt.fenceToken,
+        kind: 'timeout', reason: input.reason,
+        idempotencyKey: `worker-group-timeout:${group.groupId}:${member.memberId}`,
+      });
+    }
+    const cancelled = input.engine.cancelJob({
+      jobId: member.childJobId, reason: input.reason, producer,
+      eventIdempotencyKey: `worker-group-${input.kind}:${group.groupId}:${member.memberId}`,
+    });
+    if (cancelled.applied) attemptIds.push(member.childAttemptId);
+  }
+  for (const attemptId of attemptIds) input.interruptAttempt?.(attemptId, input.reason);
+  reconcileInterruptedReadOnlyRepositoryWorkerGroups({
+    engine: input.engine,
+    parentJobId: group.parentJobId,
+    producer,
+  });
+  return { interrupted: attemptIds.length, group: input.engine.worker.getWorkerGroup(group.groupId)! };
+}
+
+export function reconcileInterruptedReadOnlyRepositoryWorkerGroups(input: {
+  engine: JobEngine;
+  parentJobId: string;
+  producer?: string;
+}): { inspected: number; settled: number } {
+  const producer = input.producer ?? 'repository-worker-group-reconciliation';
+  const groups = input.engine.worker.listWorkerGroupsForParent(input.parentJobId)
+    .filter((group) => group.state === 'cancelling' || group.state === 'timed_out');
+  let settled = 0;
+  for (const group of groups) {
+    for (const member of input.engine.worker.listWorkerGroupMembers(group.groupId)) {
+      if (!['pending', 'admitted'].includes(member.outcome)) continue;
+      const child = member.childJobId ? input.engine.getJob(member.childJobId) : null;
+      const outcome: Exclude<WorkerGroupMemberOutcome, 'pending' | 'admitted' | 'verified'> | null =
+        member.childJobId === null ? 'rejected'
+          : child?.status === 'cancelled' ? (group.timeoutRequestedAt === null ? 'cancelled' : 'timed_out')
+            : child?.status === 'blocked' ? 'blocked'
+              : child?.status === 'unknown' ? 'unknown'
+                : ['failed', 'crashed', 'dead_letter'].includes(child?.status ?? '') ? 'failed' : null;
+      if (!outcome) continue;
+      input.engine.worker.reconcileWorkerGroupMember({
+        groupId: group.groupId,
+        memberId: member.memberId,
+        outcome,
+        reason: `canonical_child_${outcome}`,
+        producer,
+        idempotencyKey: `worker-group-reconcile-member:${member.memberId}:${outcome}`,
+      });
+    }
+    const aggregate = buildWorkerGroupAggregate(
+      group.groupId,
+      group.policy,
+      input.engine.worker.listWorkerGroupMembers(group.groupId),
+    );
+    if (aggregate.counts.pending === 0) {
+      input.engine.worker.reconcileWorkerGroup({
+        groupId: group.groupId,
+        state: aggregate.outcome === 'unknown' ? 'blocked_unknown' : 'settled',
+        aggregateHash: aggregate.aggregateHash,
+        reason: `aggregate_${aggregate.outcome}`,
+        producer,
+        idempotencyKey: `worker-group-reconcile:${group.groupId}`,
+      });
+      for (const member of aggregate.members) {
+        const slot = input.engine.resources.getWorkerProviderConcurrencyForMember(member.memberId);
+        if (!slot || slot.state !== 'reserved') continue;
+        const unknown = member.outcome === 'unknown';
+        input.engine.resources.settleWorkerProviderConcurrency({
+          providerSlotId: slot.providerSlotId,
+          unknown,
+          safeToRelease: !unknown,
+          reason: unknown ? 'provider_outcome_unknown' : 'member_settled',
+        });
+      }
+      settled += 1;
+    }
+  }
+  return { inspected: groups.length, settled };
+}
+
+export function projectReadOnlyRepositoryWorkerGroups(input: {
+  engine: JobEngine;
+  limit?: number;
+}): { inspected: number; pendingVerification: string[] } {
+  const groups = input.engine.worker.listWorkerGroupsPendingSettlement({ limit: input.limit ?? 100 });
+  const pendingVerification: string[] = [];
+  for (const group of groups) {
+    for (const member of input.engine.worker.listWorkerGroupMembers(group.groupId)) {
+      if (!['pending', 'admitted'].includes(member.outcome)) continue;
+      if (!member.childJobId) {
+        input.engine.worker.reconcileWorkerGroupMember({
+          groupId: group.groupId, memberId: member.memberId, outcome: 'rejected',
+          reason: 'canonical_admission_rejected', producer: 'repository-worker-group-recovery',
+          idempotencyKey: `worker-group-recovery:${member.memberId}:rejected`,
+        });
+        continue;
+      }
+      const runs = input.engine.worker.listWorkerRunsForChild(member.childJobId);
+      if (runs.some((run) => run.acceptedResultId !== null)) {
+        pendingVerification.push(group.groupId);
+        continue;
+      }
+      const child = input.engine.getJob(member.childJobId);
+      const outcome: Exclude<WorkerGroupMemberOutcome, 'pending' | 'admitted' | 'verified'> | null =
+        child?.status === 'cancelled' ? (group.timeoutRequestedAt === null ? 'cancelled' : 'timed_out')
+          : child?.status === 'blocked' ? 'blocked'
+            : child?.status === 'unknown' ? 'unknown'
+              : ['failed', 'crashed', 'dead_letter'].includes(child?.status ?? '') ? 'failed' : null;
+      if (outcome) {
+        input.engine.worker.reconcileWorkerGroupMember({
+          groupId: group.groupId, memberId: member.memberId, outcome,
+          reason: `canonical_child_${outcome}`, producer: 'repository-worker-group-recovery',
+          idempotencyKey: `worker-group-recovery:${member.memberId}:${outcome}`,
+        });
+      }
+    }
+    const aggregate = buildWorkerGroupAggregate(
+      group.groupId,
+      group.policy,
+      input.engine.worker.listWorkerGroupMembers(group.groupId),
+    );
+    if (aggregate.counts.pending === 0) {
+      input.engine.worker.reconcileWorkerGroup({
+        groupId: group.groupId,
+        state: aggregate.outcome === 'unknown' ? 'blocked_unknown' : 'settled',
+        aggregateHash: aggregate.aggregateHash,
+        reason: `aggregate_${aggregate.outcome}`,
+        producer: 'repository-worker-group-recovery',
+        idempotencyKey: `worker-group-recovery:${group.groupId}:settled`,
+      });
+      for (const member of aggregate.members) {
+        const slot = input.engine.resources.getWorkerProviderConcurrencyForMember(member.memberId);
+        if (!slot || slot.state !== 'reserved') continue;
+        const unknown = member.outcome === 'unknown';
+        input.engine.resources.settleWorkerProviderConcurrency({
+          providerSlotId: slot.providerSlotId,
+          unknown,
+          safeToRelease: !unknown,
+          reason: unknown ? 'provider_outcome_unknown' : 'member_settled',
+        });
+      }
+    }
+  }
+  return { inspected: groups.length, pendingVerification: [...new Set(pendingVerification)].sort() };
+}

--- a/core/v4/worker/workerProviderBridge.ts
+++ b/core/v4/worker/workerProviderBridge.ts
@@ -171,6 +171,14 @@ export function createDurableWorkerProviderBridge(options: BridgeOptions): Durab
 
   const runCall = async (input: ProviderCallInput, stream: boolean): Promise<ProviderCallOutput | StreamEvent[]> => {
     completeActive();
+    const groupMember = options.engine.worker.getWorkerGroupMemberForAssignment(options.assignment.assignmentId);
+    if (groupMember) {
+      const providerSlot = options.engine.resources.getWorkerProviderConcurrencyForMember(groupMember.memberId);
+      if (!providerSlot || providerSlot.state !== 'reserved'
+        || providerSlot.providerId !== options.binding.providerId) {
+        throw new Error('Parallel Worker provider dispatch requires an active provider concurrency reservation');
+      }
+    }
     const logicalCallId = input.usageContext?.logicalCallId;
     if (!logicalCallId) throw new Error('Worker provider call is missing a logical identity');
     const ordinal = options.engine.workerProviderCalls.listForWorkerRun(options.workerRun.workerRunId).length + 1;

--- a/core/v4/worker/workerProviderReconciliation.ts
+++ b/core/v4/worker/workerProviderReconciliation.ts
@@ -102,6 +102,19 @@ export function reconcileWorkerProviderCall(input: {
     physicalAttempts: facts,
     now,
   });
+  const groupMember = input.engine.worker.getWorkerGroupMemberForAssignment(call.assignmentId);
+  if (groupMember && (result.retrySafety === 'blocked_unknown' || result.outcomeKnowledge === 'outcome_unknown')) {
+    const providerSlot = input.engine.resources.getWorkerProviderConcurrencyForMember(groupMember.memberId);
+    if (providerSlot?.state === 'reserved') {
+      input.engine.resources.settleWorkerProviderConcurrency({
+        providerSlotId: providerSlot.providerSlotId,
+        unknown: true,
+        safeToRelease: false,
+        reason: 'provider_outcome_unknown',
+        now,
+      });
+    }
+  }
   const reservation = input.engine.resources.getWorkerReservationForChild(call.childJobId);
   let usageFacts = 0;
   if (reservation && reservation.workerRunId === call.workerRunId) {

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,13 +31,13 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(39);
+    expect(LATEST_SCHEMA_VERSION).toBe(40);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 39 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: 40 });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
       { name: 'repository_change_intents' }, { name: 'repository_change_records' },
     ]);
@@ -53,7 +53,7 @@ describe('repository snapshot migration v32', () => {
       ]);
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('repository_architecture_notes','execution_graph_node_references') ORDER BY name").all())
       .toEqual([{ name: 'execution_graph_node_references' }, { name: 'repository_architecture_notes' }]);
-    expect(runMigrations(db)).toEqual({ from: 39, to: 39 });
+    expect(runMigrations(db)).toEqual({ from: 40, to: 40 });
   });
 
   it('adds validation records to a v33 database without changing repository history', () => {
@@ -77,7 +77,7 @@ describe('repository snapshot migration v32', () => {
       (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence)
       VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
 
-    expect(runMigrations(db)).toEqual({ from: 33, to: 39 });
+    expect(runMigrations(db)).toEqual({ from: 33, to: 40 });
     expect(db.prepare('SELECT id,status FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued' });
     expect(db.prepare('SELECT attempt_id,status FROM runs WHERE attempt_id=?').get('attempt'))
       .toEqual({ attempt_id: 'attempt', status: 'queued' });

--- a/tests/v4/worker/workerMigration.test.ts
+++ b/tests/v4/worker/workerMigration.test.ts
@@ -83,11 +83,14 @@ describe('Worker persistence migration', () => {
     ).run('a'.repeat(64), 'b'.repeat(64));
     db.pragma('foreign_keys = ON');
     const before = new Set(tables());
-    expect(runMigrations(db)).toEqual({ from: 38, to: 39 });
-    expect(LATEST_SCHEMA_VERSION).toBe(39);
+    expect(runMigrations(db)).toEqual({ from: 38, to: 40 });
+    expect(LATEST_SCHEMA_VERSION).toBe(40);
     expect(tables().filter((table) => !before.has(table))).toEqual([
       'job_budget_reservation_reconciliations',
+      'worker_group_members',
+      'worker_groups',
       'worker_provider_call_reconciliations',
+      'worker_provider_concurrency_reservations',
       'worker_provider_late_responses',
     ]);
     expect(columns('worker_logical_provider_calls')).toEqual(expect.arrayContaining([
@@ -144,14 +147,45 @@ describe('Worker persistence migration', () => {
       idempotencyNamespace: 'fixture', idempotencyKey: 'job', goal: 'legacy job',
     });
 
-    expect(runMigrations(db)).toEqual({ from: 36, to: 39 });
+    expect(runMigrations(db)).toEqual({ from: 36, to: 40 });
     const engine = createJobEngine({ db });
     expect(engine.getJob(before.jobId)?.goal).toBe('legacy job');
     expect(engine.worker.listWorkerRunsForParent(before.jobId)).toEqual([]);
   });
 
-  it('is idempotent when v39 is already installed', () => {
-    expect(runMigrations(db)).toEqual({ from: 0, to: 39 });
-    expect(runMigrations(db)).toEqual({ from: 39, to: 39 });
+  it('is idempotent when v40 is already installed', () => {
+    expect(runMigrations(db)).toEqual({ from: 0, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: 40, to: 40 });
+    expect(LATEST_SCHEMA_VERSION).toBe(40);
+    expect(tables()).toEqual(expect.arrayContaining([
+      'worker_groups', 'worker_group_members', 'worker_provider_concurrency_reservations',
+    ]));
+  });
+
+  it('upgrades v39 additively and preserves reconciliation rows on reopen', () => {
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((entry) => entry.version <= 39)) {
+      db.transaction(() => {
+        if (migration.apply) migration.apply(db);
+        else db.exec(migration.sql ?? '');
+        db.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,?,?)')
+          .run(migration.version, 1);
+      })();
+    }
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO worker_provider_call_reconciliations
+         (reconciliation_id,logical_call_id,idempotency_key,worker_run_id,child_job_id,child_attempt_id,
+          child_generation,reason,outcome_knowledge,retry_safety,physical_attempt_ids_json,
+          unknown_spend,unsettled_downstream,state,created_at)
+       VALUES ('reconciliation_existing','call_existing','existing','run_existing','job_existing','attempt_existing',
+               1,'restart','outcome_unknown','blocked_unknown','[]',1,0,'blocked_unknown',1)`,
+    ).run();
+    db.pragma('foreign_keys = ON');
+    expect(runMigrations(db)).toEqual({ from: 39, to: 40 });
+    expect(db.prepare(
+      `SELECT outcome_knowledge,retry_safety,unknown_spend
+         FROM worker_provider_call_reconciliations WHERE reconciliation_id='reconciliation_existing'`,
+    ).get()).toEqual({ outcome_knowledge: 'outcome_unknown', retry_safety: 'blocked_unknown', unknown_spend: 1 });
+    expect(runMigrations(db)).toEqual({ from: 40, to: 40 });
   });
 });

--- a/tests/v4/worker/workerParallelAdmission.test.ts
+++ b/tests/v4/worker/workerParallelAdmission.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createTriggerBus, type TriggerBus } from '../../../core/v4/daemon/triggerBus';
+import {
+  admitReadOnlyRepositoryWorkerGroup,
+  DEFAULT_READ_ONLY_WORKER_GROUP_SIZE,
+  MAX_READ_ONLY_WORKER_GROUP_SIZE,
+  normalizeReadOnlyWorkerGroupSize,
+} from '../../../core/v4/worker/workerParallel';
+
+const provider = {
+  providerId: 'custom_openai', modelId: 'custom-default',
+  providerRuntimeIdentity: 'runtime:custom_openai', credentialReference: null,
+  endpointReference: 'endpoint:configured', supportsToolCalling: true,
+  contextWindow: 32_768, maxOutputTokens: 4_096, selectionReason: 'configured provider',
+} as const;
+
+describe('bounded parallel read-only Worker admission', () => {
+  let db: Database.Database;
+  let engine: JobEngine;
+  let triggerBus: TriggerBus;
+  let root: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+       VALUES ('worker-instance',1,'localhost',1,1,'4.18.0')`,
+    ).run();
+    engine = createJobEngine({ db });
+    triggerBus = createTriggerBus({ db });
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-parallel-worker-'));
+    await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function setupParent(key = 'parent') {
+    const parent = engine.submitJob({
+      entryPoint: 'test', source: 'test', sessionId: 'parallel-worker', workspaceId: root,
+      instanceId: 'worker-instance', idempotencyNamespace: 'parallel-worker',
+      idempotencyKey: key, goal: 'Coordinate repository inspection.',
+    });
+    const lease = engine.claimAttempt({ attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000 });
+    const snapshot = await engine.repository.captureSnapshot({
+      jobId: parent.jobId, attemptId: parent.attemptId, generation: lease.generation!,
+      fenceToken: lease.fenceToken!, requestedPath: root, producer: 'test',
+    });
+    return {
+      parent,
+      authority: {
+        jobId: parent.jobId, attemptId: parent.attemptId,
+        generation: lease.generation!, fenceToken: lease.fenceToken!,
+      },
+      snapshot,
+    };
+  }
+
+  it('defaults to two members and never admits more than four', () => {
+    expect(DEFAULT_READ_ONLY_WORKER_GROUP_SIZE).toBe(2);
+    expect(MAX_READ_ONLY_WORKER_GROUP_SIZE).toBe(4);
+    expect(normalizeReadOnlyWorkerGroupSize(undefined)).toBe(2);
+    expect(normalizeReadOnlyWorkerGroupSize(4)).toBe(4);
+    expect(() => normalizeReadOnlyWorkerGroupSize(5)).toThrow(/maximum.*4/i);
+  });
+
+  it('rejects nested or mutating Worker requests', () => {
+    expect(() => normalizeReadOnlyWorkerGroupSize(2, { depth: 1 })).toThrow(/nested/i);
+    expect(() => normalizeReadOnlyWorkerGroupSize(2, { mutation: true })).toThrow(/mutation/i);
+  });
+
+  it('atomically projects and dispatches two immutable read-only members', async () => {
+    const setup = await setupParent();
+    const admitted = admitReadOnlyRepositoryWorkerGroup({
+      engine, triggerBus, parent: setup.authority, idempotencyKey: 'group-two',
+      policy: 'require_all', repositorySnapshotId: setup.snapshot.id,
+      members: [
+        { goal: 'Inspect source exports.', provider },
+        { goal: 'Inspect source constants.', provider },
+      ],
+      providerConcurrencyLimit: 2,
+    });
+    expect(admitted.failures).toEqual([]);
+    expect(admitted.admissions).toHaveLength(2);
+    expect(admitted.group).toMatchObject({ state: 'active', requestedMemberCount: 2, admittedMemberCount: 2 });
+    expect(engine.worker.listWorkerGroupMembers(admitted.group.groupId).map((member) => member.ordinal)).toEqual([1, 2]);
+    expect(engine.worker.listWorkerAssignmentsForParent(setup.parent.jobId)).toHaveLength(2);
+    expect(engine.resources.listWorkerProviderConcurrencyForGroup(admitted.group.groupId)).toHaveLength(2);
+    expect(triggerBus.stats().pending).toBe(2);
+    for (const item of admitted.admissions) {
+      expect(engine.resources.authorize({
+        jobId: item.admission.child.jobId, kind: 'tool', value: 'shell_exec',
+      })).toBe(false);
+    }
+  });
+
+  it('admits four only with explicit parent and provider capacity and rejects a fifth', async () => {
+    const setup = await setupParent();
+    const admitted = admitReadOnlyRepositoryWorkerGroup({
+      engine, triggerBus, parent: setup.authority, idempotencyKey: 'group-four',
+      policy: 'allow_partial', repositorySnapshotId: setup.snapshot.id,
+      memberTemplate: { goal: 'Inspect the pinned snapshot.', provider }, memberCount: 4,
+      parentConcurrencyLimit: 4, providerConcurrencyLimit: 4,
+    });
+    expect(admitted.admissions).toHaveLength(4);
+    expect(admitted.failures).toEqual([]);
+    expect(() => admitReadOnlyRepositoryWorkerGroup({
+      engine, triggerBus, parent: setup.authority, idempotencyKey: 'group-five',
+      policy: 'require_all', repositorySnapshotId: setup.snapshot.id,
+      memberTemplate: { goal: 'Inspect.', provider }, memberCount: 5,
+      parentConcurrencyLimit: 4, providerConcurrencyLimit: 5,
+    })).toThrow(/maximum.*4/i);
+  });
+
+  it('enforces provider capacity durably and represents rejected admission', async () => {
+    const setup = await setupParent();
+    const admitted = admitReadOnlyRepositoryWorkerGroup({
+      engine, triggerBus, parent: setup.authority, idempotencyKey: 'provider-limited',
+      policy: 'allow_partial', repositorySnapshotId: setup.snapshot.id,
+      memberTemplate: { goal: 'Inspect.', provider }, memberCount: 2,
+      providerConcurrencyLimit: 1,
+    });
+    expect(admitted.admissions).toHaveLength(1);
+    expect(admitted.failures).toHaveLength(1);
+    expect(engine.worker.listWorkerGroupMembers(admitted.group.groupId).map((member) => member.outcome))
+      .toEqual(['admitted', 'rejected']);
+    expect(engine.resources.listWorkerProviderConcurrencyForGroup(admitted.group.groupId)).toHaveLength(1);
+  });
+
+  it('deduplicates the same group, members, child Jobs, reservations and dispatches', async () => {
+    const setup = await setupParent();
+    const input = {
+      engine, triggerBus, parent: setup.authority, idempotencyKey: 'duplicate-group',
+      policy: 'require_all' as const, repositorySnapshotId: setup.snapshot.id,
+      memberTemplate: { goal: 'Inspect.', provider }, memberCount: 2,
+      providerConcurrencyLimit: 2,
+    };
+    const first = admitReadOnlyRepositoryWorkerGroup(input);
+    const duplicate = admitReadOnlyRepositoryWorkerGroup(input);
+    expect(duplicate.group.groupId).toBe(first.group.groupId);
+    expect(duplicate.admissions.map((item) => item.admission.child.jobId))
+      .toEqual(first.admissions.map((item) => item.admission.child.jobId));
+    expect(duplicate.admissions.every((item) => item.admission.triggerEvent.inserted === false)).toBe(true);
+    expect(engine.worker.listWorkerAssignmentsForParent(setup.parent.jobId)).toHaveLength(2);
+    expect(engine.resources.listWorkerReservations(setup.parent.jobId)).toHaveLength(2);
+  });
+});

--- a/tests/v4/worker/workerParallelCancellation.test.ts
+++ b/tests/v4/worker/workerParallelCancellation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
+import { fanOutReadOnlyRepositoryWorkerGroup } from '../../../core/v4/worker/workerParallel';
+import {
+  admitParallelWorkers,
+  createParallelWorkerFixture,
+  type ParallelWorkerFixture,
+} from './workerParallelFixture';
+
+describe('parallel read-only Worker interruption', () => {
+  let fixture: ParallelWorkerFixture | undefined;
+  afterEach(async () => fixture?.close());
+
+  it('persists parent and group cancellation intent before cancelling every child exactly once', async () => {
+    fixture = await createParallelWorkerFixture();
+    const admitted = admitParallelWorkers(fixture);
+    const controls = createJobControlAuthority({ db: fixture.db, jobEngine: fixture.engine });
+    const command = {
+      jobId: fixture.parent.jobId,
+      attemptId: fixture.parent.attemptId,
+      generation: fixture.authority.generation,
+      kind: 'cancel' as const,
+      source: 'test',
+      reason: 'operator_cancelled',
+      idempotencyNamespace: 'parallel-control',
+      idempotencyKey: 'cancel-parent-group',
+    };
+    expect(controls.commands.request(command)).toMatchObject({ persisted: true, applied: true, duplicate: false });
+    expect(controls.commands.request(command)).toMatchObject({ persisted: true, duplicate: true });
+    expect(fixture.engine.worker.getWorkerGroup(admitted.group.groupId)).toMatchObject({
+      state: 'settled', cancellationRequestedAt: expect.any(Number), cancelledMemberCount: 2,
+    });
+    expect(admitted.admissions.map((item) => fixture!.engine.getJob(item.admission.child.jobId)?.status))
+      .toEqual(['cancelled', 'cancelled']);
+    const eventTypes = fixture.engine.listEvents(fixture.parent.jobId).map((event) => event.type);
+    expect(eventTypes.indexOf('control.persisted')).toBeLessThan(eventTypes.indexOf('worker.group_interruption_requested'));
+    expect(eventTypes.indexOf('worker.group_interruption_requested')).toBeLessThan(eventTypes.indexOf('attempt.cancelled'));
+    expect(eventTypes.filter((type) => type === 'worker.group_interruption_requested')).toHaveLength(1);
+  });
+
+  it('persists timeout intent before physical interruption and fans out idempotently', async () => {
+    fixture = await createParallelWorkerFixture();
+    const admitted = admitParallelWorkers(fixture);
+    for (const item of admitted.admissions) {
+      fixture.engine.claimAttempt({
+        attemptId: item.admission.child.attemptId,
+        ownerId: 'worker-instance',
+        ttlMs: 60_000,
+      });
+    }
+    const interrupted: string[] = [];
+    const first = fanOutReadOnlyRepositoryWorkerGroup({
+      engine: fixture.engine,
+      groupId: admitted.group.groupId,
+      kind: 'timeout',
+      reason: 'worker_group_deadline',
+      producer: 'test',
+      interruptAttempt(attemptId) { interrupted.push(attemptId); },
+    });
+    const duplicate = fanOutReadOnlyRepositoryWorkerGroup({
+      engine: fixture.engine,
+      groupId: admitted.group.groupId,
+      kind: 'timeout',
+      reason: 'worker_group_deadline',
+      producer: 'test',
+      interruptAttempt(attemptId) { interrupted.push(attemptId); },
+    });
+    expect(first.interrupted).toBe(2);
+    expect(duplicate.interrupted).toBe(0);
+    expect(interrupted).toHaveLength(2);
+    expect(fixture.engine.worker.getWorkerGroup(admitted.group.groupId)).toMatchObject({
+      state: 'settled', timeoutRequestedAt: expect.any(Number), failedMemberCount: 2,
+    });
+    expect(admitted.admissions.map((item) => fixture!.engine.getJob(item.admission.child.jobId)?.status))
+      .toEqual(['cancelled', 'cancelled']);
+  });
+});

--- a/tests/v4/worker/workerParallelFixture.ts
+++ b/tests/v4/worker/workerParallelFixture.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
+import { createTriggerBus, type TriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { admitReadOnlyRepositoryWorkerGroup } from '../../../core/v4/worker/workerParallel';
+
+export const parallelWorkerProvider = {
+  providerId: 'custom_openai', modelId: 'custom-default',
+  providerRuntimeIdentity: 'runtime:custom_openai', credentialReference: null,
+  endpointReference: 'endpoint:configured', supportsToolCalling: true,
+  contextWindow: 32_768, maxOutputTokens: 4_096, selectionReason: 'configured provider',
+} as const;
+
+export interface ParallelWorkerFixture {
+  db: Database.Database;
+  engine: JobEngine;
+  triggerBus: TriggerBus;
+  root: string;
+  parent: ReturnType<JobEngine['submitJob']>;
+  authority: { jobId: string; attemptId: string; generation: number; fenceToken: string };
+  snapshotId: string;
+  close(): Promise<void>;
+}
+
+export async function createParallelWorkerFixture(databasePath = ':memory:'): Promise<ParallelWorkerFixture> {
+  const db = new Database(databasePath);
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  db.prepare(
+    `INSERT OR IGNORE INTO daemon_instances (instance_id,pid,hostname,started_at,last_heartbeat,version)
+     VALUES ('worker-instance',1,'localhost',1,1,'4.18.0')`,
+  ).run();
+  const engine = createJobEngine({ db });
+  const triggerBus = createTriggerBus({ db });
+  const root = await mkdtemp(path.join(os.tmpdir(), 'aiden-parallel-worker-'));
+  await writeFile(path.join(root, 'source.ts'), 'export const value = 1;\n');
+  const parent = engine.submitJob({
+    entryPoint: 'test', source: 'test', sessionId: 'parallel-worker', workspaceId: root,
+    instanceId: 'worker-instance', idempotencyNamespace: 'parallel-worker',
+    idempotencyKey: 'parent', goal: 'Coordinate repository inspection.',
+  });
+  const lease = engine.claimAttempt({
+    attemptId: parent.attemptId, ownerId: 'worker-instance', ttlMs: 60_000,
+  });
+  const snapshot = await engine.repository.captureSnapshot({
+    jobId: parent.jobId, attemptId: parent.attemptId, generation: lease.generation!,
+    fenceToken: lease.fenceToken!, requestedPath: root, producer: 'test',
+  });
+  return {
+    db, engine, triggerBus, root, parent,
+    authority: {
+      jobId: parent.jobId, attemptId: parent.attemptId,
+      generation: lease.generation!, fenceToken: lease.fenceToken!,
+    },
+    snapshotId: snapshot.id,
+    async close() {
+      if (db.open) db.close();
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+export function admitParallelWorkers(fixture: ParallelWorkerFixture, input: {
+  idempotencyKey?: string;
+  count?: number;
+  policy?: 'require_all' | 'allow_partial';
+  providerConcurrencyLimit?: number;
+} = {}) {
+  return admitReadOnlyRepositoryWorkerGroup({
+    engine: fixture.engine,
+    triggerBus: fixture.triggerBus,
+    parent: fixture.authority,
+    idempotencyKey: input.idempotencyKey ?? 'parallel-group',
+    policy: input.policy ?? 'require_all',
+    repositorySnapshotId: fixture.snapshotId,
+    memberTemplate: { goal: 'Inspect the pinned repository snapshot.', provider: parallelWorkerProvider },
+    memberCount: input.count ?? 2,
+    parentConcurrencyLimit: input.count ?? 2,
+    providerConcurrencyLimit: input.providerConcurrencyLimit ?? input.count ?? 2,
+  });
+}

--- a/tests/v4/worker/workerParallelJoin.test.ts
+++ b/tests/v4/worker/workerParallelJoin.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildWorkerGroupAggregate,
+  joinReadOnlyRepositoryWorkerGroup,
+} from '../../../core/v4/worker/workerParallel';
+import { resultPayload } from './fixture';
+import {
+  admitParallelWorkers,
+  createParallelWorkerFixture,
+  type ParallelWorkerFixture,
+} from './workerParallelFixture';
+
+describe('parallel read-only Worker deterministic join', () => {
+  let fixture: ParallelWorkerFixture | undefined;
+  afterEach(async () => fixture?.close());
+  const member = (
+    ordinal: number,
+    memberId: string,
+    outcome: 'verified' | 'failed' | 'unknown',
+  ) => ({ ordinal, memberId, assignmentId: `assignment_${memberId}`, childJobId: `job_${memberId}`, outcome });
+
+  it('orders by immutable ordinal rather than completion order', () => {
+    const aggregate = buildWorkerGroupAggregate('group_one', 'allow_partial', [
+      member(2, 'second', 'verified'),
+      member(1, 'first', 'verified'),
+    ]);
+    expect(aggregate.members.map((item) => item.memberId)).toEqual(['first', 'second']);
+    expect(aggregate.outcome).toBe('verified');
+  });
+
+  it('keeps failed and unknown members visible under allow_partial', () => {
+    const aggregate = buildWorkerGroupAggregate('group_partial', 'allow_partial', [
+      member(3, 'unknown', 'unknown'),
+      member(1, 'verified', 'verified'),
+      member(2, 'failed', 'failed'),
+    ]);
+    expect(aggregate.outcome).toBe('partial');
+    expect(aggregate.counts).toMatchObject({ verified: 1, failed: 1, unknown: 1 });
+    expect(aggregate.members).toHaveLength(3);
+  });
+
+  it('requires every member to verify under require_all', () => {
+    expect(buildWorkerGroupAggregate('group_required', 'require_all', [
+      member(1, 'verified', 'verified'),
+      member(2, 'failed', 'failed'),
+    ])).toMatchObject({ outcome: 'failed' });
+  });
+
+  it('independently verifies accepted results and joins by ordinal, not completion order', async () => {
+    fixture = await createParallelWorkerFixture();
+    const admitted = admitParallelWorkers(fixture);
+    const recorded: Array<{ memberId: string; resultId: string; resultHash: string }> = [];
+    for (const item of [...admitted.admissions].reverse()) {
+      const lease = fixture.engine.claimAttempt({
+        attemptId: item.admission.child.attemptId,
+        ownerId: 'worker-instance',
+        ttlMs: 60_000,
+      });
+      const run = fixture.engine.worker.bindWorkerRunFromAssignment({
+        childJobId: item.admission.child.jobId,
+        childAttemptId: item.admission.child.attemptId,
+        childGeneration: lease.generation!,
+        childFenceToken: lease.fenceToken!,
+        workerRunId: item.admission.reservation.workerRunId,
+        schemaVersion: 1,
+        assignmentId: item.admission.assignment.assignmentId,
+        providerBindingId: item.admission.providerBinding.providerBindingId,
+        contextEnvelopeId: item.admission.contextEnvelope.contextEnvelopeId,
+        producer: 'test',
+        idempotencyKey: `run-${item.memberId}`,
+      });
+      const payload = resultPayload(item.admission.assignment.inputHash);
+      const result = fixture.engine.worker.recordWorkerResultFromRun({
+        childJobId: item.admission.child.jobId,
+        childAttemptId: item.admission.child.attemptId,
+        childGeneration: lease.generation!,
+        childFenceToken: lease.fenceToken!,
+        workerResultId: `result_${item.memberId}`,
+        workerRunId: run.workerRunId,
+        assignmentId: item.admission.assignment.assignmentId,
+        payload,
+        producer: 'test',
+        idempotencyKey: `result-${item.memberId}`,
+      });
+      recorded.push({ memberId: item.memberId, resultId: result.workerResultId, resultHash: result.resultHash });
+    }
+    expect(() => fixture!.engine.worker.settleWorkerGroupMember({
+      parentJobId: fixture!.authority.jobId,
+      parentAttemptId: fixture!.authority.attemptId,
+      parentGeneration: fixture!.authority.generation,
+      parentFenceToken: fixture!.authority.fenceToken,
+      producer: 'test',
+      idempotencyKey: 'unverified-parent-consumption',
+      groupId: admitted.group.groupId,
+      memberId: recorded[0]!.memberId,
+      outcome: 'verified',
+      workerResultId: recorded[0]!.resultId,
+      resultHash: recorded[0]!.resultHash,
+      reason: 'not_independently_verified',
+    })).toThrow(/independently verified/i);
+    const aggregate = await joinReadOnlyRepositoryWorkerGroup({
+      engine: fixture.engine,
+      groupId: admitted.group.groupId,
+      producer: 'test',
+    });
+    expect(aggregate).toMatchObject({ outcome: 'verified', counts: { total: 2, verified: 2 } });
+    expect(aggregate.members.map((member) => member.ordinal)).toEqual([1, 2]);
+    expect(fixture.engine.worker.getWorkerGroup(admitted.group.groupId)).toMatchObject({
+      state: 'settled', successfulMemberCount: 2, settledMemberCount: 2,
+    });
+    expect(fixture.engine.resources.listWorkerProviderConcurrencyForGroup(admitted.group.groupId)
+      .map((slot) => slot.state)).toEqual(['released', 'released']);
+    expect(await joinReadOnlyRepositoryWorkerGroup({
+      engine: fixture.engine,
+      groupId: admitted.group.groupId,
+      producer: 'test',
+    })).toEqual(aggregate);
+  });
+});

--- a/tests/v4/worker/workerParallelMultiprocess.test.ts
+++ b/tests/v4/worker/workerParallelMultiprocess.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createParallelWorkerFixture, type ParallelWorkerFixture } from './workerParallelFixture';
+
+function runContender(payload: Record<string, unknown>, cwd: string): Promise<string> {
+  const script = [
+    "const fs=require('node:fs');",
+    "const Database=require('better-sqlite3');",
+    "const {createJobEngine}=require('./core/v4/daemon/jobEngine.ts');",
+    'const input=JSON.parse(process.env.WORKER_SLOT_INPUT);',
+    'while(!fs.existsSync(input.gate)){Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,5);}',
+    'const db=new Database(input.databasePath);db.pragma(\'foreign_keys = ON\');db.pragma(\'busy_timeout = 5000\');',
+    'try{createJobEngine({db}).resources.reserveWorkerProviderConcurrency(input.command);process.stdout.write(\'reserved\');}',
+    'catch(error){process.stdout.write(`rejected:${error instanceof Error?error.message:String(error)}`);}',
+    'finally{db.close();}',
+  ].join('');
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['-r', 'ts-node/register/transpile-only', '-e', script], {
+      cwd,
+      env: { ...process.env, WORKER_SLOT_INPUT: JSON.stringify(payload) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8').on('data', (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding('utf8').on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('exit', (code) => code === 0 ? resolve(stdout) : reject(new Error(stderr || `child exited ${code}`)));
+  });
+}
+
+describe('parallel Worker multi-process provider admission', () => {
+  let fixture: ParallelWorkerFixture | undefined;
+  let root: string | undefined;
+  afterEach(async () => {
+    await fixture?.close();
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it('cannot exceed the durable provider limit across two Node processes', async () => {
+    root = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-multiprocess-'));
+    const databasePath = path.join(root, 'jobs.db');
+    const gate = path.join(root, 'start');
+    fixture = await createParallelWorkerFixture(databasePath);
+    const groupId = 'worker_group_multiprocess';
+    fixture.engine.worker.createWorkerGroup({
+      parentJobId: fixture.authority.jobId,
+      parentAttemptId: fixture.authority.attemptId,
+      parentGeneration: fixture.authority.generation,
+      parentFenceToken: fixture.authority.fenceToken,
+      producer: 'test',
+      idempotencyKey: 'multiprocess-group',
+      groupId,
+      schemaVersion: 1,
+      policy: 'allow_partial',
+      members: [
+        { memberId: 'worker_member_process_one', ordinal: 1, requestedProviderId: 'custom_openai' },
+        { memberId: 'worker_member_process_two', ordinal: 2, requestedProviderId: 'custom_openai' },
+      ],
+    });
+    const base = {
+      groupId,
+      parentJobId: fixture.authority.jobId,
+      parentAttemptId: fixture.authority.attemptId,
+      parentGeneration: fixture.authority.generation,
+      parentFenceToken: fixture.authority.fenceToken,
+      providerId: 'custom_openai',
+      limit: 1,
+    };
+    const cwd = path.resolve(__dirname, '../../..');
+    const contenders = [1, 2].map((ordinal) => runContender({
+      databasePath,
+      gate,
+      command: {
+        ...base,
+        providerSlotId: `worker_provider_slot_process_${ordinal}`,
+        idempotencyKey: `provider-slot-process-${ordinal}`,
+        memberId: `worker_member_process_${ordinal === 1 ? 'one' : 'two'}`,
+      },
+    }, cwd));
+    await writeFile(gate, 'go');
+    const results = await Promise.all(contenders);
+    expect(results.filter((value) => value === 'reserved')).toHaveLength(1);
+    expect(results.filter((value) => /limit exceeded/iu.test(value))).toHaveLength(1);
+    expect(fixture.engine.resources.listWorkerProviderConcurrencyForGroup(groupId)).toHaveLength(1);
+  });
+});

--- a/tests/v4/worker/workerParallelRecovery.test.ts
+++ b/tests/v4/worker/workerParallelRecovery.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
+import { projectReadOnlyRepositoryWorkerGroups } from '../../../core/v4/worker/workerParallel';
+import {
+  admitParallelWorkers,
+  createParallelWorkerFixture,
+  type ParallelWorkerFixture,
+} from './workerParallelFixture';
+
+describe('parallel read-only Worker restart projection', () => {
+  let fixture: ParallelWorkerFixture | undefined;
+  let databaseRoot: string | undefined;
+  afterEach(async () => {
+    await fixture?.close();
+    if (databaseRoot) await rm(databaseRoot, { recursive: true, force: true });
+  });
+
+  it('reopens nonterminal groups with stable member order and exact reservations', async () => {
+    databaseRoot = await mkdtemp(path.join(os.tmpdir(), 'aiden-parallel-reopen-'));
+    const databasePath = path.join(databaseRoot, 'jobs.db');
+    fixture = await createParallelWorkerFixture(databasePath);
+    const admitted = admitParallelWorkers(fixture);
+    fixture.db.close();
+
+    const reopened = new Database(databasePath);
+    reopened.pragma('foreign_keys = ON');
+    expect(runMigrations(reopened)).toEqual({ from: 40, to: 40 });
+    const engine = createJobEngine({ db: reopened });
+    expect(engine.worker.getWorkerGroup(admitted.group.groupId)).toMatchObject({
+      state: 'active', requestedMemberCount: 2, admittedMemberCount: 2,
+    });
+    expect(engine.worker.listWorkerGroupMembers(admitted.group.groupId).map((member) => member.ordinal))
+      .toEqual([1, 2]);
+    expect(engine.resources.listWorkerProviderConcurrencyForGroup(admitted.group.groupId)
+      .map((slot) => slot.state)).toEqual(['reserved', 'reserved']);
+    expect(projectReadOnlyRepositoryWorkerGroups({ engine })).toEqual({ inspected: 1, pendingVerification: [] });
+    for (const item of admitted.admissions) {
+      expect(engine.cancelJob({
+        jobId: item.admission.child.jobId,
+        reason: 'restart_reconciliation_fixture',
+        producer: 'test',
+        eventIdempotencyKey: `cancel-${item.memberId}`,
+      })).toMatchObject({ applied: true });
+    }
+    expect(projectReadOnlyRepositoryWorkerGroups({ engine })).toEqual({ inspected: 1, pendingVerification: [] });
+    expect(engine.worker.getWorkerGroup(admitted.group.groupId)).toMatchObject({
+      state: 'settled', cancelledMemberCount: 2, settledMemberCount: 2,
+    });
+    expect(engine.resources.listWorkerProviderConcurrencyForGroup(admitted.group.groupId)
+      .map((slot) => slot.state)).toEqual(['released', 'released']);
+    expect(projectReadOnlyRepositoryWorkerGroups({ engine })).toEqual({ inspected: 0, pendingVerification: [] });
+    reopened.close();
+  });
+});

--- a/tests/v4/worker/workerParallelRuntime.test.ts
+++ b/tests/v4/worker/workerParallelRuntime.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createDispatcher, makeRunner } from '../../../core/v4/daemon/dispatcher';
+import { createRunStore } from '../../../core/v4/daemon/runStore';
+import {
+  admitParallelWorkers,
+  createParallelWorkerFixture,
+  type ParallelWorkerFixture,
+} from './workerParallelFixture';
+
+describe('bounded parallel read-only Worker delivery', () => {
+  let fixture: ParallelWorkerFixture | undefined;
+  afterEach(async () => fixture?.close());
+
+  for (const count of [2, 4]) {
+    it(`delivers ${count} canonical child Jobs concurrently through the existing dispatcher`, async () => {
+      fixture = await createParallelWorkerFixture();
+      const admitted = admitParallelWorkers(fixture, { count });
+      let active = 0;
+      let peak = 0;
+      let release!: () => void;
+      const barrier = new Promise<void>((resolve) => { release = resolve; });
+      let processing!: Promise<Array<number | null>>;
+      const entered = new Promise<void>((resolve) => {
+        const dispatcher = createDispatcher({
+          triggerBus: fixture!.triggerBus,
+          runStore: createRunStore({ db: fixture!.db }),
+          db: fixture!.db,
+          jobEngine: fixture!.engine,
+          ownerId: 'worker-instance',
+          instanceId: 'worker-instance',
+          workerCount: count,
+          runnerFactory: () => makeRunner(async (input) => {
+            active += 1;
+            peak = Math.max(peak, active);
+            if (active === count) resolve();
+            await barrier;
+            active -= 1;
+            return { runId: input.admission!.runId, finishReason: 'stop' };
+          }),
+        });
+        processing = Promise.all(Array.from({ length: count }, () => dispatcher._pumpOnce()));
+      });
+      await entered;
+      expect(peak).toBe(count);
+      expect(admitted.admissions).toHaveLength(count);
+      for (const item of admitted.admissions) {
+        expect(fixture.engine.resources.authorize({
+          jobId: item.admission.child.jobId,
+          kind: 'tool',
+          value: 'shell_exec',
+        })).toBe(false);
+        expect(fixture.engine.resources.getWorkerProviderConcurrencyForMember(item.memberId))
+          .toMatchObject({ state: 'reserved', providerId: 'custom_openai' });
+      }
+      release();
+      await processing;
+      expect(fixture.triggerBus.stats().pending).toBe(0);
+    });
+  }
+});

--- a/tests/v4/worker/workerRecoveryReconciliation.test.ts
+++ b/tests/v4/worker/workerRecoveryReconciliation.test.ts
@@ -137,6 +137,55 @@ describe('Worker provider recovery reconciliation', () => {
     });
   });
 
+  it('keeps parallel provider capacity blocked when the physical outcome is unknown', () => {
+    const current = fixture = createWorkerFixture();
+    const records = bindRun(current);
+    current.engine.worker.createWorkerGroup({
+      ...current.parentAuthority,
+      producer: 'test', idempotencyKey: 'unknown-capacity-group',
+      groupId: 'worker_group_unknown_capacity', schemaVersion: 1, policy: 'require_all',
+      members: [{ memberId: 'worker_member_unknown_capacity', ordinal: 1, requestedProviderId: 'custom_openai' }],
+      now: 20,
+    });
+    current.engine.worker.bindWorkerGroupMember({
+      ...current.parentAuthority,
+      producer: 'test', idempotencyKey: 'unknown-capacity-member',
+      groupId: 'worker_group_unknown_capacity', memberId: 'worker_member_unknown_capacity',
+      assignmentId: records.assignment.assignmentId, childJobId: current.child.jobId,
+      childAttemptId: current.child.attemptId, childGeneration: current.childAuthority.childGeneration,
+      providerBindingId: records.providerBinding.providerBindingId,
+      now: 21,
+    });
+    current.engine.worker.completeWorkerGroupAdmission({
+      ...current.parentAuthority,
+      producer: 'test', idempotencyKey: 'unknown-capacity-admission', groupId: 'worker_group_unknown_capacity',
+      now: 22,
+    });
+    const slot = current.engine.resources.reserveWorkerProviderConcurrency({
+      providerSlotId: 'worker_provider_slot_unknown_capacity', idempotencyKey: 'unknown-capacity-slot',
+      groupId: 'worker_group_unknown_capacity', memberId: 'worker_member_unknown_capacity',
+      ...current.parentAuthority, providerId: 'custom_openai', limit: 1, now: 29,
+    });
+    const command = {
+      ...current.childAuthority,
+      logicalCallId: 'logical_unknown_capacity', idempotencyKey: 'logical-unknown-capacity',
+      workerRunId: records.run.workerRunId, assignmentId: records.assignment.assignmentId,
+      providerBindingId: records.providerBinding.providerBindingId, callOrdinal: 1,
+      requestHash: 'c'.repeat(64), toolSchemaHash: 'd'.repeat(64), now: 30,
+    };
+    current.engine.workerProviderCalls.prepare(command);
+    current.engine.workerProviderCalls.markAttempting(command);
+    current.db.prepare('UPDATE runs SET lease_expires_at=40 WHERE attempt_id=?').run(current.child.attemptId);
+    expect(sweepDurableJobRecovery({
+      jobEngine: current.engine,
+      triggerBus: createTriggerBus({ db: current.db }),
+      now: 41, instanceId: 'worker-instance', producer: 'test', maxCrashes: 3,
+    })).toMatchObject({ needsUser: 1, retried: 0 });
+    expect(current.engine.resources.getWorkerProviderConcurrency(slot.providerSlotId)).toMatchObject({
+      state: 'blocked_unknown', settlementReason: 'provider_outcome_unknown',
+    });
+  });
+
   it('persists cancellation intent through JobEngine before terminal Attempt settlement', () => {
     const { current, command } = prepare('attempting');
     expect(current.engine.cancelJob({


### PR DESCRIPTION
## Base

- Base commit: `a4f6e678b4088f44fef577cec68cd535effc5ea2`
- Package version remains `4.18.0`.

## Summary

- adds durable bounded groups for concurrent read-only repository Workers;
- defaults groups to two members and caps them at four;
- enforces parent and provider concurrency through durable resource reservations;
- keeps immutable group/member identity and canonical child Job/Attempt bindings;
- joins results deterministically by ordinal and stable member identity;
- supports explicit `require_all` and `allow_partial` aggregation;
- fans cancellation and timeout intent out durably before physical interruption;
- reconciles nonterminal groups after restart without replacing accepted results;
- requires independent parent verification before a candidate result can be aggregated as verified;
- keeps unknown provider outcomes blocked until reconciliation.

## Authority boundaries

- JobEngine remains authoritative for Job and Attempt lifecycle state.
- WorkerAuthority stores thin group/member relations to canonical child work.
- JobResourceAuthority owns parent and provider reservations.
- TriggerBus and the existing dispatcher deliver child Jobs.
- Existing provider-call, usage, proof, approval, cancellation, and execution-graph authorities remain unchanged.
- No second scheduler, queue, lifecycle authority, or Worker state machine was introduced.

## Migration

Schema migration v40 adds:

- `worker_groups`;
- `worker_group_members`;
- `worker_provider_concurrency_reservations`.

The migration is additive, preserves v39 data, supports reopen/idempotency, and includes bounded recovery indexes.

## Validation

Validated with Node `v22.23.1` / ABI 127:

- PR1–PR5 Worker matrix: 116/116 passed;
- dedicated Windows PTY files, serial: 44/44 passed;
- Git effect authority, isolated: 16/16 passed;
- codebase matrix, isolated by file: 87/87 passed;
- neighboring lifecycle/resource/accounting matrix: 80/80 passed;
- bootstrap/dispatcher matrix: 97/97 passed;
- typecheck passed;
- production build passed;
- package dry-run passed for `aiden-runtime@4.18.0`: 1,072 files, 2.4 MB packed, 9.1 MB unpacked;
- diff, NUL, secret, attribution, and scope scans passed.

The unchanged monolithic Windows command completed with 7,498 passed and 39 skipped, plus four load-sensitive failures. Each reported failure passed in its dedicated bounded run (PTY: 44/44; Git effect: 16/16). The draft remains gated on the clean GitHub CI matrix.

## Explicit exclusions

This change does not add nested or mutating Workers, dynamic fan-out, worktrees, distributed execution, a new scheduler/queue/lifecycle, UI changes, marketplace work, or package-version changes.

## PR6 handover

No PR6 work is included. A later slice can consume the durable group/member records, provider reservations, and deterministic aggregate without replacing the authority boundaries established here.