### PR TITLE
fix(tui): tighten activity-to-answer transition

### DIFF
--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -2434,9 +2434,13 @@ export class ChatSession implements ChatSessionLike {
     if (loopTracer.isEnabled()) {
       loopTracer.setHistory(baseHistory);
     }
-    const emitToolReplySeparator = (): void => {
-      if (separatorEmitted || !turnHadTools) return;
+    const takeToolReplySeparator = (): boolean => {
+      if (separatorEmitted || !turnHadTools) return false;
       separatorEmitted = true;
+      return true;
+    };
+    const emitToolReplySeparator = (): void => {
+      if (!takeToolReplySeparator()) return;
       // Same chrome pattern as the existing pre-turn rule (line ~1100)
       // and the post-reply rule (line ~1297): two-space indent + the
       // body-width muted rule + newline. The 2-space indent is the
@@ -2688,12 +2692,13 @@ export class ChatSession implements ChatSessionLike {
               //   ┃ Aiden
               //   {text}
               // Idempotent via `firstStreamByteSeen` + the
-              // `separatorEmitted` flag inside emitToolReplySeparator.
+              // the shared `separatorEmitted` gate.
               // No-op when no tool fired (turnHadTools=false).
+              let activityDivider = false;
               if (!firstStreamByteSeen) {
                 firstStreamByteSeen = true;
                 this.opts.callbacks.settleActivitiesBeforeOutput?.();
-                emitToolReplySeparator();
+                activityDivider = takeToolReplySeparator();
               }
               // v4.11 Slice 1 — first delta of the segment paints
               // immediately (TTFT untouched); subsequent deltas batch
@@ -2705,7 +2710,7 @@ export class ChatSession implements ChatSessionLike {
               if (!streamSegmentPainted) {
                 streamSegmentPainted = true;
                 progressBar?.hide();
-                this.opts.display.streamPartial(text);
+                this.opts.display.streamPartial(text, activityDivider);
               } else {
                 coalesceBuf += text;
                 if (coalesceBuf.length >= STREAM_COALESCE_MAX_CHARS) {
@@ -3139,9 +3144,9 @@ export class ChatSession implements ChatSessionLike {
         // v4.1.5 Issue O — non-streaming reply path. Emit the muted
         // rule between the tool trail and the agent header before
         // the one-shot reply lands. Idempotent + tool-gated by
-        // `emitToolReplySeparator`.
-        emitToolReplySeparator();
-        this.opts.display.write(this.opts.display.agentTurn(result.finalContent));
+        // the shared separator gate.
+        const activityDivider = takeToolReplySeparator();
+        this.opts.display.write(this.opts.display.agentTurn(result.finalContent, { activityDivider }));
       }
 
       if (streamingActive && durableEvidenceForDisplay.length > 0) {

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -399,6 +399,8 @@ export interface AgentTurnOptions {
   markdown?: boolean;
   /** Optional reasoning preface (rendered muted). */
   reasoning?: string;
+  /** Include the settled-activity divider in the same transcript write. */
+  activityDivider?: boolean;
 }
 
 /**
@@ -2260,7 +2262,8 @@ export class Display {
     const reasoning = opts.reasoning
       ? `${frameGetIndent(0)}${sk.applyColors(opts.reasoning.trim(), 'muted')}\n`
       : '';
-    return `${this.agentHeader()}${reasoning}${indented}\n`;
+    const activityDivider = opts.activityDivider ? `  ${this.rule()}\n` : '';
+    return `${activityDivider}${this.agentHeader()}${reasoning}${indented}\n`;
   }
 
   /**
@@ -2795,6 +2798,7 @@ export class Display {
   private streamProjectionSequence = 0;
   private streamProjectionId = '';
   private streamProjectionHeaderPending = false;
+  private streamProjectionActivityDividerPending = false;
 
   private projectedStreamOwner(): ComposerLane | null {
     return this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()
@@ -2839,13 +2843,17 @@ export class Display {
     } else {
       body = body.split('\n').map((line) => `  ${line}`).join('\n');
     }
-    return `${this.streamProjectionHeaderPending ? this.agentHeader().trimEnd() + '\n' : ''}${body}`;
+    const activityDivider = this.streamProjectionActivityDividerPending
+      ? `  ${this.rule()}\n`
+      : '';
+    return `${activityDivider}${this.streamProjectionHeaderPending ? this.agentHeader().trimEnd() + '\n' : ''}${body}`;
   }
 
   private settleProjectedStream(owner: ComposerLane): void {
     if (this.streamBuffer) {
       owner.settleLiveRow(this.streamProjectionId, this.projectedStreamText(true));
       this.streamProjectionHeaderPending = false;
+      this.streamProjectionActivityDividerPending = false;
     } else {
       owner.removeLiveRow(this.streamProjectionId, true);
     }
@@ -2891,18 +2899,22 @@ export class Display {
    * showing raw streamed text and reformatting on completion only when
    * the full body is in hand.
    */
-  streamPartial(text: string): void {
+  streamPartial(text: string, activityDivider = false): void {
     if (!text) return;
     const projectedOwner = this.projectedStreamOwner();
     if (!this.streamHeaderShown) {
       // Phase 26.2.3 — share the `▎ Aiden` header with non-streaming
       // agentTurn so streamed + non-streamed responses open identically.
-      if (!projectedOwner) this.writeOutput(this.agentHeader());
+      if (!projectedOwner) {
+        const divider = activityDivider ? `  ${this.rule()}\n` : '';
+        this.writeOutput(`${divider}${this.agentHeader()}`);
+      }
       this.streamHeaderShown = true;
       this.streamBuffer = '';
       this.streamLineCount = 0;
       this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
       this.streamProjectionHeaderPending = true;
+      this.streamProjectionActivityDividerPending = projectedOwner !== null && activityDivider;
       this.uiEventsFiredThisTurn = false;
       // agentHeader emits trailing `\n\n`; cursor is at col 0 of a fresh
       // line, so the very next chunk needs the leading indent.

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -410,20 +410,84 @@ describe('settled activity row spacing', () => {
     }
   });
 
-  it('keeps the assistant header between activity and prose without extra padding', () => {
+  function expectActivityAnswerBoundary(
+    screen: TerminalScreen,
+    activityTerms: readonly string[],
+    answerText: string,
+    blankAfterHeader = true,
+  ): void {
+    const lines = compactTranscriptLines(screen);
+    const activity = findSemanticLine(lines, activityTerms);
+    const divider = lines.findIndex((line, index) => index > activity && /^\s*─{10,}\s*$/u.test(line));
+    const header = findSemanticLine(lines, ['Aiden']);
+    const answer = findSemanticLine(lines, [answerText]);
+    expect(activity).toBeGreaterThanOrEqual(0);
+    expect(divider, lines.join('\n')).toBe(activity + 1);
+    expect(header, lines.join('\n')).toBe(divider + 1);
+    if (blankAfterHeader) expect(lines[header + 1], lines.join('\n')).toBe('');
+    expect(answer, lines.join('\n')).toBe(header + (blankAfterHeader ? 2 : 1));
+  }
+
+  it('keeps a completed activity directly beside the assistant boundary', () => {
+    const { display, screen } = prepare();
+    display.toolRow('file_read', { path: 'src/completed.ts' }).ok(12);
+    display.write(display.agentTurn('Completed activity answer.', { activityDivider: true }));
+
+    expectActivityAnswerBoundary(screen, ['completed', 'completed.ts'], 'Completed activity answer.');
+  });
+
+  it('keeps a failed activity directly beside the assistant boundary', () => {
+    const { display, screen } = prepare();
+    display.toolRow('shell_exec', { command: 'echo failed-transition' }).fail(18);
+    display.write(display.agentTurn('Failed activity answer.', { activityDivider: true }));
+
+    expectActivityAnswerBoundary(screen, ['failed', 'failed-transition'], 'Failed activity answer.');
+  });
+
+  it('keeps a skill activity directly beside the assistant boundary', () => {
+    const { display, screen } = prepare();
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-answer-spacing',
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.write(display.agentTurn('Skill activity answer.', { activityDivider: true }));
+
+    expectActivityAnswerBoundary(screen, ['skill', 'systematic-debugging'], 'Skill activity answer.');
+  });
+
+  it('preserves activity adjacency and assistant paragraph spacing', () => {
     const { display, screen } = prepare();
     display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
     display.toolRow('file_read', { path: 'src/second.ts' }).ok(14);
-    display.write('\n│ Aiden\nFinal answer remains separate.\n');
+    display.write(display.agentTurn('First paragraph.\n\nSecond paragraph.', { activityDivider: true }));
 
     const lines = compactTranscriptLines(screen);
-    const activity = findSemanticLine(lines, ['completed', 'second.ts']);
-    const answer = findSemanticLine(lines, ['Final answer remains separate.']);
-    expect(activity).toBeGreaterThanOrEqual(0);
-    expect(answer).toBeGreaterThan(activity);
-    const separation = lines.slice(activity + 1, answer);
-    expect(separation.filter((line) => /Aiden/u.test(line)), lines.join('\n')).toHaveLength(1);
-    expect(separation.filter((line) => line.length === '')).toHaveLength(0);
+    expectAdjacent(lines, ['completed', 'first.ts'], ['completed', 'second.ts']);
+    expectActivityAnswerBoundary(screen, ['completed', 'second.ts'], 'First paragraph.');
+    const first = findSemanticLine(lines, ['First paragraph.']);
+    const second = findSemanticLine(lines, ['Second paragraph.']);
+    expect(lines.slice(first + 1, second)).toEqual(['']);
+  });
+
+  it('keeps the streamed assistant boundary compact after activity', () => {
+    const { display, screen } = prepare();
+    display.toolRow('file_read', { path: 'src/first.ts' }).ok(12);
+    display.toolRow('file_read', { path: 'src/second.ts' }).ok(14);
+    display.streamPartial('Streamed activity answer.', true);
+    display.streamComplete();
+
+    expectActivityAnswerBoundary(screen, ['completed', 'second.ts'], 'Streamed activity answer.', false);
+  });
+
+  it('keeps the activity-to-answer transition bounded at narrow width', () => {
+    const { display, screen } = prepare(44);
+    display.toolRow('file_read', { path: 'src/narrow-transition.ts' }).ok(12);
+    display.write(display.agentTurn('Narrow answer remains readable.', { activityDivider: true }));
+
+    expectActivityAnswerBoundary(screen, ['completed', 'narrow-transition'], 'Narrow answer remains');
+    expect(compactTranscriptLines(screen).every((line) => line.length <= 43)).toBe(true);
   });
 });
 

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -232,10 +232,21 @@ describe('settled activity row spacing', () => {
   }
 
   function findSemanticLine(lines: string[], terms: readonly string[]): number {
-    const normalizedTerms = terms.map((term) => term.toLowerCase());
+    const normalizeSemanticText = (value: string): string => value
+      .normalize('NFC')
+      .replace(/\\/gu, '/')
+      .toLowerCase();
+    const normalizedTerms = terms.map(normalizeSemanticText);
     return lines.findIndex((line) => {
-      const normalizedLine = line.toLowerCase();
-      return normalizedTerms.every((term) => normalizedLine.includes(term));
+      const normalizedLine = normalizeSemanticText(line);
+      return normalizedTerms.every((term) => {
+        if (normalizedLine.includes(term)) return true;
+        const basename = term.split('/').at(-1) ?? term;
+        const truncatedFragments = normalizedLine.match(/[\p{L}\p{N}_.-]+(?=…)/gu) ?? [];
+        return truncatedFragments.some((fragment) => (
+          fragment.length >= 6 && basename.startsWith(fragment)
+        ));
+      });
     });
   }
 
@@ -274,6 +285,16 @@ describe('settled activity row spacing', () => {
   it('preserves genuine blank logical rows during normalisation', () => {
     const lines = logicalTerminalLines('┊ ✓ completed first\r\n\r\n┊ ✓ completed second');
     expect(lines).toEqual(['┊ ✓ completed first', '', '┊ ✓ completed second']);
+  });
+
+  it.each([
+    ['Unix', '/home/runner/work/aiden/aiden/src/narrow-transi…\n'],
+    ['Windows', 'C:\\repo\\src\\narrow-transi…\r\n'],
+  ])('finds a semantically matching %s path after legitimate narrow truncation', (_label, target) => {
+    const lines = logicalTerminalLines(
+      `\x1b[90m┊\x1b[0m \x1b[32m✓\x1b[0m completed ${target}`,
+    );
+    expect(findSemanticLine(lines, ['completed', 'narrow-transition'])).toBe(0);
   });
 
   it('keeps consecutive completed tool rows adjacent', () => {


### PR DESCRIPTION
## Summary

- make the settled-activity divider part of the same transcript projection as the response
- preserve compact consecutive activity rows and normal response paragraph spacing
- cover completed, failed, skill, streamed, and narrow-width transitions

## Root cause

The activity divider and response header were emitted as separate transcript operations. After the live activity surface settled, the fixed bottom-region cursor could expose the reclaimed rows between those operations. The divider is now consumed once and rendered atomically with the response boundary.

## Scope

This change is limited to activity-to-response spacing. It does not change transcript ownership, footer geometry, startup rendering, provider-progress ownership, PageUp behavior, paste handling, approvals, Worker behavior, package metadata, or Stage 2 architecture.

## Validation

- bottom-region tests: 65 passed
- neighboring TUI matrix: 327 passed, 1 skipped
- built/startup PTY matrix: 25 passed
- typecheck passed
- production build passed
