### PR TITLE
fix(runtime): fence trigger claims and reconcile worker admission

### DIFF
--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -2281,6 +2281,13 @@ function applyV40(db: Database.Database): void {
   `);
 }
 
+/** Durable claim identity for cross-process TriggerBus lease fencing. */
+function applyV41(db: Database.Database): void {
+  addMissingColumns(db, 'trigger_events', [
+    ['claim_token', 'TEXT'],
+  ]);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -2322,6 +2329,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 38, name: 'durable Worker provider calls and budget reservations', apply: applyV38 },
   { version: 39, name: 'Worker provider restart and reconciliation', apply: applyV39 },
   { version: 40, name: 'bounded parallel read-only Worker groups', apply: applyV40 },
+  { version: 41, name: 'durable TriggerBus claim fencing', apply: applyV41 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/db/schema/v1.spec.ts
+++ b/core/v4/daemon/db/schema/v1.spec.ts
@@ -55,6 +55,7 @@ export interface TriggerEventRowSql {
   status:           string;
   attempts:         number;
   claim_owner:      string | null;
+  claim_token:      string | null;
   claim_expires_at: number | null;
   last_error:       string | null;
   created_at:       number;

--- a/core/v4/daemon/triggerBus.ts
+++ b/core/v4/daemon/triggerBus.ts
@@ -65,11 +65,6 @@ export interface TriggerBus {
   get(eventId: number): TriggerEventRow | null;
 }
 
-interface InternalClaim {
-  eventId:    number;
-  claimToken: string;
-}
-
 function rowToTs(r: TriggerEventRowSql): TriggerEventRow {
   return {
     id:              r.id,
@@ -111,10 +106,6 @@ export interface CreateTriggerBusOptions {
 
 export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
   const db = opts.db;
-  // In-memory map of valid claim tokens. Stored separately from
-  // SQLite so cross-daemon claim attempts can't forge a token by
-  // reading the row. Token is wiped on markDone/release/markFailed.
-  const activeClaims: Map<number, string> = new Map();
 
   return {
     insert(ev: TriggerEventInput): { id: number; inserted: boolean } {
@@ -214,12 +205,13 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
             `UPDATE trigger_events
                 SET status           = 'claimed',
                     claim_owner      = ?,
+                    claim_token      = ?,
                     claim_expires_at = ?,
                     updated_at       = ?,
                     attempts         = attempts + 1
               WHERE id = ? AND status = 'pending'`,
           )
-          .run(opts2.ownerId, expires, now, candidate.id);
+          .run(opts2.ownerId, claimToken, expires, now, candidate.id);
         if (upd.changes === 0) return null;     // race lost
         const row = db
           .prepare('SELECT * FROM trigger_events WHERE id = ?')
@@ -228,52 +220,48 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
       });
       const row = tx();
       if (!row) return null;
-      activeClaims.set(row.id, claimToken);
       return { ...row, claimToken };
     },
 
     renewClaim(eventId: number, claimToken: string, extendMs: number): boolean {
-      if (activeClaims.get(eventId) !== claimToken) return false;
       const now = Date.now();
       const upd = db
         .prepare(
           `UPDATE trigger_events
               SET claim_expires_at = ?,
                   updated_at       = ?
-            WHERE id = ? AND status = 'claimed'`,
+            WHERE id = ? AND status = 'claimed' AND claim_token = ?`,
         )
-        .run(now + extendMs, now, eventId);
+        .run(now + extendMs, now, eventId, claimToken);
       return upd.changes > 0;
     },
 
     release(eventId: number, claimToken: string): void {
-      if (activeClaims.get(eventId) !== claimToken) return;
       const now = Date.now();
       db.prepare(
         `UPDATE trigger_events
             SET status           = 'pending',
                 claim_owner      = NULL,
+                claim_token      = NULL,
                 claim_expires_at = NULL,
                 updated_at       = ?
-          WHERE id = ? AND status = 'claimed'`,
-      ).run(now, eventId);
-      activeClaims.delete(eventId);
+          WHERE id = ? AND status = 'claimed' AND claim_token = ?`,
+      ).run(now, eventId, claimToken);
     },
 
     markDone(eventId: number, claimToken: string, runId?: number): void {
-      if (activeClaims.get(eventId) !== claimToken) return;
       const now = Date.now();
       db.prepare(
         `UPDATE trigger_events
             SET status           = 'done',
                 claim_owner      = NULL,
+                claim_token      = NULL,
                 claim_expires_at = NULL,
                 updated_at       = ?,
                 completed_at     = ?,
                 run_id           = COALESCE(?, run_id)
-          WHERE id = ? AND status = 'claimed'`,
-      ).run(now, now, runId ?? null, eventId);
-      activeClaims.delete(eventId);
+          WHERE id = ? AND status = 'claimed' AND claim_token = ?`,
+      ).run(now, now, runId ?? null, eventId, claimToken);
     },
 
     markFailed(
@@ -282,7 +270,6 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
       error:      string,
       opts2: { maxAttempts?: number; cooldownMs?: number } = {},
     ): void {
-      if (activeClaims.get(eventId) !== claimToken) return;
       const max = opts2.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
       const now = Date.now();
       const truncated = error.length > 1024 ? error.slice(0, 1024) + '…' : error;
@@ -297,8 +284,8 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
         : null;
       const tx = db.transaction((): void => {
         const row = db
-          .prepare('SELECT attempts FROM trigger_events WHERE id = ?')
-          .get(eventId) as { attempts: number } | undefined;
+          .prepare("SELECT attempts FROM trigger_events WHERE id = ? AND status = 'claimed' AND claim_token = ?")
+          .get(eventId, claimToken) as { attempts: number } | undefined;
         if (!row) return;
         // attempts was already incremented at claim time. Move to
         // dead_letter when the count hits max, else return to pending.
@@ -307,26 +294,27 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
             `UPDATE trigger_events
                 SET status           = 'dead_letter',
                     claim_owner      = NULL,
+                    claim_token      = NULL,
                     claim_expires_at = NULL,
                     last_error       = ?,
                     updated_at       = ?,
                     completed_at     = ?
-              WHERE id = ?`,
-          ).run(truncated, now, now, eventId);
+              WHERE id = ? AND status = 'claimed' AND claim_token = ?`,
+          ).run(truncated, now, now, eventId, claimToken);
         } else {
           db.prepare(
             `UPDATE trigger_events
                 SET status           = 'pending',
                     claim_owner      = NULL,
+                    claim_token      = NULL,
                     claim_expires_at = ?,
                     last_error       = ?,
                     updated_at       = ?
-              WHERE id = ?`,
-          ).run(cooldownUntil, truncated, now, eventId);
+              WHERE id = ? AND status = 'claimed' AND claim_token = ?`,
+          ).run(cooldownUntil, truncated, now, eventId, claimToken);
         }
       });
       tx();
-      activeClaims.delete(eventId);
     },
 
     reclaimExpired(now?: number): { reclaimed: number } {
@@ -336,6 +324,7 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
           `UPDATE trigger_events
               SET status           = 'pending',
                   claim_owner      = NULL,
+                  claim_token      = NULL,
                   claim_expires_at = NULL,
                   last_error       = COALESCE(last_error, 'claim lease expired'),
                   updated_at       = ?
@@ -353,13 +342,13 @@ export function createTriggerBus(opts: CreateTriggerBusOptions): TriggerBus {
         `UPDATE trigger_events
             SET status           = 'dead_letter',
                 claim_owner      = NULL,
+                claim_token      = NULL,
                 claim_expires_at = NULL,
                 last_error       = ?,
                 updated_at       = ?,
                 completed_at     = ?
           WHERE id = ?`,
       ).run(reason.length > 1024 ? reason.slice(0, 1024) + '…' : reason, now, now, eventId);
-      activeClaims.delete(eventId);
     },
 
     stats(): {

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,13 +31,13 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(40);
+    expect(LATEST_SCHEMA_VERSION).toBe(41);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([
       { name: 'repository_snapshot_entries' }, { name: 'repository_snapshots' },
     ]);
-    expect(runMigrations(db)).toEqual({ from: 32, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: 32, to: LATEST_SCHEMA_VERSION });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_change_%' ORDER BY name").all()).toEqual([
       { name: 'repository_change_intents' }, { name: 'repository_change_records' },
     ]);
@@ -53,7 +53,7 @@ describe('repository snapshot migration v32', () => {
       ]);
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('repository_architecture_notes','execution_graph_node_references') ORDER BY name").all())
       .toEqual([{ name: 'execution_graph_node_references' }, { name: 'repository_architecture_notes' }]);
-    expect(runMigrations(db)).toEqual({ from: 40, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: LATEST_SCHEMA_VERSION, to: LATEST_SCHEMA_VERSION });
   });
 
   it('adds validation records to a v33 database without changing repository history', () => {
@@ -77,7 +77,7 @@ describe('repository snapshot migration v32', () => {
       (session_id,instance_id,status,started_at,task_id,attempt_id,attempt_number,generation,state_version,next_event_sequence)
       VALUES ('session','instance','queued',?,'job','attempt',1,1,0,1)`).run(now);
 
-    expect(runMigrations(db)).toEqual({ from: 33, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: 33, to: LATEST_SCHEMA_VERSION });
     expect(db.prepare('SELECT id,status FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued' });
     expect(db.prepare('SELECT attempt_id,status FROM runs WHERE attempt_id=?').get('attempt'))
       .toEqual({ attempt_id: 'attempt', status: 'queued' });

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -3,7 +3,11 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { runMigrations, LATEST_SCHEMA_VERSION } from '../../../../core/v4/daemon/db/migrations';
+import {
+  runMigrations,
+  LATEST_SCHEMA_VERSION,
+  MIGRATIONS_FOR_TESTS,
+} from '../../../../core/v4/daemon/db/migrations';
 
 let db: Database.Database;
 
@@ -93,5 +97,32 @@ describe('runMigrations', () => {
     const row = db.prepare('SELECT * FROM schema_version').get() as { version: number; applied_at: number };
     expect(row.version).toBe(LATEST_SCHEMA_VERSION);
     expect(row.applied_at).toBeGreaterThan(0);
+  });
+
+  it('adds durable TriggerBus claim fencing without changing existing events', () => {
+    for (const migration of MIGRATIONS_FOR_TESTS.filter((item) => item.version <= 40)) {
+      if (migration.apply) migration.apply(db);
+      else db.exec(migration.sql ?? '');
+      db.prepare(
+        'INSERT OR REPLACE INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)',
+      ).run(migration.version, Date.now());
+    }
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO trigger_events
+         (source,source_key,payload_json,status,attempts,claim_owner,claim_expires_at,created_at,updated_at)
+       VALUES ('manual','preserved','{"value":1}','claimed',1,'legacy-owner',?,?,?)`,
+    ).run(now + 60_000, now, now);
+
+    expect(runMigrations(db)).toEqual({ from: 40, to: 41 });
+    expect(db.prepare(
+      'SELECT source_key,payload_json,status,claim_owner,claim_token FROM trigger_events WHERE source_key=?',
+    ).get('preserved')).toEqual({
+      source_key: 'preserved',
+      payload_json: '{"value":1}',
+      status: 'claimed',
+      claim_owner: 'legacy-owner',
+      claim_token: null,
+    });
   });
 });

--- a/tests/v4/daemon/triggerBus.test.ts
+++ b/tests/v4/daemon/triggerBus.test.ts
@@ -3,6 +3,9 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
 import type { TriggerBus } from '../../../core/v4/daemon/triggerBus';
@@ -156,6 +159,66 @@ describe('triggerBus.reclaimExpired', () => {
     bus.insert({ source: 'manual', sourceKey: 'a', payload: {} });
     bus.claim({ ownerId: 'inst-1', leaseMs: 60_000 })!;
     expect(bus.reclaimExpired(Date.now()).reclaimed).toBe(0);
+  });
+
+  it.each(['markDone', 'markFailed', 'release', 'renewClaim'] as const)(
+    'fences a stale claimant from %s after another bus reclaims the lease',
+    (operation) => {
+      const busA = createTriggerBus({ db });
+      const busB = createTriggerBus({ db });
+      const inserted = busA.insert({ source: 'manual', sourceKey: operation, payload: {} });
+      const claimA = busA.claim({ ownerId: 'instance-a', leaseMs: 1 })!;
+
+      expect(busB.reclaimExpired(Date.now() + 60_000)).toEqual({ reclaimed: 1 });
+      const claimB = busB.claim({ ownerId: 'instance-b', leaseMs: 60_000 })!;
+      expect(claimB.id).toBe(inserted.id);
+      expect(claimB.claimToken).not.toBe(claimA.claimToken);
+
+      if (operation === 'markDone') busA.markDone(claimA.id, claimA.claimToken);
+      if (operation === 'markFailed') busA.markFailed(claimA.id, claimA.claimToken, 'stale failure');
+      if (operation === 'release') busA.release(claimA.id, claimA.claimToken);
+      if (operation === 'renewClaim') {
+        expect(busA.renewClaim(claimA.id, claimA.claimToken, 60_000)).toBe(false);
+      }
+
+      expect(busB.get(claimB.id)).toMatchObject({
+        status: 'claimed',
+        claimOwner: 'instance-b',
+        attempts: 2,
+      });
+      busB.markDone(claimB.id, claimB.claimToken);
+      expect(busB.get(claimB.id)?.status).toBe('done');
+      busB.markDone(claimB.id, claimB.claimToken);
+      expect(busB.get(claimB.id)?.status).toBe('done');
+    },
+  );
+
+  it('persists the claim fence across independent SQLite connections', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'aiden-trigger-fence-'));
+    const databasePath = path.join(root, 'daemon.db');
+    const dbA = new Database(databasePath);
+    const dbB = new Database(databasePath);
+    try {
+      runMigrations(dbA);
+      const busA = createTriggerBus({ db: dbA });
+      const busB = createTriggerBus({ db: dbB });
+      busA.insert({ source: 'manual', sourceKey: 'cross-connection', payload: {} });
+      const claimA = busA.claim({ ownerId: 'process-a', leaseMs: 1 })!;
+      expect(busB.reclaimExpired(Date.now() + 60_000)).toEqual({ reclaimed: 1 });
+      const claimB = busB.claim({ ownerId: 'process-b', leaseMs: 60_000 })!;
+
+      busA.markDone(claimA.id, claimA.claimToken);
+      expect(busB.get(claimB.id)).toMatchObject({
+        status: 'claimed',
+        claimOwner: 'process-b',
+      });
+      busB.markDone(claimB.id, claimB.claimToken);
+      expect(busB.get(claimB.id)?.status).toBe('done');
+    } finally {
+      dbB.close();
+      dbA.close();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/v4/worker/readOnlyRepositoryWorkerAdmission.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerAdmission.test.ts
@@ -7,7 +7,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
@@ -167,6 +167,134 @@ describe('durable read-only repository Worker admission', () => {
     expect(() => admitReadOnlyRepositoryWorker({
       ...input, idempotencyKey: 'second-worker', goal: 'Inspect AGENTS.md.',
     })).toThrow(/one active read-only repository Worker/i);
+  });
+
+  it.each([
+    'after_child_job',
+    'after_assignment',
+    'after_reservation',
+    'after_group_binding',
+    'before_trigger_insert',
+    'after_trigger_insert',
+  ] as const)('reconciles an interrupted %s admission through the same durable identity', async (boundary) => {
+    const { parent, lease, snapshot, claim } = await parentAuthority();
+    const group = boundary === 'after_group_binding'
+      ? {
+          groupId: 'worker_group_crash_recovery',
+          memberId: 'worker_member_crash_recovery',
+          ordinal: 1,
+        }
+      : undefined;
+    if (group) {
+      engine.worker.createWorkerGroup({
+        parentJobId: parent.jobId,
+        parentAttemptId: parent.attemptId,
+        parentGeneration: lease.generation!,
+        parentFenceToken: lease.fenceToken!,
+        producer: 'test',
+        idempotencyKey: 'crash-recovery-group',
+        groupId: group.groupId,
+        schemaVersion: 1,
+        policy: 'require_all',
+        members: [{
+          memberId: group.memberId,
+          ordinal: group.ordinal,
+          requestedProviderId: 'custom_openai',
+        }],
+      });
+    }
+    const makeInput = () => ({
+      engine,
+      triggerBus,
+      parent: {
+        jobId: parent.jobId,
+        attemptId: parent.attemptId,
+        generation: lease.generation!,
+        fenceToken: lease.fenceToken!,
+      },
+      idempotencyKey: 'crash-recovery-admission',
+      goal: 'Inspect source.ts after admission recovery.',
+      repositorySnapshotId: snapshot.id,
+      planStepIds: ['inspect-source'],
+      claimIds: [claim.claimId],
+      provider: {
+        providerId: 'custom_openai',
+        modelId: 'custom-default',
+        providerRuntimeIdentity: 'runtime:custom_openai',
+        credentialReference: null,
+        endpointReference: 'endpoint:configured',
+        supportsToolCalling: true,
+        contextWindow: 32_768,
+        maxOutputTokens: 4_096,
+        selectionReason: 'configured provider',
+      },
+      ...(group ? { group } : {}),
+    } as const);
+
+    const crash = new Error(`simulated process failure ${boundary}`);
+    let restore: () => void;
+    if (boundary === 'after_child_job') {
+      const original = engine.submitJob.bind(engine);
+      const spy = vi.spyOn(engine, 'submitJob').mockImplementation((command) => {
+        original(command);
+        throw crash;
+      });
+      restore = () => spy.mockRestore();
+    } else if (boundary === 'after_assignment') {
+      const original = engine.worker.createWorkerAssignment.bind(engine.worker);
+      const spy = vi.spyOn(engine.worker, 'createWorkerAssignment').mockImplementation((command) => {
+        original(command);
+        throw crash;
+      });
+      restore = () => spy.mockRestore();
+    } else if (boundary === 'after_reservation') {
+      const original = engine.resources.reserveWorker.bind(engine.resources);
+      const spy = vi.spyOn(engine.resources, 'reserveWorker').mockImplementation((command) => {
+        original(command);
+        throw crash;
+      });
+      restore = () => spy.mockRestore();
+    } else if (boundary === 'after_group_binding') {
+      const original = engine.worker.bindWorkerGroupMember.bind(engine.worker);
+      const spy = vi.spyOn(engine.worker, 'bindWorkerGroupMember').mockImplementation((command) => {
+        original(command);
+        throw crash;
+      });
+      restore = () => spy.mockRestore();
+    } else if (boundary === 'before_trigger_insert') {
+      const spy = vi.spyOn(triggerBus, 'insert').mockImplementation(() => { throw crash; });
+      restore = () => spy.mockRestore();
+    } else {
+      const original = triggerBus.insert.bind(triggerBus);
+      const spy = vi.spyOn(triggerBus, 'insert').mockImplementation((event) => {
+        original(event);
+        throw crash;
+      });
+      restore = () => spy.mockRestore();
+    }
+
+    expect(() => admitReadOnlyRepositoryWorker(makeInput())).toThrow(crash);
+    restore();
+
+    engine = createJobEngine({ db });
+    triggerBus = createTriggerBus({ db });
+    const recovered = admitReadOnlyRepositoryWorker(makeInput());
+
+    expect(db.prepare('SELECT COUNT(*) AS count FROM tasks WHERE parent_task_id=?')
+      .get(parent.jobId)).toEqual({ count: 1 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM worker_assignments WHERE parent_job_id=?')
+      .get(parent.jobId)).toEqual({ count: 1 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM job_budget_reservations WHERE parent_job_id=?')
+      .get(parent.jobId)).toEqual({ count: 1 });
+    expect(db.prepare("SELECT COUNT(*) AS count FROM trigger_events WHERE source_key LIKE 'worker:%'")
+      .get()).toEqual({ count: 1 });
+    expect(recovered.triggerEvent.inserted).toBe(boundary !== 'after_trigger_insert');
+    if (group) {
+      expect(engine.worker.getWorkerGroupMember(group.memberId)).toMatchObject({
+        assignmentId: recovered.assignment.assignmentId,
+        childJobId: recovered.child.jobId,
+      });
+    }
   });
 
   it.each([

--- a/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorkerRuntime.test.ts
@@ -262,6 +262,18 @@ describe('read-only repository Worker runtime', () => {
 
     expect(childExecution.value.workerResult.acceptanceState).toBe('accepted');
     expect(childExecution.value.workerResult.providerAttemptIds).toHaveLength(2);
+    const childRuntime = engine.resources.getBudgets(admitted.child.jobId)
+      .find((item) => item.kind === 'runtime_ms');
+    const parentRuntime = engine.resources.getBudgets(parent.jobId)
+      .find((item) => item.kind === 'runtime_ms');
+    expect(childRuntime?.used).toBeGreaterThanOrEqual(0);
+    expect(parentRuntime?.used).toBe(childRuntime?.used);
+    expect(db.prepare(
+      "SELECT COUNT(*) AS count FROM job_budget_debits WHERE job_id=? AND kind='runtime_ms'",
+    ).get(admitted.child.jobId)).toEqual({ count: 1 });
+    expect(db.prepare(
+      "SELECT COUNT(*) AS count FROM job_budget_debits WHERE job_id=? AND kind='runtime_ms'",
+    ).get(parent.jobId)).toEqual({ count: 1 });
     expect(engine.proof.listEvidence(admitted.child.jobId)).toHaveLength(1);
     expect(engine.getChildContract(admitted.child.jobId)).toMatchObject({
       resultAttemptId: admitted.child.attemptId,

--- a/tests/v4/worker/workerMigration.test.ts
+++ b/tests/v4/worker/workerMigration.test.ts
@@ -83,8 +83,8 @@ describe('Worker persistence migration', () => {
     ).run('a'.repeat(64), 'b'.repeat(64));
     db.pragma('foreign_keys = ON');
     const before = new Set(tables());
-    expect(runMigrations(db)).toEqual({ from: 38, to: 40 });
-    expect(LATEST_SCHEMA_VERSION).toBe(40);
+    expect(runMigrations(db)).toEqual({ from: 38, to: LATEST_SCHEMA_VERSION });
+    expect(LATEST_SCHEMA_VERSION).toBe(41);
     expect(tables().filter((table) => !before.has(table))).toEqual([
       'job_budget_reservation_reconciliations',
       'worker_group_members',
@@ -147,16 +147,16 @@ describe('Worker persistence migration', () => {
       idempotencyNamespace: 'fixture', idempotencyKey: 'job', goal: 'legacy job',
     });
 
-    expect(runMigrations(db)).toEqual({ from: 36, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: 36, to: LATEST_SCHEMA_VERSION });
     const engine = createJobEngine({ db });
     expect(engine.getJob(before.jobId)?.goal).toBe('legacy job');
     expect(engine.worker.listWorkerRunsForParent(before.jobId)).toEqual([]);
   });
 
-  it('is idempotent when v40 is already installed', () => {
-    expect(runMigrations(db)).toEqual({ from: 0, to: 40 });
-    expect(runMigrations(db)).toEqual({ from: 40, to: 40 });
-    expect(LATEST_SCHEMA_VERSION).toBe(40);
+  it('is idempotent when the latest schema is already installed', () => {
+    expect(runMigrations(db)).toEqual({ from: 0, to: LATEST_SCHEMA_VERSION });
+    expect(runMigrations(db)).toEqual({ from: LATEST_SCHEMA_VERSION, to: LATEST_SCHEMA_VERSION });
+    expect(LATEST_SCHEMA_VERSION).toBe(41);
     expect(tables()).toEqual(expect.arrayContaining([
       'worker_groups', 'worker_group_members', 'worker_provider_concurrency_reservations',
     ]));
@@ -181,11 +181,11 @@ describe('Worker persistence migration', () => {
                1,'restart','outcome_unknown','blocked_unknown','[]',1,0,'blocked_unknown',1)`,
     ).run();
     db.pragma('foreign_keys = ON');
-    expect(runMigrations(db)).toEqual({ from: 39, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: 39, to: LATEST_SCHEMA_VERSION });
     expect(db.prepare(
       `SELECT outcome_knowledge,retry_safety,unknown_spend
          FROM worker_provider_call_reconciliations WHERE reconciliation_id='reconciliation_existing'`,
     ).get()).toEqual({ outcome_knowledge: 'outcome_unknown', retry_safety: 'blocked_unknown', unknown_spend: 1 });
-    expect(runMigrations(db)).toEqual({ from: 40, to: 40 });
+    expect(runMigrations(db)).toEqual({ from: LATEST_SCHEMA_VERSION, to: LATEST_SCHEMA_VERSION });
   });
 });

--- a/tests/v4/worker/workerParallelRecovery.test.ts
+++ b/tests/v4/worker/workerParallelRecovery.test.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { runMigrations } from '../../../core/v4/daemon/db/migrations';
+import { LATEST_SCHEMA_VERSION, runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 import { projectReadOnlyRepositoryWorkerGroups } from '../../../core/v4/worker/workerParallel';
 import {
@@ -35,7 +35,10 @@ describe('parallel read-only Worker restart projection', () => {
 
     const reopened = new Database(databasePath);
     reopened.pragma('foreign_keys = ON');
-    expect(runMigrations(reopened)).toEqual({ from: 40, to: 40 });
+    expect(runMigrations(reopened)).toEqual({
+      from: LATEST_SCHEMA_VERSION,
+      to: LATEST_SCHEMA_VERSION,
+    });
     const engine = createJobEngine({ db: reopened });
     expect(engine.worker.getWorkerGroup(admitted.group.groupId)).toMatchObject({
       state: 'active', requestedMemberCount: 2, admittedMemberCount: 2,


### PR DESCRIPTION
## Summary

- persists each TriggerBus claim identity in SQLite and fences completion, failure, release, and renewal against that exact identity;
- invalidates the prior claim identity when an expired lease is reclaimed while preserving existing database records through migration v41;
- adds deterministic crash-boundary coverage proving the existing read-only Worker admission path reconciles all six partial-admission boundaries without duplicate durable state;
- adds exactly-once runtime accounting coverage confirming child usage and parent roll-up are not double-debited.

## Root cause

TriggerBus claim identity was held only in process memory. Settlement updated a database row by event ID and claimed status, so a stale claimant could mutate a newer claimant's lease after expiry and reclaim.

## Validation

- focused prerequisite matrix: 12 passed;
- Worker and TriggerBus matrix: 151 passed;
- JobEngine, lifecycle, recovery, and resource matrix: 119 passed;
- Windows process subset: 31 passed;
- Windows PTY suite: 44 passed;
- offline integration: 33 passed, 7 skipped;
- deterministic Node 22 suite: 7,514 passed, 39 skipped;
- typecheck passed;
- production build passed;
- package dry-run passed for aiden-runtime@4.18.0;
- diff, NUL, secret, attribution, scope, and process-cleanup checks passed.

## Scope

Package version remains 4.18.0. This change contains only the kernel prerequisite correction and regression coverage.