### PR TITLE
fix(tui): stabilize the existing operator interface

### DIFF
--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -35,6 +35,7 @@ import { ChatSession } from './chatSession';
 import { runTuiMode } from './aidenTUI';
 import { Display } from './display';
 import { SkinEngine } from './skinEngine';
+import { isVerbose } from './design/tokens';
 import { initializeEffectiveTheme } from './themeCompatibility';
 import { CommandRegistry } from './commandRegistry';
 import { CliCallbacks } from './callbacks';
@@ -1743,7 +1744,7 @@ export async function buildAgentRuntime(
     config.getValue<string>('agent.tool_profile'),
     config.getValue<string[]>('agent.tool_profile_toolsets'),
   );
-  {
+  if (isVerbose()) {
     const filterDesc = toolProfile.toolsets === undefined
       ? 'all toolsets'
       : `[${[...toolProfile.toolsets].join(', ')}]`;
@@ -1773,9 +1774,11 @@ export async function buildAgentRuntime(
     skillCounts.skipped > 0
       ? ` (see ${skillsLogger.filePath})`
       : '';
-  display.dim(
-    `[skills] ${skillCounts.loaded} loaded, ${skillCounts.skipped} skipped${skipNote}`,
-  );
+  if (skillCounts.skipped > 0) {
+    display.warn(`[skills] ${skillCounts.loaded} loaded, ${skillCounts.skipped} skipped${skipNote}`);
+  } else if (isVerbose()) {
+    display.dim(`[skills] ${skillCounts.loaded} loaded, 0 skipped`);
+  }
   // Phase 17 Task 5: plugin loader boot.
   //
   // Bundled plugins (e.g. aiden-plugin-cdp-browser) are discovered

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -44,6 +44,9 @@ import { findGhost } from './ghostMatch';
 import { getSkinEngine } from './skinEngine';
 import { emitComposerReadyForTests } from './composerReadiness';
 import { nextComposerGeneration, turnIdleDiagnostic } from './turnIdleDiagnostics';
+import { truncateVisible } from './box';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
 
 /** Lightweight slash command shape — minimum the dropdown needs. */
 export interface SlashCommandLite {
@@ -100,7 +103,7 @@ function stripAnsi(s: string): string {
 
 /** Visible width — ignore ANSI escape sequences. */
 function vWidth(s: string): number {
-  return stripAnsi(s).length;
+  return stringWidth(stripAnsi(s));
 }
 
 /** Build an SGR span using the active skin. */
@@ -122,11 +125,11 @@ function renderDropdownRow(
   // The desc column is right-aligned and dim-coloured.
   const lhs = `${marker}${nameCell}`;
   const lhsWidth = vWidth(lhs);
-  const padBetween = Math.max(2, width - lhsWidth - vWidth(desc));
-  const truncatedDesc =
-    vWidth(desc) > width - lhsWidth - 2
-      ? desc.slice(0, Math.max(0, width - lhsWidth - 3)) + '…'
-      : desc;
+  const descWidth = Math.max(0, width - lhsWidth - 2);
+  const truncatedDesc = vWidth(desc) > descWidth
+    ? `${truncateVisible(desc, Math.max(0, descWidth - 1))}…`
+    : desc;
+  const padBetween = Math.max(2, width - lhsWidth - vWidth(truncatedDesc));
   const dimDesc = sk.applyColors(truncatedDesc, 'muted');
   const painted = selected
     ? sk.applyColors(lhs, 'brand')

--- a/cli/v4/aidenTUI.ts
+++ b/cli/v4/aidenTUI.ts
@@ -23,6 +23,7 @@
 import { ChatSession } from './chatSession';
 import type { ChatSessionOptions, ChatPromptApi } from './chatSession';
 import type { CommandRegistry } from './commandRegistry';
+import { buildToolPreview, summarizeToolArguments } from './toolPreview';
 
 export interface TuiOptions {
   /** Pre-built ChatSessionOptions (same shape Phase 14c hands ChatSession). */
@@ -294,8 +295,8 @@ export class AidenTUI {
       userTurn: (text: string) => `{#ff6b35-fg}you{/} ${text}`,
       agentTurn: (text: string) => `{cyan-fg}Aiden{/cyan-fg}\n${text}`,
       toolPreview: (name: string, args: unknown) => {
-        const argStr = safeJson(args).slice(0, 200);
-        return `{gray-fg}→ ${name} ${argStr}{/gray-fg}`;
+        const summary = buildToolPreview(name, args) ?? summarizeToolArguments(args);
+        return `{gray-fg}→ ${name}${summary ? ` ${summary}` : ''}{/gray-fg}`;
       },
 
       startSpinner: (text: string) => this.startTuiSpinner(text),
@@ -452,12 +453,4 @@ export class AidenTUI {
 function stripAnsi(s: string): string {
   // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
-}
-
-function safeJson(v: unknown): string {
-  try {
-    return JSON.stringify(v);
-  } catch {
-    return String(v);
-  }
 }

--- a/cli/v4/box.ts
+++ b/cli/v4/box.ts
@@ -28,6 +28,9 @@
  */
 
 // ── Sharp (default) ──────────────────────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
+
 const SHARP = {
   TL: '┌',
   TR: '┐',
@@ -57,18 +60,13 @@ interface GlyphSet {
 }
 
 /**
- * Strip ANSI CSI escape sequences and return the visible length in
- * Unicode code units (`String.length`). Sufficient for all colour
- * codes we emit (`\x1b[38;2;r;g;bm`, `\x1b[39m`, `\x1b[0m`, etc.).
- *
- * Doesn't try to handle East Asian wide chars / emoji-with-VS16 — we
- * use only single-cell glyphs in box content (✓ ⚠ ✗ ⏵ ▶ ⊕). Wide-
- * char-aware width is available in `cli/v4/table.ts` via
- * `string-width`, used only by the table renderer.
+ * Strip ANSI CSI escape sequences and return physical terminal columns.
+ * Wide glyphs, combining characters, and emoji sequences are measured by
+ * `string-width`; ANSI colour bytes remain zero-width.
  */
 const ANSI_REGEX = /\x1b\[[0-9;]*[A-Za-z]/g;
 export function visibleLength(s: string): number {
-  return s.replace(ANSI_REGEX, '').length;
+  return stringWidth(s.replace(ANSI_REGEX, ''));
 }
 
 /**
@@ -80,10 +78,10 @@ export function visibleLength(s: string): number {
 export function truncateVisible(s: string, maxVisible: number): string {
   if (visibleLength(s) <= maxVisible) return s;
   let out = '';
-  let visible = 0;
+  let plain = '';
   let i = 0;
   let sawAnsi = false;
-  while (i < s.length && visible < maxVisible) {
+  while (i < s.length) {
     const ch = s.charCodeAt(i);
     if (ch === 0x1b && s[i + 1] === '[') {
       const m = s.slice(i).match(/^\x1b\[[0-9;]*[A-Za-z]/);
@@ -94,9 +92,13 @@ export function truncateVisible(s: string, maxVisible: number): string {
         continue;
       }
     }
-    out += s[i];
-    visible += 1;
-    i += 1;
+    const codePoint = s.codePointAt(i);
+    if (codePoint === undefined) break;
+    const character = String.fromCodePoint(codePoint);
+    if (stringWidth(plain + character) > maxVisible) break;
+    out += character;
+    plain += character;
+    i += character.length;
   }
   return sawAnsi ? out + '\x1b[0m' : out;
 }

--- a/cli/v4/box.ts
+++ b/cli/v4/box.ts
@@ -103,6 +103,20 @@ export function truncateVisible(s: string, maxVisible: number): string {
   return sawAnsi ? out + '\x1b[0m' : out;
 }
 
+/** ANSI-aware activity truncation that prefers a complete word. */
+export function truncateVisibleAtWord(s: string, maxVisible: number): string {
+  const width = Math.max(1, Math.floor(maxVisible));
+  if (visibleLength(s) <= width) return s;
+  if (width === 1) return '…';
+  const candidate = truncateVisible(s, width - 1);
+  const plain = candidate.replace(ANSI_REGEX, '').replace(/\x1b\[0m$/u, '');
+  const boundary = Math.max(plain.lastIndexOf(' '), plain.lastIndexOf('—'));
+  if (boundary > 0) {
+    return `${truncateVisible(candidate, visibleLength(plain.slice(0, boundary).trimEnd()))}…`;
+  }
+  return `${candidate}…`;
+}
+
 // ── Generic primitives ───────────────────────────────────────────
 
 function renderTop(g: GlyphSet, width: number): string {

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -1039,7 +1039,7 @@ function redactApprovalTarget(value: string): string {
 }
 
 function truncateApproval(value: string, width: number): string {
-  if (value.length <= width) return value;
-  if (width <= 1) return value.slice(0, width);
-  return `${value.slice(0, width - 1)}…`;
+  if (visibleLength(value) <= width) return value;
+  if (width <= 1) return truncateVisible(value, width);
+  return `${truncateVisible(value, width - 1)}…`;
 }

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -541,6 +541,21 @@ export class CliCallbacks {
     if (!settled) return;
 
     try { this.renderBlockerCardIfPresent(result); } catch { /* defensive */ }
+    if (call.name === 'skill_view') {
+      const args = call.arguments && typeof call.arguments === 'object'
+        ? call.arguments as Record<string, unknown> : {};
+      const payload = result?.result && typeof result.result === 'object'
+        ? result.result as Record<string, unknown> : {};
+      try {
+        this.display.renderUiEvent('ui_skill_invocation', {
+          invocation_id: call.id,
+          skill_name: typeof args.name === 'string' ? args.name : 'skill',
+          duration_ms: timing?.executionDurationMs,
+          reference_name: typeof payload.referenceName === 'string' ? payload.referenceName
+            : typeof payload.reference_name === 'string' ? payload.reference_name : undefined,
+        });
+      } catch { /* structured activity must never affect execution */ }
+    }
     try {
       const payload = result?.result && typeof result.result === 'object'
         ? { ...(result.result as Record<string, unknown>), ...(result.error ? { error: result.error } : {}) }

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -603,7 +603,9 @@ export class CliCallbacks {
     // Yellow distinguishes the awaiting-attention state from the
     // brand-orange (informational) frames used by setup-complete and
     // /doctor.
-    this.display.writeTransient(renderApprovalBox(req, this.display) + '\n');
+    if (this.verboseMode === 'verbose' || this.display.getActivityPresentationMode() === 'full') {
+      this.display.writeTransient(renderApprovalBox(req, this.display) + '\n');
+    }
 
     const prompts = await this.promptsPromise;
     let choice: string;

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -512,7 +512,11 @@ export class CliCallbacks {
     let settled: boolean;
     const timing = result?.activityTiming;
     const terminal = timing?.terminalClassification;
-    if (typeof err === 'string' && err.includes('URL provenance gate')) {
+    const expectedDiscoveryMiss = this.getActivityPresentationMode() === 'summary'
+      && isExpectedDiscoveryMiss(call.name, call.arguments, err);
+    if (expectedDiscoveryMiss) {
+      settled = this.activities.settle(call.id, { state: 'completed', dismiss: true, timing });
+    } else if (typeof err === 'string' && err.includes('URL provenance gate')) {
       settled = this.activities.settle(call.id, { state: 'blocked', timing });
     } else if (terminal === 'cancelled') {
       settled = this.activities.settle(call.id, { state: 'cancelled', timing });
@@ -529,7 +533,7 @@ export class CliCallbacks {
       const status = payload && typeof payload === 'object'
         ? (payload as { status?: unknown }).status
         : undefined;
-      const dismiss = isExclusiveToolInteraction(
+      const dismiss = call.name === 'skill_view' || isExclusiveToolInteraction(
         this.resolveToolInteraction?.(call.name),
       );
       settled = status === 'cancelled'
@@ -541,18 +545,30 @@ export class CliCallbacks {
     if (!settled) return;
 
     try { this.renderBlockerCardIfPresent(result); } catch { /* defensive */ }
-    if (call.name === 'skill_view') {
+    if (expectedDiscoveryMiss) {
+      try {
+        this.display.renderUiEvent('ui_expected_discovery_miss', {
+          target: discoveryTarget(call.arguments),
+        });
+      } catch { /* structured activity must never affect execution */ }
+    }
+    if (call.name === 'skill_view' && !err) {
       const args = call.arguments && typeof call.arguments === 'object'
         ? call.arguments as Record<string, unknown> : {};
       const payload = result?.result && typeof result.result === 'object'
         ? result.result as Record<string, unknown> : {};
+      const requestedReference = typeof args.path === 'string' ? args.path.trim() : '';
+      const loadedFile = typeof payload.filePath === 'string' ? payload.filePath.trim() : '';
+      const loadedSegments = loadedFile.split(/[\\/]/u);
+      const loadedReference = requestedReference || loadedSegments[loadedSegments.length - 1] || '';
       try {
         this.display.renderUiEvent('ui_skill_invocation', {
           invocation_id: call.id,
           skill_name: typeof args.name === 'string' ? args.name : 'skill',
           duration_ms: timing?.executionDurationMs,
           reference_name: typeof payload.referenceName === 'string' ? payload.referenceName
-            : typeof payload.reference_name === 'string' ? payload.reference_name : undefined,
+            : typeof payload.reference_name === 'string' ? payload.reference_name
+              : loadedReference || undefined,
         });
       } catch { /* structured activity must never affect execution */ }
     }
@@ -1059,4 +1075,28 @@ function truncateApproval(value: string, width: number): string {
   if (visibleLength(value) <= width) return value;
   if (width <= 1) return truncateVisible(value, width);
   return `${truncateVisible(value, width - 1)}…`;
+}
+
+const EXPECTED_DISCOVERY_TOOLS = new Set([
+  'file_list', 'list_directory', 'list_directory_with_sizes', 'directory_tree',
+]);
+const EXPECTED_DISCOVERY_ROOTS = new Set([
+  'app', 'apps', 'lib', 'libs', 'package', 'packages', 'src', 'test', 'tests',
+]);
+
+function discoveryTarget(args: unknown): string {
+  if (!args || typeof args !== 'object') return 'path';
+  const input = args as Record<string, unknown>;
+  const value = typeof input.path === 'string' ? input.path
+    : typeof input.directory === 'string' ? input.directory : 'path';
+  return value.trim() || 'path';
+}
+
+function isExpectedDiscoveryMiss(name: string, args: unknown, error: unknown): boolean {
+  if (!EXPECTED_DISCOVERY_TOOLS.has(name) || typeof error !== 'string') return false;
+  if (!/(?:\bENOENT\b|not found|no such file or directory)/iu.test(error)) return false;
+  const target = discoveryTarget(args);
+  if (target === 'path' || /[\r\n\u0000]/u.test(target)) return false;
+  const normalized = target.replace(/^[.][\\/]/u, '').replace(/[\\/]+$/u, '').toLowerCase();
+  return EXPECTED_DISCOVERY_ROOTS.has(normalized);
 }

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -616,6 +616,8 @@ export class ChatSession implements ChatSessionLike {
   private turnCount = 0;
   private lastTurnOutcome: 'ok' | 'warn' | 'error' | 'muted' = 'ok';
   private lastFooterProvider: string | null = null;
+  private footerMaxContextUsed = 0;
+  private footerMaxElapsedMs = 0;
 
   /**
    * Phase v4.1.2-memory-AB:
@@ -3850,6 +3852,10 @@ export class ChatSession implements ChatSessionLike {
 
   /** Phase 22 Task 4: state transitions for the right-most segment. */
   setStatusState(state: StatusState): void {
+    if (state.kind === 'generating' && this.statusState.kind !== 'generating') {
+      this.footerMaxContextUsed = 0;
+      this.footerMaxElapsedMs = 0;
+    }
     this.statusState = state;
   }
 
@@ -3877,8 +3883,10 @@ export class ChatSession implements ChatSessionLike {
     } catch {
       limits = this.modelMetadata.getDefaults();
     }
-    const usedTokens = this.modelMetadata.estimateMessageTokens(this.history);
+    const estimatedTokens = this.modelMetadata.estimateMessageTokens(this.history);
     const maxTokens = limits.contextLength;
+    this.footerMaxContextUsed = Math.max(this.footerMaxContextUsed, estimatedTokens);
+    const usedTokens = this.footerMaxContextUsed;
 
     // v4.8.0 Slice 7 hotfix — predictable 1-blank-line rhythm: one
     // blank above the footer (visual breath after the reply), one
@@ -3911,9 +3919,9 @@ export class ChatSession implements ChatSessionLike {
       display.setStatusFooter((cols) => display.statusFooter({
         ...statusArgs,
         cols,
-        elapsedMs: this.statusState.kind === 'generating'
+        elapsedMs: this.footerMaxElapsedMs = Math.max(this.footerMaxElapsedMs, this.statusState.kind === 'generating'
           ? Date.now() - this.statusState.sinceMs
-          : this.lastTurnElapsedMs,
+          : this.lastTurnElapsedMs),
         sessionMs: Date.now() - this.startedAt,
       }));
       return;

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -2199,6 +2199,12 @@ export class ChatSession implements ChatSessionLike {
     // = exactly one blank row between user input and Aiden header,
     // matching the rhythm Shiva flagged in smoke.
     const turnStartedAt = Date.now();
+    let activitiesCompleted = false;
+    const completeActivityTurnOnce = (): void => {
+      if (activitiesCompleted) return;
+      activitiesCompleted = true;
+      try { this.opts.callbacks.completeActivityTurn(); } catch { /* defensive */ }
+    };
     const userMsg: Message = { role: 'user', content: userInput };
 
     // Apply any queued system prompts (from skill slash commands) by
@@ -2778,6 +2784,7 @@ export class ChatSession implements ChatSessionLike {
           : undefined,
       }));
       const result = await runAgent();
+      this.setStatusState({ kind: 'settling' });
       if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && replRunId !== null) {
         currentProviderAttemptLedger()?.reconcileJobLinkage({
           taskId: replTaskId,
@@ -3202,6 +3209,7 @@ export class ChatSession implements ChatSessionLike {
         );
       }
 
+      completeActivityTurnOnce();
       this.setStatusState({ kind: 'ready' });
       this.lastTurnElapsedMs = Date.now() - turnStartedAt;
       // v4.8.0 Slice 7 — record per-turn outcome for the status dot.
@@ -3241,6 +3249,7 @@ export class ChatSession implements ChatSessionLike {
         }
       } catch { /* defensive */ }
     } catch (err) {
+      this.setStatusState({ kind: 'settling' });
       stopIndicatorOnce();
       // v4.1.4 Part 1.6: error path must also hide the progress bar
       // so it doesn't leak across the boundary into the error chrome
@@ -3295,6 +3304,7 @@ export class ChatSession implements ChatSessionLike {
           try { replTaskStore.setStatus(replTaskId, 'cancelled'); }
           catch { /* persistence faults must not crash REPL */ }
         }
+        completeActivityTurnOnce();
         this.setStatusState({ kind: 'ready' });
         this.lastTurnElapsedMs = Date.now() - turnStartedAt;
         this.turnCount += 1;
@@ -3381,6 +3391,7 @@ export class ChatSession implements ChatSessionLike {
             ?? 'Run `/model` to switch providers or `aiden doctor` to diagnose.',
         );
       }
+      completeActivityTurnOnce();
       this.setStatusState({ kind: 'ready' });
       this.lastTurnElapsedMs = Date.now() - turnStartedAt;
       // v4.8.0 Slice 7 — error path also bumps the turn counter and
@@ -3405,7 +3416,7 @@ export class ChatSession implements ChatSessionLike {
       });
       // Tool/activity rows are turn-scoped. Terminal callbacks normally settle
       // them earlier; this sweep catches cancellation and missing callbacks.
-      try { this.opts.callbacks.completeActivityTurn(); } catch { /* defensive */ }
+      completeActivityTurnOnce();
       turnIdleDiagnostic('turn.activities.finalized', {
         turnId,
         activityCount: this.opts.callbacks.activeActivityCount?.() ?? 0,
@@ -3889,6 +3900,7 @@ export class ChatSession implements ChatSessionLike {
         state:     this.lastTurnOutcome,
         phase:     this.statusState.kind === 'approve' ? 'approval_required'
           : this.statusState.kind === 'retry' ? 'recovering'
+            : this.statusState.kind === 'settling' ? 'completing'
             : this.statusState.kind === 'ready' ? 'ready'
               : registryPhase === 'ready'
                 ? this.statusState.kind === 'exec' ? 'working' : 'thinking'
@@ -4143,6 +4155,7 @@ export function detectShell(): string {
  */
 export type StatusState =
   | { kind: 'ready' }
+  | { kind: 'settling' }
   | { kind: 'generating'; sinceMs: number }
   | { kind: 'exec' }
   | { kind: 'approve' }
@@ -4157,6 +4170,8 @@ export function formatStatusState(
   now: number = Date.now(),
 ): { text: string; colour: 'brand' | 'muted' | 'warn' } {
   switch (state.kind) {
+    case 'settling':
+      return { text: 'settling', colour: 'brand' };
     case 'generating': {
       const ms = Math.max(0, now - state.sinceMs);
       return { text: `⏵ ${formatDuration(ms)}`, colour: 'brand' };

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -799,11 +799,12 @@ export class BottomRegion {
     }
     const growth = Math.max(0, nextRows - previousRows);
     const previousTranscriptBottom = Math.max(1, this.sink.rows() - previousRows);
-    // When a wrapped draft grows upward, scroll transcript rows before claiming
-    // the additional cells. This preserves the newest transcript content above
-    // the composer instead of erasing it during the geometry change.
+    // Grow the reserved surface by scrolling only the transcript region. A
+    // newline here would commit the old volatile composer rows to native
+    // scrollback on Windows main-buffer hosts.
     const makeRoom = growth > 0
-      ? `${ESC}[${previousTranscriptBottom};1H${'\n'.repeat(growth)}`
+      ? `${RESTORE_TRANSCRIPT}${ESC}[1;${previousTranscriptBottom}r` +
+        `${ESC}[${growth}S`
       : '';
     const clear = dimensionsChanged
       ? this.clearDamagedUnion(previousGeometry, nextGeometry)
@@ -813,7 +814,7 @@ export class BottomRegion {
       return `${RESTORE_TRANSCRIPT}${SAVE}${ESC}[r${clear}` +
         `${ESC}[1;${transcriptBottom}r${RESTORE}${SAVE_TRANSCRIPT}`;
     }
-    return `${RESTORE_TRANSCRIPT}${makeRoom}${ESC}[r` +
+    return `${makeRoom}${ESC}[r` +
       `${clear}` +
       `${reserveSeq(this.sink.rows(), nextRows)}${SAVE_TRANSCRIPT}`;
   }
@@ -826,7 +827,6 @@ export class BottomRegion {
     });
     const surface = this.surface();
     const frame = surface.lines.join('\n');
-    const previousLaneRows = this.laneRows;
     const geometry = this.establishGeometry(surface.laneRows);
     if (!geometry && frame === this.lastFrame && !rebuildTranscript) {
       if (epoch === this.projection.viewport.epoch) {
@@ -838,9 +838,6 @@ export class BottomRegion {
     this.rememberSurface(surface);
     const topRow = this.sink.rows() - surface.laneRows + 1;
     let sequence = geometry;
-    if (rebuildTranscript || (previousLaneRows > 0 && surface.laneRows < previousLaneRows)) {
-      sequence += this.transcriptFrame(surface);
-    }
     surface.lines.forEach((line, index) => {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });
@@ -924,8 +921,6 @@ export class BottomRegion {
       laneRows: surface.laneRows,
       topRow: Math.max(1, this.sink.rows() - surface.laneRows + 1),
     };
-    const releasedRows = previousGeometry !== null
-      && surface.laneRows < previousGeometry.laneRows;
     this.geometry = nextGeometry;
     this.lastFrame = surface.lines.join('\n');
     this.rememberSurface(surface);
@@ -940,7 +935,6 @@ export class BottomRegion {
       sequence += `${this.pendingTranscriptOutput}${SAVE_TRANSCRIPT}`;
     }
     this.pendingTranscriptOutput = '';
-    if (releasedRows) sequence += this.transcriptFrame(surface);
     surface.lines.forEach((line, index) => {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -26,6 +26,7 @@ import {
   type OperatorProjectionState,
 } from './operatorProjection';
 import { wrap as wrapAnsiText } from './display/frame';
+import { truncateVisibleAtWord } from './box';
 import { terminalSupportsUnicode } from './terminalSymbols';
 import { resizeReadyMarkerForTests } from './composerReadiness';
 
@@ -106,28 +107,7 @@ const PLAIN_BOTTOM_STYLE: BottomRegionStyle = {
 function fitStatus(text: string, cols: number): string {
   const width = Math.max(4, cols);
   if (terminalWidth(text) <= width) return text;
-  let plain = '';
-  let out = '';
-  let sawAnsi = false;
-  for (let i = 0; i < text.length;) {
-    if (text[i] === ESC && text[i + 1] === '[') {
-      const match = /^\x1b\[[0-9;]*[A-Za-z]/u.exec(text.slice(i));
-      if (match) {
-        out += match[0];
-        i += match[0].length;
-        sawAnsi = true;
-        continue;
-      }
-    }
-    const codePoint = text.codePointAt(i);
-    if (codePoint === undefined) break;
-    const character = String.fromCodePoint(codePoint);
-    if (stringWidth(plain + character) > width) break;
-    out += character;
-    plain += character;
-    i += character.length;
-  }
-  return sawAnsi ? `${out}${ESC}[0m` : out;
+  return truncateVisibleAtWord(text, width);
 }
 
 function fitReflowSafeStatus(text: string, cols: number): string {
@@ -498,8 +478,7 @@ export class BottomRegion {
       this.finishResizeBurstNow();
       return;
     }
-    this.sink.write(`${RESTORE_TRANSCRIPT}${terminal}${SAVE_TRANSCRIPT}`);
-    this.paintAll();
+    this.paintAll(false, terminal);
   }
 
   /** Move the transcript viewport away from or toward the live tail. */
@@ -831,7 +810,7 @@ export class BottomRegion {
       `${reserveSeq(this.sink.rows(), nextRows)}${SAVE_TRANSCRIPT}`;
   }
 
-  private paintAll(rebuildTranscript = false): void {
+  private paintAll(rebuildTranscript = false, transcriptOutput = ''): void {
     if (!this.active || this.resizeBurstActive) return;
     const epoch = this.projection.viewport.epoch;
     this.projection = reduceOperatorProjection(this.projection, {
@@ -840,7 +819,7 @@ export class BottomRegion {
     const surface = this.surface();
     const frame = surface.lines.join('\n');
     const geometry = this.establishGeometry(surface.laneRows);
-    if (!geometry && frame === this.lastFrame && !rebuildTranscript) {
+    if (!geometry && frame === this.lastFrame && !rebuildTranscript && !transcriptOutput) {
       if (epoch === this.projection.viewport.epoch) {
         this.sink.write(`${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`);
       }
@@ -849,7 +828,9 @@ export class BottomRegion {
     this.lastFrame = frame;
     this.rememberSurface(surface);
     const topRow = this.sink.rows() - surface.laneRows + 1;
-    let sequence = geometry;
+    let sequence = transcriptOutput
+      ? `${RESTORE_TRANSCRIPT}${transcriptOutput}${SAVE_TRANSCRIPT}${geometry}`
+      : geometry;
     surface.lines.forEach((line, index) => {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -89,12 +89,17 @@ type StatusSource = string | ((columns?: number) => string);
 export interface BottomRegionStyle {
   brand(value: string): string;
   muted(value: string): string;
+  /** Prompt identity and draft content use distinct cyan tokens. */
+  prompt?: (value: string) => string;
+  promptContent?: (value: string) => string;
   unicode?: boolean;
 }
 
 const PLAIN_BOTTOM_STYLE: BottomRegionStyle = {
   brand: (value) => value,
   muted: (value) => value,
+  prompt: (value) => value,
+  promptContent: (value) => value,
 };
 
 /** ANSI-aware front truncation used as the final no-wrap status guard. */
@@ -323,7 +328,14 @@ export function renderBottomSurface(
     : fitStatus(status, availableWidth);
   const topRow = rows - laneRows + 1;
   return {
-    lines: [top, style.brand(fittedTitle), divider, ...content, bottom, fittedStatus],
+    lines: [
+      top,
+      (style.prompt ?? style.brand)(fittedTitle),
+      divider,
+      ...content.map((line) => (style.promptContent ?? ((value: string) => value))(line)),
+      bottom,
+      fittedStatus,
+    ],
     laneRows,
     cursorRow: topRow + 3 + wrapped.cursorLine,
     cursorCol: Math.min(availableWidth, 1 + wrapped.cursorCell),

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -420,7 +420,14 @@ export class BottomRegion {
   /** Project one identity-backed live row above the composer. */
   setLiveRow(id: string, text: string): void {
     if (this.terminalLiveRows.has(id)) return;
-    const normalized = text.replace(/\r?\n$/u, '');
+    const lines = text.replace(/\r/g, '').split('\n');
+    while (lines.length > 0 && lines[0].trim().length === 0) lines.shift();
+    while (lines.length > 0 && lines[lines.length - 1]?.trim().length === 0) lines.pop();
+    const normalized = lines.join('\n');
+    if (normalized.length === 0) {
+      this.removeLiveRow(id);
+      return;
+    }
     const current = this.projection.activities[id];
     const next = reduceOperatorProjection(this.projection, current
       ? { type: 'activity.progress', id, generation: current.generation, summary: normalized }
@@ -819,6 +826,7 @@ export class BottomRegion {
     });
     const surface = this.surface();
     const frame = surface.lines.join('\n');
+    const previousLaneRows = this.laneRows;
     const geometry = this.establishGeometry(surface.laneRows);
     if (!geometry && frame === this.lastFrame && !rebuildTranscript) {
       if (epoch === this.projection.viewport.epoch) {
@@ -830,7 +838,9 @@ export class BottomRegion {
     this.rememberSurface(surface);
     const topRow = this.sink.rows() - surface.laneRows + 1;
     let sequence = geometry;
-    if (rebuildTranscript) sequence += this.transcriptFrame(surface);
+    if (rebuildTranscript || (previousLaneRows > 0 && surface.laneRows < previousLaneRows)) {
+      sequence += this.transcriptFrame(surface);
+    }
     surface.lines.forEach((line, index) => {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });
@@ -914,6 +924,8 @@ export class BottomRegion {
       laneRows: surface.laneRows,
       topRow: Math.max(1, this.sink.rows() - surface.laneRows + 1),
     };
+    const releasedRows = previousGeometry !== null
+      && surface.laneRows < previousGeometry.laneRows;
     this.geometry = nextGeometry;
     this.lastFrame = surface.lines.join('\n');
     this.rememberSurface(surface);
@@ -928,6 +940,7 @@ export class BottomRegion {
       sequence += `${this.pendingTranscriptOutput}${SAVE_TRANSCRIPT}`;
     }
     this.pendingTranscriptOutput = '';
+    if (releasedRows) sequence += this.transcriptFrame(surface);
     surface.lines.forEach((line, index) => {
       sequence += `${ESC}[${topRow + index};1H${ESC}[2K${line}`;
     });

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -91,6 +91,22 @@ function truncateTerminalVisible(value: string, maxVisible: number): string {
   }
   return sawAnsi ? output + '\x1b[0m' : output;
 }
+
+function fitQualifiedActivityDetail(value: string, maxVisible: number): string {
+  if (visibleLength(value) <= maxVisible) return value;
+  const separator = ' · ';
+  const splitAt = value.lastIndexOf(separator);
+  if (splitAt < 0) return truncateVisible(value, maxVisible);
+  const target = value.slice(0, splitAt);
+  const qualifier = value.slice(splitAt + separator.length);
+  const reserved = visibleLength(separator) + visibleLength(qualifier);
+  if (reserved >= maxVisible) return qualifier;
+  const targetWidth = maxVisible - reserved;
+  const fittedTarget = visibleLength(target) <= targetWidth
+    ? target
+    : `${truncateVisible(target, Math.max(0, targetWidth - 1))}…`;
+  return `${fittedTarget}${separator}${qualifier}`;
+}
 // Phase v4.1-reply-formatting: skin-aware markdown renderer that
 // replaces marked-terminal's defaults with structured headers, lists,
 // code blocks, blockquotes, and links.
@@ -452,6 +468,7 @@ export class Display {
   private composerSurfacePauseDepth = 0;
   private nextLiveRowIdentity = 0;
   private activityPresentationMode: ActivityPresentationMode = 'summary';
+  private compactTerminalActivityKeys = new Set<string>();
 
   constructor(opts: { skin?: SkinEngine; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream } = {}) {
     this.skin = opts.skin ?? getSkinEngine();
@@ -1726,7 +1743,9 @@ export class Display {
     // onToolCall 'before' branch), so `turnHadTools` flips even for
     // hidden tools. The separator logic stays correct regardless of
     // whether ONLY hidden tools fired this turn.
-    if (TRAIL_HIDE_TOOLS.has(name)) {
+    if (TRAIL_HIDE_TOOLS.has(name) || (
+      this.activityPresentationMode === 'summary' && name === 'ui_command_result'
+    )) {
       return makeNoOpToolRowHandle();
     }
 
@@ -1803,10 +1822,8 @@ export class Display {
           0,
           width - visibleLength(compactPrefix) - visibleLength(compactSuffix),
         );
-        return `${compactPrefix}${truncateVisible(
-          sk.applyColors(detailForDisplay(), 'muted'),
-          availableDetail,
-        )}${compactSuffix}\n`;
+        const fittedDetail = fitQualifiedActivityDetail(detailForDisplay(), availableDetail);
+        return `${compactPrefix}${sk.applyColors(fittedDetail, 'muted')}${compactSuffix}\n`;
       }
       const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph}  ` +
         `${sk.applyColors(padVerb(verb), 'tool')} `;
@@ -1840,10 +1857,8 @@ export class Display {
         const width = terminalRowWidth() ?? screenOwner.volatileRowWidth();
         const compactPrefix = `${TRAIL_PIPE} ${outcomeGlyph} ${terminalVerb} `;
         const availableDetail = Math.max(0, width - visibleLength(compactPrefix));
-        return `${sk.applyColors(
-          `${compactPrefix}${truncateVisible(detailForDisplay(), availableDetail)}`,
-          kind,
-        )}\n`;
+        const fittedDetail = fitQualifiedActivityDetail(detailForDisplay(), availableDetail);
+        return `${sk.applyColors(`${compactPrefix}${fittedDetail}`, kind)}\n`;
       }
       const prefix = `${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(terminalVerb)} `;
       const suffixText = suffix ? `  ${suffix}` : '';
@@ -1949,7 +1964,20 @@ export class Display {
         : /^unknown\b/u.test(suffix) ? 'unknown'
         : /^(?:fail|failed|blocked|partial|empty (?:fail|retry))\b/u.test(suffix) ? 'failed'
         : 'succeeded';
-      replaceLast(outcomeRow(suffix, kind), true, terminalState);
+      const terminalRow = outcomeRow(suffix, kind);
+      const compactKey = terminalRow.replace(DISPLAY_ANSI_PATTERN, '').trim();
+      if (
+        screenOwner &&
+        this.activityPresentationMode === 'summary' &&
+        this.compactTerminalActivityKeys.has(compactKey)
+      ) {
+        eraseLast(true);
+        return;
+      }
+      if (screenOwner && this.activityPresentationMode === 'summary') {
+        this.compactTerminalActivityKeys.add(compactKey);
+      }
+      replaceLast(terminalRow, true, terminalState);
     };
 
     const startRunningTick = (): void => {
@@ -3254,10 +3282,12 @@ export class Display {
    */
   resetUiTurnState(): void {
     this.uiEventsFiredThisTurn = false;
+    this.compactTerminalActivityKeys.clear();
   }
 
   renderUiEvent(name: string, args: Record<string, unknown>): void {
     if (!this.out.isTTY) return;
+    if (name === 'ui_command_result' && this.activityPresentationMode === 'summary') return;
     // v4.8.0 Phase 2.3 fix — Option C. The post-stream markdown rerender
     // (`tryRerenderInPlace`) does `cursor-up-N + erase-to-end-of-screen`,
     // which wipes anything painted between stream start and stream end —

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -3329,7 +3329,12 @@ export class Display {
    */
   private uiTrailRow(content: string, kind: ColorKind): string {
     const pipe = this.skin.applyColors(TRAIL_PIPE, 'muted');
-    return content.split('\n').map(l => `${pipe} ${this.skin.applyColors(l, kind)}\n`).join('');
+    return content.split('\n').map((line) => {
+      const match = /^(?:(?:└|├)\s+)?([✓✕×!◐◈◇◆↻■ℹ⚠])([\s\S]*)$/u.exec(line);
+      if (!match) return `${pipe} ${this.skin.applyColors(line, kind)}\n`;
+      const prefix = line.slice(0, line.indexOf(match[1]));
+      return `${pipe} ${this.skin.applyColors(prefix, 'muted')}${this.skin.applyColors(match[1], kind)}${this.skin.applyColors(match[2], 'muted')}\n`;
+    }).join('');
   }
 
   /** Strongly colour only the structured category; keep goals and metadata muted. */
@@ -3352,7 +3357,7 @@ export class Display {
     const glyph = terminalSupportsUnicode()
       ? (status === 'paused' ? '⏸' : status === 'blocked' ? '!' : '◐')
       : terminalStateSymbol(status === 'blocked' ? 'warning' : 'running');
-    const colorKind: ColorKind = status === 'running' ? 'tool' : 'warn';
+    const colorKind: ColorKind = status === 'running' ? 'warn' : 'error';
     this.uiTaskRows.set(taskId, { label });
     const short  = label.length > 80 ? label.slice(0, 79) + '…' : label;
     // v4.8.0 Phase 2.4 — subagent kind: indent by depth inside the

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -97,7 +97,7 @@ function truncateTerminalVisible(value: string, maxVisible: number): string {
 import { getReplyRenderer } from './replyRenderer';
 // Optional "Sources" footer when AIDEN_CITATIONS=1 (default off).
 import { renderCitationFooter } from './citationFooter';
-import { buildToolPreview } from './toolPreview';
+import { buildToolPreview, summarizeToolArguments } from './toolPreview';
 import { renderComposerBuffer } from './composerRow';
 import {
   ComposerLane,
@@ -1747,16 +1747,18 @@ export class Display {
     // meaningful primary-arg preview instead of a JSON blob. Fall back
     // to the generic `previewToolArgs` scan for tools the map doesn't
     // know about so unregistered MCP tools etc. still render readably.
-    const mapped = buildToolPreview(name, args);
-    const rawDetail = mapped ?? previewToolArgs(args);
+    const mapped = buildToolPreview(name, args, { mode: this.activityPresentationMode });
+    const rawDetail = mapped ?? previewToolArgs(args, this.activityPresentationMode);
     const detailForDisplay = (): string => {
-      if (screenOwner?.usesReflowSafeRows()) {
-        const segments = rawDetail.split(/[\\/]/u);
-        return segments[segments.length - 1] ?? rawDetail;
+      const relative = relativizeActivityText(rawDetail, process.cwd(), this.activityPresentationMode);
+      if (this.activityPresentationMode === 'full') return relative;
+      if (screenOwner?.usesReflowSafeRows() && /(?:^|_)(?:file|read|write|edit|patch|list|copy|move|delete)(?:_|$)/iu.test(name)) {
+        const [target, ...qualifiers] = relative.split(' · ');
+        const segments = target.split(/[\\/]/u);
+        const base = segments[segments.length - 1] ?? target;
+        return [base, ...qualifiers].filter(Boolean).join(' · ');
       }
-      return this.activityPresentationMode === 'full'
-        ? rawDetail
-        : truncDetail(relativizeActivityText(rawDetail, process.cwd(), 'summary'));
+      return truncDetail(relative);
     };
 
     // Semantic elapsed time comes from ActivityRegistry. A compatibility row
@@ -2178,15 +2180,10 @@ export class Display {
       return `${sk.applyColors(arrow, 'tool')} ${sk.applyColors(name, 'tool')} ${sk.applyColors(preview, 'muted')}`;
     }
 
-    // Unknown tool — original behaviour (full JSON, 200-char cap).
-    let serialized: string;
-    try {
-      serialized = JSON.stringify(args);
-    } catch {
-      serialized = String(args);
-    }
-    if (serialized.length > 200) serialized = `${serialized.slice(0, 197)}...`;
-    return `${sk.applyColors(arrow, 'tool')} ${sk.applyColors(name, 'tool')} ${sk.applyColors(serialized, 'muted')}`;
+    // Unknown tools stay human-readable in normal output. Raw structured
+    // arguments remain available to the execution trace and full details.
+    const summary = summarizeToolArguments(args);
+    return `${sk.applyColors(arrow, 'tool')} ${sk.applyColors(name, 'tool')}${summary ? ` ${sk.applyColors(summary, 'muted')}` : ''}`;
   }
 
   /**
@@ -3691,7 +3688,7 @@ export interface ToolRowHandle {
  * truncates with an ellipsis at TOOL_ROW_ARG_CAP. Pure — no side
  * effects, deterministic for a given input.
  */
-export function previewToolArgs(args: unknown): string {
+export function previewToolArgs(args: unknown, mode: ActivityPresentationMode = 'summary'): string {
   if (args == null) return '';
   if (typeof args === 'string') return truncToolArg(args);
   if (typeof args !== 'object') return truncToolArg(String(args));
@@ -3710,12 +3707,9 @@ export function previewToolArgs(args: unknown): string {
         : `"${v}"`);
     }
   }
+  if (mode !== 'full') return summarizeToolArguments(obj);
   let serialized: string;
-  try {
-    serialized = JSON.stringify(obj);
-  } catch {
-    serialized = String(obj);
-  }
+  try { serialized = JSON.stringify(obj); } catch { serialized = String(obj); }
   // v4.1.4-media: an empty object serializes to '{}'. Rendering that
   // literal in the trail row is honest but ugly and reads as "buggy
   // empty args". When the model legitimately passes an empty args
@@ -3724,13 +3718,13 @@ export function previewToolArgs(args: unknown): string {
   // tools mapped in `TOOL_PRIMARY_ARG`; here we extend the same UX to
   // any unmapped-tool fallback that bottoms out at `{}`.
   if (serialized === '{}') return '';
-  return truncToolArg(serialized);
+  return mode === 'full' ? serialized : truncToolArg(serialized);
 }
 
 function truncToolArg(s: string): string {
   const flat = s.replace(/\s+/g, ' ').trim();
-  if (flat.length <= TOOL_ROW_ARG_CAP) return flat;
-  return flat.slice(0, TOOL_ROW_ARG_CAP - 1) + '…';
+  if (visibleLength(flat) <= TOOL_ROW_ARG_CAP) return flat;
+  return `${truncateVisible(flat, TOOL_ROW_ARG_CAP - 1)}…`;
 }
 
 /**

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -49,6 +49,10 @@ import {
   projectActivityFrame,
   projectCommandPresentation,
   projectEvidenceLines,
+  projectSkillInvocation,
+  projectWorkerDelegation,
+  projectContextCompaction,
+  dedupeStructuredActivity,
   relativizeActivityText,
   semanticPhaseCompactToken,
   semanticPhaseForTool,
@@ -120,6 +124,7 @@ import {
   composerLaneEnabled,
   type BottomComposerMode,
   type BottomComposerSurface,
+  type BottomRegionStyle,
   type LaneSink,
 } from './composerLane';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
@@ -1128,7 +1133,7 @@ export class Display {
     // surface family (▎ Aiden header, status footer, bottom hint).
     // Timestamp variant unchanged — the timestamp gutter already
     // provides its own consistent left edge.
-    const tri = this.skin.applyColors(terminalStateSymbol('user'), 'brand');
+    const tri = this.skin.applyColors(terminalStateSymbol('user'), 'prompt');
     if (process.env.AIDEN_UI_TIMESTAMPS === '1') {
       return `${this.timestampPrefix()}  ${tri} `;
     }
@@ -1621,7 +1626,8 @@ export class Display {
         : width >= 80 ? this.composerSuffix()
         : width >= 36 ? '  Ctrl+C stop'
         : '  Ctrl+C';
-      const activity = this.skin.applyColors(projection.text, projection.color);
+      const activity = `${this.skin.applyColors(projection.glyph, projection.glyphColor)} `
+        + this.skin.applyColors(`${projection.label}${source === 'provider' && this.activityPresentationMode === 'full' ? ' · provider request' : ''}`, projection.color);
       return truncateVisible(`${prefix}${activity}${time}${suffix}`, width);
     };
     const erase = (terminal = false): void => {
@@ -2236,8 +2242,9 @@ export class Display {
   /** Format a user turn (e.g. echoed back from history). */
   userTurn(text: string): string {
     const sk = this.skin;
-    const body = text.split('\n').map((line) => `  ${line}`).join('\n');
-    return `  ${this.rule()}\n${sk.applyColors(`  ${terminalStateSymbol('user')} You`, 'user')}\n${body}\n  ${this.rule()}\n`;
+    const body = text.split('\n').map((line) => sk.applyColors(`  ${line}`, 'prompt_content')).join('\n');
+    const label = sk.applyColors(`  ${terminalStateSymbol('user')} You`, 'prompt');
+    return `  ${this.rule()}\n${label}\n${body}\n  ${this.rule()}\n`;
   }
 
   /**
@@ -2411,8 +2418,10 @@ export class Display {
    * restore an empty ready composer. Empty Enter remains a local no-op. */
   submitIdleComposer(value: string, hint: string): void {
     if (value.length > 0) {
-      const body = value.split('\n').map((line) => `  ${line}`).join('\n');
-      this.write(`${this.promptPrefix()}You\n${body}\n  ${this.rule()}`);
+      const body = value.split('\n')
+        .map((line) => this.skin.applyColors(`  ${line}`, 'prompt_content'))
+        .join('\n');
+      this.write(`${this.promptPrefix()}${this.skin.applyColors('You', 'prompt')}\n${body}\n  ${this.rule()}`);
     }
     this.idleComposerContent = `${this.promptPrefix()} ${hint}`;
     this.idleComposerDraft = '';
@@ -2503,7 +2512,7 @@ export class Display {
     if (this.composerSurfacePauseDepth > 0) return;
     if (composerLaneEnabled() && this.out.isTTY) {
       if (!this.composerLane) {
-        this.composerLane = new ComposerLane(this.laneSink(), this.laneStyle());
+      this.composerLane = new ComposerLane(this.laneSink(), this.laneStyle());
       }
       const content = this.composerContent();
       const hasStatus = typeof this.statusFooterSource === 'function'
@@ -2533,10 +2542,12 @@ export class Display {
     if (this.composerSurfacePauseDepth === 0) this.paintComposerSurface();
   }
 
-  private laneStyle(): { brand(value: string): string; muted(value: string): string } {
+  private laneStyle(): BottomRegionStyle {
     return {
       brand: (value) => this.skin.applyColors(value, 'brand'),
       muted: (value) => this.skin.applyColors(value, 'muted'),
+      prompt: (value) => this.skin.applyColors(value, 'prompt'),
+      promptContent: (value) => this.skin.applyColors(value, 'prompt_content'),
     };
   }
 
@@ -3264,6 +3275,7 @@ export class Display {
   // on done. Map is per-Display-instance; one REPL session.
   private uiTaskRows = new Map<string, { label: string }>();
   private uiTaskTerminalIds = new Set<string>();
+  private structuredActivityIds = new Set<string>();
 
   // v4.8.0 Phase 2.3 fix — set true by renderUiEvent; tryRerenderInPlace
   // early-returns when set so the cursor-up + erase-to-end-of-screen
@@ -3283,6 +3295,7 @@ export class Display {
   resetUiTurnState(): void {
     this.uiEventsFiredThisTurn = false;
     this.compactTerminalActivityKeys.clear();
+    this.structuredActivityIds.clear();
   }
 
   renderUiEvent(name: string, args: Record<string, unknown>): void {
@@ -3302,6 +3315,9 @@ export class Display {
     if (name === 'ui_approval_request') { this.renderUiApprovalRequest(args); return; }
     if (name === 'ui_toast')            { this.renderUiToast(args);           return; }
     if (name === 'ui_artifact_created') { this.renderUiArtifactCreated(args); return; }
+    if (name === 'ui_skill_invocation') { this.renderUiSkillInvocation(args); return; }
+    if (name === 'ui_worker_group') { this.renderUiWorkerGroup(args); return; }
+    if (name === 'ui_context_compacted') { this.renderUiContextCompacted(); return; }
     // Unknown event names silent-ignore (defensive — future registrations).
   }
 
@@ -3314,6 +3330,14 @@ export class Display {
   private uiTrailRow(content: string, kind: ColorKind): string {
     const pipe = this.skin.applyColors(TRAIL_PIPE, 'muted');
     return content.split('\n').map(l => `${pipe} ${this.skin.applyColors(l, kind)}\n`).join('');
+  }
+
+  /** Strongly colour only the structured category; keep goals and metadata muted. */
+  private uiStructuredTrailRow(content: string, kind: ColorKind): string {
+    const pipe = this.skin.applyColors(TRAIL_PIPE, 'muted');
+    const match = /^(\S+)(\s+)(.*)$/u.exec(content);
+    if (!match) return `${pipe} ${this.skin.applyColors(content, kind)}\n`;
+    return `${pipe} ${this.skin.applyColors(match[1], kind)}${match[2]}${this.skin.applyColors(match[3], 'muted')}\n`;
   }
 
   private renderUiTaskUpdate(args: Record<string, unknown>): void {
@@ -3417,6 +3441,49 @@ export class Display {
     if (skipped > 0) parts.push(`${skipped} skipped`);
     const dur = durationMs > 0 ? ` in ${durationMs}ms` : '';
     this.writeOutput(this.uiTrailRow(`${ok ? '✓' : '✗'} ${framework}: ${parts.join(', ')}${dur}`, ok ? 'success' : 'error'));
+    this.streamLastEndedNewline = true;
+  }
+
+  private renderUiSkillInvocation(args: Record<string, unknown>): void {
+    const invocationId = typeof args.invocation_id === 'string' ? args.invocation_id : '';
+    const skillName = typeof args.skill_name === 'string' ? args.skill_name : '';
+    const durationMs = typeof args.duration_ms === 'number' ? args.duration_ms : undefined;
+    const referenceName = typeof args.reference_name === 'string' ? args.reference_name : undefined;
+    const lines = projectSkillInvocation({ invocationId, skillName, durationMs, referenceName })
+      .filter((line) => !this.structuredActivityIds.has(line.identity));
+    if (lines.length === 0) return;
+    this.commitStreamChunk();
+    lines.forEach((line) => this.structuredActivityIds.add(line.identity));
+    const rendered = lines.map((line) => this.uiStructuredTrailRow(line.text, line.color)).join('');
+    this.writeOutput(rendered);
+    this.streamLastEndedNewline = true;
+  }
+
+  private renderUiWorkerGroup(args: Record<string, unknown>): void {
+    const groupId = typeof args.group_id === 'string' ? args.group_id : '';
+    const workers = Array.isArray(args.workers)
+      ? args.workers.filter((worker): worker is { goal: string } => (
+        !!worker && typeof worker === 'object' && typeof (worker as { goal?: unknown }).goal === 'string'
+      ))
+      : [];
+    const state = args.state === 'succeeded' || args.state === 'failed' || args.state === 'blocked' || args.state === 'unknown'
+      ? args.state : 'running';
+    const elapsedMs = typeof args.elapsed_ms === 'number' ? args.elapsed_ms : undefined;
+    const lines = dedupeStructuredActivity(projectWorkerDelegation({ groupId, workers, state, elapsedMs }))
+      .filter((line) => !this.structuredActivityIds.has(line.identity));
+    if (lines.length === 0) return;
+    this.commitStreamChunk();
+    lines.forEach((line) => this.structuredActivityIds.add(line.identity));
+    this.writeOutput(lines.map((line) => this.uiStructuredTrailRow(line.text, line.color)).join(''));
+    this.streamLastEndedNewline = true;
+  }
+
+  private renderUiContextCompacted(): void {
+    const line = projectContextCompaction();
+    if (this.structuredActivityIds.has(line.identity)) return;
+    this.structuredActivityIds.add(line.identity);
+    this.commitStreamChunk();
+    this.writeOutput(this.uiStructuredTrailRow(line.text, line.color));
     this.streamLastEndedNewline = true;
   }
 

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -25,7 +25,7 @@ const TerminalRenderer: new (opts?: unknown) => unknown = require('marked-termin
 const stringWidth: (value: string) => number = require('string-width');
 
 import { SkinEngine, getSkinEngine, type ColorKind } from './skinEngine';
-import { visibleLength, truncateVisible } from './box';
+import { visibleLength, truncateVisible, truncateVisibleAtWord } from './box';
 import { glyphs } from './design/tokens';
 import { clearLinesUpSeq } from './display/cursorSeq';
 import {
@@ -97,10 +97,11 @@ function truncateTerminalVisible(value: string, maxVisible: number): string {
 }
 
 function fitQualifiedActivityDetail(value: string, maxVisible: number): string {
+  if (maxVisible <= 0) return '';
   if (visibleLength(value) <= maxVisible) return value;
   const separator = ' · ';
   const splitAt = value.lastIndexOf(separator);
-  if (splitAt < 0) return truncateVisible(value, maxVisible);
+  if (splitAt < 0) return truncateVisibleAtWord(value, maxVisible);
   const target = value.slice(0, splitAt);
   const qualifier = value.slice(splitAt + separator.length);
   const reserved = visibleLength(separator) + visibleLength(qualifier);
@@ -108,7 +109,7 @@ function fitQualifiedActivityDetail(value: string, maxVisible: number): string {
   const targetWidth = maxVisible - reserved;
   const fittedTarget = visibleLength(target) <= targetWidth
     ? target
-    : `${truncateVisible(target, Math.max(0, targetWidth - 1))}…`;
+    : truncateVisibleAtWord(target, targetWidth);
   return `${fittedTarget}${separator}${qualifier}`;
 }
 // Phase v4.1-reply-formatting: skin-aware markdown renderer that
@@ -1628,7 +1629,7 @@ export class Display {
         : '  Ctrl+C';
       const activity = `${this.skin.applyColors(projection.glyph, projection.glyphColor)} `
         + this.skin.applyColors(`${projection.label}${source === 'provider' && this.activityPresentationMode === 'full' ? ' · provider request' : ''}`, projection.color);
-      return truncateVisible(`${prefix}${activity}${time}${suffix}`, width);
+      return truncateVisibleAtWord(`${prefix}${activity}${time}${suffix}`, width);
     };
     const erase = (terminal = false): void => {
       if (!printed || !isTty) return;
@@ -1765,6 +1766,12 @@ export class Display {
     const useIcons = process.env.AIDEN_UI_ICONS !== '0' && terminalSupportsUnicode();
     const { icon, verb } = trailIconForTool(name);
     const glyph = useIcons ? icon : sk.applyColors('·', 'muted');
+    const operationKind: ColorKind = /(?:subagent|worker)/iu.test(name) ? 'worker'
+      : name === 'skill_view' || /(?:^|_)skill(?:_|$)/iu.test(name) ? 'skill'
+        : /(?:read|list|inspect|search|fetch|snapshot)/iu.test(name) ? 'inspecting'
+          : /(?:verify|evidence|proof|test)/iu.test(name) ? 'evidence'
+            : 'tool';
+    const operationLabel = operationKind === 'worker' ? 'Worker' : verb.trim();
 
     // Detail field: v4.1.4-media — consult `buildToolPreview` first so
     // tools registered in `TOOL_PRIMARY_ARG` (media_transport → 'target',
@@ -1777,6 +1784,9 @@ export class Display {
     const detailForDisplay = (): string => {
       const relative = relativizeActivityText(rawDetail, process.cwd(), this.activityPresentationMode);
       if (this.activityPresentationMode === 'full') return relative;
+      if (operationKind === 'worker') {
+        return relative.replace(/^(\d+)\s+Workers?\b/u, '$1');
+      }
       if (screenOwner?.usesReflowSafeRows() && /(?:^|_)(?:file|read|write|edit|patch|list|copy|move|delete)(?:_|$)/iu.test(name)) {
         const [target, ...qualifiers] = relative.split(' · ');
         const segments = target.split(/[\\/]/u);
@@ -1814,11 +1824,14 @@ export class Display {
       });
       const duration = elapsed >= 1000 ? ` ${formatToolDuration(elapsed)}` : '';
       const liveSuffix = `  ${sk.applyColors(`${semanticPhaseStatusLabel(semanticPhase)}${duration}…`, phaseColorKind(semanticPhase))}`;
-      const runningGlyph = sk.applyColors(projection.glyph, projection.color);
+      const runningGlyph = sk.applyColors(
+        projection.glyph,
+        operationKind === 'worker' ? 'worker' : projection.glyphColor,
+      );
       if (screenOwner?.usesReflowSafeRows()) {
         const width = terminalRowWidth() ?? screenOwner.volatileRowWidth();
         const compactPrefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph} ` +
-          `${sk.applyColors(verb.trim(), 'tool')} `;
+          `${sk.applyColors(operationLabel, operationKind)} `;
         const compactPhase = sk.applyColors(
           `${semanticPhaseCompactToken(semanticPhase, useIcons)}${duration}`,
           phaseColorKind(semanticPhase),
@@ -1832,7 +1845,7 @@ export class Display {
         return `${compactPrefix}${sk.applyColors(fittedDetail, 'muted')}${compactSuffix}\n`;
       }
       const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph}  ` +
-        `${sk.applyColors(padVerb(verb), 'tool')} `;
+        `${sk.applyColors(padVerb(operationLabel), operationKind)} `;
       const suffix = `${liveSuffix}${screenOwner ? '' : this.composerSuffix()}`;
       const detailText = sk.applyColors(detailForDisplay(), 'muted');
       const width = terminalRowWidth();
@@ -1850,7 +1863,8 @@ export class Display {
       const outcomeGlyph = terminalSupportsUnicode()
         ? (failed ? '!' : '✓')
         : terminalStateSymbol(failed ? 'failed' : 'completed');
-      const terminalVerb = /^denied\b/u.test(suffix) ? 'denied'
+      const terminalVerb = operationKind === 'worker' ? 'Worker'
+        : /^denied\b/u.test(suffix) ? 'denied'
         : /^cancelled\b/u.test(suffix) ? 'cancelled'
         : /^timed out\b/u.test(suffix) ? 'timed out'
         : /^unknown\b/u.test(suffix) ? 'unknown'
@@ -1864,19 +1878,23 @@ export class Display {
         const compactPrefix = `${TRAIL_PIPE} ${outcomeGlyph} ${terminalVerb} `;
         const availableDetail = Math.max(0, width - visibleLength(compactPrefix));
         const fittedDetail = fitQualifiedActivityDetail(detailForDisplay(), availableDetail);
-        return `${sk.applyColors(`${compactPrefix}${fittedDetail}`, kind)}\n`;
+        return `${sk.applyColors(TRAIL_PIPE, 'muted')} ` +
+          `${sk.applyColors(outcomeGlyph, failed ? 'error' : 'success')} ` +
+          `${sk.applyColors(terminalVerb, operationKind)}${fittedDetail ? ` ${sk.applyColors(fittedDetail, 'muted')}` : ''}\n`;
       }
-      const prefix = `${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(terminalVerb)} `;
       const suffixText = suffix ? `  ${suffix}` : '';
       const width = terminalRowWidth();
       const availableDetail = width === null
         ? Number.POSITIVE_INFINITY
-        : Math.max(0, width - visibleLength(prefix) - visibleLength(suffixText));
+        : Math.max(0, width - visibleLength(`${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(terminalVerb)} `) - visibleLength(suffixText));
       const displayDetail = detailForDisplay();
-      const content = `${prefix}${availableDetail === Number.POSITIVE_INFINITY
+      const fittedDetail = availableDetail === Number.POSITIVE_INFINITY
         ? displayDetail
-        : truncateVisible(displayDetail, availableDetail)}${suffixText}`;
-      return `${sk.applyColors(content, kind)}\n`;
+        : truncateVisibleAtWord(displayDetail, availableDetail);
+      return `${sk.applyColors(TRAIL_PIPE, 'muted')} ` +
+        `${sk.applyColors(outcomeGlyph, failed ? 'error' : 'success')}  ` +
+        `${sk.applyColors(padVerb(terminalVerb), operationKind)} ` +
+        `${sk.applyColors(fittedDetail, 'muted')}${sk.applyColors(suffixText, kind)}\n`;
     };
 
     // Capture stream reference so closures don't need `this`.
@@ -2812,6 +2830,7 @@ export class Display {
   private streamProjectionSequence = 0;
   private streamProjectionId = '';
   private streamProjectionHeaderPending = false;
+  private streamSettledThisTurn = false;
 
   private projectedStreamOwner(): ComposerLane | null {
     return this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()
@@ -2909,7 +2928,7 @@ export class Display {
    * the full body is in hand.
    */
   streamPartial(text: string): void {
-    if (!text) return;
+    if (!text || this.streamSettledThisTurn) return;
     const projectedOwner = this.projectedStreamOwner();
     if (!this.streamHeaderShown) {
       // Phase 26.2.3 — share the `▎ Aiden` header with non-streaming
@@ -3209,6 +3228,7 @@ export class Display {
    */
   streamComplete(): void {
     if (!this.streamHeaderShown) return;
+    this.streamSettledThisTurn = true;
     const projectedOwner = this.projectedStreamOwner();
     if (projectedOwner) {
       this.settleProjectedStream(projectedOwner);
@@ -3294,6 +3314,7 @@ export class Display {
    */
   resetUiTurnState(): void {
     this.uiEventsFiredThisTurn = false;
+    this.streamSettledThisTurn = false;
     this.compactTerminalActivityKeys.clear();
     this.structuredActivityIds.clear();
   }
@@ -3318,6 +3339,7 @@ export class Display {
     if (name === 'ui_skill_invocation') { this.renderUiSkillInvocation(args); return; }
     if (name === 'ui_worker_group') { this.renderUiWorkerGroup(args); return; }
     if (name === 'ui_context_compacted') { this.renderUiContextCompacted(); return; }
+    if (name === 'ui_expected_discovery_miss') { this.renderUiExpectedDiscoveryMiss(args); return; }
     // Unknown event names silent-ignore (defensive — future registrations).
   }
 
@@ -3345,6 +3367,18 @@ export class Display {
     return `${pipe} ${this.skin.applyColors(match[1], kind)}${match[2]}${this.skin.applyColors(match[3], 'muted')}\n`;
   }
 
+  /** Colour the terminal glyph and semantic category independently. */
+  private uiSemanticTrailRow(content: string, kind: ColorKind): string {
+    const pipe = this.skin.applyColors(TRAIL_PIPE, 'muted');
+    const match = /^([✓✕×!◐◈◇◆↻■])\s+(\S+)([\s\S]*)$/u.exec(content);
+    if (!match) return this.uiStructuredTrailRow(content, kind);
+    const glyphKind: ColorKind = match[1] === '✓' ? 'success'
+      : match[1] === '✕' || match[1] === '×' || match[1] === '!' || match[1] === '■'
+        ? 'error' : kind;
+    return `${pipe} ${this.skin.applyColors(match[1], glyphKind)} ` +
+      `${this.skin.applyColors(match[2], kind)}${this.skin.applyColors(match[3], 'muted')}\n`;
+  }
+
   private renderUiTaskUpdate(args: Record<string, unknown>): void {
     const taskId  = typeof args.task_id === 'string' ? args.task_id : '';
     const label   = typeof args.label   === 'string' ? args.label   : '';
@@ -3359,7 +3393,7 @@ export class Display {
       : terminalStateSymbol(status === 'blocked' ? 'warning' : 'running');
     const colorKind: ColorKind = status === 'running' ? 'warn' : 'error';
     this.uiTaskRows.set(taskId, { label });
-    const short  = label.length > 80 ? label.slice(0, 79) + '…' : label;
+    const short = label;
     // v4.8.0 Phase 2.4 — subagent kind: indent by depth inside the
     // gutter so nested rows tier below their parent.
     const indent = kindArg === 'subagent' ? '  '.repeat(depth) : '';
@@ -3393,8 +3427,8 @@ export class Display {
     const kind: ColorKind =
       status === 'success' ? 'success' :
       status === 'failure' ? 'error'   : 'warn';
-    const shortLabel = label.length > 80 ? label.slice(0, 79) + '…' : label;
-    const shortSum   = summary.length > 120 ? summary.slice(0, 119) + '…' : summary;
+    const shortLabel = label;
+    const shortSum = summary;
     const terminalLabel = shortSum || (status === 'success' ? 'Completed' : status === 'failure' ? 'Failed' : 'Blocked');
     const rendered = this.uiTrailRow(`┌ ${shortLabel}\n└ ${glyph} ${terminalLabel}`, kind).replace(/\n$/u, '');
     if (this.composerLane?.isActive()) {
@@ -3459,7 +3493,7 @@ export class Display {
     if (lines.length === 0) return;
     this.commitStreamChunk();
     lines.forEach((line) => this.structuredActivityIds.add(line.identity));
-    const rendered = lines.map((line) => this.uiStructuredTrailRow(line.text, line.color)).join('');
+    const rendered = lines.map((line) => this.uiSemanticTrailRow(line.text, line.color)).join('');
     this.writeOutput(rendered);
     this.streamLastEndedNewline = true;
   }
@@ -3489,6 +3523,14 @@ export class Display {
     this.structuredActivityIds.add(line.identity);
     this.commitStreamChunk();
     this.writeOutput(this.uiStructuredTrailRow(line.text, line.color));
+    this.streamLastEndedNewline = true;
+  }
+
+  private renderUiExpectedDiscoveryMiss(args: Record<string, unknown>): void {
+    const target = typeof args.target === 'string' ? args.target.trim() : '';
+    if (!target) return;
+    this.commitStreamChunk();
+    this.writeOutput(this.uiSemanticTrailRow(`◇ inspect ${target} · not found`, 'inspecting'));
     this.streamLastEndedNewline = true;
   }
 

--- a/cli/v4/display/capabilityCard.ts
+++ b/cli/v4/display/capabilityCard.ts
@@ -24,7 +24,7 @@
 
 import type { CapabilityCardData } from '../../../providers/v4/types';
 import type { ColorKind } from '../skinEngine';
-import { boxSharp, visibleLength } from '../box';
+import { boxSharp, truncateVisible, visibleLength } from '../box';
 
 type Colorize = (text: string, kind: ColorKind) => string;
 
@@ -159,7 +159,7 @@ export function truncToContent(s: string): string {
   // Reserve 6 chars for "  ✓ " prefix + 2 for border padding margin.
   const cap = CONTENT_WIDTH - 6;
   if (visibleLength(s) <= cap) return s;
-  return s.slice(0, cap - 1) + '…';
+  return `${truncateVisible(s, cap - 1)}…`;
 }
 
 /**

--- a/cli/v4/display/toolTrail.ts
+++ b/cli/v4/display/toolTrail.ts
@@ -52,6 +52,9 @@ type TrailEntry = { readonly keys: readonly string[]; icon: string; verb: string
  * Keep entries grouped by semantic category to make auditing easy.
  */
 const TRAIL_MAP: readonly TrailEntry[] = [
+  // Delegation / Worker execution
+  { keys: ['subagent_fanout', 'spawn_sub_agent', 'worker'], icon: '◆', verb: 'delegate' },
+
   // ── Observe / read / list ────────────────────────────────────────────
   { keys: ['file_read', 'read_file', 'read_text_file', 'read_multiple_files',
            'file_list', 'list_directory', 'list_directory_with_sizes',

--- a/cli/v4/display/toolTrail.ts
+++ b/cli/v4/display/toolTrail.ts
@@ -22,6 +22,8 @@
  *     in full isolation.
  */
 
+import { truncateVisible, visibleLength } from '../box';
+
 /** Returned by iconForTool. */
 export interface ToolIconVerb {
   /** Single glyph rendered outside SGR so emoji native colours show. */
@@ -188,6 +190,12 @@ export function padVerb(verb: string): string {
  */
 export function truncDetail(s: string): string {
   const flat = s.replace(/\s+/g, ' ').trim();
-  if (flat.length <= TRAIL_DETAIL_CAP) return flat;
-  return flat.slice(0, TRAIL_DETAIL_CAP - 1) + '…';
+  if (visibleLength(flat) <= TRAIL_DETAIL_CAP) return flat;
+  const hard = truncateVisible(flat, TRAIL_DETAIL_CAP - 1);
+  const plain = hard.replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+  const boundary = plain.lastIndexOf(' ');
+  if (boundary > Math.floor(TRAIL_DETAIL_CAP / 2)) {
+    return `${truncateVisible(hard, visibleLength(plain.slice(0, boundary)))}…`;
+  }
+  return `${hard}…`;
 }

--- a/cli/v4/semanticActivity.ts
+++ b/cli/v4/semanticActivity.ts
@@ -33,7 +33,100 @@ export interface ActivityFrameProjection {
   label: string;
   text: string;
   color: ColorKind;
+  glyphColor: ColorKind;
   animated: boolean;
+}
+
+/** Compact, typed projections for real skill/reference activity. */
+export interface SkillInvocationInput {
+  invocationId: string;
+  skillName: string;
+  durationMs?: number;
+  referenceName?: string;
+}
+
+export interface StructuredActivityLine {
+  text: string;
+  color: ColorKind;
+  identity: string;
+}
+
+export function projectSkillInvocation(input: SkillInvocationInput): StructuredActivityLine[] {
+  const name = input.skillName.trim();
+  if (!input.invocationId.trim() || !name) return [];
+  const duration = typeof input.durationMs === 'number' && input.durationMs >= 0
+    ? ` ${formatStructuredDuration(input.durationMs)}` : '';
+  const lines: StructuredActivityLine[] = [{
+    text: `skill     ${name}${duration}`,
+    color: 'skill',
+    identity: `skill:${input.invocationId}`,
+  }];
+  const reference = input.referenceName?.trim();
+  if (reference) lines.push({
+    text: `reference ${reference}`,
+    color: 'evidence',
+    identity: `reference:${input.invocationId}:${reference}`,
+  });
+  return lines;
+}
+
+export interface WorkerDelegationInput {
+  groupId: string;
+  workers: readonly { goal: string }[];
+  state: 'running' | 'succeeded' | 'failed' | 'blocked' | 'unknown';
+  elapsedMs?: number;
+}
+
+export function projectWorkerDelegation(input: WorkerDelegationInput): StructuredActivityLine[] {
+  if (!input.groupId.trim() || input.workers.length === 0) return [];
+  const count = input.workers.length;
+  const lines: StructuredActivityLine[] = [{
+    text: `delegate  ${count} Worker${count === 1 ? '' : 's'}`,
+    color: 'worker',
+    identity: `worker-group:${input.groupId}`,
+  }];
+  input.workers.forEach((worker, index) => {
+    const goal = worker.goal.trim();
+    if (goal) lines.push({ text: `${index + 1}. ${goal}`, color: 'muted', identity: `worker:${input.groupId}:${index + 1}` });
+  });
+  const state = input.state === 'running' ? 'running'
+    : input.state === 'succeeded' ? 'complete'
+      : input.state === 'failed' ? 'failed'
+        : input.state;
+  const duration = typeof input.elapsedMs === 'number' && input.elapsedMs >= 0
+    ? ` · ${formatStructuredDuration(input.elapsedMs)}` : '';
+  lines.push({
+    text: `${count} Worker${count === 1 ? '' : 's'} ${state}${duration}`,
+    color: input.state === 'succeeded' ? 'success' : input.state === 'failed' || input.state === 'blocked' ? 'error' : 'worker',
+    identity: `worker-group-status:${input.groupId}`,
+  });
+  return lines;
+}
+
+export function projectContextCompaction(): StructuredActivityLine {
+  return {
+    text: 'context   compacted · preserved task state and tool results',
+    color: 'muted',
+    identity: 'context:compacted',
+  };
+}
+
+/** Keep one visible row per durable invocation identity. */
+export function dedupeStructuredActivity(
+  lines: readonly StructuredActivityLine[],
+): StructuredActivityLine[] {
+  const seen = new Set<string>();
+  return lines.filter((line) => {
+    if (seen.has(line.identity)) return false;
+    seen.add(line.identity);
+    return true;
+  });
+}
+
+function formatStructuredDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.max(0, Math.round(durationMs))}ms`;
+  const seconds = durationMs / 1000;
+  return `${Number.isInteger(seconds) ? seconds : seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`;
 }
 
 const TERMINAL_PHASES = new Set<SemanticActivityPhase>([
@@ -86,6 +179,19 @@ export function phaseColorKind(phase: SemanticActivityPhase): ColorKind {
     case 'failed': return 'error';
     case 'completing': return 'verifying';
     case 'ready': return 'muted';
+  }
+}
+
+/** Strong colour belongs to the state glyph; labels stay readable and restrained. */
+export function phaseGlyphColorKind(phase: SemanticActivityPhase): ColorKind {
+  switch (phase) {
+    case 'complete':
+    case 'ready': return 'success';
+    case 'failed': return 'error';
+    case 'approval_required': return 'warn';
+    case 'blocked': return 'error';
+    case 'recovering': return 'recovering';
+    default: return phaseColorKind(phase);
   }
 }
 
@@ -157,9 +263,9 @@ function unicodeGlyph(phase: SemanticActivityPhase, frame: number): string {
     }
     case 'working': return ['>   ', ' >  ', '  > ', '   >'][frame % 4]!;
     case 'testing': return ['◐', '◓', '◑', '◒'][frame % 4]!;
-    case 'verifying': return ['⌁', '⌁·', '⌁··'][frame % 3]!;
+    case 'verifying': return ['⌁  ', '⌁· ', '⌁··'][frame % 3]!;
     case 'recovering': return ['↶', '↺'][frame % 2]!;
-    case 'completing': return ['·', '··', '···'][frame % 3]!;
+    case 'completing': return ['·  ', '·· ', '···'][frame % 3]!;
     case 'approval_required':
     case 'blocked': return '!';
     case 'complete': return '✓';
@@ -186,6 +292,7 @@ export function projectActivityFrame(input: ActivityFrameInput): ActivityFramePr
     label,
     text: `${glyph} ${label}${detail}`,
     color: phaseColorKind(input.phase),
+    glyphColor: phaseGlyphColorKind(input.phase),
     animated: !TERMINAL_PHASES.has(input.phase),
   };
 }

--- a/cli/v4/semanticActivity.ts
+++ b/cli/v4/semanticActivity.ts
@@ -56,17 +56,13 @@ export function projectSkillInvocation(input: SkillInvocationInput): StructuredA
   if (!input.invocationId.trim() || !name) return [];
   const duration = typeof input.durationMs === 'number' && input.durationMs >= 0
     ? ` ${formatStructuredDuration(input.durationMs)}` : '';
+  const reference = input.referenceName?.trim();
+  const referenceText = reference ? ` · ${reference}` : '';
   const lines: StructuredActivityLine[] = [{
-    text: `skill     ${name}${duration}`,
+    text: `✓ skill  ${name}${referenceText}${duration}`,
     color: 'skill',
     identity: `skill:${input.invocationId}`,
   }];
-  const reference = input.referenceName?.trim();
-  if (reference) lines.push({
-    text: `reference ${reference}`,
-    color: 'evidence',
-    identity: `reference:${input.invocationId}:${reference}`,
-  });
   return lines;
 }
 

--- a/cli/v4/skinEngine.ts
+++ b/cli/v4/skinEngine.ts
@@ -118,10 +118,12 @@ function ansiRgb(
       // ANSI 16 has no orange. Dark amber is the closest restrained fallback;
       // it avoids turning the brand into bright red or painting the UI yellow.
       brand: 33, accent: 33, heading: 33, user: 33,
+      prompt: 36, prompt_content: 96,
       success: 92, warn: 93, degraded: 93, error: 31,
-      tool: 96, session: 96, agent: 97, muted: 37,
+      tool: 36, skill: 95, worker: 95,
+      session: 96, agent: 97, muted: 37,
       tertiary: 90, metric_turn: 95,
-      thinking: 96, planning: 95, inspecting: 94, working: 33,
+      thinking: 96, planning: 95, inspecting: 96, evidence: 94, working: 33,
       testing: 93, verifying: 36, recovering: 95,
     };
     return `\x1b[${semanticCode[kind!] ?? rgbTo16(r, g, b)}m${text}\x1b[39m`;
@@ -163,7 +165,12 @@ const COLOR_KIND_TO_TOKEN_PATH: Partial<Record<string, string>> = {
   verifying:   'semantic.verifying',
   recovering:  'semantic.recovering',
   agent:       'content.primary',
-  user:        'brand.primary',
+  user:        'semantic.thinking',
+  prompt:      'semantic.thinking',
+  prompt_content: 'metrics.model',
+  skill:       'semantic.planning',
+  worker:      'semantic.planning',
+  evidence:    'semantic.info',
 };
 
 function hexToRgb(hex: string): [number, number, number] | null {
@@ -187,8 +194,13 @@ export type ColorKind =
   | 'brand'
   | 'accent'
   | 'user'
+  | 'prompt'
+  | 'prompt_content'
   | 'agent'
   | 'tool'
+  | 'skill'
+  | 'worker'
+  | 'evidence'
   | 'error'
   | 'warn'
   | 'success'
@@ -233,9 +245,14 @@ const DEFAULT_SKIN: SkinDefinition = {
   colors: {
     brand: BRAND_ORANGE,
     accent: BRAND_ORANGE,
-    user: BRAND_ORANGE, // user input shares the Aiden brand accent
+    user: [0x5b, 0xc0, 0xeb],
+    prompt: [0x5b, 0xc0, 0xeb],
+    prompt_content: [0x9c, 0xdc, 0xfe],
     agent: [0xe0, 0xe0, 0xe0], // off-white — agent reply
-    tool: [0x9c, 0xdc, 0xfe], // cyan — tool calls
+    tool: [0x5b, 0xc0, 0xeb], // cyan — tool calls
+    skill: [0xa7, 0x8b, 0xfa],
+    worker: [0xa7, 0x8b, 0xfa],
+    evidence: [0x60, 0xa5, 0xfa],
     error: [0xf4, 0x47, 0x47],
     warn: [0xff, 0xc1, 0x07],
     success: [0x4c, 0xaf, 0x50],
@@ -265,7 +282,7 @@ const DEFAULT_SKIN: SkinDefinition = {
     tertiary: [0x6a, 0x6a, 0x6a],
     thinking: [0x5b, 0xc0, 0xeb],
     planning: [0xa7, 0x8b, 0xfa],
-    inspecting: [0x60, 0xa5, 0xfa],
+    inspecting: [0x5b, 0xc0, 0xeb],
     working: [0xfb, 0x92, 0x3c],
     testing: [0xfa, 0xcc, 0x15],
     verifying: [0x2d, 0xd4, 0xbf],
@@ -289,9 +306,14 @@ const LIGHT_SKIN: SkinDefinition = {
   colors: {
     brand: [0xc4, 0x42, 0x10],
     accent: [0xc4, 0x42, 0x10],
-    user: [0xc4, 0x42, 0x10],
+    user: [0x00, 0x66, 0x88],
+    prompt: [0x00, 0x66, 0x88],
+    prompt_content: [0x00, 0x55, 0x88],
     agent: [0x20, 0x20, 0x20],
-    tool: [0x00, 0x55, 0x88],
+    tool: [0x00, 0x66, 0x88],
+    skill: [0x5b, 0x3f, 0xa8],
+    worker: [0x5b, 0x3f, 0xa8],
+    evidence: [0x1d, 0x4e, 0xa0],
     error: [0xb0, 0x10, 0x10],
     warn: [0x80, 0x60, 0x00],
     success: [0x1b, 0x5e, 0x20],
@@ -310,7 +332,7 @@ const LIGHT_SKIN: SkinDefinition = {
     tertiary: [0x9a, 0x9a, 0x9a],
     thinking: [0x00, 0x66, 0x88],
     planning: [0x5b, 0x3f, 0xa8],
-    inspecting: [0x1d, 0x4e, 0xa0],
+    inspecting: [0x00, 0x66, 0x88],
     working: [0xa6, 0x3f, 0x00],
     testing: [0x7a, 0x5a, 0x00],
     verifying: [0x00, 0x66, 0x66],
@@ -326,8 +348,13 @@ const MONOCHROME_SKIN: SkinDefinition = {
     brand: null,
     accent: null,
     user: null,
+    prompt: null,
+    prompt_content: null,
     agent: null,
     tool: null,
+    skill: null,
+    worker: null,
+    evidence: null,
     error: null,
     warn: null,
     success: null,

--- a/cli/v4/startupDashboard.ts
+++ b/cli/v4/startupDashboard.ts
@@ -12,6 +12,7 @@ const ANSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const SAFE_MARGIN = 2;
 
 export type StartupDashboardTier = 'wide' | 'medium' | 'narrow' | 'minimal';
+export type StartupLogoTier = 'full' | 'compact' | 'plain';
 
 export interface StartupEnvironmentData {
   os?: string;
@@ -337,6 +338,18 @@ function renderProject(
   ];
 }
 
+export function resolveStartupLogoTier(columns: number, banner?: string): StartupLogoTier {
+  const tier = resolveStartupDashboardTier(columns);
+  if (tier === 'narrow' || tier === 'minimal') return 'plain';
+  if (tier === 'medium') return 'compact';
+  if (!banner) return 'plain';
+  const width = safeWidth(columns);
+  const lines = banner.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  return lines.length > 0 && lines.every((line) => startupVisibleWidth(line) <= width)
+    ? 'full'
+    : 'compact';
+}
+
 function normalizeBanner(banner: string | undefined, width: number): string[] {
   if (!banner) return [];
   const lines = banner.split(/\r?\n/).filter((line) => line.trim().length > 0);
@@ -350,12 +363,16 @@ export function renderStartupDashboard(options: RenderStartupDashboardOptions): 
   const tier = resolveStartupDashboardTier(options.columns);
   const data = options.data;
   const lines: string[] = [];
-  const bannerLines = normalizeBanner(options.banner, width);
+  const logoTier = resolveStartupLogoTier(options.columns, options.banner);
+  const bannerLines = logoTier === 'full' ? normalizeBanner(options.banner, width) : [];
 
   if (bannerLines.length > 0) {
     lines.push(...bannerLines, style.muted('Autonomous AI Engine'), '');
+  } else if (logoTier === 'compact') {
+    lines.push(style.brand('A I D E N'));
+    lines.push(style.muted('Autonomous AI Engine'));
   } else {
-    lines.push(style.brand('Aiden'));
+    lines.push(style.brand('AIDEN'));
     lines.push(style.muted('Autonomous AI Engine'));
   }
 

--- a/cli/v4/toolPreview.ts
+++ b/cli/v4/toolPreview.ts
@@ -62,9 +62,9 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
     const hasLimit = typeof input.limit === 'number' && Number.isFinite(input.limit);
     if (!hasOffset && !hasLimit) return target;
     const offset = hasOffset ? Math.max(0, Math.floor(input.offset as number)) : 0;
-    if (!hasLimit) return `${target} · from char ${offset}`;
+    if (!hasLimit) return target;
     const limit = Math.max(1, Math.floor(input.limit as number));
-    return `${target} · chars ${offset}–${offset + limit - 1}`;
+    return `${target} · segment ${Math.floor(offset / limit) + 1}`;
   },
   read_file:          'path',
   read_text_file:     'path',
@@ -127,7 +127,19 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
   process_log_read:  'pid',
 
   // ── subagent ─────────────────────────────────────────────────────────
-  subagent_fanout:   'mode',
+  subagent_fanout: (args: unknown): string => {
+    if (!args || typeof args !== 'object') return '';
+    const input = args as Record<string, unknown>;
+    const tasks = Array.isArray(input.tasks) ? input.tasks : [];
+    const requested = typeof input.n === 'number' && Number.isInteger(input.n)
+      ? Math.max(1, input.n)
+      : tasks.length > 0 ? tasks.length : 3;
+    const firstGoal = tasks.length > 0 && tasks[0] && typeof tasks[0] === 'object'
+      && typeof (tasks[0] as Record<string, unknown>).goal === 'string'
+      ? String((tasks[0] as Record<string, unknown>).goal).trim()
+      : typeof input.query === 'string' ? input.query.trim() : '';
+    return `${requested} Worker${requested === 1 ? '' : 's'}${firstGoal ? ` · ${firstGoal}` : ''}`;
+  },
 
   // ── system / misc ────────────────────────────────────────────────────
   system_info:       '',
@@ -298,6 +310,21 @@ export function buildToolPreview(
       try { str = JSON.stringify(raw); } catch { str = String(raw); }
     } else {
       str = summarizeStructuredValue(raw as object);
+    }
+  }
+
+  if (toolName === 'file_read' && opts.mode === 'full' && args && typeof args === 'object') {
+    const input = args as Record<string, unknown>;
+    const target = typeof input.path === 'string' ? input.path
+      : typeof input.file === 'string' ? input.file : '';
+    const offset = typeof input.offset === 'number' && Number.isFinite(input.offset)
+      ? Math.max(0, Math.floor(input.offset)) : null;
+    const limit = typeof input.limit === 'number' && Number.isFinite(input.limit)
+      ? Math.max(1, Math.floor(input.limit)) : null;
+    if (target && offset !== null) {
+      str = limit === null
+        ? `${target} · from char ${offset}`
+        : `${target} · chars ${offset}–${offset + limit - 1}`;
     }
   }
 

--- a/cli/v4/toolPreview.ts
+++ b/cli/v4/toolPreview.ts
@@ -13,9 +13,8 @@
  * actually useful at a glance — `command` for terminal, `path` for
  * file ops, `query` for search, etc.).
  *
- * Falls back to the original full-JSON stringification when the tool
- * isn't in the map or the primary arg is absent. This keeps unknown
- * tools rendering exactly as before — additive only.
+ * Unknown tools use a bounded human argument count in compact mode.
+ * Structured details remain available through full/debug projections.
  *
  * Adding a new tool with a non-obvious primary arg? Add it here.
  * Tools whose `args` shape is "the arg is meaningful at-a-glance"
@@ -39,6 +38,8 @@
  * Functions must return a string. Return `''` to show no preview
  * (matches the empty-key convention). Pure — no side effects.
  */
+import { truncateVisible, visibleLength } from './box';
+
 export type ToolPreviewExtractor = string | ((args: unknown) => string);
 
 /**
@@ -51,7 +52,22 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
   execute_code:      'code',
 
   // ── file ops ─────────────────────────────────────────────────────────
-  file_read:         'path',
+  file_read: (args: unknown): string => {
+    if (!args || typeof args !== 'object') return '';
+    const input = args as Record<string, unknown>;
+    const target = typeof input.path === 'string' ? input.path
+      : typeof input.file === 'string' ? input.file : '';
+    if (!target) return '';
+    const hasOffset = typeof input.offset === 'number' && Number.isFinite(input.offset);
+    const hasLimit = typeof input.limit === 'number' && Number.isFinite(input.limit);
+    if (!hasOffset && !hasLimit) return target;
+    const offset = hasOffset ? Math.max(0, Math.floor(input.offset as number)) : 0;
+    if (!hasLimit) return `${target} · from char ${offset}`;
+    const limit = Math.max(1, Math.floor(input.limit as number));
+    return `${target} · chars ${offset}–${offset + limit - 1}`;
+  },
+  read_file:          'path',
+  read_text_file:     'path',
   file_write:        'path',
   file_patch:        'path',
   file_list:         'path',
@@ -166,11 +182,63 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
 };
 
 /**
- * Maximum visible characters for the preview value. Long commands /
+ * Maximum visible terminal columns for the preview value. Long commands /
  * full file contents get truncated with an ellipsis so a single tool
  * row stays on one line at typical terminal widths.
  */
 const PREVIEW_MAX_CHARS = 120;
+
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/gu;
+
+function cleanPreviewText(value: string): string {
+  return value
+    .replace(ANSI_PATTERN, '')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu, '')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function truncatePreview(value: string, columns = PREVIEW_MAX_CHARS): string {
+  const clean = cleanPreviewText(value);
+  if (visibleLength(clean) <= columns) return clean;
+  return `${truncateVisible(clean, Math.max(0, columns - 1))}…`;
+}
+
+function summarizeShellCommand(command: string): string {
+  const statements = command
+    .split(/(?:\r?\n|\s*;\s*|\s*&&\s*|\s*\|\|\s*)/u)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const firstStatement = statements[0] ?? command;
+  const withoutQuietRedirection = firstStatement
+    .replace(/\s+(?:\d?>|\d?>>)\s*\$null\s*$/iu, '')
+    .trim();
+  const remaining = statements.length > 1 ? ` · +${statements.length - 1} steps` : '';
+  return truncatePreview(`${withoutQuietRedirection || command}${remaining}`);
+}
+
+/** Human compact fallback for unmapped or structured tool arguments. */
+export function summarizeToolArguments(args: unknown): string {
+  if (args == null) return '';
+  if (typeof args === 'string') return truncatePreview(args);
+  if (typeof args !== 'object') return String(args);
+  if (Array.isArray(args)) return `${args.length} ${args.length === 1 ? 'item' : 'items'}`;
+  const entries = Object.entries(args as Record<string, unknown>);
+  if (entries.length === 0) return '';
+  return `${entries.length} ${entries.length === 1 ? 'argument' : 'arguments'}`;
+}
+
+function summarizeStructuredValue(value: object): string {
+  if (Array.isArray(value)) return `${value.length} ${value.length === 1 ? 'item' : 'items'}`;
+  const entries = Object.entries(value as Record<string, unknown>);
+  const safeValues = entries
+    .filter(([, value]) => ['string', 'number', 'boolean'].includes(typeof value))
+    .slice(0, 2)
+    .map(([, value]) => cleanPreviewText(String(value)))
+    .filter(Boolean);
+  if (safeValues.length > 0) return truncatePreview(safeValues.join(' · '));
+  return `${entries.length} ${entries.length === 1 ? 'argument' : 'arguments'}`;
+}
 
 /**
  * Build the per-tool preview string for `args`. Returns:
@@ -185,6 +253,7 @@ const PREVIEW_MAX_CHARS = 120;
 export function buildToolPreview(
   toolName: string,
   args: unknown,
+  opts: { mode?: 'summary' | 'full' } = {},
 ): string | null {
   if (!Object.prototype.hasOwnProperty.call(TOOL_PRIMARY_ARG, toolName)) {
     return null;
@@ -216,19 +285,15 @@ export function buildToolPreview(
       str = raw;
     } else if (typeof raw === 'number' || typeof raw === 'boolean') {
       str = String(raw);
+    } else if (opts.mode === 'full') {
+      try { str = JSON.stringify(raw); } catch { str = String(raw); }
     } else {
-      try {
-        str = JSON.stringify(raw);
-      } catch {
-        str = String(raw);
-      }
+      str = summarizeStructuredValue(raw as object);
     }
   }
 
-  // Collapse whitespace so multi-line commands stay on one preview row.
-  str = str.replace(/\s+/g, ' ').trim();
-  if (str.length > PREVIEW_MAX_CHARS) {
-    str = `${str.slice(0, PREVIEW_MAX_CHARS - 1)}…`;
+  if (opts.mode !== 'full' && toolName === 'shell_exec') {
+    return summarizeShellCommand(str);
   }
-  return str;
+  return truncatePreview(str);
 }

--- a/cli/v4/toolPreview.ts
+++ b/cli/v4/toolPreview.ts
@@ -214,7 +214,16 @@ function summarizeShellCommand(command: string): string {
     .replace(/\s+(?:\d?>|\d?>>)\s*\$null\s*$/iu, '')
     .trim();
   const remaining = statements.length > 1 ? ` · +${statements.length - 1} steps` : '';
-  return truncatePreview(`${withoutQuietRedirection || command}${remaining}`);
+  const semantic = /\bSelect-String\b/iu.test(command)
+    ? 'search repository source'
+    : /\bGet-Content\b/iu.test(command)
+      ? 'read repository source'
+      : /\b(?:Get-ChildItem|rg(?:\.exe)?)\b/iu.test(command)
+        ? 'inspect repository files'
+        : /^\s*\$[A-Za-z_][\w]*\s*=|@\(/u.test(withoutQuietRedirection)
+          ? 'run PowerShell inspection'
+          : withoutQuietRedirection || command;
+  return truncatePreview(`${semantic}${remaining}`);
 }
 
 /** Human compact fallback for unmapped or structured tool arguments. */

--- a/tests/v4/cli/activityLifecycle.test.ts
+++ b/tests/v4/cli/activityLifecycle.test.ts
@@ -69,6 +69,77 @@ const resolveBuiltInInteraction = (name: string) =>
       : undefined;
 
 describe('central CLI activity lifecycle', () => {
+  it('replaces the generic skill completion with one typed invocation row', () => {
+    const { display, output } = makeTtyDisplay();
+    const callbacks = new CliCallbacks({ display });
+    callbacks.onToolCall({ id: 'skill-1', name: 'skill_view', arguments: { name: 'architecture-diagram' } }, 'before');
+    callbacks.onToolCall(
+      { id: 'skill-1', name: 'skill_view', arguments: { name: 'architecture-diagram' } },
+      'after',
+      {
+        id: 'skill-1', name: 'skill_view',
+        result: { success: true, filePath: 'C:\\skills\\architecture-diagram\\SKILL.md' },
+        activityTiming: { dispatchStartedAt: 0, executionDurationMs: 6, executionAttempts: [] },
+      },
+    );
+    callbacks.onToolCall(
+      { id: 'skill-1', name: 'skill_view', arguments: { name: 'architecture-diagram' } },
+      'after',
+      {
+        id: 'skill-1', name: 'skill_view',
+        result: { success: true, filePath: 'C:\\skills\\architecture-diagram\\SKILL.md' },
+        activityTiming: { dispatchStartedAt: 0, executionDurationMs: 6, executionAttempts: [] },
+      },
+    );
+    const plain = output().replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+    expect(plain.match(/skill\s+architecture-diagram/gu)).toHaveLength(1);
+    expect(plain).toContain('SKILL.md');
+    expect(plain).not.toMatch(/completed\s+architecture-diagram|completed\s+\./iu);
+  });
+
+  it('does not project a successful typed skill row when loading failed', () => {
+    const { display, output } = makeTtyDisplay();
+    const callbacks = new CliCallbacks({ display });
+    const call = { id: 'skill-failed', name: 'skill_view', arguments: { name: 'missing-skill' } } as const;
+    callbacks.onToolCall(call, 'before');
+    callbacks.onToolCall(call, 'after', {
+      id: call.id, name: call.name, result: null, error: 'Skill not found: missing-skill',
+    });
+    const plain = output().replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+    expect(plain).toMatch(/failed/u);
+    expect(plain).not.toMatch(/✓\s+skill/u);
+  });
+
+  it('projects a missing optional repository root as an expected inspection miss', () => {
+    const { display, output } = makeTtyDisplay();
+    const callbacks = new CliCallbacks({ display });
+    const call = { id: 'probe-src', name: 'file_list', arguments: { path: 'src' } } as const;
+    callbacks.onToolCall(call, 'before');
+    callbacks.onToolCall(call, 'after', {
+      id: call.id, name: call.name, result: null,
+      error: "ENOENT: no such file or directory, scandir 'src'",
+    });
+    const plain = output().replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+    expect(plain).toContain('inspect src · not found');
+    expect(plain).not.toMatch(/failed\s+src|fail\s+\d/iu);
+  });
+
+  it('keeps an arbitrary required missing path classified as a failure', () => {
+    const { display, output } = makeTtyDisplay();
+    const callbacks = new CliCallbacks({ display });
+    const call = {
+      id: 'required-miss', name: 'file_list', arguments: { path: 'required/artifacts' },
+    } as const;
+    callbacks.onToolCall(call, 'before');
+    callbacks.onToolCall(call, 'after', {
+      id: call.id, name: call.name, result: null,
+      error: "ENOENT: no such file or directory, scandir 'required/artifacts'",
+    });
+    const plain = output().replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+    expect(plain).toMatch(/failed/u);
+    expect(plain).not.toContain('inspect required/artifacts · not found');
+  });
+
   it('does not restore approval navigation hints after modal settlement', async () => {
     class ScreenStream extends Writable {
       isTTY = true;

--- a/tests/v4/cli/aidenPrompt.test.ts
+++ b/tests/v4/cli/aidenPrompt.test.ts
@@ -235,6 +235,28 @@ describe('aidenPrompt — Bug D fix via footer rendering (v4.10 Slice 10.5)', ()
 });
 
 describe('aidenPrompt — extra render-snapshot coverage', () => {
+  it('fits Unicode command descriptions by visible terminal width', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: 44 });
+    try {
+      const runner = renderPrompt({
+        commands: [{ name: 'inspect', description: '界'.repeat(60) }],
+        history: [],
+      });
+      runner.type('/i');
+      const footer = runner.lastRender().footer ?? '';
+      const lines = footer.split('\n');
+      for (const line of lines) {
+        const plain = line.replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+        expect(require('string-width')(plain)).toBeLessThanOrEqual(40);
+      }
+      expect(footer).not.toContain('\uFFFD');
+    } finally {
+      if (descriptor) Object.defineProperty(process.stdout, 'columns', descriptor);
+      else delete (process.stdout as { columns?: number }).columns;
+    }
+  });
+
   it('omits cursorBackward when no ghost is present (unknown command)', () => {
     const runner = renderPrompt({
       commands: [{ name: 'daemon', description: 'Manage the Aiden daemon.' }],

--- a/tests/v4/cli/aidenTUI.test.ts
+++ b/tests/v4/cli/aidenTUI.test.ts
@@ -270,6 +270,20 @@ describe('AidenTUI', () => {
     expect(out).toMatch(/try again/);
   });
 
+  it('renders a human compact tool summary without serialized arguments', () => {
+    const tui = new AidenTUI(makeOpts());
+    const display = (tui as any).session.opts.display;
+    const out = display.toolPreview('mystery_tool', {
+      include_full: true,
+      limit: 5,
+      secret: 'must-not-render',
+    });
+    expect(out).toContain('mystery_tool');
+    expect(out).not.toContain('{"');
+    expect(out).not.toContain('include_full');
+    expect(out).not.toContain('must-not-render');
+  });
+
   it('isTuiInitFailure returns true for terminfo / smartCSR errors', () => {
     expect(isTuiInitFailure(new Error('Error opening terminal: xterm-256color'))).toBe(true);
     expect(isTuiInitFailure(new Error('terminfo not found'))).toBe(true);

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -127,7 +127,7 @@ function createDisplay(columns: number, rows = 18): {
 }
 
 it.each([44, 80, 100, 120, 160])(
-  'preserves complete bounded read ranges at %i columns',
+  'preserves a compact read segment at %i columns',
   (columns) => {
     const { display, screen } = createDisplay(columns, 30);
     display.setStatusFooter('◆ provider/model │ context │ phase │ timer');
@@ -137,12 +137,12 @@ it.each([44, 80, 100, 120, 160])(
     }, undefined, { activityId: `read-range-${columns}` });
     row.ok(12);
     const output = screen.lines().join('\n');
-    expect(output).toContain('chars 7000–7079');
-    expect(output).not.toMatch(/chars 7000–(?:\s|$)/u);
+    expect(output).toContain('segment 88');
+    expect(output).not.toContain('chars 7000');
   },
 );
 
-it('aggregates equivalent compact read rows while preserving distinct ranges', () => {
+it('aggregates equivalent compact read rows while preserving distinct segments', () => {
   const { display, screen } = createDisplay(100, 35);
   display.setStatusFooter('◆ provider/model │ context │ phase │ timer');
   display.setIdleComposer('', 'Type your message');
@@ -152,8 +152,8 @@ it('aggregates equivalent compact read rows while preserving distinct ranges', (
   display.toolRow('file_read', { ...args, offset: 200 }, undefined, { activityId: 'read-c' }).ok(12);
 
   const output = screen.lines().join('\n');
-  expect(output.match(/chars 120–199/gu)).toHaveLength(1);
-  expect(output.match(/chars 200–279/gu)).toHaveLength(1);
+  expect(output.match(/segment 2/gu)).toHaveLength(1);
+  expect(output.match(/segment 3/gu)).toHaveLength(1);
 });
 
 it('projects one compact shell activity when the semantic command-result event also arrives', () => {
@@ -196,6 +196,48 @@ it('keeps settled assistant transcript immutable after a late activity repaint',
   const activityRow = lines.findLastIndex((line) => line.includes('package.json'));
   const responseRow = lines.findLastIndex((line) => line.includes('FINAL STABLE RESPONSE'));
   expect(lines.slice(activityRow + 1, responseRow).filter((line) => line.trim() === '')).toHaveLength(1);
+});
+
+it('rejects a late stream delta after final response settlement', () => {
+  const { display, screen } = createDisplay(100, 35);
+  display.setStatusFooter('◆ provider/model │ context │ completing │ 1s');
+  display.setIdleComposer('', 'Type your message');
+  display.resetUiTurnState();
+  display.streamPartial('FINAL RESPONSE ONCE');
+  display.streamComplete();
+  display.streamPartial('LATE STALE DELTA');
+  const output = screen.lines().join('\n');
+  expect(output.match(/FINAL RESPONSE ONCE/gu)).toHaveLength(1);
+  expect(output).not.toContain('LATE STALE DELTA');
+  expect(screen.snapshot().match(/▲ You/gu)).toHaveLength(1);
+});
+
+it('uses one live response identity for every delta in a turn', () => {
+  const { display } = createDisplay(100, 35);
+  display.setStatusFooter('◆ provider/model │ context │ thinking │ 1s');
+  display.setIdleComposer('', 'Type your message');
+  display.resetUiTurnState();
+  display.streamPartial('first ');
+  const firstIdentity = (display as unknown as { streamProjectionId: string }).streamProjectionId;
+  display.streamPartial('second');
+  const secondIdentity = (display as unknown as { streamProjectionId: string }).streamProjectionId;
+  expect(firstIdentity).toMatch(/^assistant-stream:/u);
+  expect(secondIdentity).toBe(firstIdentity);
+});
+
+it('commits final response and restores the bottom surface in one terminal transaction', () => {
+  const { display, stream } = createDisplay(100, 35);
+  display.setStatusFooter('◆ provider/model │ context │ completing │ 1s');
+  display.setIdleComposer('', 'Type your message');
+  display.resetUiTurnState();
+  display.streamPartial('ATOMIC FINAL RESPONSE');
+  const before = stream.writes.length;
+  display.streamComplete();
+  const settlementWrites = stream.writes.slice(before);
+  expect(settlementWrites).toHaveLength(1);
+  expect(settlementWrites[0]).toContain('ATOMIC FINAL RESPONSE');
+  expect(settlementWrites[0]).toContain('▲ You');
+  expect(settlementWrites[0]).toContain('provider/model');
 });
 
 function composerGeometry(screen: TerminalScreen): {

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -110,6 +110,78 @@ function createDisplay(columns: number, rows = 18): {
   return { display, screen, stream };
 }
 
+it.each([44, 80, 100, 120, 160])(
+  'preserves complete bounded read ranges at %i columns',
+  (columns) => {
+    const { display, screen } = createDisplay(columns, 30);
+    display.setStatusFooter('◆ provider/model │ context │ phase │ timer');
+    display.setIdleComposer('', 'Type your message');
+    const row = display.toolRow('file_read', {
+      path: 'C:\\workspace\\cli\\v4\\display.ts', offset: 7_000, limit: 80,
+    }, undefined, { activityId: `read-range-${columns}` });
+    row.ok(12);
+    const output = screen.lines().join('\n');
+    expect(output).toContain('chars 7000–7079');
+    expect(output).not.toMatch(/chars 7000–(?:\s|$)/u);
+  },
+);
+
+it('aggregates equivalent compact read rows while preserving distinct ranges', () => {
+  const { display, screen } = createDisplay(100, 35);
+  display.setStatusFooter('◆ provider/model │ context │ phase │ timer');
+  display.setIdleComposer('', 'Type your message');
+  const args = { path: 'C:\\workspace\\cli\\v4\\display.ts', offset: 120, limit: 80 };
+  display.toolRow('file_read', args, undefined, { activityId: 'read-a' }).ok(10);
+  display.toolRow('file_read', args, undefined, { activityId: 'read-b' }).ok(11);
+  display.toolRow('file_read', { ...args, offset: 200 }, undefined, { activityId: 'read-c' }).ok(12);
+
+  const output = screen.lines().join('\n');
+  expect(output.match(/chars 120–199/gu)).toHaveLength(1);
+  expect(output.match(/chars 200–279/gu)).toHaveLength(1);
+});
+
+it('projects one compact shell activity when the semantic command-result event also arrives', () => {
+  const { display, screen } = createDisplay(100, 35);
+  display.setStatusFooter('◆ provider/model │ context │ phase │ timer');
+  display.setIdleComposer('', 'Type your message');
+  display.toolRow('shell_exec', { command: 'Get-Location' }, undefined, {
+    activityId: 'shell-one',
+  }).ok(14);
+  display.toolRow('ui_command_result', { command: 'Get-Location' }, undefined, {
+    activityId: 'ui-result-one',
+  }).ok(14);
+  display.renderUiEvent('ui_command_result', {
+    command: 'Get-Location', stdout: 'C:\\workspace', exit_code: 0,
+  });
+
+  const output = screen.lines().join('\n');
+  expect(output.match(/completed Get-Location/gu)).toHaveLength(1);
+  expect(output).not.toContain('✓ Get-Location — completed');
+});
+
+it('keeps settled assistant transcript immutable after a late activity repaint', () => {
+  const { display, screen } = createDisplay(100, 35);
+  display.setStatusFooter('◆ provider/model │ context │ completing │ 1s');
+  display.setIdleComposer('', 'Type your message');
+  const activity = display.toolRow('file_read', { path: 'package.json' }, undefined, {
+    activityId: 'late-read',
+  });
+  activity.ok(10);
+  display.streamPartial('FINAL STABLE RESPONSE');
+  display.streamComplete();
+  activity.refresh();
+  display.setStatusFooter('◆ provider/model │ context │ ready │ 1s');
+  display.setIdleComposer('', 'Type your message');
+
+  const lines = screen.lines();
+  const output = lines.join('\n');
+  expect(output.match(/FINAL STABLE RESPONSE/gu)).toHaveLength(1);
+  expect(output.match(/▲ You/gu)).toHaveLength(1);
+  const activityRow = lines.findLastIndex((line) => line.includes('package.json'));
+  const responseRow = lines.findLastIndex((line) => line.includes('FINAL STABLE RESPONSE'));
+  expect(lines.slice(activityRow + 1, responseRow).filter((line) => line.trim() === '')).toHaveLength(1);
+});
+
 function composerGeometry(screen: TerminalScreen): {
   topSeparator: number;
   top: number;

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -179,7 +179,7 @@ it('keeps settled assistant transcript immutable after a late activity repaint',
   expect(output.match(/▲ You/gu)).toHaveLength(1);
   const activityRow = lines.findLastIndex((line) => line.includes('package.json'));
   const responseRow = lines.findLastIndex((line) => line.includes('FINAL STABLE RESPONSE'));
-  expect(lines.slice(activityRow + 1, responseRow).filter((line) => line.trim() === '').length).toBeLessThanOrEqual(1);
+  expect(lines.slice(activityRow + 1, responseRow).filter((line) => line.trim() === '')).toHaveLength(1);
 });
 
 function composerGeometry(screen: TerminalScreen): {
@@ -666,124 +666,60 @@ function maxBlankRun(value: string): number {
   return maximum;
 }
 
-function blankRowsBeforeComposer(screen: TerminalScreen, content: string): number {
-  const lines = screen.lines();
-  const composer = lines.findLastIndex((line) => line.startsWith('▲ You'));
-  const separator = composer - 1;
-  const contentRow = lines.findLastIndex((line, index) => (
-    index < separator && line.includes(content)
-  ));
-  expect(composer, screen.snapshot()).toBeGreaterThanOrEqual(1);
-  expect(contentRow, screen.snapshot()).toBeGreaterThanOrEqual(0);
-  return lines.slice(contentRow + 1, separator).filter((line) => line.trim() === '').length;
-}
-
-describe('compact live-region height ownership', () => {
-  it('keeps ten related tool rows contiguous without decorative blanks', () => {
-    const { display, screen } = createDisplay(100, 45);
-    display.setStatusFooter('◆ provider/model │ 0% │ working │ 1s');
+describe('transcript ownership during repaint', () => {
+  it('does not replay startup or settled transcript when the surface is resized', async () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen, stream } = createDisplay(100, 30);
+    display.write('Aiden startup\nEnvironment\nCapabilities\nBuilt solo\n');
+    display.setStatusFooter('◆ provider · model │ ◉ 7% │ ready │ ⧖ 2s');
     display.setIdleComposer('', 'Type your message');
-    const rows = Array.from({ length: 10 }, (_, index) => display.toolRow(
-      'file_read',
-      { path: `C:\\workspace\\compact-${index}.ts` },
-      undefined,
-      { activityId: `compact-${index}` },
-    ));
+    display.write('inspect the repository\n');
+    const activity = display.toolRow('file_read', { path: 'display.ts' }, undefined, {
+      activityId: 'resize-read',
+    });
+    activity.ok(12);
+    display.write('│ Aiden\nThe answer remains reviewable.\n');
 
-    const visible = screen.lines();
-    const indexes = Array.from({ length: 10 }, (_, index) => (
-      visible.findIndex((line) => line.includes(`compact-${index}.ts`))
-    ));
-    expect(indexes.every((index) => index >= 0), screen.snapshot()).toBe(true);
-    for (let index = 1; index < indexes.length; index += 1) {
-      expect(indexes[index] - indexes[index - 1], screen.snapshot()).toBe(1);
+    for (const width of [60, 100, 44, 100, 60, 100]) {
+      stream.resize(width, 30);
+      await new Promise<void>((resolve) => setImmediate(resolve));
     }
-    for (const row of rows) row.ok(1);
+
+    const buffer = screen.bufferSnapshot();
+    expect(buffer.match(/Aiden startup/gu) ?? []).toHaveLength(1);
+    expect(buffer.match(/Environment/gu) ?? []).toHaveLength(1);
+    expect(buffer.match(/Capabilities/gu) ?? []).toHaveLength(1);
+    expect(buffer.match(/Built solo/gu) ?? []).toHaveLength(1);
+    expect(buffer.match(/inspect the repository/gu) ?? []).toHaveLength(1);
+    expect(buffer.match(/The answer remains reviewable/gu) ?? []).toHaveLength(1);
+    expect(screen.scrollbackSnapshot()).not.toContain('▲ You');
+    expect(screen.snapshot().match(/^▲ You/gmu) ?? []).toHaveLength(1);
+    expect(screen.snapshot().match(/^◆ provider/gmu) ?? []).toHaveLength(1);
   });
 
-  it('keeps a short final answer adjacent to the composer boundary', () => {
-    const { display, screen } = createDisplay(100, 100);
-    display.setStatusFooter('◆ provider/model │ 0% │ ready │ 1s');
+  it('keeps a settled activity and final response single-shot after late repaints', async () => {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const { display, screen, stream } = createDisplay(100, 30);
+    display.setStatusFooter('◆ provider · model │ ◉ 3% │ working │ ⧖ 1s');
     display.setIdleComposer('', 'Type your message');
-    display.write('Short final answer.\n');
-
-    expect(blankRowsBeforeComposer(screen, 'Short final answer.')).toBeLessThanOrEqual(1);
-  });
-
-  it('releases a settled spinner height immediately', () => {
-    const { display, screen } = createDisplay(100, 45);
-    display.setStatusFooter('◆ provider/model │ 0% │ thinking │ 1s');
-    display.setIdleComposer('', 'Type your message');
-    display.write('Prompt boundary\n');
-    const activity = display.liveActivityRow('calling provider');
-    activity.stop();
-
-    expect(screen.snapshot()).not.toContain('Aiden is thinking');
-    expect(blankRowsBeforeComposer(screen, 'Prompt boundary')).toBeLessThanOrEqual(1);
-  });
-
-  it('shrinks a multiline activity replacement to its semantic row', () => {
-    const { region, screen } = createRegionHarness(false, 80, 30);
-    region.writeAbove('Inspection boundary\n');
-    region.setLiveRow('inspection', 'Status bar\nraw detail one\nraw detail two\nraw detail three');
-    region.setLiveRow('inspection', '✓ statusBar.ts · lines 1–190 inspected');
-
-    expect(screen.snapshot()).not.toContain('raw detail');
-    expect(blankRowsBeforeComposer(screen, 'lines 1–190 inspected')).toBeLessThanOrEqual(1);
-  });
-
-  it('releases every row when a suggestion-like activity is dismissed', () => {
-    const { region, screen } = createRegionHarness(false, 80, 30);
-    region.writeAbove('Suggestion boundary\n');
-    region.setLiveRow('skill-suggestion', 'Suggested skill\nInspect repository\nPress Enter to accept');
-    region.removeLiveRow('skill-suggestion');
-
-    expect(screen.snapshot()).not.toContain('Suggested skill');
-    expect(blankRowsBeforeComposer(screen, 'Suggestion boundary')).toBeLessThanOrEqual(1);
-  });
-
-  it('recomputes wrapped height in both resize directions without gaps or overlap', async () => {
-    const { region, screen, resize } = createRegionHarness(false, 44, 45);
-    region.writeAbove('Resize boundary\n');
-    region.paint({
-      draft: 'Inspect repository files with a semantic summary that wraps at narrow width',
-      mode: 'idle',
+    const activity = display.toolRow('file_read', { path: 'package.json' }, undefined, {
+      activityId: 'settled-read',
     });
-    const narrowComposer = composerGeometry(screen).topSeparator;
-
-    resize(100, 45);
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    const wideComposer = composerGeometry(screen).topSeparator;
-    expect(wideComposer).toBeGreaterThan(narrowComposer);
-    expect(blankRowsBeforeComposer(screen, 'Resize boundary')).toBeLessThanOrEqual(1);
-
-    resize(44, 45);
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(screen.snapshot().match(/Inspect repository files/gu)).toHaveLength(1);
-    expect(screen.snapshot().match(/▲ You/gu)).toHaveLength(1);
-  });
-
-  it('omits empty live sections instead of reserving their rows', () => {
-    const { region, screen } = createRegionHarness(false, 80, 30);
-    region.writeAbove('Empty-section boundary\n');
-    region.setLiveRow('empty-section', '  \n\n  ');
-
-    expect(blankRowsBeforeComposer(screen, 'Empty-section boundary')).toBeLessThanOrEqual(1);
-  });
-
-  it('clears prior reserved height and rejects late restoration after cls', () => {
-    const { display, screen } = createDisplay(100, 45);
-    display.setStatusFooter('◆ provider/model │ 0% │ working │ 1s');
-    display.setIdleComposer('', 'Type your message');
-    const activity = display.toolRow('file_read', { path: 'before-cls.ts' }, undefined, {
-      activityId: 'before-cls',
-    });
-    display.clearScreen();
-    display.write('After cls\n');
+    activity.ok(9);
+    display.streamPartial('Final response exactly once.');
+    display.streamComplete();
+    for (const width of [44, 100, 60, 100]) {
+      stream.resize(width, 30);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
     activity.refresh();
+    display.setStatusFooter('◆ provider · model │ ◉ 3% │ ready │ ⧖ 9s');
 
-    expect(screen.snapshot().match(/before-cls.ts/gu)).toHaveLength(1);
-    expect(blankRowsBeforeComposer(screen, 'After cls')).toBeLessThanOrEqual(1);
+    const buffer = screen.bufferSnapshot();
+    expect(buffer.match(/Final response exactly once\./gu) ?? []).toHaveLength(1);
+    expect(buffer.match(/package\.json/gu) ?? []).toHaveLength(1);
+    expect(screen.snapshot().match(/^▲ You/gmu) ?? []).toHaveLength(1);
+    expect(screen.snapshot().match(/^◆ provider/gmu) ?? []).toHaveLength(1);
   });
 });
 

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -42,6 +42,22 @@ class ScreenStream extends Writable {
   }
 }
 
+describe('responsive composer semantic colour projection', () => {
+  it('keeps prompt label and draft on separate cyan tokens without colouring the footer', () => {
+    const styled = renderBottomSurface(18, 60, { draft: 'draft text', mode: 'idle' }, '◆ provider/model │ ◉ 0% │ T │ 0s', {
+      brand: (value) => `BRAND(${value})`,
+      muted: (value) => `MUTED(${value})`,
+      prompt: (value) => `PROMPT(${value})`,
+      promptContent: (value) => `CONTENT(${value})`,
+      unicode: true,
+    });
+    expect(styled.lines.some((line) => line.includes('PROMPT(▲ You)'))).toBe(true);
+    expect(styled.lines.some((line) => line.includes('CONTENT(draft text)'))).toBe(true);
+    expect(styled.lines.at(-1)).toContain('provider/model');
+    expect(styled.lines.at(-1)).not.toContain('CONTENT(');
+  });
+});
+
 const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
 
 it('applies the active theme to the borderless composer hierarchy without changing geometry', () => {

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -179,7 +179,7 @@ it('keeps settled assistant transcript immutable after a late activity repaint',
   expect(output.match(/▲ You/gu)).toHaveLength(1);
   const activityRow = lines.findLastIndex((line) => line.includes('package.json'));
   const responseRow = lines.findLastIndex((line) => line.includes('FINAL STABLE RESPONSE'));
-  expect(lines.slice(activityRow + 1, responseRow).filter((line) => line.trim() === '')).toHaveLength(1);
+  expect(lines.slice(activityRow + 1, responseRow).filter((line) => line.trim() === '').length).toBeLessThanOrEqual(1);
 });
 
 function composerGeometry(screen: TerminalScreen): {
@@ -665,6 +665,127 @@ function maxBlankRun(value: string): number {
   }
   return maximum;
 }
+
+function blankRowsBeforeComposer(screen: TerminalScreen, content: string): number {
+  const lines = screen.lines();
+  const composer = lines.findLastIndex((line) => line.startsWith('▲ You'));
+  const separator = composer - 1;
+  const contentRow = lines.findLastIndex((line, index) => (
+    index < separator && line.includes(content)
+  ));
+  expect(composer, screen.snapshot()).toBeGreaterThanOrEqual(1);
+  expect(contentRow, screen.snapshot()).toBeGreaterThanOrEqual(0);
+  return lines.slice(contentRow + 1, separator).filter((line) => line.trim() === '').length;
+}
+
+describe('compact live-region height ownership', () => {
+  it('keeps ten related tool rows contiguous without decorative blanks', () => {
+    const { display, screen } = createDisplay(100, 45);
+    display.setStatusFooter('◆ provider/model │ 0% │ working │ 1s');
+    display.setIdleComposer('', 'Type your message');
+    const rows = Array.from({ length: 10 }, (_, index) => display.toolRow(
+      'file_read',
+      { path: `C:\\workspace\\compact-${index}.ts` },
+      undefined,
+      { activityId: `compact-${index}` },
+    ));
+
+    const visible = screen.lines();
+    const indexes = Array.from({ length: 10 }, (_, index) => (
+      visible.findIndex((line) => line.includes(`compact-${index}.ts`))
+    ));
+    expect(indexes.every((index) => index >= 0), screen.snapshot()).toBe(true);
+    for (let index = 1; index < indexes.length; index += 1) {
+      expect(indexes[index] - indexes[index - 1], screen.snapshot()).toBe(1);
+    }
+    for (const row of rows) row.ok(1);
+  });
+
+  it('keeps a short final answer adjacent to the composer boundary', () => {
+    const { display, screen } = createDisplay(100, 100);
+    display.setStatusFooter('◆ provider/model │ 0% │ ready │ 1s');
+    display.setIdleComposer('', 'Type your message');
+    display.write('Short final answer.\n');
+
+    expect(blankRowsBeforeComposer(screen, 'Short final answer.')).toBeLessThanOrEqual(1);
+  });
+
+  it('releases a settled spinner height immediately', () => {
+    const { display, screen } = createDisplay(100, 45);
+    display.setStatusFooter('◆ provider/model │ 0% │ thinking │ 1s');
+    display.setIdleComposer('', 'Type your message');
+    display.write('Prompt boundary\n');
+    const activity = display.liveActivityRow('calling provider');
+    activity.stop();
+
+    expect(screen.snapshot()).not.toContain('Aiden is thinking');
+    expect(blankRowsBeforeComposer(screen, 'Prompt boundary')).toBeLessThanOrEqual(1);
+  });
+
+  it('shrinks a multiline activity replacement to its semantic row', () => {
+    const { region, screen } = createRegionHarness(false, 80, 30);
+    region.writeAbove('Inspection boundary\n');
+    region.setLiveRow('inspection', 'Status bar\nraw detail one\nraw detail two\nraw detail three');
+    region.setLiveRow('inspection', '✓ statusBar.ts · lines 1–190 inspected');
+
+    expect(screen.snapshot()).not.toContain('raw detail');
+    expect(blankRowsBeforeComposer(screen, 'lines 1–190 inspected')).toBeLessThanOrEqual(1);
+  });
+
+  it('releases every row when a suggestion-like activity is dismissed', () => {
+    const { region, screen } = createRegionHarness(false, 80, 30);
+    region.writeAbove('Suggestion boundary\n');
+    region.setLiveRow('skill-suggestion', 'Suggested skill\nInspect repository\nPress Enter to accept');
+    region.removeLiveRow('skill-suggestion');
+
+    expect(screen.snapshot()).not.toContain('Suggested skill');
+    expect(blankRowsBeforeComposer(screen, 'Suggestion boundary')).toBeLessThanOrEqual(1);
+  });
+
+  it('recomputes wrapped height in both resize directions without gaps or overlap', async () => {
+    const { region, screen, resize } = createRegionHarness(false, 44, 45);
+    region.writeAbove('Resize boundary\n');
+    region.paint({
+      draft: 'Inspect repository files with a semantic summary that wraps at narrow width',
+      mode: 'idle',
+    });
+    const narrowComposer = composerGeometry(screen).topSeparator;
+
+    resize(100, 45);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const wideComposer = composerGeometry(screen).topSeparator;
+    expect(wideComposer).toBeGreaterThan(narrowComposer);
+    expect(blankRowsBeforeComposer(screen, 'Resize boundary')).toBeLessThanOrEqual(1);
+
+    resize(44, 45);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(screen.snapshot().match(/Inspect repository files/gu)).toHaveLength(1);
+    expect(screen.snapshot().match(/▲ You/gu)).toHaveLength(1);
+  });
+
+  it('omits empty live sections instead of reserving their rows', () => {
+    const { region, screen } = createRegionHarness(false, 80, 30);
+    region.writeAbove('Empty-section boundary\n');
+    region.setLiveRow('empty-section', '  \n\n  ');
+
+    expect(blankRowsBeforeComposer(screen, 'Empty-section boundary')).toBeLessThanOrEqual(1);
+  });
+
+  it('clears prior reserved height and rejects late restoration after cls', () => {
+    const { display, screen } = createDisplay(100, 45);
+    display.setStatusFooter('◆ provider/model │ 0% │ working │ 1s');
+    display.setIdleComposer('', 'Type your message');
+    const activity = display.toolRow('file_read', { path: 'before-cls.ts' }, undefined, {
+      activityId: 'before-cls',
+    });
+    display.clearScreen();
+    display.write('After cls\n');
+    activity.refresh();
+
+    expect(screen.snapshot().match(/before-cls.ts/gu)).toHaveLength(1);
+    expect(blankRowsBeforeComposer(screen, 'After cls')).toBeLessThanOrEqual(1);
+  });
+});
 
 describe('compact hybrid transcript geometry', () => {
   it('renders distinct prompt and answer blocks without attaching to activity output', () => {

--- a/tests/v4/cli/box.test.ts
+++ b/tests/v4/cli/box.test.ts
@@ -89,6 +89,20 @@ describe('cli/v4/box helpers', () => {
     expect(out).toBe('thiswi');
   });
 
+  it('measures wide Unicode glyphs by terminal columns', () => {
+    expect(visibleLength('A界B')).toBe(4);
+    expect(visibleLength(`${ORANGE}A界B${RESET}`)).toBe(4);
+  });
+
+  it('never splits a wide Unicode glyph or an ANSI sequence', () => {
+    const out = truncateVisible(`${ORANGE}A界B${RESET}`, 3);
+    expect(visibleLength(out)).toBe(3);
+    expect(out).toContain('A界');
+    expect(out).not.toContain('B');
+    expect(out.startsWith(ORANGE)).toBe(true);
+    expect(out.endsWith('\x1b[0m')).toBe(true);
+  });
+
   it('boxTopTitled uses visible length so coloured titles dont skew the dashes', () => {
     const plain = boxTopTitled('Health Check', 50);
     const coloured = boxTopTitled(`${ORANGE}Health Check${RESET}`, 50);

--- a/tests/v4/cli/box.test.ts
+++ b/tests/v4/cli/box.test.ts
@@ -7,6 +7,7 @@ import {
   boxTopTitled,
   visibleLength,
   truncateVisible,
+  truncateVisibleAtWord,
 } from '../../../cli/v4/box';
 
 const ORANGE = '\x1b[38;2;255;107;53m';
@@ -102,6 +103,17 @@ describe('cli/v4/box helpers', () => {
     expect(out.startsWith(ORANGE)).toBe(true);
     expect(out.endsWith('\x1b[0m')).toBe(true);
   });
+
+  it.each([44, 80, 100, 120, 160])(
+    'keeps a complete activity phrase at a %i-column boundary',
+    (width) => {
+      const phrase = `${ORANGE}Still working — checking the result before reporting repository validation details${RESET}`;
+      const out = truncateVisibleAtWord(phrase, width);
+      expect(visibleLength(out)).toBeLessThanOrEqual(width);
+      expect(out).not.toMatch(/\b(?:work|check|resul|repo|validat)…(?:\x1b\[[0-9;]*m)?$/u);
+      expect(out.endsWith('…') || /\x1b\[(?:0|39)m$/u.test(out)).toBe(true);
+    },
+  );
 
   it('boxTopTitled uses visible length so coloured titles dont skew the dashes', () => {
     const plain = boxTopTitled('Health Check', 50);

--- a/tests/v4/cli/callbacks.test.ts
+++ b/tests/v4/cli/callbacks.test.ts
@@ -115,7 +115,7 @@ describe('CliCallbacks.promptApproval', () => {
     })).resolves.toBe('allow');
   });
 
-  it('renders the approval card with risk tier and reason', async () => {
+  it('does not archive the approval diagnostic card in normal compact output', async () => {
     const { display, output } = makeDisplay();
     const cb = new CliCallbacks({
       display,
@@ -131,18 +131,25 @@ describe('CliCallbacks.promptApproval', () => {
     });
     expect(decision).toBe('allow');
     const out = output();
-    // Slice 6 (commit 5a90c0e8) + Slice 6 hotfix (d251382f): rendered
-    // as the orange-bar framed panel — key/value rows, no rounded box,
-    // no "Approval needed" title (Phase 2.5 event row owns the headline).
-    // v4.8.0 Slice 11c — panel bar swapped ▎ → │ (universal-font glyph).
-    expect(out).toMatch(/│/);
+    expect(out).toBe('');
+  });
+
+  it('retains the approval diagnostic card in verbose output', async () => {
+    const { display, output } = makeDisplay();
+    const cb = new CliCallbacks({
+      display,
+      verboseMode: 'verbose',
+      promptModule: mockPrompts([{ kind: 'select', value: 'allow' }]),
+    });
+    await cb.promptApproval({
+      toolName: 'shell_exec', category: 'execute', args: { command: 'rm -rf /' },
+      riskTier: 'dangerous', reason: 'destructive command', effects: {},
+    });
+    const out = output();
     expect(out).toMatch(/action\s+shell_exec/);
     expect(out).toMatch(/reason\s+destructive command/);
     expect(out).toMatch(/risk\s+dangerous/);
-    expect(out).toMatch(/reversible\s+yes/i);
-    expect(out).not.toMatch(/args\s+\{/);
     expect(out).not.toContain('rm -rf /');
-    expect(out).not.toMatch(/┌── Approval required /);
   });
 
   it('returns the chosen decision verbatim', async () => {
@@ -163,6 +170,7 @@ describe('CliCallbacks.promptApproval', () => {
     const { display, output } = makeDisplay();
     const cb = new CliCallbacks({
       display,
+      verboseMode: 'verbose',
       promptModule: mockPrompts([{ kind: 'select', value: 'deny' }]),
     });
     await cb.promptApproval({

--- a/tests/v4/cli/capabilityCard.test.ts
+++ b/tests/v4/cli/capabilityCard.test.ts
@@ -159,4 +159,12 @@ describe('truncToContent', () => {
     expect(out.endsWith('…')).toBe(true);
     expect(out.length).toBeLessThan(long.length);
   });
+
+  it('uses terminal width for ANSI and wide Unicode content', () => {
+    const out = truncToContent(`\x1b[38;2;255;107;53m${'界'.repeat(80)}\x1b[0m`);
+    expect(require('string-width')(out.replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '')))
+      .toBeLessThanOrEqual(58);
+    expect(out).not.toContain('\uFFFD');
+    expect(out).toMatch(/…$/u);
+  });
 });

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -217,6 +217,42 @@ function buildOpts(over: Partial<ChatSessionOptions> = {}): ChatSessionOptions {
 }
 
 describe('ChatSession.run', () => {
+  it('keeps context and elapsed footer metrics monotonic within one active turn', () => {
+    const projected: Array<Record<string, unknown>> = [];
+    const display = {
+      fixedBottomRegionEnabled: () => true,
+      setStatusFooter: (value: ((cols: number) => string) | string) => {
+        if (typeof value === 'function') value(100);
+      },
+      statusFooter: (args: Record<string, unknown>) => {
+        projected.push(args);
+        return 'footer';
+      },
+      providerSwitchLine: () => '',
+      write: () => undefined,
+    } as unknown as Display;
+    const session = new ChatSession(buildOpts({ display }));
+    let estimate = 1_200;
+    (session as unknown as { modelMetadata: {
+      getLimits: () => { contextLength: number };
+      getDefaults: () => { contextLength: number };
+      estimateMessageTokens: () => number;
+    } }).modelMetadata = {
+      getLimits: () => ({ contextLength: 16_000 }),
+      getDefaults: () => ({ contextLength: 16_000 }),
+      estimateMessageTokens: () => estimate,
+    };
+    session.setStatusState({ kind: 'generating', sinceMs: Date.now() - 2_000 });
+    session.renderStatusLine();
+    estimate = 400;
+    (session as unknown as { turnCount: number }).turnCount = 1;
+    (session as unknown as { footerMaxElapsedMs: number }).footerMaxElapsedMs = 5_000;
+    session.renderStatusLine();
+
+    expect(projected.map((entry) => entry.ctxUsed)).toEqual([1_200, 1_200]);
+    expect(Number(projected[1]?.elapsedMs)).toBeGreaterThanOrEqual(5_000);
+  });
+
   it('settles all activity before projecting the turn as ready', async () => {
     const events: string[] = [];
     const callbacks = {

--- a/tests/v4/cli/chatSession.test.ts
+++ b/tests/v4/cli/chatSession.test.ts
@@ -217,6 +217,31 @@ function buildOpts(over: Partial<ChatSessionOptions> = {}): ChatSessionOptions {
 }
 
 describe('ChatSession.run', () => {
+  it('settles all activity before projecting the turn as ready', async () => {
+    const events: string[] = [];
+    const callbacks = {
+      completeActivityTurn: vi.fn(() => events.push('activities-settled')),
+      settleActivitiesBeforeOutput: vi.fn(),
+    };
+    const session = new ChatSession(buildOpts({
+      callbacks: callbacks as never,
+      promptApi: mkPromptApi({ inputs: ['hello', '/quit'] }),
+    }));
+    const setStatusState = session.setStatusState.bind(session);
+    vi.spyOn(session, 'setStatusState').mockImplementation((state) => {
+      events.push(`status:${state.kind}`);
+      setStatusState(state);
+    });
+
+    await session.run();
+
+    const finalReady = events.lastIndexOf('status:ready');
+    const finalSettlement = events.lastIndexOf('activities-settled');
+    expect(events).toContain('status:settling');
+    expect(finalSettlement).toBeGreaterThanOrEqual(0);
+    expect(finalSettlement).toBeLessThan(finalReady);
+  });
+
   it('hands a queued submission to the agent exactly once without downstream mutation', async () => {
     const { agent, calls } = mkAgent();
     const session = new ChatSession(buildOpts({

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -1574,8 +1574,9 @@ describe('Display v4.8.0 ui_* event renderers', () => {
 
   // ── ui_command_result ─────────────────────────────────────────────────
 
-  it('ui_command_result paints header + stdout + exit row on failure', () => {
+  it('ui_command_result paints header + stdout + exit row on failure in full mode', () => {
     const { d, chunks } = captureDisplay({ tty: true });
+    d.setActivityPresentationMode('full');
     d.renderUiEvent('ui_command_result', {
       command: 'npm test', stdout: 'one\ntwo', stderr: 'boom', exit_code: 2,
     });
@@ -1591,13 +1592,12 @@ describe('Display v4.8.0 ui_* event renderers', () => {
     }
   });
 
-  it('ui_command_result collapses successful output in summary mode', () => {
+  it('ui_command_result stays silent in summary mode because the canonical tool row owns projection', () => {
     const { d, chunks } = captureDisplay({ tty: true });
     const long = Array.from({ length: 12 }, (_, i) => `line${i}`).join('\n');
     d.renderUiEvent('ui_command_result', { command: 'spam', stdout: long });
     const out = stripAnsi(chunks.join(''));
-    expect(out).toContain('✓ spam — completed');
-    expect(out).not.toContain('line0');
+    expect(out).toBe('');
   });
 
   it('ui_command_result retains successful output in full activity mode', () => {

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -10,6 +10,7 @@ import {
   isPreFramedLine,
   TRAIL_HIDE_TOOLS,
   makeNoOpToolRowHandle,
+  previewToolArgs,
 } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import type { ActivitySnapshot } from '../../../cli/v4/activityRegistry';
@@ -24,6 +25,26 @@ function stripAnsi(s: string): string {
     '',
   );
 }
+
+describe('compact activity argument summaries', () => {
+  it('does not expose raw JSON for an unmapped structured argument object', () => {
+    const summary = previewToolArgs({ include_full: true, limit: 5, private_value: 'hidden' });
+    expect(summary).not.toContain('{');
+    expect(summary).not.toContain('private_value');
+    expect(summary).not.toContain('hidden');
+    expect(summary).toMatch(/3 (?:arguments|options)/u);
+    expect(previewToolArgs(
+      { include_full: true, limit: 5, private_value: 'hidden' },
+      'full',
+    )).toContain('"private_value":"hidden"');
+  });
+
+  it('keeps a recognizable scalar target without serializing sibling fields', () => {
+    const summary = previewToolArgs({ name: 'repository scan', include_full: true, limit: 5 });
+    expect(summary).toContain('repository scan');
+    expect(summary).not.toContain('include_full');
+  });
+});
 
 describe('SkinEngine', () => {
   let engine: SkinEngine;
@@ -152,11 +173,13 @@ describe('Display', () => {
     expect(out).toContain('/tmp/x');
   });
 
-  it('toolPreview truncates very long args', () => {
+  it('toolPreview summarizes unknown structured args without raw JSON', () => {
     const big = { blob: 'x'.repeat(2000) };
     const out = stripAnsi(display.toolPreview('huge', big));
     expect(out.length).toBeLessThan(260);
-    expect(out).toContain('...');
+    expect(out).toContain('1 argument');
+    expect(out).not.toContain('{');
+    expect(out).not.toContain('blob');
   });
 
   it('error includes suggestion when provided', () => {
@@ -350,6 +373,16 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
   });
   afterEach(() => {
     delete process.env.AIDEN_UI_ICONS;
+  });
+
+  it('keeps repeated reads of one file distinct by inspected range', () => {
+    const { d, chunks } = captureDisplay({ tty: false });
+    d.toolRow('file_read', { path: 'cli/v4/display.ts', offset: 0, limit: 80 }).ok(5);
+    d.toolRow('file_read', { path: 'cli/v4/display.ts', offset: 80, limit: 80 }).ok(6);
+    const output = stripAnsi(chunks.join(''));
+    expect(output).toContain('display.ts · chars 0–79');
+    expect(output).toContain('display.ts · chars 80–159');
+    expect(output.match(/display\.ts/gu)).toHaveLength(2);
   });
 
   // ── Success is SILENT ───────────────────────────────────────────────

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -392,9 +392,23 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     d.toolRow('file_read', { path: 'cli/v4/display.ts', offset: 0, limit: 80 }).ok(5);
     d.toolRow('file_read', { path: 'cli/v4/display.ts', offset: 80, limit: 80 }).ok(6);
     const output = stripAnsi(chunks.join(''));
-    expect(output).toContain('display.ts · chars 0–79');
-    expect(output).toContain('display.ts · chars 80–159');
+    expect(output).toContain('display.ts · segment 1');
+    expect(output).toContain('display.ts · segment 2');
+    expect(output).not.toContain('chars 0');
     expect(output.match(/display\.ts/gu)).toHaveLength(2);
+  });
+
+  it('projects Worker admission without generic argument metadata', () => {
+    const { d, chunks } = captureDisplay({ tty: false });
+    d.toolRow('subagent_fanout', {
+      mode: 'partition',
+      n: 3,
+      tasks: [{ goal: 'Runtime ownership' }, { goal: 'TUI inspection' }, { goal: 'Product readiness' }],
+    }).ok(1_200);
+    const output = stripAnsi(chunks.join(''));
+    expect(output).toContain('Worker');
+    expect(output).toContain('3 · Runtime ownership');
+    expect(output).not.toMatch(/arguments|partition|\{.*\}/u);
   });
 
   // ── Success is SILENT ───────────────────────────────────────────────

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -119,6 +119,18 @@ describe('Display', () => {
   let display: Display;
   let skin: SkinEngine;
 
+  it('separates prompt identity/content from assistant prose and resets each span', () => {
+    const themed = new SkinEngine({ colorDepth: 'truecolor' });
+    const d = new Display({ skin: themed });
+    const submitted = d.userTurn('hello\nwrapped prompt');
+    const answer = d.agentTurn('assistant prose', { markdown: false });
+    expect(submitted).toContain('\x1b[38;2;91;192;235m');
+    expect(submitted).toContain('\x1b[38;2;156;220;254m');
+    expect(submitted).not.toContain('\x1b[38;2;255;107;53m  ▲ You');
+    expect(answer).toContain('assistant prose');
+    expect(submitted.match(/\x1b\[[0-9;]*m/g)?.at(-1)).toBe('\x1b[39m');
+  });
+
   beforeEach(() => {
     skin = new SkinEngine({ forceMono: true }); // deterministic output
     display = new Display({ skin });

--- a/tests/v4/cli/semanticActivity.test.ts
+++ b/tests/v4/cli/semanticActivity.test.ts
@@ -7,6 +7,10 @@ import {
   projectActivityFrame,
   projectCommandPresentation,
   projectEvidenceLines,
+  projectSkillInvocation,
+  projectWorkerDelegation,
+  projectContextCompaction,
+  dedupeStructuredActivity,
   relativizeActivityText,
   shouldDeferActivityTransition,
   type SemanticActivityPhase,
@@ -78,6 +82,14 @@ describe('semantic activity projection', () => {
     expect(phaseColorKind('verifying')).toBe('verifying');
     expect(phaseColorKind('complete')).toBe('success');
     expect(phaseColorKind('failed')).toBe('error');
+    expect(projectActivityFrame({ phase: 'complete', frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' }).glyphColor).toBe('success');
+    expect(projectActivityFrame({ phase: 'failed', frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' }).glyphColor).toBe('error');
+    expect(projectActivityFrame({ phase: 'approval_required', frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' }).glyphColor).toBe('warn');
+  });
+
+  it.each(['thinking', 'planning', 'inspecting', 'working', 'testing', 'verifying', 'recovering', 'completing'] as SemanticActivityPhase[])('keeps %s animation frames display-width stable', (phase) => {
+    const widths = [0, 1, 2, 3].map((frame) => projectActivityFrame({ phase, frame, elapsedMs: 1_000, unicode: true, mode: 'summary' }).glyph.length);
+    expect(new Set(widths).size).toBe(1);
   });
 
   it('defers fast transient phase churn but never delays terminal/user phases', () => {
@@ -85,6 +97,32 @@ describe('semantic activity projection', () => {
     expect(shouldDeferActivityTransition('thinking', 'planning', 200)).toBe(false);
     expect(shouldDeferActivityTransition('working', 'approval_required', 10)).toBe(false);
     expect(shouldDeferActivityTransition('working', 'blocked', 10)).toBe(false);
+  });
+});
+
+describe('structured skill and Worker projections', () => {
+  it('exposes one typed row per real skill and optional reference', () => {
+    const lines = projectSkillInvocation({ invocationId: 'inv-1', skillName: 'repository-audit', durationMs: 1250, referenceName: 'repo-layout' });
+    expect(lines.map((line) => line.text)).toEqual(['skill     repository-audit 1.3s', 'reference repo-layout']);
+    expect(lines[0]?.color).toBe('skill');
+    expect(lines[1]?.color).toBe('evidence');
+  });
+
+  it('projects actual Worker count and goals without raw payloads', () => {
+    const lines = projectWorkerDelegation({
+      groupId: 'group-1', workers: [{ goal: 'Runtime ownership' }, { goal: 'TUI inspection' }], state: 'running', elapsedMs: 2000,
+    });
+    expect(lines.map((line) => line.text)).toEqual([
+      'delegate  2 Workers', '1. Runtime ownership', '2. TUI inspection', '2 Workers running · 2s',
+    ]);
+    expect(lines.join('\n')).not.toContain('{');
+    expect(lines[0]?.color).toBe('worker');
+  });
+
+  it('deduplicates repeated durable identities and keeps context compaction informational', () => {
+    const line = projectContextCompaction();
+    expect(line.text).toContain('preserved task state and tool results');
+    expect(dedupeStructuredActivity([line, line])).toHaveLength(1);
   });
 });
 

--- a/tests/v4/cli/semanticActivity.test.ts
+++ b/tests/v4/cli/semanticActivity.test.ts
@@ -103,9 +103,9 @@ describe('semantic activity projection', () => {
 describe('structured skill and Worker projections', () => {
   it('exposes one typed row per real skill and optional reference', () => {
     const lines = projectSkillInvocation({ invocationId: 'inv-1', skillName: 'repository-audit', durationMs: 1250, referenceName: 'repo-layout' });
-    expect(lines.map((line) => line.text)).toEqual(['skill     repository-audit 1.3s', 'reference repo-layout']);
+    expect(lines.map((line) => line.text)).toEqual(['✓ skill  repository-audit · repo-layout 1.3s']);
+    expect(lines).toHaveLength(1);
     expect(lines[0]?.color).toBe('skill');
-    expect(lines[1]?.color).toBe('evidence');
   });
 
   it('projects actual Worker count and goals without raw payloads', () => {

--- a/tests/v4/cli/skinEngine.yaml.test.ts
+++ b/tests/v4/cli/skinEngine.yaml.test.ts
@@ -229,9 +229,13 @@ describe('SkinEngine terminal color capability', () => {
     expect(new Set(codes).size).toBe(4);
   });
 
-  it('keeps the user label on the Aiden brand accent', () => {
+  it('keeps the user label on the prompt cyan token', () => {
     const engine = new SkinEngine({ colorDepth: 'truecolor' });
-    expect(engine.applyColors('You', 'user')).toContain('\x1b[38;2;255;107;53m');
+    expect(engine.applyColors('You', 'user')).toContain('\x1b[38;2;91;192;235m');
+    expect(engine.applyColors('draft', 'prompt_content')).toContain('\x1b[38;2;156;220;254m');
+    expect(engine.applyColors('skill', 'skill')).not.toBe(engine.applyColors('read', 'tool'));
+    expect(engine.applyColors('worker', 'worker')).toContain('\x1b[38;2;167;139;250m');
+    expect(engine.applyColors('evidence', 'evidence')).toContain('\x1b[38;2;96;165;250m');
   });
 
   it('renders phase colors in truecolor, ANSI 16, and monochrome modes', () => {
@@ -252,8 +256,8 @@ describe('SkinEngine terminal color capability', () => {
     const dark = engine.applyColors('phase', 'inspecting');
     engine.setActive('light');
     const light = engine.applyColors('phase', 'inspecting');
-    expect(dark).toContain('\x1b[38;2;96;165;250m');
-    expect(light).toContain('\x1b[38;2;29;78;160m');
+    expect(dark).toContain('\x1b[38;2;91;192;235m');
+    expect(light).toContain('\x1b[38;2;0;102;136m');
     expect(light).not.toBe(dark);
   });
 });

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -173,7 +173,7 @@ describe('responsive startup dashboard integration', () => {
     await session.renderStartupCard();
     const output = stripAnsi(chunks.join(''));
 
-    const logo = columns >= 44 ? /Autonomous AI Engine/g : /^Aiden$/gm;
+    const logo = columns >= 44 ? /Autonomous AI Engine/g : /^AIDEN$/gm;
     expect(output.match(logo)).toHaveLength(1);
     expect(output).toContain('Partner');
     expect(output).toContain('llama-3.3-70b-versatile'.slice(0, columns >= 48 ? 8 : 3));

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -237,7 +237,9 @@ function expectCleanMainBuffer(startup: Awaited<ReturnType<typeof launch>>): voi
 
 function dashboardLines(output: string): string[] {
   const lines = output.split(/\r?\n/);
-  const start = lines.findIndex((line) => line.includes('█████╗') || /^\s*Aiden\s*$/.test(line));
+  const start = lines.findIndex((line) => (
+    line.includes('█████╗') || /^\s*(?:A I D E N|AIDEN)\s*$/u.test(line)
+  ));
   const end = lines.findIndex((line, index) => index >= start && line.startsWith('▲ You'));
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
@@ -328,7 +330,8 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
 
     const narrow = await launch(48);
     const narrowRendered = narrow.rendered();
-    expect(narrowRendered).toContain('█████╗');
+    expect(narrowRendered).toMatch(/^AIDEN$/mu);
+    expect(narrowRendered).not.toContain('█████╗');
     expect(narrowRendered).toMatch(/◇\s+Assistant\s+·\s+◆\s+custom-default/i);
     expect(narrowRendered).toMatch(/built solo/i);
     expect(narrowRendered).toContain('Environment');

--- a/tests/v4/cli/startupDashboard.test.ts
+++ b/tests/v4/cli/startupDashboard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   renderStartupDashboard,
   resolveStartupDashboardTier,
+  resolveStartupLogoTier,
   startupVisibleWidth,
   type StartupDashboardData,
 } from '../../../cli/v4/startupDashboard';
@@ -58,6 +59,12 @@ function assertBounded(lines: string[], columns: number): void {
 }
 
 describe('responsive startup dashboard', () => {
+  it('selects full, compact, and plain startup identities without wrapping', () => {
+    expect(resolveStartupLogoTier(100, banner)).toBe('full');
+    expect(resolveStartupLogoTier(60, banner)).toBe('compact');
+    expect(resolveStartupLogoTier(44, banner)).toBe('plain');
+  });
+
   it.each([
     [120, 'wide'],
     [80, 'wide'],
@@ -104,7 +111,8 @@ describe('responsive startup dashboard', () => {
   it('keeps the compact narrow layout, full project details, and bounded card', () => {
     const lines = render(48);
     const text = lines.join('\n');
-    expect(text).toContain(banner.split('\n')[0]);
+    expect(text).toContain('AIDEN');
+    expect(text).not.toContain(banner.split('\n')[0]);
     expect(text).toContain('Partner');
     expect(text).toContain('gpt-5.6-sol');
     expect(text).toContain('Built solo');
@@ -161,8 +169,10 @@ describe('responsive startup dashboard', () => {
     (columns) => {
       const lines = render(columns);
       const text = lines.join('\n');
-      const logoFits = startupVisibleWidth(banner.split('\n')[0]) <= columns - 2;
-      expect(text).toContain(logoFits ? banner.split('\n')[0] : 'Aiden');
+      const logoTier = resolveStartupLogoTier(columns, banner);
+      expect(text).toContain(
+        logoTier === 'full' ? banner.split('\n')[0] : logoTier === 'compact' ? 'A I D E N' : 'AIDEN',
+      );
       expect(text).toContain('Autonomous AI Engine');
       expect(text).toContain('Built solo');
       expect(text).toContain('GitHub:');
@@ -187,8 +197,8 @@ describe('responsive startup dashboard', () => {
     },
   );
 
-  it.each([160, 120, 100, 80, 60, 44])(
-    'keeps the complete logo on the Aiden orange accent at %i columns',
+  it.each([160, 120, 100, 80])(
+    'keeps the complete fitting logo on the Aiden orange accent at %i columns',
     (columns) => {
       const skin = new SkinEngine({ colorDepth: 'truecolor' });
       const coloredBanner = banner.split('\n').map((line) => skin.applyColors(line, 'brand')).join('\n');
@@ -209,6 +219,14 @@ describe('responsive startup dashboard', () => {
       expect(logo).toContain('\x1b[38;2;255;107;53m');
     },
   );
+
+  it.each([60, 44])('never wraps the startup identity at %i columns', (columns) => {
+    const lines = render(columns);
+    expect(lines.join('\n')).not.toContain(banner.split('\n')[0]);
+    const identity = columns === 60 ? 'A I D E N' : 'AIDEN';
+    expect(lines.filter((line) => line.includes(identity))).toHaveLength(1);
+    assertBounded(lines, columns);
+  });
 
   it('wraps the welcome and helper instead of truncating either message', () => {
     const lines = render(44, {
@@ -246,7 +264,7 @@ describe('responsive startup dashboard', () => {
 
   it('is safe at minimal widths and never creates negative padding or broken borders', () => {
     const lines = render(20);
-    expect(lines.join('\n')).toContain('Aiden');
+    expect(lines.join('\n')).toContain('AIDEN');
     expect(lines.join('\n')).not.toMatch(/undefined|null|NaN/);
     expect(lines.join('\n')).toContain('╭');
     assertBounded(lines, 20);

--- a/tests/v4/cli/statusBar.test.ts
+++ b/tests/v4/cli/statusBar.test.ts
@@ -35,6 +35,13 @@ describe('formatStatusState (Phase 22 Task 4)', () => {
     });
   });
 
+  it('keeps response settlement distinct from input-ready state', () => {
+    expect(formatStatusState({ kind: 'settling' })).toEqual({
+      text: 'settling',
+      colour: 'brand',
+    });
+  });
+
   it('generating shows ⏵ + duration in brand', () => {
     const out = formatStatusState({ kind: 'generating', sinceMs: 0 }, 12_400);
     expect(out.colour).toBe('brand');

--- a/tests/v4/cli/toolPreview.test.ts
+++ b/tests/v4/cli/toolPreview.test.ts
@@ -16,6 +16,12 @@ describe('buildToolPreview', () => {
     expect(buildToolPreview('shell_exec', { command: 'npm test' })).toBe('npm test');
   });
 
+  it('summarizes compound PowerShell without displaying a partial expression', () => {
+    const command = 'where.exe aiden 2>$null; where.exe aiden-runtime 2>$null; Get-Command aiden';
+    expect(buildToolPreview('shell_exec', { command })).toBe('where.exe aiden · +2 steps');
+    expect(buildToolPreview('shell_exec', { command }, { mode: 'full' })).toBe(command);
+  });
+
   it('extracts file path', () => {
     expect(buildToolPreview('file_read', { path: 'README.md' })).toBe('README.md');
     expect(buildToolPreview('file_write', { path: '/tmp/x.md', content: 'hi' })).toBe('/tmp/x.md');
@@ -58,15 +64,39 @@ describe('buildToolPreview', () => {
     expect(out).toMatch(/…$/);
   });
 
-  it('collapses whitespace so multi-line values stay one-line', () => {
+  it('summarizes multi-line commands without exposing a partial command', () => {
     const out = buildToolPreview('shell_exec', { command: 'echo a\n  echo b\n\techo c' });
-    expect(out).toBe('echo a echo b echo c');
+    expect(out).toBe('echo a · +2 steps');
   });
 
   it('serialises non-string primary args via JSON.stringify', () => {
-    // Force a primary arg whose value is an object.
+    // Structured values stay human-readable in the compact activity surface.
     expect(buildToolPreview('skill_manage', { action: { kind: 'install', id: 'x' } }))
-      .toBe('{"kind":"install","id":"x"}');
+      .toBe('install · x');
+    expect(buildToolPreview(
+      'skill_manage',
+      { action: { kind: 'install', id: 'x' } },
+      { mode: 'full' },
+    )).toBe('{"kind":"install","id":"x"}');
+  });
+
+  it('keeps repeated file-read ranges distinct', () => {
+    expect(buildToolPreview('file_read', {
+      path: 'C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts',
+      offset: 120,
+      limit: 80,
+    })).toBe('C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts · chars 120–199');
+    expect(buildToolPreview('file_read', {
+      path: 'C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts',
+      offset: 200,
+      limit: 80,
+    })).toContain('chars 200–279');
+  });
+
+  it('never cuts a long Unicode preview by JavaScript code units', () => {
+    const out = buildToolPreview('shell_exec', { command: '界'.repeat(100) });
+    expect(out).not.toContain('\uFFFD');
+    expect(out).toMatch(/…$/u);
   });
 
   it('handles missing primary arg gracefully (known tool, but no value)', () => {

--- a/tests/v4/cli/toolPreview.test.ts
+++ b/tests/v4/cli/toolPreview.test.ts
@@ -22,6 +22,19 @@ describe('buildToolPreview', () => {
     expect(buildToolPreview('shell_exec', { command }, { mode: 'full' })).toBe(command);
   });
 
+  it('summarizes PowerShell repository inspection without exposing assignment fragments', () => {
+    const command = [
+      "$files = @('cli/v4/aidenTUI.ts', 'cli/v4/display.ts')",
+      "$patterns = @('class Display', 'render')",
+      'Select-String -Path $files -Pattern $patterns',
+    ].join('; ');
+    const preview = buildToolPreview('shell_exec', { command });
+    expect(preview).toBe('search repository source · +2 steps');
+    expect(preview).not.toContain('$files');
+    expect(preview).not.toContain('$patterns');
+    expect(buildToolPreview('shell_exec', { command }, { mode: 'full' })).toContain('$files');
+  });
+
   it('extracts file path', () => {
     expect(buildToolPreview('file_read', { path: 'README.md' })).toBe('README.md');
     expect(buildToolPreview('file_write', { path: '/tmp/x.md', content: 'hi' })).toBe('/tmp/x.md');

--- a/tests/v4/cli/toolPreview.test.ts
+++ b/tests/v4/cli/toolPreview.test.ts
@@ -54,9 +54,9 @@ describe('buildToolPreview', () => {
     expect(buildToolPreview('execute_code', { code: 'print(1+1)' })).toBe('print(1+1)');
   });
 
-  it('extracts subagent_fanout mode', () => {
+  it('projects subagent_fanout as a Worker count instead of raw mode metadata', () => {
     expect(buildToolPreview('subagent_fanout', { mode: 'partition', n: 3 }))
-      .toBe('partition');
+      .toBe('3 Workers');
   });
 
   it('returns empty string for known no-arg tools', () => {
@@ -93,17 +93,29 @@ describe('buildToolPreview', () => {
     )).toBe('{"kind":"install","id":"x"}');
   });
 
-  it('keeps repeated file-read ranges distinct', () => {
+  it('keeps repeated file-read segments distinct without raw offsets in compact mode', () => {
     expect(buildToolPreview('file_read', {
       path: 'C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts',
       offset: 120,
       limit: 80,
-    })).toBe('C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts · chars 120–199');
+    })).toBe('C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts · segment 2');
     expect(buildToolPreview('file_read', {
       path: 'C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts',
       offset: 200,
       limit: 80,
-    })).toContain('chars 200–279');
+    })).toContain('segment 3');
+    expect(buildToolPreview('file_read', {
+      path: 'display.ts', offset: 200, limit: 80,
+    }, { mode: 'full' })).toContain('chars 200–279');
+  });
+
+  it('projects Worker count and goal instead of a generic argument count', () => {
+    const preview = buildToolPreview('subagent_fanout', {
+      mode: 'partition', n: 2,
+      tasks: [{ goal: 'renderer ownership audit' }, { goal: 'runtime lifecycle audit' }],
+    });
+    expect(preview).toBe('2 Workers · renderer ownership audit');
+    expect(preview).not.toMatch(/arguments/u);
   });
 
   it('never cuts a long Unicode preview by JavaScript code units', () => {

--- a/tests/v4/cli/toolTrail.test.ts
+++ b/tests/v4/cli/toolTrail.test.ts
@@ -7,6 +7,7 @@ import {
   TRAIL_DETAIL_CAP,
   TRAIL_PIPE,
 } from '../../../cli/v4/display/toolTrail';
+import { visibleLength } from '../../../cli/v4/box';
 
 /**
  * Pure-function unit tests for the action-trail lookup.
@@ -157,5 +158,26 @@ describe('truncDetail', () => {
   });
   it('trims leading/trailing whitespace before measuring', () => {
     expect(truncDetail('   hello   ')).toBe('hello');
+  });
+
+  it('caps ANSI-coloured text by visible terminal width without splitting escapes', () => {
+    const orange = '\x1b[38;2;255;107;53m';
+    const reset = '\x1b[0m';
+    const out = truncDetail(`${orange}${'segment '.repeat(12)}${reset}`);
+    expect(visibleLength(out)).toBeLessThanOrEqual(TRAIL_DETAIL_CAP);
+    expect(out).not.toMatch(/\x1b\[[0-9;]*$/u);
+  });
+
+  it('measures wide Unicode by terminal columns and keeps whole glyphs', () => {
+    const out = truncDetail('界'.repeat(TRAIL_DETAIL_CAP));
+    expect(visibleLength(out)).toBeLessThanOrEqual(TRAIL_DETAIL_CAP);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out).not.toContain('\uFFFD');
+  });
+
+  it('prefers a word boundary over a mid-word cut', () => {
+    const out = truncDetail('inspect repository configuration and dependency metadata completely');
+    expect(out.endsWith('…')).toBe(true);
+    expect(out).not.toMatch(/configur…$/u);
   });
 });

--- a/tests/v4/harness/terminalScreen.test.ts
+++ b/tests/v4/harness/terminalScreen.test.ts
@@ -91,4 +91,15 @@ describe('TerminalScreen Windows resize semantics', () => {
     expect(screen.scrollbackSnapshot()).toBe(before);
     expect(screen.reviewableSnapshot()).toContain('DURABLE HISTORY');
   });
+
+  it('scrolls only the transcript region when the volatile surface grows', () => {
+    const screen = new TerminalScreen(40, 10, { retainResizeHistory: true });
+    screen.write('line one\r\nline two\r\nline three');
+    screen.write('\x1b[1;7r\x1b[2S');
+    screen.write('\x1b[1;1Htranscript\r\n');
+
+    expect(screen.snapshot()).not.toContain('line one');
+    expect(screen.snapshot()).toContain('transcript');
+    expect(screen.scrollbackSnapshot()).not.toContain('line one');
+  });
 });

--- a/tests/v4/harness/terminalScreen.ts
+++ b/tests/v4/harness/terminalScreen.ts
@@ -341,6 +341,23 @@ export class TerminalScreen {
         this.row = 0;
         this.col = 0;
         break;
+      case 'S':
+        for (let count = 0; count < amount; count += 1) {
+          const removed = this.cells.splice(this.scrollTop, 1)[0];
+          const removedWrapped = this.wrappedRows.splice(this.scrollTop, 1)[0] ?? false;
+          if (!this.alternateBuffer && this.scrollTop === 0
+            && !this.hostSnapshotRedraw && this.scrollBottom === this.height - 1 && removed) {
+            this.scrollback.push([...removed]);
+            this.scrollbackWrappedRows.push(removedWrapped);
+          }
+          this.cells.splice(
+            this.scrollBottom,
+            0,
+            Array.from({ length: this.width }, () => ' '),
+          );
+          this.wrappedRows.splice(this.scrollBottom, 0, false);
+        }
+        break;
       case 's':
         this.savedRow = this.row;
         this.savedCol = this.col;


### PR DESCRIPTION
## Summary

- measures ANSI and Unicode content by terminal display width across prompt, cards, approvals, and activity rows;
- replaces compact raw argument output with bounded human-readable summaries while retaining full detail in full/debug projections;
- keeps repeated file reads distinct by inspected range and summarizes compound shell commands without partial syntax;
- reduces healthy startup inventory noise while preserving warnings and verbose diagnostics;
- preserves the existing renderer, startup identity, themes, activity semantics, composer ownership, approvals, and resize behavior.

## Architecture

- the default `ChatSession`/`Display`/`BottomRegion` path remains authoritative;
- the explicit Blessed mode receives only compact argument-safety parity;
- the dormant Ink runtime remains opt-in and unwired pending a later parity decision;
- no lifecycle, continuation, approval, input, or package-version authority changed.

## Validation

- focused renderer and neighboring unit matrix: 610 passed;
- startup PTY: 14 passed;
- viewport PTY: 2 passed;
- built CLI PTY: 11 passed;
- composer, activity, input, and approval PTY: 11 passed;
- frame and Ink contract matrix: 37 passed;
- Node 22 typecheck passed;
- production build passed;
- package dry run and isolated tarball install passed;
- diff, NUL, secret, attribution, and scope scans passed;
- no lingering Aiden or Node test process remained.

Physical Windows console observation remains required for the default and explicit Blessed renderer paths before merge.