### PR TITLE
fix(tui): improve terminal presentation safety

### DIFF
--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -35,6 +35,7 @@ import { ChatSession } from './chatSession';
 import { runTuiMode } from './aidenTUI';
 import { Display } from './display';
 import { SkinEngine } from './skinEngine';
+import { isVerbose } from './design/tokens';
 import { initializeEffectiveTheme } from './themeCompatibility';
 import { CommandRegistry } from './commandRegistry';
 import { CliCallbacks } from './callbacks';
@@ -1350,7 +1351,7 @@ export async function buildAgentRuntime(
   // to config.yaml. Core modules (sandboxConfig, turnState,
   // browserState) consult this singleton; precedence is
   // env > config.yaml > default per Q-P8a-1(a).
-  {
+  if (isVerbose()) {
     const { initRuntimeToggles } = await import('../../core/v4/runtimeToggles');
     initRuntimeToggles({
       configRead: (key) => config.getValue(key),
@@ -1773,9 +1774,11 @@ export async function buildAgentRuntime(
     skillCounts.skipped > 0
       ? ` (see ${skillsLogger.filePath})`
       : '';
-  display.dim(
-    `[skills] ${skillCounts.loaded} loaded, ${skillCounts.skipped} skipped${skipNote}`,
-  );
+  if (skillCounts.skipped > 0) {
+    display.warn(`[skills] ${skillCounts.loaded} loaded, ${skillCounts.skipped} skipped${skipNote}`);
+  } else if (isVerbose()) {
+    display.dim(`[skills] ${skillCounts.loaded} loaded, 0 skipped`);
+  }
   // Phase 17 Task 5: plugin loader boot.
   //
   // Bundled plugins (e.g. aiden-plugin-cdp-browser) are discovered

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -44,6 +44,9 @@ import { findGhost } from './ghostMatch';
 import { getSkinEngine } from './skinEngine';
 import { emitComposerReadyForTests } from './composerReadiness';
 import { nextComposerGeneration, turnIdleDiagnostic } from './turnIdleDiagnostics';
+import { truncateVisible } from './box';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
 
 /** Lightweight slash command shape — minimum the dropdown needs. */
 export interface SlashCommandLite {
@@ -100,7 +103,7 @@ function stripAnsi(s: string): string {
 
 /** Visible width — ignore ANSI escape sequences. */
 function vWidth(s: string): number {
-  return stripAnsi(s).length;
+  return stringWidth(stripAnsi(s));
 }
 
 /** Build an SGR span using the active skin. */
@@ -122,11 +125,11 @@ function renderDropdownRow(
   // The desc column is right-aligned and dim-coloured.
   const lhs = `${marker}${nameCell}`;
   const lhsWidth = vWidth(lhs);
-  const padBetween = Math.max(2, width - lhsWidth - vWidth(desc));
-  const truncatedDesc =
-    vWidth(desc) > width - lhsWidth - 2
-      ? desc.slice(0, Math.max(0, width - lhsWidth - 3)) + '…'
-      : desc;
+  const descWidth = Math.max(0, width - lhsWidth - 2);
+  const truncatedDesc = vWidth(desc) > descWidth
+    ? `${truncateVisible(desc, Math.max(0, descWidth - 1))}…`
+    : desc;
+  const padBetween = Math.max(2, width - lhsWidth - vWidth(truncatedDesc));
   const dimDesc = sk.applyColors(truncatedDesc, 'muted');
   const painted = selected
     ? sk.applyColors(lhs, 'brand')

--- a/cli/v4/aidenTUI.ts
+++ b/cli/v4/aidenTUI.ts
@@ -23,6 +23,7 @@
 import { ChatSession } from './chatSession';
 import type { ChatSessionOptions, ChatPromptApi } from './chatSession';
 import type { CommandRegistry } from './commandRegistry';
+import { buildToolPreview, summarizeToolArguments } from './toolPreview';
 
 export interface TuiOptions {
   /** Pre-built ChatSessionOptions (same shape Phase 14c hands ChatSession). */
@@ -294,8 +295,8 @@ export class AidenTUI {
       userTurn: (text: string) => `{#ff6b35-fg}you{/} ${text}`,
       agentTurn: (text: string) => `{cyan-fg}Aiden{/cyan-fg}\n${text}`,
       toolPreview: (name: string, args: unknown) => {
-        const argStr = safeJson(args).slice(0, 200);
-        return `{gray-fg}→ ${name} ${argStr}{/gray-fg}`;
+        const summary = buildToolPreview(name, args) ?? summarizeToolArguments(args);
+        return `{gray-fg}→ ${name}${summary ? ` ${summary}` : ''}{/gray-fg}`;
       },
 
       startSpinner: (text: string) => this.startTuiSpinner(text),
@@ -452,12 +453,4 @@ export class AidenTUI {
 function stripAnsi(s: string): string {
   // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
-}
-
-function safeJson(v: unknown): string {
-  try {
-    return JSON.stringify(v);
-  } catch {
-    return String(v);
-  }
 }

--- a/cli/v4/box.ts
+++ b/cli/v4/box.ts
@@ -28,6 +28,9 @@
  */
 
 // ── Sharp (default) ──────────────────────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
+
 const SHARP = {
   TL: '┌',
   TR: '┐',
@@ -68,7 +71,7 @@ interface GlyphSet {
  */
 const ANSI_REGEX = /\x1b\[[0-9;]*[A-Za-z]/g;
 export function visibleLength(s: string): number {
-  return s.replace(ANSI_REGEX, '').length;
+  return stringWidth(s.replace(ANSI_REGEX, ''));
 }
 
 /**
@@ -80,10 +83,10 @@ export function visibleLength(s: string): number {
 export function truncateVisible(s: string, maxVisible: number): string {
   if (visibleLength(s) <= maxVisible) return s;
   let out = '';
-  let visible = 0;
+  let plain = '';
   let i = 0;
   let sawAnsi = false;
-  while (i < s.length && visible < maxVisible) {
+  while (i < s.length) {
     const ch = s.charCodeAt(i);
     if (ch === 0x1b && s[i + 1] === '[') {
       const m = s.slice(i).match(/^\x1b\[[0-9;]*[A-Za-z]/);
@@ -94,11 +97,29 @@ export function truncateVisible(s: string, maxVisible: number): string {
         continue;
       }
     }
-    out += s[i];
-    visible += 1;
-    i += 1;
+    const codePoint = s.codePointAt(i);
+    if (codePoint === undefined) break;
+    const character = String.fromCodePoint(codePoint);
+    if (stringWidth(plain + character) > maxVisible) break;
+    out += character;
+    plain += character;
+    i += character.length;
   }
   return sawAnsi ? out + '\x1b[0m' : out;
+}
+
+/** ANSI-aware activity truncation that prefers a complete word. */
+export function truncateVisibleAtWord(s: string, maxVisible: number): string {
+  const width = Math.max(1, Math.floor(maxVisible));
+  if (visibleLength(s) <= width) return s;
+  if (width === 1) return '…';
+  const candidate = truncateVisible(s, width - 1);
+  const plain = candidate.replace(ANSI_REGEX, '').replace(/\x1b\[0m$/u, '');
+  const boundary = Math.max(plain.lastIndexOf(' '), plain.lastIndexOf('—'));
+  if (boundary > 0) {
+    return `${truncateVisible(candidate, visibleLength(plain.slice(0, boundary).trimEnd()))}…`;
+  }
+  return `${candidate}…`;
 }
 
 // ── Generic primitives ───────────────────────────────────────────

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -529,7 +529,7 @@ export class CliCallbacks {
       const status = payload && typeof payload === 'object'
         ? (payload as { status?: unknown }).status
         : undefined;
-      const dismiss = isExclusiveToolInteraction(
+      const dismiss = call.name === 'skill_view' || isExclusiveToolInteraction(
         this.resolveToolInteraction?.(call.name),
       );
       settled = status === 'cancelled'
@@ -541,6 +541,26 @@ export class CliCallbacks {
     if (!settled) return;
 
     try { this.renderBlockerCardIfPresent(result); } catch { /* defensive */ }
+    if (call.name === 'skill_view' && !err) {
+      const args = call.arguments && typeof call.arguments === 'object'
+        ? call.arguments as Record<string, unknown> : {};
+      const payload = result?.result && typeof result.result === 'object'
+        ? result.result as Record<string, unknown> : {};
+      const requestedReference = typeof args.path === 'string' ? args.path.trim() : '';
+      const loadedFile = typeof payload.filePath === 'string' ? payload.filePath.trim() : '';
+      const loadedSegments = loadedFile.split(/[\\/]/u);
+      const loadedReference = requestedReference || loadedSegments[loadedSegments.length - 1] || '';
+      try {
+        this.display.renderUiEvent('ui_skill_invocation', {
+          invocation_id: call.id,
+          skill_name: typeof args.name === 'string' ? args.name : 'skill',
+          duration_ms: timing?.executionDurationMs,
+          reference_name: typeof payload.referenceName === 'string' ? payload.referenceName
+            : typeof payload.reference_name === 'string' ? payload.reference_name
+              : loadedReference || undefined,
+        });
+      } catch { /* structured activity must never affect execution */ }
+    }
     try {
       const payload = result?.result && typeof result.result === 'object'
         ? { ...(result.result as Record<string, unknown>), ...(result.error ? { error: result.error } : {}) }
@@ -1039,7 +1059,7 @@ function redactApprovalTarget(value: string): string {
 }
 
 function truncateApproval(value: string, width: number): string {
-  if (value.length <= width) return value;
-  if (width <= 1) return value.slice(0, width);
-  return `${value.slice(0, width - 1)}…`;
+  if (visibleLength(value) <= width) return value;
+  if (width <= 1) return truncateVisible(value, width);
+  return `${truncateVisible(value, width - 1)}…`;
 }

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -807,8 +807,14 @@ export class BottomRegion {
     // When a wrapped draft grows upward, scroll transcript rows before claiming
     // the additional cells. This preserves the newest transcript content above
     // the composer instead of erasing it during the geometry change.
-    const makeRoom = growth > 0
-      ? `${ESC}[${previousTranscriptBottom};1H${'\n'.repeat(growth)}`
+    // A settled activity projection leaves the transcript cursor on one empty
+    // row. Reuse that row for the next activity instead of advancing it into
+    // scrollback and leaving a permanent blank between adjacent terminal rows.
+    const previousProjection = this.projection.transcript[this.projection.transcript.length - 1];
+    const reusableCursorRow = previousProjection?.id.startsWith('activity-terminal:') ? 1 : 0;
+    const rowsToCreate = Math.max(0, growth - reusableCursorRow);
+    const makeRoom = rowsToCreate > 0
+      ? `${ESC}[${previousTranscriptBottom};1H${'\n'.repeat(rowsToCreate)}`
       : '';
     const clear = dimensionsChanged
       ? this.clearDamagedUnion(previousGeometry, nextGeometry)

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -89,12 +89,17 @@ type StatusSource = string | ((columns?: number) => string);
 export interface BottomRegionStyle {
   brand(value: string): string;
   muted(value: string): string;
+  /** Prompt identity and draft content use distinct semantic tokens. */
+  prompt?: (value: string) => string;
+  promptContent?: (value: string) => string;
   unicode?: boolean;
 }
 
 const PLAIN_BOTTOM_STYLE: BottomRegionStyle = {
   brand: (value) => value,
   muted: (value) => value,
+  prompt: (value) => value,
+  promptContent: (value) => value,
 };
 
 /** ANSI-aware front truncation used as the final no-wrap status guard. */
@@ -323,7 +328,14 @@ export function renderBottomSurface(
     : fitStatus(status, availableWidth);
   const topRow = rows - laneRows + 1;
   return {
-    lines: [top, style.brand(fittedTitle), divider, ...content, bottom, fittedStatus],
+    lines: [
+      top,
+      (style.prompt ?? style.brand)(fittedTitle),
+      divider,
+      ...content.map((line) => (style.promptContent ?? ((value: string) => value))(line)),
+      bottom,
+      fittedStatus,
+    ],
     laneRows,
     cursorRow: topRow + 3 + wrapped.cursorLine,
     cursorCol: Math.min(availableWidth, 1 + wrapped.cursorCell),

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -25,7 +25,7 @@ const TerminalRenderer: new (opts?: unknown) => unknown = require('marked-termin
 const stringWidth: (value: string) => number = require('string-width');
 
 import { SkinEngine, getSkinEngine, type ColorKind } from './skinEngine';
-import { visibleLength, truncateVisible } from './box';
+import { visibleLength, truncateVisible, truncateVisibleAtWord } from './box';
 import { glyphs } from './design/tokens';
 import { clearLinesUpSeq } from './display/cursorSeq';
 import {
@@ -49,6 +49,7 @@ import {
   projectActivityFrame,
   projectCommandPresentation,
   projectEvidenceLines,
+  projectSkillInvocation,
   relativizeActivityText,
   semanticPhaseCompactToken,
   semanticPhaseForTool,
@@ -97,13 +98,14 @@ function truncateTerminalVisible(value: string, maxVisible: number): string {
 import { getReplyRenderer } from './replyRenderer';
 // Optional "Sources" footer when AIDEN_CITATIONS=1 (default off).
 import { renderCitationFooter } from './citationFooter';
-import { buildToolPreview } from './toolPreview';
+import { buildToolPreview, summarizeToolArguments } from './toolPreview';
 import { renderComposerBuffer } from './composerRow';
 import {
   ComposerLane,
   composerLaneEnabled,
   type BottomComposerMode,
   type BottomComposerSurface,
+  type BottomRegionStyle,
   type LaneSink,
 } from './composerLane';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
@@ -1111,7 +1113,7 @@ export class Display {
     // surface family (▎ Aiden header, status footer, bottom hint).
     // Timestamp variant unchanged — the timestamp gutter already
     // provides its own consistent left edge.
-    const tri = this.skin.applyColors(terminalStateSymbol('user'), 'brand');
+    const tri = this.skin.applyColors(terminalStateSymbol('user'), 'prompt');
     if (process.env.AIDEN_UI_TIMESTAMPS === '1') {
       return `${this.timestampPrefix()}  ${tri} `;
     }
@@ -1604,8 +1606,12 @@ export class Display {
         : width >= 80 ? this.composerSuffix()
         : width >= 36 ? '  Ctrl+C stop'
         : '  Ctrl+C';
-      const activity = this.skin.applyColors(projection.text, projection.color);
-      return truncateVisible(`${prefix}${activity}${time}${suffix}`, width);
+      const activity = `${this.skin.applyColors(projection.glyph, projection.glyphColor)} `
+        + this.skin.applyColors(
+          `${projection.label}${source === 'provider' && this.activityPresentationMode === 'full' ? ' · provider request' : ''}`,
+          projection.color,
+        );
+      return truncateVisibleAtWord(`${prefix}${activity}${time}${suffix}`, width);
     };
     const erase = (terminal = false): void => {
       if (!printed || !isTty) return;
@@ -1740,6 +1746,12 @@ export class Display {
     const useIcons = process.env.AIDEN_UI_ICONS !== '0' && terminalSupportsUnicode();
     const { icon, verb } = trailIconForTool(name);
     const glyph = useIcons ? icon : sk.applyColors('·', 'muted');
+    const operationKind: ColorKind = /(?:subagent|worker)/iu.test(name) ? 'worker'
+      : name === 'skill_view' || /(?:^|_)skill(?:_|$)/iu.test(name) ? 'skill'
+        : /(?:read|list|inspect|search|fetch|snapshot)/iu.test(name) ? 'inspecting'
+          : /(?:verify|evidence|proof|test)/iu.test(name) ? 'evidence'
+            : 'tool';
+    const operationLabel = operationKind === 'worker' ? 'Worker' : verb.trim();
 
     // Detail field: v4.1.4-media — consult `buildToolPreview` first so
     // tools registered in `TOOL_PRIMARY_ARG` (media_transport → 'target',
@@ -1747,16 +1759,18 @@ export class Display {
     // meaningful primary-arg preview instead of a JSON blob. Fall back
     // to the generic `previewToolArgs` scan for tools the map doesn't
     // know about so unregistered MCP tools etc. still render readably.
-    const mapped = buildToolPreview(name, args);
-    const rawDetail = mapped ?? previewToolArgs(args);
+    const mapped = buildToolPreview(name, args, { mode: this.activityPresentationMode });
+    const rawDetail = mapped ?? previewToolArgs(args, this.activityPresentationMode);
     const detailForDisplay = (): string => {
-      if (screenOwner?.usesReflowSafeRows()) {
-        const segments = rawDetail.split(/[\\/]/u);
-        return segments[segments.length - 1] ?? rawDetail;
+      const relative = relativizeActivityText(rawDetail, process.cwd(), this.activityPresentationMode);
+      if (this.activityPresentationMode === 'full') return relative;
+      if (screenOwner?.usesReflowSafeRows() && /(?:^|_)(?:file|read|write|edit|patch|list|copy|move|delete)(?:_|$)/iu.test(name)) {
+        const [target, ...qualifiers] = relative.split(' · ');
+        const segments = target.split(/[\\/]/u);
+        const base = segments[segments.length - 1] ?? target;
+        return [base, ...qualifiers].filter(Boolean).join(' · ');
       }
-      return this.activityPresentationMode === 'full'
-        ? rawDetail
-        : truncDetail(relativizeActivityText(rawDetail, process.cwd(), 'summary'));
+      return truncDetail(relative);
     };
 
     // Semantic elapsed time comes from ActivityRegistry. A compatibility row
@@ -1787,11 +1801,14 @@ export class Display {
       });
       const duration = elapsed >= 1000 ? ` ${formatToolDuration(elapsed)}` : '';
       const liveSuffix = `  ${sk.applyColors(`${semanticPhaseStatusLabel(semanticPhase)}${duration}…`, phaseColorKind(semanticPhase))}`;
-      const runningGlyph = sk.applyColors(projection.glyph, projection.color);
+      const runningGlyph = sk.applyColors(
+        projection.glyph,
+        operationKind === 'worker' ? 'worker' : projection.glyphColor,
+      );
       if (screenOwner?.usesReflowSafeRows()) {
         const width = terminalRowWidth() ?? screenOwner.volatileRowWidth();
         const compactPrefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph} ` +
-          `${sk.applyColors(verb.trim(), 'tool')} `;
+          `${sk.applyColors(operationLabel, operationKind)} `;
         const compactPhase = sk.applyColors(
           `${semanticPhaseCompactToken(semanticPhase, useIcons)}${duration}`,
           phaseColorKind(semanticPhase),
@@ -1801,13 +1818,11 @@ export class Display {
           0,
           width - visibleLength(compactPrefix) - visibleLength(compactSuffix),
         );
-        return `${compactPrefix}${truncateVisible(
-          sk.applyColors(detailForDisplay(), 'muted'),
-          availableDetail,
-        )}${compactSuffix}\n`;
+        const fittedDetail = fitQualifiedActivityDetail(detailForDisplay(), availableDetail);
+        return `${compactPrefix}${sk.applyColors(fittedDetail, 'muted')}${compactSuffix}\n`;
       }
       const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${runningGlyph}  ` +
-        `${sk.applyColors(padVerb(verb), 'tool')} `;
+        `${sk.applyColors(padVerb(operationLabel), operationKind)} `;
       const suffix = `${liveSuffix}${screenOwner ? '' : this.composerSuffix()}`;
       const detailText = sk.applyColors(detailForDisplay(), 'muted');
       const width = terminalRowWidth();
@@ -1816,7 +1831,7 @@ export class Display {
         0,
         width - visibleLength(prefix) - visibleLength(suffix),
       );
-      return `${prefix}${truncateVisible(detailText, availableDetail)}${suffix}\n`;
+      return `${prefix}${truncateVisibleAtWord(detailText, availableDetail)}${suffix}\n`;
     };
 
     // Outcome row — entire line colored by outcome kind.
@@ -1825,7 +1840,8 @@ export class Display {
       const outcomeGlyph = terminalSupportsUnicode()
         ? (failed ? '!' : '✓')
         : terminalStateSymbol(failed ? 'failed' : 'completed');
-      const terminalVerb = /^denied\b/u.test(suffix) ? 'denied'
+      const terminalVerb = operationKind === 'worker' ? 'Worker'
+        : /^denied\b/u.test(suffix) ? 'denied'
         : /^cancelled\b/u.test(suffix) ? 'cancelled'
         : /^timed out\b/u.test(suffix) ? 'timed out'
         : /^unknown\b/u.test(suffix) ? 'unknown'
@@ -1838,22 +1854,25 @@ export class Display {
         const width = terminalRowWidth() ?? screenOwner.volatileRowWidth();
         const compactPrefix = `${TRAIL_PIPE} ${outcomeGlyph} ${terminalVerb} `;
         const availableDetail = Math.max(0, width - visibleLength(compactPrefix));
-        return `${sk.applyColors(
-          `${compactPrefix}${truncateVisible(detailForDisplay(), availableDetail)}`,
-          kind,
-        )}\n`;
+        const fittedDetail = fitQualifiedActivityDetail(detailForDisplay(), availableDetail);
+        return `${sk.applyColors(TRAIL_PIPE, 'muted')} `
+          + `${sk.applyColors(outcomeGlyph, failed ? 'error' : 'success')} `
+          + `${sk.applyColors(terminalVerb, operationKind)} `
+          + `${sk.applyColors(fittedDetail, 'muted')}\n`;
       }
-      const prefix = `${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(terminalVerb)} `;
       const suffixText = suffix ? `  ${suffix}` : '';
       const width = terminalRowWidth();
       const availableDetail = width === null
         ? Number.POSITIVE_INFINITY
-        : Math.max(0, width - visibleLength(prefix) - visibleLength(suffixText));
+        : Math.max(0, width - visibleLength(`${TRAIL_PIPE} ${outcomeGlyph}  ${padVerb(terminalVerb)} `) - visibleLength(suffixText));
       const displayDetail = detailForDisplay();
-      const content = `${prefix}${availableDetail === Number.POSITIVE_INFINITY
+      const fittedDetail = availableDetail === Number.POSITIVE_INFINITY
         ? displayDetail
-        : truncateVisible(displayDetail, availableDetail)}${suffixText}`;
-      return `${sk.applyColors(content, kind)}\n`;
+        : truncateVisibleAtWord(displayDetail, availableDetail);
+      return `${sk.applyColors(TRAIL_PIPE, 'muted')} `
+        + `${sk.applyColors(outcomeGlyph, failed ? 'error' : 'success')}  `
+        + `${sk.applyColors(padVerb(terminalVerb), operationKind)} `
+        + `${sk.applyColors(fittedDetail, 'muted')}${sk.applyColors(suffixText, kind)}\n`;
     };
 
     // Capture stream reference so closures don't need `this`.
@@ -2178,15 +2197,10 @@ export class Display {
       return `${sk.applyColors(arrow, 'tool')} ${sk.applyColors(name, 'tool')} ${sk.applyColors(preview, 'muted')}`;
     }
 
-    // Unknown tool — original behaviour (full JSON, 200-char cap).
-    let serialized: string;
-    try {
-      serialized = JSON.stringify(args);
-    } catch {
-      serialized = String(args);
-    }
-    if (serialized.length > 200) serialized = `${serialized.slice(0, 197)}...`;
-    return `${sk.applyColors(arrow, 'tool')} ${sk.applyColors(name, 'tool')} ${sk.applyColors(serialized, 'muted')}`;
+    // Unknown tools stay human-readable in normal output. Raw structured
+    // arguments remain available to the execution trace and full details.
+    const summary = summarizeToolArguments(args);
+    return `${sk.applyColors(arrow, 'tool')} ${sk.applyColors(name, 'tool')}${summary ? ` ${sk.applyColors(summary, 'muted')}` : ''}`;
   }
 
   /**
@@ -2211,8 +2225,9 @@ export class Display {
   /** Format a user turn (e.g. echoed back from history). */
   userTurn(text: string): string {
     const sk = this.skin;
-    const body = text.split('\n').map((line) => `  ${line}`).join('\n');
-    return `  ${this.rule()}\n${sk.applyColors(`  ${terminalStateSymbol('user')} You`, 'user')}\n${body}\n  ${this.rule()}\n`;
+    const body = text.split('\n').map((line) => sk.applyColors(`  ${line}`, 'prompt_content')).join('\n');
+    const label = sk.applyColors(`  ${terminalStateSymbol('user')} You`, 'prompt');
+    return `  ${this.rule()}\n${label}\n${body}\n  ${this.rule()}\n`;
   }
 
   /**
@@ -2386,8 +2401,10 @@ export class Display {
    * restore an empty ready composer. Empty Enter remains a local no-op. */
   submitIdleComposer(value: string, hint: string): void {
     if (value.length > 0) {
-      const body = value.split('\n').map((line) => `  ${line}`).join('\n');
-      this.write(`${this.promptPrefix()}You\n${body}\n  ${this.rule()}`);
+      const body = value.split('\n')
+        .map((line) => this.skin.applyColors(`  ${line}`, 'prompt_content'))
+        .join('\n');
+      this.write(`${this.promptPrefix()}${this.skin.applyColors('You', 'prompt')}\n${body}\n  ${this.rule()}`);
     }
     this.idleComposerContent = `${this.promptPrefix()} ${hint}`;
     this.idleComposerDraft = '';
@@ -2508,10 +2525,12 @@ export class Display {
     if (this.composerSurfacePauseDepth === 0) this.paintComposerSurface();
   }
 
-  private laneStyle(): { brand(value: string): string; muted(value: string): string } {
+  private laneStyle(): BottomRegionStyle {
     return {
       brand: (value) => this.skin.applyColors(value, 'brand'),
       muted: (value) => this.skin.applyColors(value, 'muted'),
+      prompt: (value) => this.skin.applyColors(value, 'prompt'),
+      promptContent: (value) => this.skin.applyColors(value, 'prompt_content'),
     };
   }
 
@@ -3237,8 +3256,9 @@ export class Display {
   // rows. ui_task_done looks up the label so the completion row can
   // echo it even when the model only sends task_id + status. Cleared
   // on done. Map is per-Display-instance; one REPL session.
-  private uiTaskRows = new Map<string, { label: string }>();
+  private uiTaskRows = new Map<string, { label: string; kind: string }>();
   private uiTaskTerminalIds = new Set<string>();
+  private structuredActivityIds = new Set<string>();
 
   // v4.8.0 Phase 2.3 fix — set true by renderUiEvent; tryRerenderInPlace
   // early-returns when set so the cursor-up + erase-to-end-of-screen
@@ -3257,6 +3277,7 @@ export class Display {
    */
   resetUiTurnState(): void {
     this.uiEventsFiredThisTurn = false;
+    this.structuredActivityIds.clear();
   }
 
   renderUiEvent(name: string, args: Record<string, unknown>): void {
@@ -3275,6 +3296,7 @@ export class Display {
     if (name === 'ui_approval_request') { this.renderUiApprovalRequest(args); return; }
     if (name === 'ui_toast')            { this.renderUiToast(args);           return; }
     if (name === 'ui_artifact_created') { this.renderUiArtifactCreated(args); return; }
+    if (name === 'ui_skill_invocation') { this.renderUiSkillInvocation(args); return; }
     // Unknown event names silent-ignore (defensive — future registrations).
   }
 
@@ -3286,7 +3308,19 @@ export class Display {
    */
   private uiTrailRow(content: string, kind: ColorKind): string {
     const pipe = this.skin.applyColors(TRAIL_PIPE, 'muted');
-    return content.split('\n').map(l => `${pipe} ${this.skin.applyColors(l, kind)}\n`).join('');
+    return content.split('\n').map((line) => {
+      const match = /^(\s*(?:(?:└|├)\s+)?)([✓✕×!◐◈◇◆↻■ℹ⚠])([\s\S]*)$/u.exec(line);
+      if (!match) return `${pipe} ${this.skin.applyColors(line, 'muted')}\n`;
+      return `${pipe} ${this.skin.applyColors(match[1], 'muted')}${this.skin.applyColors(match[2], kind)}${this.skin.applyColors(match[3], 'muted')}\n`;
+    }).join('');
+  }
+
+  /** Strongly colour the state glyph and operation category; keep metadata restrained. */
+  private uiStructuredTrailRow(content: string, kind: ColorKind): string {
+    const pipe = this.skin.applyColors(TRAIL_PIPE, 'muted');
+    const match = /^(\S+\s+\S+)(\s+)(.*)$/u.exec(content);
+    if (!match) return `${pipe} ${this.skin.applyColors(content, kind)}\n`;
+    return `${pipe} ${this.skin.applyColors(match[1], kind)}${match[2]}${this.skin.applyColors(match[3], 'muted')}\n`;
   }
 
   private renderUiTaskUpdate(args: Record<string, unknown>): void {
@@ -3299,15 +3333,17 @@ export class Display {
     if (this.uiTaskTerminalIds.has(taskId)) return;
     this.commitStreamChunk();
     const glyph = terminalSupportsUnicode()
-      ? (status === 'paused' ? '⏸' : status === 'blocked' ? '!' : '◐')
+      ? (kindArg === 'subagent' ? '◆' : status === 'paused' ? '⏸' : status === 'blocked' ? '!' : '◐')
       : terminalStateSymbol(status === 'blocked' ? 'warning' : 'running');
-    const colorKind: ColorKind = status === 'running' ? 'tool' : 'warn';
-    this.uiTaskRows.set(taskId, { label });
+    const colorKind: ColorKind = kindArg === 'subagent' ? 'worker'
+      : status === 'running' ? 'warn' : 'error';
+    this.uiTaskRows.set(taskId, { label, kind: kindArg });
     const short  = label.length > 80 ? label.slice(0, 79) + '…' : label;
     // v4.8.0 Phase 2.4 — subagent kind: indent by depth inside the
     // gutter so nested rows tier below their parent.
     const indent = kindArg === 'subagent' ? '  '.repeat(depth) : '';
-    const stateLabel = status === 'paused' ? 'Paused' : status === 'blocked' ? 'Blocked' : 'Working';
+    const stateLabel = kindArg === 'subagent' ? 'Worker running'
+      : status === 'paused' ? 'Paused' : status === 'blocked' ? 'Blocked' : 'Working';
     const rendered = this.uiTrailRow(
       `${indent}┌ ${short}\n${indent}└ ${glyph} ${stateLabel}`,
       colorKind,
@@ -3390,6 +3426,20 @@ export class Display {
     if (skipped > 0) parts.push(`${skipped} skipped`);
     const dur = durationMs > 0 ? ` in ${durationMs}ms` : '';
     this.writeOutput(this.uiTrailRow(`${ok ? '✓' : '✗'} ${framework}: ${parts.join(', ')}${dur}`, ok ? 'success' : 'error'));
+    this.streamLastEndedNewline = true;
+  }
+
+  private renderUiSkillInvocation(args: Record<string, unknown>): void {
+    const invocationId = typeof args.invocation_id === 'string' ? args.invocation_id : '';
+    const skillName = typeof args.skill_name === 'string' ? args.skill_name : '';
+    const durationMs = typeof args.duration_ms === 'number' ? args.duration_ms : undefined;
+    const referenceName = typeof args.reference_name === 'string' ? args.reference_name : undefined;
+    const lines = projectSkillInvocation({ invocationId, skillName, durationMs, referenceName })
+      .filter((line) => !this.structuredActivityIds.has(line.identity));
+    if (lines.length === 0) return;
+    this.commitStreamChunk();
+    lines.forEach((line) => this.structuredActivityIds.add(line.identity));
+    this.writeOutput(lines.map((line) => this.uiStructuredTrailRow(line.text, line.color)).join(''));
     this.streamLastEndedNewline = true;
   }
 
@@ -3691,7 +3741,7 @@ export interface ToolRowHandle {
  * truncates with an ellipsis at TOOL_ROW_ARG_CAP. Pure — no side
  * effects, deterministic for a given input.
  */
-export function previewToolArgs(args: unknown): string {
+export function previewToolArgs(args: unknown, mode: ActivityPresentationMode = 'summary'): string {
   if (args == null) return '';
   if (typeof args === 'string') return truncToolArg(args);
   if (typeof args !== 'object') return truncToolArg(String(args));
@@ -3710,6 +3760,7 @@ export function previewToolArgs(args: unknown): string {
         : `"${v}"`);
     }
   }
+  if (mode !== 'full') return summarizeToolArguments(obj);
   let serialized: string;
   try {
     serialized = JSON.stringify(obj);
@@ -3724,13 +3775,30 @@ export function previewToolArgs(args: unknown): string {
   // tools mapped in `TOOL_PRIMARY_ARG`; here we extend the same UX to
   // any unmapped-tool fallback that bottoms out at `{}`.
   if (serialized === '{}') return '';
-  return truncToolArg(serialized);
+  return mode === 'full' ? serialized : truncToolArg(serialized);
+}
+
+function fitQualifiedActivityDetail(value: string, maxVisible: number): string {
+  if (maxVisible <= 0) return '';
+  if (visibleLength(value) <= maxVisible) return value;
+  const separator = ' · ';
+  const splitAt = value.lastIndexOf(separator);
+  if (splitAt < 0) return truncateVisibleAtWord(value, maxVisible);
+  const target = value.slice(0, splitAt);
+  const qualifier = value.slice(splitAt + separator.length);
+  const reserved = visibleLength(separator) + visibleLength(qualifier);
+  if (reserved >= maxVisible) return truncateVisibleAtWord(qualifier, maxVisible);
+  const targetWidth = maxVisible - reserved;
+  const fittedTarget = visibleLength(target) <= targetWidth
+    ? target
+    : truncateVisibleAtWord(target, targetWidth);
+  return `${fittedTarget}${separator}${qualifier}`;
 }
 
 function truncToolArg(s: string): string {
   const flat = s.replace(/\s+/g, ' ').trim();
-  if (flat.length <= TOOL_ROW_ARG_CAP) return flat;
-  return flat.slice(0, TOOL_ROW_ARG_CAP - 1) + '…';
+  if (visibleLength(flat) <= TOOL_ROW_ARG_CAP) return flat;
+  return `${truncateVisible(flat, TOOL_ROW_ARG_CAP - 1)}…`;
 }
 
 /**

--- a/cli/v4/display/capabilityCard.ts
+++ b/cli/v4/display/capabilityCard.ts
@@ -24,7 +24,7 @@
 
 import type { CapabilityCardData } from '../../../providers/v4/types';
 import type { ColorKind } from '../skinEngine';
-import { boxSharp, visibleLength } from '../box';
+import { boxSharp, truncateVisible, visibleLength } from '../box';
 
 type Colorize = (text: string, kind: ColorKind) => string;
 
@@ -159,7 +159,7 @@ export function truncToContent(s: string): string {
   // Reserve 6 chars for "  ✓ " prefix + 2 for border padding margin.
   const cap = CONTENT_WIDTH - 6;
   if (visibleLength(s) <= cap) return s;
-  return s.slice(0, cap - 1) + '…';
+  return `${truncateVisible(s, cap - 1)}…`;
 }
 
 /**

--- a/cli/v4/display/toolTrail.ts
+++ b/cli/v4/display/toolTrail.ts
@@ -22,6 +22,8 @@
  *     in full isolation.
  */
 
+import { truncateVisible, visibleLength } from '../box';
+
 /** Returned by iconForTool. */
 export interface ToolIconVerb {
   /** Single glyph rendered outside SGR so emoji native colours show. */
@@ -50,6 +52,9 @@ type TrailEntry = { readonly keys: readonly string[]; icon: string; verb: string
  * Keep entries grouped by semantic category to make auditing easy.
  */
 const TRAIL_MAP: readonly TrailEntry[] = [
+  // Delegation / Worker execution
+  { keys: ['subagent_fanout', 'spawn_sub_agent', 'worker'], icon: '◆', verb: 'delegate' },
+
   // ── Observe / read / list ────────────────────────────────────────────
   { keys: ['file_read', 'read_file', 'read_text_file', 'read_multiple_files',
            'file_list', 'list_directory', 'list_directory_with_sizes',
@@ -188,6 +193,12 @@ export function padVerb(verb: string): string {
  */
 export function truncDetail(s: string): string {
   const flat = s.replace(/\s+/g, ' ').trim();
-  if (flat.length <= TRAIL_DETAIL_CAP) return flat;
-  return flat.slice(0, TRAIL_DETAIL_CAP - 1) + '…';
+  if (visibleLength(flat) <= TRAIL_DETAIL_CAP) return flat;
+  const hard = truncateVisible(flat, TRAIL_DETAIL_CAP - 1);
+  const plain = hard.replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+  const boundary = plain.lastIndexOf(' ');
+  if (boundary > Math.floor(TRAIL_DETAIL_CAP / 2)) {
+    return `${truncateVisible(hard, visibleLength(plain.slice(0, boundary)))}…`;
+  }
+  return `${hard}…`;
 }

--- a/cli/v4/semanticActivity.ts
+++ b/cli/v4/semanticActivity.ts
@@ -33,7 +33,42 @@ export interface ActivityFrameProjection {
   label: string;
   text: string;
   color: ColorKind;
+  glyphColor: ColorKind;
   animated: boolean;
+}
+
+/** Compact typed projection for an actual skill invocation. */
+export interface SkillInvocationInput {
+  invocationId: string;
+  skillName: string;
+  durationMs?: number;
+  referenceName?: string;
+}
+
+export interface StructuredActivityLine {
+  text: string;
+  color: ColorKind;
+  identity: string;
+}
+
+export function projectSkillInvocation(input: SkillInvocationInput): StructuredActivityLine[] {
+  const name = input.skillName.trim();
+  if (!input.invocationId.trim() || !name) return [];
+  const duration = typeof input.durationMs === 'number' && input.durationMs >= 0
+    ? ` ${formatStructuredDuration(input.durationMs)}` : '';
+  const reference = input.referenceName?.trim();
+  const referenceText = reference ? ` · ${reference}` : '';
+  return [{
+    text: `✓ skill  ${name}${referenceText}${duration}`,
+    color: 'skill',
+    identity: `skill:${input.invocationId}`,
+  }];
+}
+
+function formatStructuredDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.max(0, Math.round(durationMs))}ms`;
+  const seconds = durationMs / 1000;
+  return `${Number.isInteger(seconds) ? seconds : seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`;
 }
 
 const TERMINAL_PHASES = new Set<SemanticActivityPhase>([
@@ -86,6 +121,19 @@ export function phaseColorKind(phase: SemanticActivityPhase): ColorKind {
     case 'failed': return 'error';
     case 'completing': return 'verifying';
     case 'ready': return 'muted';
+  }
+}
+
+/** Strong colour belongs to the state glyph; labels stay readable and restrained. */
+export function phaseGlyphColorKind(phase: SemanticActivityPhase): ColorKind {
+  switch (phase) {
+    case 'complete':
+    case 'ready': return 'success';
+    case 'failed': return 'error';
+    case 'approval_required': return 'warn';
+    case 'blocked': return 'error';
+    case 'recovering': return 'recovering';
+    default: return phaseColorKind(phase);
   }
 }
 
@@ -157,9 +205,9 @@ function unicodeGlyph(phase: SemanticActivityPhase, frame: number): string {
     }
     case 'working': return ['>   ', ' >  ', '  > ', '   >'][frame % 4]!;
     case 'testing': return ['◐', '◓', '◑', '◒'][frame % 4]!;
-    case 'verifying': return ['⌁', '⌁·', '⌁··'][frame % 3]!;
+    case 'verifying': return ['⌁  ', '⌁· ', '⌁··'][frame % 3]!;
     case 'recovering': return ['↶', '↺'][frame % 2]!;
-    case 'completing': return ['·', '··', '···'][frame % 3]!;
+    case 'completing': return ['·  ', '·· ', '···'][frame % 3]!;
     case 'approval_required':
     case 'blocked': return '!';
     case 'complete': return '✓';
@@ -186,6 +234,7 @@ export function projectActivityFrame(input: ActivityFrameInput): ActivityFramePr
     label,
     text: `${glyph} ${label}${detail}`,
     color: phaseColorKind(input.phase),
+    glyphColor: phaseGlyphColorKind(input.phase),
     animated: !TERMINAL_PHASES.has(input.phase),
   };
 }

--- a/cli/v4/skinEngine.ts
+++ b/cli/v4/skinEngine.ts
@@ -118,10 +118,12 @@ function ansiRgb(
       // ANSI 16 has no orange. Dark amber is the closest restrained fallback;
       // it avoids turning the brand into bright red or painting the UI yellow.
       brand: 33, accent: 33, heading: 33, user: 33,
+      prompt: 36, prompt_content: 96,
       success: 92, warn: 93, degraded: 93, error: 31,
-      tool: 96, session: 96, agent: 97, muted: 37,
+      tool: 36, skill: 95, worker: 95,
+      session: 96, agent: 97, muted: 37,
       tertiary: 90, metric_turn: 95,
-      thinking: 96, planning: 95, inspecting: 94, working: 33,
+      thinking: 96, planning: 95, inspecting: 96, evidence: 94, working: 33,
       testing: 93, verifying: 36, recovering: 95,
     };
     return `\x1b[${semanticCode[kind!] ?? rgbTo16(r, g, b)}m${text}\x1b[39m`;
@@ -163,7 +165,12 @@ const COLOR_KIND_TO_TOKEN_PATH: Partial<Record<string, string>> = {
   verifying:   'semantic.verifying',
   recovering:  'semantic.recovering',
   agent:       'content.primary',
-  user:        'brand.primary',
+  user:        'semantic.thinking',
+  prompt:      'semantic.thinking',
+  prompt_content: 'metrics.model',
+  skill:       'semantic.planning',
+  worker:      'semantic.planning',
+  evidence:    'semantic.info',
 };
 
 function hexToRgb(hex: string): [number, number, number] | null {
@@ -187,8 +194,13 @@ export type ColorKind =
   | 'brand'
   | 'accent'
   | 'user'
+  | 'prompt'
+  | 'prompt_content'
   | 'agent'
   | 'tool'
+  | 'skill'
+  | 'worker'
+  | 'evidence'
   | 'error'
   | 'warn'
   | 'success'
@@ -233,9 +245,14 @@ const DEFAULT_SKIN: SkinDefinition = {
   colors: {
     brand: BRAND_ORANGE,
     accent: BRAND_ORANGE,
-    user: BRAND_ORANGE, // user input shares the Aiden brand accent
+    user: [0x5b, 0xc0, 0xeb],
+    prompt: [0x5b, 0xc0, 0xeb],
+    prompt_content: [0x9c, 0xdc, 0xfe],
     agent: [0xe0, 0xe0, 0xe0], // off-white — agent reply
-    tool: [0x9c, 0xdc, 0xfe], // cyan — tool calls
+    tool: [0x5b, 0xc0, 0xeb], // cyan — tool calls
+    skill: [0xa7, 0x8b, 0xfa],
+    worker: [0xa7, 0x8b, 0xfa],
+    evidence: [0x60, 0xa5, 0xfa],
     error: [0xf4, 0x47, 0x47],
     warn: [0xff, 0xc1, 0x07],
     success: [0x4c, 0xaf, 0x50],
@@ -265,7 +282,7 @@ const DEFAULT_SKIN: SkinDefinition = {
     tertiary: [0x6a, 0x6a, 0x6a],
     thinking: [0x5b, 0xc0, 0xeb],
     planning: [0xa7, 0x8b, 0xfa],
-    inspecting: [0x60, 0xa5, 0xfa],
+    inspecting: [0x5b, 0xc0, 0xeb],
     working: [0xfb, 0x92, 0x3c],
     testing: [0xfa, 0xcc, 0x15],
     verifying: [0x2d, 0xd4, 0xbf],
@@ -289,9 +306,14 @@ const LIGHT_SKIN: SkinDefinition = {
   colors: {
     brand: [0xc4, 0x42, 0x10],
     accent: [0xc4, 0x42, 0x10],
-    user: [0xc4, 0x42, 0x10],
+    user: [0x00, 0x66, 0x88],
+    prompt: [0x00, 0x66, 0x88],
+    prompt_content: [0x00, 0x55, 0x88],
     agent: [0x20, 0x20, 0x20],
-    tool: [0x00, 0x55, 0x88],
+    tool: [0x00, 0x66, 0x88],
+    skill: [0x5b, 0x3f, 0xa8],
+    worker: [0x5b, 0x3f, 0xa8],
+    evidence: [0x1d, 0x4e, 0xa0],
     error: [0xb0, 0x10, 0x10],
     warn: [0x80, 0x60, 0x00],
     success: [0x1b, 0x5e, 0x20],
@@ -310,7 +332,7 @@ const LIGHT_SKIN: SkinDefinition = {
     tertiary: [0x9a, 0x9a, 0x9a],
     thinking: [0x00, 0x66, 0x88],
     planning: [0x5b, 0x3f, 0xa8],
-    inspecting: [0x1d, 0x4e, 0xa0],
+    inspecting: [0x00, 0x66, 0x88],
     working: [0xa6, 0x3f, 0x00],
     testing: [0x7a, 0x5a, 0x00],
     verifying: [0x00, 0x66, 0x66],
@@ -326,8 +348,13 @@ const MONOCHROME_SKIN: SkinDefinition = {
     brand: null,
     accent: null,
     user: null,
+    prompt: null,
+    prompt_content: null,
     agent: null,
     tool: null,
+    skill: null,
+    worker: null,
+    evidence: null,
     error: null,
     warn: null,
     success: null,

--- a/cli/v4/startupDashboard.ts
+++ b/cli/v4/startupDashboard.ts
@@ -12,6 +12,7 @@ const ANSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const SAFE_MARGIN = 2;
 
 export type StartupDashboardTier = 'wide' | 'medium' | 'narrow' | 'minimal';
+export type StartupLogoTier = 'full' | 'compact' | 'plain';
 
 export interface StartupEnvironmentData {
   os?: string;
@@ -337,6 +338,18 @@ function renderProject(
   ];
 }
 
+export function resolveStartupLogoTier(columns: number, banner?: string): StartupLogoTier {
+  const tier = resolveStartupDashboardTier(columns);
+  if (tier === 'narrow' || tier === 'minimal') return 'plain';
+  if (tier === 'medium') return 'compact';
+  if (!banner) return 'plain';
+  const width = safeWidth(columns);
+  const lines = banner.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  return lines.length > 0 && lines.every((line) => startupVisibleWidth(line) <= width)
+    ? 'full'
+    : 'compact';
+}
+
 function normalizeBanner(banner: string | undefined, width: number): string[] {
   if (!banner) return [];
   const lines = banner.split(/\r?\n/).filter((line) => line.trim().length > 0);
@@ -350,12 +363,16 @@ export function renderStartupDashboard(options: RenderStartupDashboardOptions): 
   const tier = resolveStartupDashboardTier(options.columns);
   const data = options.data;
   const lines: string[] = [];
-  const bannerLines = normalizeBanner(options.banner, width);
+  const logoTier = resolveStartupLogoTier(options.columns, options.banner);
+  const bannerLines = logoTier === 'full' ? normalizeBanner(options.banner, width) : [];
 
   if (bannerLines.length > 0) {
     lines.push(...bannerLines, style.muted('Autonomous AI Engine'), '');
+  } else if (logoTier === 'compact') {
+    lines.push(style.brand('A I D E N'));
+    lines.push(style.muted('Autonomous AI Engine'));
   } else {
-    lines.push(style.brand('Aiden'));
+    lines.push(style.brand('AIDEN'));
     lines.push(style.muted('Autonomous AI Engine'));
   }
 

--- a/cli/v4/toolPreview.ts
+++ b/cli/v4/toolPreview.ts
@@ -39,6 +39,8 @@
  * Functions must return a string. Return `''` to show no preview
  * (matches the empty-key convention). Pure — no side effects.
  */
+import { truncateVisible, visibleLength } from './box';
+
 export type ToolPreviewExtractor = string | ((args: unknown) => string);
 
 /**
@@ -52,6 +54,8 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
 
   // ── file ops ─────────────────────────────────────────────────────────
   file_read:         'path',
+  read_file:         'path',
+  read_text_file:    'path',
   file_write:        'path',
   file_patch:        'path',
   file_list:         'path',
@@ -111,7 +115,7 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
   process_log_read:  'pid',
 
   // ── subagent ─────────────────────────────────────────────────────────
-  subagent_fanout:   'mode',
+  subagent_fanout:   '',
 
   // ── system / misc ────────────────────────────────────────────────────
   system_info:       '',
@@ -172,6 +176,67 @@ export const TOOL_PRIMARY_ARG: Record<string, ToolPreviewExtractor> = {
  */
 const PREVIEW_MAX_CHARS = 120;
 
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/gu;
+
+function cleanPreviewText(value: string): string {
+  return value
+    .replace(ANSI_PATTERN, '')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu, '')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function truncatePreview(value: string, columns = PREVIEW_MAX_CHARS): string {
+  const clean = cleanPreviewText(value);
+  if (visibleLength(clean) <= columns) return clean;
+  return `${truncateVisible(clean, Math.max(0, columns - 1))}…`;
+}
+
+function summarizeShellCommand(command: string): string {
+  const statements = command
+    .split(/(?:\r?\n|\s*;\s*|\s*&&\s*|\s*\|\|\s*)/u)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const firstStatement = statements[0] ?? command;
+  const withoutQuietRedirection = firstStatement
+    .replace(/\s+(?:\d?>|\d?>>)\s*\$null\s*$/iu, '')
+    .trim();
+  const remaining = statements.length > 1 ? ` · +${statements.length - 1} steps` : '';
+  const semantic = /\bSelect-String\b/iu.test(command)
+    ? 'search repository source'
+    : /\bGet-Content\b/iu.test(command)
+      ? 'read repository source'
+      : /\b(?:Get-ChildItem|rg(?:\.exe)?)\b/iu.test(command)
+        ? 'inspect repository files'
+        : /^\s*\$[A-Za-z_][\w]*\s*=|@\(/u.test(withoutQuietRedirection)
+          ? 'run PowerShell inspection'
+          : withoutQuietRedirection || command;
+  return truncatePreview(`${semantic}${remaining}`);
+}
+
+/** Human compact fallback for unmapped or structured tool arguments. */
+export function summarizeToolArguments(args: unknown): string {
+  if (args == null) return '';
+  if (typeof args === 'string') return truncatePreview(args);
+  if (typeof args !== 'object') return String(args);
+  if (Array.isArray(args)) return `${args.length} ${args.length === 1 ? 'item' : 'items'}`;
+  const entries = Object.entries(args as Record<string, unknown>);
+  if (entries.length === 0) return '';
+  return `${entries.length} ${entries.length === 1 ? 'argument' : 'arguments'}`;
+}
+
+function summarizeStructuredValue(value: object): string {
+  if (Array.isArray(value)) return `${value.length} ${value.length === 1 ? 'item' : 'items'}`;
+  const entries = Object.entries(value as Record<string, unknown>);
+  const safeValues = entries
+    .filter(([, entry]) => ['string', 'number', 'boolean'].includes(typeof entry))
+    .slice(0, 2)
+    .map(([, entry]) => cleanPreviewText(String(entry)))
+    .filter(Boolean);
+  if (safeValues.length > 0) return truncatePreview(safeValues.join(' · '));
+  return `${entries.length} ${entries.length === 1 ? 'argument' : 'arguments'}`;
+}
+
 /**
  * Build the per-tool preview string for `args`. Returns:
  *   - `null` when the tool isn't in the map (caller falls back to the
@@ -185,6 +250,7 @@ const PREVIEW_MAX_CHARS = 120;
 export function buildToolPreview(
   toolName: string,
   args: unknown,
+  opts: { mode?: 'summary' | 'full' } = {},
 ): string | null {
   if (!Object.prototype.hasOwnProperty.call(TOOL_PRIMARY_ARG, toolName)) {
     return null;
@@ -216,19 +282,34 @@ export function buildToolPreview(
       str = raw;
     } else if (typeof raw === 'number' || typeof raw === 'boolean') {
       str = String(raw);
-    } else {
+    } else if (opts.mode === 'full') {
       try {
         str = JSON.stringify(raw);
       } catch {
         str = String(raw);
       }
+    } else {
+      str = summarizeStructuredValue(raw as object);
     }
   }
 
-  // Collapse whitespace so multi-line commands stay on one preview row.
-  str = str.replace(/\s+/g, ' ').trim();
-  if (str.length > PREVIEW_MAX_CHARS) {
-    str = `${str.slice(0, PREVIEW_MAX_CHARS - 1)}…`;
+  if (toolName === 'file_read' && opts.mode === 'full' && args && typeof args === 'object') {
+    const input = args as Record<string, unknown>;
+    const target = typeof input.path === 'string' ? input.path
+      : typeof input.file === 'string' ? input.file : '';
+    const offset = typeof input.offset === 'number' && Number.isFinite(input.offset)
+      ? Math.max(0, Math.floor(input.offset)) : null;
+    const limit = typeof input.limit === 'number' && Number.isFinite(input.limit)
+      ? Math.max(1, Math.floor(input.limit)) : null;
+    if (target && offset !== null) {
+      str = limit === null
+        ? `${target} · from char ${offset}`
+        : `${target} · chars ${offset}–${offset + limit - 1}`;
+    }
   }
-  return str;
+
+  if (opts.mode !== 'full' && toolName === 'shell_exec') {
+    return summarizeShellCommand(str);
+  }
+  return truncatePreview(str);
 }

--- a/tests/v4/cli/activityLifecycle.test.ts
+++ b/tests/v4/cli/activityLifecycle.test.ts
@@ -69,6 +69,47 @@ const resolveBuiltInInteraction = (name: string) =>
       : undefined;
 
 describe('central CLI activity lifecycle', () => {
+  it('replaces the generic skill completion with one typed invocation row', () => {
+    const { display, output } = makeTtyDisplay();
+    const callbacks = new CliCallbacks({ display });
+    callbacks.onToolCall({ id: 'skill-1', name: 'skill_view', arguments: { name: 'architecture-diagram' } }, 'before');
+    callbacks.onToolCall(
+      { id: 'skill-1', name: 'skill_view', arguments: { name: 'architecture-diagram' } },
+      'after',
+      {
+        id: 'skill-1', name: 'skill_view',
+        result: { success: true, filePath: 'C:\\skills\\architecture-diagram\\SKILL.md' },
+        activityTiming: { dispatchStartedAt: 0, executionDurationMs: 6, executionAttempts: [] },
+      },
+    );
+    callbacks.onToolCall(
+      { id: 'skill-1', name: 'skill_view', arguments: { name: 'architecture-diagram' } },
+      'after',
+      {
+        id: 'skill-1', name: 'skill_view',
+        result: { success: true, filePath: 'C:\\skills\\architecture-diagram\\SKILL.md' },
+        activityTiming: { dispatchStartedAt: 0, executionDurationMs: 6, executionAttempts: [] },
+      },
+    );
+    const plain = output().replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+    expect(plain.match(/skill\s+architecture-diagram/gu)).toHaveLength(1);
+    expect(plain).toContain('SKILL.md');
+    expect(plain).not.toMatch(/completed\s+architecture-diagram|completed\s+\./iu);
+  });
+
+  it('does not project a successful typed skill row when loading failed', () => {
+    const { display, output } = makeTtyDisplay();
+    const callbacks = new CliCallbacks({ display });
+    const call = { id: 'skill-failed', name: 'skill_view', arguments: { name: 'missing-skill' } } as const;
+    callbacks.onToolCall(call, 'before');
+    callbacks.onToolCall(call, 'after', {
+      id: call.id, name: call.name, result: null, error: 'Skill not found: missing-skill',
+    });
+    const plain = output().replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+    expect(plain).toMatch(/failed/u);
+    expect(plain).not.toMatch(/✓\s+skill/u);
+  });
+
   it('does not restore approval navigation hints after modal settlement', async () => {
     class ScreenStream extends Writable {
       isTTY = true;

--- a/tests/v4/cli/aidenPrompt.test.ts
+++ b/tests/v4/cli/aidenPrompt.test.ts
@@ -235,6 +235,28 @@ describe('aidenPrompt — Bug D fix via footer rendering (v4.10 Slice 10.5)', ()
 });
 
 describe('aidenPrompt — extra render-snapshot coverage', () => {
+  it('fits Unicode command descriptions by visible terminal width', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: 44 });
+    try {
+      const runner = renderPrompt({
+        commands: [{ name: 'inspect', description: '界'.repeat(60) }],
+        history: [],
+      });
+      runner.type('/i');
+      const footer = runner.lastRender().footer ?? '';
+      const lines = footer.split('\n');
+      for (const line of lines) {
+        const plain = line.replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '');
+        expect(require('string-width')(plain)).toBeLessThanOrEqual(40);
+      }
+      expect(footer).not.toContain('\uFFFD');
+    } finally {
+      if (descriptor) Object.defineProperty(process.stdout, 'columns', descriptor);
+      else delete (process.stdout as { columns?: number }).columns;
+    }
+  });
+
   it('omits cursorBackward when no ghost is present (unknown command)', () => {
     const runner = renderPrompt({
       commands: [{ name: 'daemon', description: 'Manage the Aiden daemon.' }],

--- a/tests/v4/cli/aidenTUI.test.ts
+++ b/tests/v4/cli/aidenTUI.test.ts
@@ -270,6 +270,20 @@ describe('AidenTUI', () => {
     expect(out).toMatch(/try again/);
   });
 
+  it('renders a human compact tool summary without serialized arguments', () => {
+    const tui = new AidenTUI(makeOpts());
+    const display = (tui as any).session.opts.display;
+    const out = display.toolPreview('mystery_tool', {
+      include_full: true,
+      limit: 5,
+      secret: 'must-not-render',
+    });
+    expect(out).toContain('mystery_tool');
+    expect(out).not.toContain('{"');
+    expect(out).not.toContain('include_full');
+    expect(out).not.toContain('must-not-render');
+  });
+
   it('isTuiInitFailure returns true for terminfo / smartCSR errors', () => {
     expect(isTuiInitFailure(new Error('Error opening terminal: xterm-256color'))).toBe(true);
     expect(isTuiInitFailure(new Error('terminfo not found'))).toBe(true);

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -207,10 +207,19 @@ function composerText(content: string[]): string {
   return content.join('');
 }
 
-function compactTranscriptLines(screen: TerminalScreen): string[] {
-  return screen.bufferSnapshot()
+const TEST_TERMINAL_CONTROL = /\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[78])/gu;
+
+function logicalTerminalLines(output: string): string[] {
+  return output
+    .replace(TEST_TERMINAL_CONTROL, '')
+    .replace(/\r\n/gu, '\n')
+    .replace(/\r/gu, '\n')
     .split('\n')
     .map((line) => line.replace(/\s+$/u, ''));
+}
+
+function compactTranscriptLines(screen: TerminalScreen): string[] {
+  return logicalTerminalLines(screen.bufferSnapshot());
 }
 
 describe('settled activity row spacing', () => {
@@ -222,12 +231,50 @@ describe('settled activity row spacing', () => {
     return harness;
   }
 
-  function expectAdjacent(lines: string[], firstPattern: RegExp, secondPattern: RegExp): void {
-    const first = lines.findIndex((line) => firstPattern.test(line));
-    const second = lines.findIndex((line) => secondPattern.test(line));
+  function findSemanticLine(lines: string[], terms: readonly string[]): number {
+    const normalizedTerms = terms.map((term) => term.toLowerCase());
+    return lines.findIndex((line) => {
+      const normalizedLine = line.toLowerCase();
+      return normalizedTerms.every((term) => normalizedLine.includes(term));
+    });
+  }
+
+  function expectAdjacent(
+    lines: string[],
+    firstTerms: readonly string[],
+    secondTerms: readonly string[],
+  ): void {
+    const first = findSemanticLine(lines, firstTerms);
+    const second = findSemanticLine(lines, secondTerms);
     expect(first, lines.join('\n')).toBeGreaterThanOrEqual(0);
     expect(second, lines.join('\n')).toBe(first + 1);
+    expect(lines.slice(first + 1, second).filter((line) => line.length === '')).toHaveLength(0);
   }
+
+  it.each([
+    [
+      'LF without colour',
+      '┊ ✓ completed src/first.ts\n┊ ✓ completed src/second.ts',
+    ],
+    [
+      'CRLF with ANSI around glyphs and categories',
+      '\x1b[90m┊\x1b[0m \x1b[32m✓\x1b[0m \x1b[36mcompleted\x1b[0m src/first.ts\r\n' +
+        '\x1b[90m┊\x1b[0m \x1b[32m✓\x1b[0m \x1b[36mcompleted\x1b[0m src/second.ts',
+    ],
+    [
+      'bare CR with OSC metadata and Unicode glyphs',
+      '\x1b]9;activity:first\x07┊ ✓ completed src/first.ts\r' +
+        '\x1b]9;activity:second\x1b\\┊ ✓ completed src/second.ts',
+    ],
+  ])('normalises %s without changing activity order', (_label, output) => {
+    const lines = logicalTerminalLines(output);
+    expectAdjacent(lines, ['completed', 'src/first.ts'], ['completed', 'src/second.ts']);
+  });
+
+  it('preserves genuine blank logical rows during normalisation', () => {
+    const lines = logicalTerminalLines('┊ ✓ completed first\r\n\r\n┊ ✓ completed second');
+    expect(lines).toEqual(['┊ ✓ completed first', '', '┊ ✓ completed second']);
+  });
 
   it('keeps consecutive completed tool rows adjacent', () => {
     const { display, screen } = prepare();
@@ -237,8 +284,8 @@ describe('settled activity row spacing', () => {
 
     expectAdjacent(
       compactTranscriptLines(screen),
-      /completed\s+first\.ts/iu,
-      /completed\s+second\.ts/iu,
+      ['completed', 'first.ts'],
+      ['completed', 'second.ts'],
     );
   });
 
@@ -249,8 +296,8 @@ describe('settled activity row spacing', () => {
 
     expectAdjacent(
       compactTranscriptLines(screen),
-      /completed\s+first\.ts/iu,
-      /failed\s+echo failed-row/iu,
+      ['completed', 'first.ts'],
+      ['failed', 'echo failed-row'],
     );
   });
 
@@ -266,8 +313,64 @@ describe('settled activity row spacing', () => {
 
     expectAdjacent(
       compactTranscriptLines(screen),
-      /skill\s+systematic-debugging/iu,
-      /completed\s+after-skill\.ts/iu,
+      ['skill', 'systematic-debugging'],
+      ['completed', 'after-skill.ts'],
+    );
+  });
+
+  it('keeps consecutive browser navigation rows adjacent', () => {
+    const { display, screen } = prepare();
+    display.toolRow('browser_navigate', { url: 'https://a.test' }).ok(10_000);
+    display.toolRow('browser_navigate', { url: 'https://b.test' }).ok(3_400);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      ['completed', 'a.test'],
+      ['completed', 'b.test'],
+    );
+  });
+
+  it('keeps click and snapshot rows adjacent', () => {
+    const { display, screen } = prepare();
+    display.toolRow('browser_click', { selector: '@e755' }).ok(300);
+    display.toolRow('browser_snapshot', { path: 'snapshot-full' }).ok(700);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      ['completed', '@e755'],
+      ['completed', 'snapshot-full'],
+    );
+  });
+
+  it('keeps a settled Worker update adjacent to verification evidence', () => {
+    const { display, screen } = prepare();
+    display.renderUiEvent('ui_task_update', {
+      task_id: 'worker-spacing', kind: 'subagent', label: 'Runtime ownership', status: 'running',
+    });
+    display.renderUiEvent('ui_task_done', {
+      task_id: 'worker-spacing', status: 'success', summary: 'Worker complete',
+    });
+    display.evidencePanel([{
+      evidenceId: 'evidence-spacing', source: 'fresh_readback',
+      verificationResult: 'verified', payload: { path: 'src/runtime.ts' },
+    }]);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      ['Worker complete'],
+      ['Evidence'],
+    );
+  });
+
+  it('keeps cancelled rows in the same compact activity list', () => {
+    const { display, screen } = prepare();
+    display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+    display.toolRow('shell_exec', { command: 'echo cancelled-row' }).cancel(18);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      ['completed', 'first.ts'],
+      ['cancelled', 'echo cancelled-row'],
     );
   });
 
@@ -285,6 +388,28 @@ describe('settled activity row spacing', () => {
     expect(activity.every(({ line }) => line.length <= 43)).toBe(true);
   });
 
+  it('keeps semantic adjacency when colour output is disabled', () => {
+    const previousNoColor = process.env.NO_COLOR;
+    const previousForceColor = process.env.FORCE_COLOR;
+    process.env.NO_COLOR = '1';
+    process.env.FORCE_COLOR = '0';
+    try {
+      const { display, screen } = prepare();
+      display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+      display.toolRow('file_read', { path: 'src/second.ts' }).ok(14);
+      expectAdjacent(
+        compactTranscriptLines(screen),
+        ['completed', 'first.ts'],
+        ['completed', 'second.ts'],
+      );
+    } finally {
+      if (previousNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = previousNoColor;
+      if (previousForceColor === undefined) delete process.env.FORCE_COLOR;
+      else process.env.FORCE_COLOR = previousForceColor;
+    }
+  });
+
   it('keeps the assistant header between activity and prose without extra padding', () => {
     const { display, screen } = prepare();
     display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
@@ -292,12 +417,12 @@ describe('settled activity row spacing', () => {
     display.write('\n│ Aiden\nFinal answer remains separate.\n');
 
     const lines = compactTranscriptLines(screen);
-    const activity = lines.findIndex((line) => /completed\s+second\.ts/iu.test(line));
-    const answer = lines.findIndex((line) => /Final answer remains separate\./u.test(line));
+    const activity = findSemanticLine(lines, ['completed', 'second.ts']);
+    const answer = findSemanticLine(lines, ['Final answer remains separate.']);
     expect(activity).toBeGreaterThanOrEqual(0);
     expect(answer).toBeGreaterThan(activity);
     const separation = lines.slice(activity + 1, answer);
-    expect(separation.some((line) => /Aiden/u.test(line)), lines.join('\n')).toBe(true);
+    expect(separation.filter((line) => /Aiden/u.test(line)), lines.join('\n')).toHaveLength(1);
     expect(separation.filter((line) => line.length === '')).toHaveLength(0);
   });
 });

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -207,6 +207,101 @@ function composerText(content: string[]): string {
   return content.join('');
 }
 
+function compactTranscriptLines(screen: TerminalScreen): string[] {
+  return screen.bufferSnapshot()
+    .split('\n')
+    .map((line) => line.replace(/\s+$/u, ''));
+}
+
+describe('settled activity row spacing', () => {
+  function prepare(columns = 100): ReturnType<typeof createDisplay> {
+    delete process.env.AIDEN_COMPOSER_LANE;
+    const harness = createDisplay(columns, 24);
+    harness.display.setStatusFooter('◆ provider · model │ ◉ context 0/32k │ ⧖ 0ms');
+    harness.display.setIdleComposer('', 'Type your message · /help');
+    return harness;
+  }
+
+  function expectAdjacent(lines: string[], firstPattern: RegExp, secondPattern: RegExp): void {
+    const first = lines.findIndex((line) => firstPattern.test(line));
+    const second = lines.findIndex((line) => secondPattern.test(line));
+    expect(first, lines.join('\n')).toBeGreaterThanOrEqual(0);
+    expect(second, lines.join('\n')).toBe(first + 1);
+  }
+
+  it('keeps consecutive completed tool rows adjacent', () => {
+    const { display, screen } = prepare();
+
+    display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+    display.toolRow('file_read', { path: 'src/second.ts' }).ok(14);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      /completed\s+first\.ts/iu,
+      /completed\s+second\.ts/iu,
+    );
+  });
+
+  it('keeps mixed completed and failed rows adjacent', () => {
+    const { display, screen } = prepare();
+    display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+    display.toolRow('shell_exec', { command: 'echo failed-row' }).fail(18);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      /completed\s+first\.ts/iu,
+      /failed\s+echo failed-row/iu,
+    );
+  });
+
+  it('keeps an exact skill row adjacent to the following file row', () => {
+    const { display, screen } = prepare();
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-spacing',
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.toolRow('file_read', { path: 'src/after-skill.ts' }).ok(7);
+
+    expectAdjacent(
+      compactTranscriptLines(screen),
+      /skill\s+systematic-debugging/iu,
+      /completed\s+after-skill\.ts/iu,
+    );
+  });
+
+  it('keeps settled rows compact at narrow width without overlap', () => {
+    const { display, screen } = prepare(44);
+    display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+    display.toolRow('file_read', { path: 'src/second.ts' }).ok(14);
+
+    const lines = compactTranscriptLines(screen);
+    const activity = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => /┊\s+✓\s+completed/iu.test(line));
+    expect(activity).toHaveLength(2);
+    expect(activity[1]?.index, lines.join('\n')).toBe((activity[0]?.index ?? -2) + 1);
+    expect(activity.every(({ line }) => line.length <= 43)).toBe(true);
+  });
+
+  it('keeps the assistant header between activity and prose without extra padding', () => {
+    const { display, screen } = prepare();
+    display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+    display.toolRow('file_read', { path: 'src/second.ts' }).ok(14);
+    display.write('\n│ Aiden\nFinal answer remains separate.\n');
+
+    const lines = compactTranscriptLines(screen);
+    const activity = lines.findIndex((line) => /completed\s+second\.ts/iu.test(line));
+    const answer = lines.findIndex((line) => /Final answer remains separate\./u.test(line));
+    expect(activity).toBeGreaterThanOrEqual(0);
+    expect(answer).toBeGreaterThan(activity);
+    const separation = lines.slice(activity + 1, answer);
+    expect(separation.some((line) => /Aiden/u.test(line)), lines.join('\n')).toBe(true);
+    expect(separation.filter((line) => line.length === '')).toHaveLength(0);
+  });
+});
+
 describe.each([100, 80, 44])('borderless fixed bottom region at %i columns', (columns) => {
   it('owns empty, normal, and Unicode drafts with the hardware cursor at insertion', () => {
     delete process.env.AIDEN_COMPOSER_LANE;

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -42,6 +42,25 @@ class ScreenStream extends Writable {
   }
 }
 
+describe('responsive composer semantic colour projection', () => {
+  it('keeps prompt label and draft on separate cyan tokens without colouring the footer', () => {
+    const plain = renderBottomSurface(18, 60, { draft: 'draft text', mode: 'idle' }, '◆ provider/model │ ◉ 0% │ T │ 0s');
+    const styled = renderBottomSurface(18, 60, { draft: 'draft text', mode: 'idle' }, '◆ provider/model │ ◉ 0% │ T │ 0s', {
+      brand: (value) => `BRAND(${value})`,
+      muted: (value) => `MUTED(${value})`,
+      prompt: (value) => `PROMPT(${value})`,
+      promptContent: (value) => `CONTENT(${value})`,
+      unicode: true,
+    });
+    expect(styled.lines.some((line) => line.includes('PROMPT(▲ You)'))).toBe(true);
+    expect(styled.lines.some((line) => line.includes('CONTENT(draft text)'))).toBe(true);
+    expect(styled.lines.at(-1)).toContain('provider/model');
+    expect(styled.lines.at(-1)).not.toContain('CONTENT(');
+    expect(styled.lines).toHaveLength(plain.lines.length);
+    expect(styled.laneRows).toBe(plain.laneRows);
+  });
+});
+
 const previousLaneSetting = process.env.AIDEN_COMPOSER_LANE;
 
 it('applies the active theme to the borderless composer hierarchy without changing geometry', () => {

--- a/tests/v4/cli/box.test.ts
+++ b/tests/v4/cli/box.test.ts
@@ -7,6 +7,7 @@ import {
   boxTopTitled,
   visibleLength,
   truncateVisible,
+  truncateVisibleAtWord,
 } from '../../../cli/v4/box';
 
 const ORANGE = '\x1b[38;2;255;107;53m';
@@ -88,6 +89,31 @@ describe('cli/v4/box helpers', () => {
     // No ANSI in input → no reset appended; length matches the cap.
     expect(out).toBe('thiswi');
   });
+
+  it('measures wide Unicode glyphs by terminal columns', () => {
+    expect(visibleLength('A界B')).toBe(4);
+    expect(visibleLength(`${ORANGE}A界B${RESET}`)).toBe(4);
+  });
+
+  it('never splits a wide Unicode glyph or an ANSI sequence', () => {
+    const out = truncateVisible(`${ORANGE}A界B${RESET}`, 3);
+    expect(visibleLength(out)).toBe(3);
+    expect(out).toContain('A界');
+    expect(out).not.toContain('B');
+    expect(out.startsWith(ORANGE)).toBe(true);
+    expect(out.endsWith('\x1b[0m')).toBe(true);
+  });
+
+  it.each([44, 80, 100, 120, 160])(
+    'keeps a complete activity phrase at a %i-column boundary',
+    (width) => {
+      const phrase = `${ORANGE}Still working — checking the result before reporting repository validation details${RESET}`;
+      const out = truncateVisibleAtWord(phrase, width);
+      expect(visibleLength(out)).toBeLessThanOrEqual(width);
+      expect(out).not.toMatch(/\b(?:work|check|resul|repo|validat)…(?:\x1b\[[0-9;]*m)?$/u);
+      expect(out.endsWith('…') || /\x1b\[(?:0|39)m$/u.test(out)).toBe(true);
+    },
+  );
 
   it('boxTopTitled uses visible length so coloured titles dont skew the dashes', () => {
     const plain = boxTopTitled('Health Check', 50);

--- a/tests/v4/cli/capabilityCard.test.ts
+++ b/tests/v4/cli/capabilityCard.test.ts
@@ -153,6 +153,14 @@ describe('truncToContent', () => {
     expect(truncToContent('short action')).toBe('short action');
   });
 
+  it('uses terminal width for ANSI and wide Unicode content', () => {
+    const out = truncToContent(`\x1b[38;2;255;107;53m${'界'.repeat(80)}\x1b[0m`);
+    expect(require('string-width')(out.replace(/\x1b\[[0-9;]*[A-Za-z]/gu, '')))
+      .toBeLessThanOrEqual(58);
+    expect(out).not.toContain('\uFFFD');
+    expect(out).toMatch(/…$/u);
+  });
+
   it('truncates with "…" when exceeding the bullet column cap', () => {
     const long = 'x'.repeat(200);
     const out = truncToContent(long);

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -10,6 +10,7 @@ import {
   isPreFramedLine,
   TRAIL_HIDE_TOOLS,
   makeNoOpToolRowHandle,
+  previewToolArgs,
 } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
 import type { ActivitySnapshot } from '../../../cli/v4/activityRegistry';
@@ -24,6 +25,26 @@ function stripAnsi(s: string): string {
     '',
   );
 }
+
+describe('compact activity argument summaries', () => {
+  it('does not expose raw JSON for an unmapped structured argument object', () => {
+    const summary = previewToolArgs({ include_full: true, limit: 5, private_value: 'hidden' });
+    expect(summary).not.toContain('{');
+    expect(summary).not.toContain('private_value');
+    expect(summary).not.toContain('hidden');
+    expect(summary).toMatch(/3 (?:arguments|options)/u);
+    expect(previewToolArgs(
+      { include_full: true, limit: 5, private_value: 'hidden' },
+      'full',
+    )).toContain('"private_value":"hidden"');
+  });
+
+  it('keeps a recognizable scalar target without serializing sibling fields', () => {
+    const summary = previewToolArgs({ name: 'repository scan', include_full: true, limit: 5 });
+    expect(summary).toContain('repository scan');
+    expect(summary).not.toContain('include_full');
+  });
+});
 
 describe('SkinEngine', () => {
   let engine: SkinEngine;
@@ -98,6 +119,18 @@ describe('Display', () => {
   let display: Display;
   let skin: SkinEngine;
 
+  it('separates prompt identity/content from assistant prose and resets each span', () => {
+    const themed = new SkinEngine({ colorDepth: 'truecolor' });
+    const d = new Display({ skin: themed });
+    const submitted = d.userTurn('hello\nwrapped prompt');
+    const answer = d.agentTurn('assistant prose', { markdown: false });
+    expect(submitted).toContain('\x1b[38;2;91;192;235m');
+    expect(submitted).toContain('\x1b[38;2;156;220;254m');
+    expect(submitted).not.toContain('\x1b[38;2;255;107;53m  ▲ You');
+    expect(answer).toContain('assistant prose');
+    expect(submitted.match(/\x1b\[[0-9;]*m/g)?.at(-1)).toBe('\x1b[39m');
+  });
+
   beforeEach(() => {
     skin = new SkinEngine({ forceMono: true }); // deterministic output
     display = new Display({ skin });
@@ -152,11 +185,13 @@ describe('Display', () => {
     expect(out).toContain('/tmp/x');
   });
 
-  it('toolPreview truncates very long args', () => {
+  it('toolPreview summarizes unknown structured args without raw JSON', () => {
     const big = { blob: 'x'.repeat(2000) };
     const out = stripAnsi(display.toolPreview('huge', big));
     expect(out.length).toBeLessThan(260);
-    expect(out).toContain('...');
+    expect(out).toContain('1 argument');
+    expect(out).not.toContain('{');
+    expect(out).not.toContain('blob');
   });
 
   it('error includes suggestion when provided', () => {
@@ -1515,7 +1550,22 @@ describe('Display v4.8.0 ui_* event renderers', () => {
     const out = stripAnsi(chunks.join(''));
     // `┊ ` then 4-space indent (depth 2 × 2 spaces) before both card rows.
     expect(out).toMatch(/┊ {5}┌ nested/);
-    expect(out).toMatch(/┊ {5}└ ◐ Working/);
+    expect(out).toMatch(/┊ {5}└ ◆ Worker running/);
+  });
+
+  it('ui_task_update uses the Worker semantic token for exact subagent activity', () => {
+    const chunks: string[] = [];
+    const terminalOut = new Writable({
+      write(chunk, _enc, cb) { chunks.push(chunk.toString()); cb(); },
+    }) as unknown as NodeJS.WriteStream;
+    (terminalOut as unknown as { isTTY: boolean }).isTTY = true;
+    const d = new Display({ skin: new SkinEngine({ colorDepth: 'truecolor' }), stdout: terminalOut });
+    d.renderUiEvent('ui_task_update', {
+      task_id: 'worker-1', label: 'inspect runtime ownership', status: 'running', kind: 'subagent', depth: 1,
+    });
+    const rendered = chunks.join('');
+    expect(stripAnsi(rendered)).toContain('◆ Worker running');
+    expect(rendered).toContain('\x1b[38;2;167;139;250m◆\x1b[39m');
   });
 
   // ── ui_task_done ──────────────────────────────────────────────────────

--- a/tests/v4/cli/semanticActivity.test.ts
+++ b/tests/v4/cli/semanticActivity.test.ts
@@ -7,10 +7,12 @@ import {
   projectActivityFrame,
   projectCommandPresentation,
   projectEvidenceLines,
+  projectSkillInvocation,
   relativizeActivityText,
   shouldDeferActivityTransition,
   type SemanticActivityPhase,
 } from '../../../cli/v4/semanticActivity';
+import { visibleLength } from '../../../cli/v4/box';
 
 const animated: SemanticActivityPhase[] = [
   'thinking', 'planning', 'inspecting', 'working', 'testing',
@@ -78,6 +80,14 @@ describe('semantic activity projection', () => {
     expect(phaseColorKind('verifying')).toBe('verifying');
     expect(phaseColorKind('complete')).toBe('success');
     expect(phaseColorKind('failed')).toBe('error');
+    expect(projectActivityFrame({ phase: 'complete', frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' }).glyphColor).toBe('success');
+    expect(projectActivityFrame({ phase: 'failed', frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' }).glyphColor).toBe('error');
+    expect(projectActivityFrame({ phase: 'approval_required', frame: 0, elapsedMs: 0, unicode: true, mode: 'summary' }).glyphColor).toBe('warn');
+  });
+
+  it.each(['thinking', 'planning', 'inspecting', 'working', 'testing', 'verifying', 'recovering', 'completing'] as SemanticActivityPhase[])('keeps %s animation frames display-width stable', (phase) => {
+    const widths = [0, 1, 2, 3].map((frame) => visibleLength(projectActivityFrame({ phase, frame, elapsedMs: 1_000, unicode: true, mode: 'summary' }).glyph));
+    expect(new Set(widths).size).toBe(1);
   });
 
   it('defers fast transient phase churn but never delays terminal/user phases', () => {
@@ -85,6 +95,15 @@ describe('semantic activity projection', () => {
     expect(shouldDeferActivityTransition('thinking', 'planning', 200)).toBe(false);
     expect(shouldDeferActivityTransition('working', 'approval_required', 10)).toBe(false);
     expect(shouldDeferActivityTransition('working', 'blocked', 10)).toBe(false);
+  });
+});
+
+describe('structured skill projection', () => {
+  it('exposes one typed row per real skill and optional reference', () => {
+    const lines = projectSkillInvocation({ invocationId: 'inv-1', skillName: 'repository-audit', durationMs: 1250, referenceName: 'repo-layout' });
+    expect(lines.map((line) => line.text)).toEqual(['✓ skill  repository-audit · repo-layout 1.3s']);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.color).toBe('skill');
   });
 });
 

--- a/tests/v4/cli/skinEngine.yaml.test.ts
+++ b/tests/v4/cli/skinEngine.yaml.test.ts
@@ -229,9 +229,13 @@ describe('SkinEngine terminal color capability', () => {
     expect(new Set(codes).size).toBe(4);
   });
 
-  it('keeps the user label on the Aiden brand accent', () => {
+  it('keeps the user label on the prompt cyan token', () => {
     const engine = new SkinEngine({ colorDepth: 'truecolor' });
-    expect(engine.applyColors('You', 'user')).toContain('\x1b[38;2;255;107;53m');
+    expect(engine.applyColors('You', 'user')).toContain('\x1b[38;2;91;192;235m');
+    expect(engine.applyColors('draft', 'prompt_content')).toContain('\x1b[38;2;156;220;254m');
+    expect(engine.applyColors('skill', 'skill')).not.toBe(engine.applyColors('read', 'tool'));
+    expect(engine.applyColors('worker', 'worker')).toContain('\x1b[38;2;167;139;250m');
+    expect(engine.applyColors('evidence', 'evidence')).toContain('\x1b[38;2;96;165;250m');
   });
 
   it('renders phase colors in truecolor, ANSI 16, and monochrome modes', () => {
@@ -252,8 +256,8 @@ describe('SkinEngine terminal color capability', () => {
     const dark = engine.applyColors('phase', 'inspecting');
     engine.setActive('light');
     const light = engine.applyColors('phase', 'inspecting');
-    expect(dark).toContain('\x1b[38;2;96;165;250m');
-    expect(light).toContain('\x1b[38;2;29;78;160m');
+    expect(dark).toContain('\x1b[38;2;91;192;235m');
+    expect(light).toContain('\x1b[38;2;0;102;136m');
     expect(light).not.toBe(dark);
   });
 });

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -173,7 +173,7 @@ describe('responsive startup dashboard integration', () => {
     await session.renderStartupCard();
     const output = stripAnsi(chunks.join(''));
 
-    const logo = columns >= 44 ? /Autonomous AI Engine/g : /^Aiden$/gm;
+    const logo = columns >= 44 ? /Autonomous AI Engine/g : /^AIDEN$/gm;
     expect(output.match(logo)).toHaveLength(1);
     expect(output).toContain('Partner');
     expect(output).toContain('llama-3.3-70b-versatile'.slice(0, columns >= 48 ? 8 : 3));

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -237,7 +237,9 @@ function expectCleanMainBuffer(startup: Awaited<ReturnType<typeof launch>>): voi
 
 function dashboardLines(output: string): string[] {
   const lines = output.split(/\r?\n/);
-  const start = lines.findIndex((line) => line.includes('█████╗') || /^\s*Aiden\s*$/.test(line));
+  const start = lines.findIndex((line) => (
+    line.includes('█████╗') || /^\s*(?:A I D E N|AIDEN)\s*$/u.test(line)
+  ));
   const end = lines.findIndex((line, index) => index >= start && line.startsWith('▲ You'));
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
@@ -328,7 +330,8 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
 
     const narrow = await launch(48);
     const narrowRendered = narrow.rendered();
-    expect(narrowRendered).toContain('█████╗');
+    expect(narrowRendered).toMatch(/^AIDEN$/mu);
+    expect(narrowRendered).not.toContain('█████╗');
     expect(narrowRendered).toMatch(/◇\s+Assistant\s+·\s+◆\s+custom-default/i);
     expect(narrowRendered).toMatch(/built solo/i);
     expect(narrowRendered).toContain('Environment');

--- a/tests/v4/cli/startupDashboard.test.ts
+++ b/tests/v4/cli/startupDashboard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   renderStartupDashboard,
   resolveStartupDashboardTier,
+  resolveStartupLogoTier,
   startupVisibleWidth,
   type StartupDashboardData,
 } from '../../../cli/v4/startupDashboard';
@@ -58,6 +59,12 @@ function assertBounded(lines: string[], columns: number): void {
 }
 
 describe('responsive startup dashboard', () => {
+  it('selects full, compact, and plain startup identities without wrapping', () => {
+    expect(resolveStartupLogoTier(100, banner)).toBe('full');
+    expect(resolveStartupLogoTier(60, banner)).toBe('compact');
+    expect(resolveStartupLogoTier(44, banner)).toBe('plain');
+  });
+
   it.each([
     [120, 'wide'],
     [80, 'wide'],
@@ -104,7 +111,8 @@ describe('responsive startup dashboard', () => {
   it('keeps the compact narrow layout, full project details, and bounded card', () => {
     const lines = render(48);
     const text = lines.join('\n');
-    expect(text).toContain(banner.split('\n')[0]);
+    expect(text).toContain('AIDEN');
+    expect(text).not.toContain(banner.split('\n')[0]);
     expect(text).toContain('Partner');
     expect(text).toContain('gpt-5.6-sol');
     expect(text).toContain('Built solo');
@@ -161,8 +169,10 @@ describe('responsive startup dashboard', () => {
     (columns) => {
       const lines = render(columns);
       const text = lines.join('\n');
-      const logoFits = startupVisibleWidth(banner.split('\n')[0]) <= columns - 2;
-      expect(text).toContain(logoFits ? banner.split('\n')[0] : 'Aiden');
+      const logoTier = resolveStartupLogoTier(columns, banner);
+      expect(text).toContain(
+        logoTier === 'full' ? banner.split('\n')[0] : logoTier === 'compact' ? 'A I D E N' : 'AIDEN',
+      );
       expect(text).toContain('Autonomous AI Engine');
       expect(text).toContain('Built solo');
       expect(text).toContain('GitHub:');
@@ -187,8 +197,8 @@ describe('responsive startup dashboard', () => {
     },
   );
 
-  it.each([160, 120, 100, 80, 60, 44])(
-    'keeps the complete logo on the Aiden orange accent at %i columns',
+  it.each([160, 120, 100, 80])(
+    'keeps the complete fitting logo on the Aiden orange accent at %i columns',
     (columns) => {
       const skin = new SkinEngine({ colorDepth: 'truecolor' });
       const coloredBanner = banner.split('\n').map((line) => skin.applyColors(line, 'brand')).join('\n');
@@ -209,6 +219,14 @@ describe('responsive startup dashboard', () => {
       expect(logo).toContain('\x1b[38;2;255;107;53m');
     },
   );
+
+  it.each([60, 44])('never wraps the startup identity at %i columns', (columns) => {
+    const lines = render(columns);
+    expect(lines.join('\n')).not.toContain(banner.split('\n')[0]);
+    const identity = columns === 60 ? 'A I D E N' : 'AIDEN';
+    expect(lines.filter((line) => line.includes(identity))).toHaveLength(1);
+    assertBounded(lines, columns);
+  });
 
   it('wraps the welcome and helper instead of truncating either message', () => {
     const lines = render(44, {
@@ -246,7 +264,7 @@ describe('responsive startup dashboard', () => {
 
   it('is safe at minimal widths and never creates negative padding or broken borders', () => {
     const lines = render(20);
-    expect(lines.join('\n')).toContain('Aiden');
+    expect(lines.join('\n')).toContain('AIDEN');
     expect(lines.join('\n')).not.toMatch(/undefined|null|NaN/);
     expect(lines.join('\n')).toContain('╭');
     assertBounded(lines, 20);

--- a/tests/v4/cli/toolPreview.test.ts
+++ b/tests/v4/cli/toolPreview.test.ts
@@ -16,6 +16,25 @@ describe('buildToolPreview', () => {
     expect(buildToolPreview('shell_exec', { command: 'npm test' })).toBe('npm test');
   });
 
+  it('summarizes compound PowerShell without displaying a partial expression', () => {
+    const command = 'where.exe aiden 2>$null; where.exe aiden-runtime 2>$null; Get-Command aiden';
+    expect(buildToolPreview('shell_exec', { command })).toBe('where.exe aiden · +2 steps');
+    expect(buildToolPreview('shell_exec', { command }, { mode: 'full' })).toBe(command);
+  });
+
+  it('summarizes PowerShell repository inspection without exposing assignment fragments', () => {
+    const command = [
+      "$files = @('cli/v4/aidenTUI.ts', 'cli/v4/display.ts')",
+      "$patterns = @('class Display', 'render')",
+      'Select-String -Path $files -Pattern $patterns',
+    ].join('; ');
+    const preview = buildToolPreview('shell_exec', { command });
+    expect(preview).toBe('search repository source · +2 steps');
+    expect(preview).not.toContain('$files');
+    expect(preview).not.toContain('$patterns');
+    expect(buildToolPreview('shell_exec', { command }, { mode: 'full' })).toContain('$files');
+  });
+
   it('extracts file path', () => {
     expect(buildToolPreview('file_read', { path: 'README.md' })).toBe('README.md');
     expect(buildToolPreview('file_write', { path: '/tmp/x.md', content: 'hi' })).toBe('/tmp/x.md');
@@ -35,9 +54,9 @@ describe('buildToolPreview', () => {
     expect(buildToolPreview('execute_code', { code: 'print(1+1)' })).toBe('print(1+1)');
   });
 
-  it('extracts subagent_fanout mode', () => {
+  it('does not infer Worker details from generic fanout arguments', () => {
     expect(buildToolPreview('subagent_fanout', { mode: 'partition', n: 3 }))
-      .toBe('partition');
+      .toBe('');
   });
 
   it('returns empty string for known no-arg tools', () => {
@@ -58,15 +77,46 @@ describe('buildToolPreview', () => {
     expect(out).toMatch(/…$/);
   });
 
-  it('collapses whitespace so multi-line values stay one-line', () => {
+  it('summarizes multi-line commands without exposing a partial command', () => {
     const out = buildToolPreview('shell_exec', { command: 'echo a\n  echo b\n\techo c' });
-    expect(out).toBe('echo a echo b echo c');
+    expect(out).toBe('echo a · +2 steps');
   });
 
-  it('serialises non-string primary args via JSON.stringify', () => {
-    // Force a primary arg whose value is an object.
+  it('summarizes non-string primary args without raw JSON in compact mode', () => {
     expect(buildToolPreview('skill_manage', { action: { kind: 'install', id: 'x' } }))
-      .toBe('{"kind":"install","id":"x"}');
+      .toBe('install · x');
+    expect(buildToolPreview(
+      'skill_manage',
+      { action: { kind: 'install', id: 'x' } },
+      { mode: 'full' },
+    )).toBe('{"kind":"install","id":"x"}');
+  });
+
+  it('does not invent segments or expose raw character offsets for file reads', () => {
+    const compact = buildToolPreview('file_read', {
+      path: 'C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts',
+      offset: 120,
+      limit: 80,
+    });
+    expect(compact).toBe('C:\\Users\\shiva\\DevOS\\cli\\v4\\display.ts');
+    expect(compact).not.toMatch(/segment|chars|120|199/u);
+    expect(buildToolPreview('file_read', {
+      path: 'display.ts', offset: 200, limit: 80,
+    }, { mode: 'full' })).toContain('chars 200–279');
+  });
+
+  it('keeps repeated reads distinguishable by exact ranges in full details', () => {
+    const first = buildToolPreview('file_read', { path: 'display.ts', offset: 0, limit: 80 }, { mode: 'full' });
+    const second = buildToolPreview('file_read', { path: 'display.ts', offset: 80, limit: 80 }, { mode: 'full' });
+    expect(first).toContain('chars 0–79');
+    expect(second).toContain('chars 80–159');
+    expect(first).not.toBe(second);
+  });
+
+  it('never cuts a long Unicode preview by JavaScript code units', () => {
+    const out = buildToolPreview('shell_exec', { command: '界'.repeat(100) });
+    expect(out).not.toContain('\uFFFD');
+    expect(out).toMatch(/…$/u);
   });
 
   it('handles missing primary arg gracefully (known tool, but no value)', () => {

--- a/tests/v4/cli/toolTrail.test.ts
+++ b/tests/v4/cli/toolTrail.test.ts
@@ -7,6 +7,7 @@ import {
   TRAIL_DETAIL_CAP,
   TRAIL_PIPE,
 } from '../../../cli/v4/display/toolTrail';
+import { visibleLength } from '../../../cli/v4/box';
 
 /**
  * Pure-function unit tests for the action-trail lookup.
@@ -157,5 +158,26 @@ describe('truncDetail', () => {
   });
   it('trims leading/trailing whitespace before measuring', () => {
     expect(truncDetail('   hello   ')).toBe('hello');
+  });
+
+  it('caps ANSI-coloured text by visible terminal width without splitting escapes', () => {
+    const orange = '\x1b[38;2;255;107;53m';
+    const reset = '\x1b[0m';
+    const out = truncDetail(`${orange}${'segment '.repeat(12)}${reset}`);
+    expect(visibleLength(out)).toBeLessThanOrEqual(TRAIL_DETAIL_CAP);
+    expect(out).not.toMatch(/\x1b\[[0-9;]*$/u);
+  });
+
+  it('measures wide Unicode by terminal columns and keeps whole glyphs', () => {
+    const out = truncDetail('界'.repeat(TRAIL_DETAIL_CAP));
+    expect(visibleLength(out)).toBeLessThanOrEqual(TRAIL_DETAIL_CAP);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out).not.toContain('\uFFFD');
+  });
+
+  it('prefers a word boundary over a mid-word cut', () => {
+    const out = truncDetail('inspect repository configuration and dependency metadata completely');
+    expect(out.endsWith('…')).toBe(true);
+    expect(out).not.toMatch(/configur…$/u);
   });
 });


### PR DESCRIPTION
## Summary

- use terminal display-cell width for ANSI-safe, Unicode-safe truncation and wrapping
- replace raw compact tool arguments with concise operation and target summaries
- preserve startup identity with responsive full, compact, and plain logo tiers
- strengthen semantic prompt, activity, result, skill, Worker, read, and verification colours through existing theme tokens
- render one typed row for each exact successful skill invocation
- keep existing shared-ticker animations width-stable and terminal after settlement

## Scope

This pull request is presentation safety only. It preserves the existing renderer ownership, layout geometry, lifecycle, and package version.

It does not fix or change:

- single-transcript ownership architecture
- the tall-window gap
- provider progress ownership
- continuation or approval behavior
- Worker scheduling, budgets, or performance
- package version 4.18.0

## Validation

- focused presentation contracts: 461 passed
- neighboring display, activity, composer, startup, and theme checks: 555 passed under Node 22; the native PTY fixture was separately green in its matching local ABI environment
- startup PTY: 14 passed
- typecheck: passed on Node 22.23.1
- production build: passed on Node 22.23.1
- package dry-run and isolated tarball version/help: passed
- diff, NUL, secret, attribution, and scope scans: passed