### PR TITLE
fix(tui): preserve the full ASCII boot identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: ${{ matrix.os }} · Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && matrix.node == '20.x' && 45 || 25 }}
     strategy:
       fail-fast: false
       matrix:

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -1168,6 +1168,8 @@ export async function buildAgentRuntime(
   // clean pipeable answer, and approvals default to auto-DENY (no TUI to
   // prompt). See runQuery / executeOneShotTurn below.
   const headless = !!cliOpts?.headless;
+  const startupDiagnostics: Array<{ severity: 'info' | 'warning'; text: string }> = [];
+  const startupActions: Array<() => Promise<void>> = [];
 
   // Slice 2 — surface (and, interactively, offer to purge) any orphaned
   // credential left by a removed OAuth provider. hasTokens gates the work, so
@@ -1176,19 +1178,20 @@ export async function buildAgentRuntime(
   // a prompt and never a delete — silence is not consent.
   try {
     const orphanInteractive = !headless && !!process.stdin.isTTY;
-    await announceRemovedProviderOrphans({
+    const announceOrphans = () => announceRemovedProviderOrphans({
       paths,
       interactive: orphanInteractive,
-      write: (l) =>
-        (orphanInteractive ? process.stdout : process.stderr).write(l + '\n'),
+      write: (line) => (orphanInteractive ? process.stdout : process.stderr).write(line + '\n'),
       confirm: orphanInteractive
-        ? async (q: string) => {
+        ? async (question: string) => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const { confirm } = require('@inquirer/prompts');
-            return confirm({ message: q, default: false });
+            return confirm({ message: question, default: false });
           }
         : undefined,
-    });
+    }).then(() => undefined);
+    if (orphanInteractive) startupActions.push(announceOrphans);
+    else await announceOrphans();
   } catch {
     // A startup notice must never block boot.
   }
@@ -1233,13 +1236,14 @@ export async function buildAgentRuntime(
   try {
     const swept = replTaskStore.sweepOrphaned(Date.now());
     if (swept > 0) {
-      // eslint-disable-next-line no-console
-      console.warn(`[tasks] swept ${swept} orphaned active task(s) from prior session(s) → interrupted`);
+      const text = `[tasks] swept ${swept} orphaned active task(s) from prior session(s) → interrupted`;
+      if (headless) process.stderr.write(`${text}\n`);
+      else startupDiagnostics.push({ severity: 'warning', text });
     }
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn('[tasks] orphan sweep failed:',
-      err instanceof Error ? err.message : String(err));
+    const text = `[tasks] orphan sweep failed: ${err instanceof Error ? err.message : String(err)}`;
+    if (headless) process.stderr.write(`${text}\n`);
+    else startupDiagnostics.push({ severity: 'warning', text });
   }
   // v4.11 — artifact registry. Shares the same daemon.db handle so
   // /artifacts listing + chatSession's per-turn capture see one WAL view.
@@ -1332,12 +1336,10 @@ export async function buildAgentRuntime(
   try {
     const sync = await syncBundledSkillsIfStale(paths);
     if (sync.versionUpdated && sync.refreshed + sync.added > 0) {
-      // Single line on stderr so users see the upgrade happen but
-      // the boot card stays clean. skillsLogger isn't constructed
-      // yet at this point in the boot sequence.
-      process.stderr.write(
-        `[skills] refreshed ${sync.refreshed}, added ${sync.added}, preserved ${sync.preserved} (bundle ${sync.installedVersion || '<fresh>'} → ${sync.bundleVersion})\n`,
-      );
+      const text = `[skills] refreshed ${sync.refreshed}, added ${sync.added}, preserved ${sync.preserved} ` +
+        `(bundle ${sync.installedVersion || '<fresh>'} → ${sync.bundleVersion})`;
+      if (headless) process.stderr.write(`${text}\n`);
+      else startupDiagnostics.push({ severity: 'info', text });
     }
   } catch {
     /* silent — sync is best-effort, restore already populated dirs */
@@ -1399,6 +1401,7 @@ export async function buildAgentRuntime(
   // real provider. Flagged here, set inside the wizard block, and
   // consumed when building the adapter.
   let exploreMode = false;
+  let startupIdentityRendered = false;
 
   if (wizardNeeded) {
     // v4.12.1 — headless one-shot must never prompt (no TTY) nor silently
@@ -1429,25 +1432,17 @@ export async function buildAgentRuntime(
       // Skip the wizard block entirely; fall through to adapter
       // build with exploreMode=true so a NullAdapter is used.
     } else {
-    if (!detection.hasAnyProvider) {
-      // Truly empty: no env, no OAuth, no Ollama, no inline config.
-      process.stdout.write(`\n${summarizeDetection(detection)}\n`);
-    } else if (configuredProviderBroken) {
-      // Config points at a provider we can't credential-resolve.
-      process.stdout.write(
-        `\nConfigured provider '${detection.configProvider}' has no usable credentials ` +
-          `at ${path.join(paths.root, 'auth', `${detection.configProvider}.json`)}.\n`,
-      );
-    } else {
-      // Detected something (env / oauth / ollama) but config.yaml is
-      // missing or empty — DEFAULT_CONFIG would route to anthropic and
-      // the resolver would fail. Surface the detection so the user
-      // sees what we found, then walk them through proper setup.
-      process.stdout.write(`\n${summarizeDetection(detection)}\n`);
-      process.stdout.write(
-        'config.yaml is empty — let\'s pick a provider that matches.\n',
-      );
-    }
+    const setupDetectionLines = !detection.hasAnyProvider
+      ? [summarizeDetection(detection)]
+      : configuredProviderBroken
+        ? [
+            `Configured provider '${detection.configProvider}' has no usable credentials ` +
+              `at ${path.join(paths.root, 'auth', `${detection.configProvider}.json`)}.`,
+          ]
+        : [
+            summarizeDetection(detection),
+            'config.yaml is empty — let\'s pick a provider that matches.',
+          ];
     // ONB1-WIRE — disclaimer + loading screens land BEFORE the wizard.
     // Only inside this TTY-guarded branch (the non-TTY branch at the
     // outer else already bails into explore mode). The detection
@@ -1461,11 +1456,13 @@ export async function buildAgentRuntime(
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { showDisclaimer } = require('./onboarding/disclaimer') as typeof import('./onboarding/disclaimer');
     const disc = await showDisclaimer();
+    startupIdentityRendered = !disc.skipped;
     if (!disc.ok) {
       // User typed 'n' / 'no'. The disclaimer already printed the
       // friendly goodbye line; just exit cleanly.
       process.exit(0);
     }
+    process.stdout.write(`\n${setupDetectionLines.join('\n')}\n`);
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { runLoadingSequence, defaultLoadingSteps } =
@@ -1585,7 +1582,16 @@ export async function buildAgentRuntime(
   const display = headless
     ? new Display({ skin, stdout: process.stderr, stderr: process.stderr })
     : new Display({ skin });
-  const warnSink = (msg: string) => display.warn(msg);
+  let startupProjectionReleased = false;
+  const projectStartupDiagnostic = (severity: 'info' | 'warning', text: string): void => {
+    if (headless || startupProjectionReleased) {
+      if (severity === 'warning') display.warn(text);
+      else display.dim(text);
+      return;
+    }
+    startupDiagnostics.push({ severity, text });
+  };
+  const warnSink = (msg: string) => projectStartupDiagnostic('warning', msg);
   const startupNotices: StartupNotice[] = [];
   const recordStartupNotice = (notice: StartupNotice | null | undefined): void => {
     if (!notice) return;
@@ -1659,9 +1665,9 @@ export async function buildAgentRuntime(
     // neither CLI flags nor persisted config specified the choice.
     // Silent on explicit selections so power users don't see noise.
     if (bootSource === 'auto-priority') {
-      display.dim(`[boot] ${providerId} · ${modelId}  (auto · first authed provider)`);
+      projectStartupDiagnostic('info', `[boot] ${providerId} · ${modelId}  (auto · first authed provider)`);
     } else if (bootSource === 'hardcoded-fallback') {
-      display.dim(
+      projectStartupDiagnostic('info',
         `[boot] ${providerId} · ${modelId}  (no authed providers detected — using legacy default)`,
       );
     }
@@ -1748,7 +1754,7 @@ export async function buildAgentRuntime(
     const filterDesc = toolProfile.toolsets === undefined
       ? 'all toolsets'
       : `[${[...toolProfile.toolsets].join(', ')}]`;
-    display.dim(
+    projectStartupDiagnostic('info',
       `[tools] profile=${toolProfile.name} (${toolProfile.source}) → ${filterDesc}`,
     );
   }
@@ -1775,9 +1781,9 @@ export async function buildAgentRuntime(
       ? ` (see ${skillsLogger.filePath})`
       : '';
   if (skillCounts.skipped > 0) {
-    display.warn(`[skills] ${skillCounts.loaded} loaded, ${skillCounts.skipped} skipped${skipNote}`);
+    projectStartupDiagnostic('warning', `[skills] ${skillCounts.loaded} loaded, ${skillCounts.skipped} skipped${skipNote}`);
   } else if (isVerbose()) {
-    display.dim(`[skills] ${skillCounts.loaded} loaded, 0 skipped`);
+    projectStartupDiagnostic('info', `[skills] ${skillCounts.loaded} loaded, 0 skipped`);
   }
   // Phase 17 Task 5: plugin loader boot.
   //
@@ -1837,7 +1843,7 @@ export async function buildAgentRuntime(
   // when set — for users with edited SOUL.md that would have been
   // silently overwritten by the upgrade).
   if (soulNotice) {
-    display.dim(`[soul] ${soulNotice}`);
+    projectStartupDiagnostic('info', `[soul] ${soulNotice}`);
   }
 
   // v4.5 update system — the old setImmediate dim/warn one-liner
@@ -2746,7 +2752,7 @@ export async function buildAgentRuntime(
       // it) AND in the log file, then the exporter stays off for the
       // session instead of writing into a garbage directory.
       (msg) => {
-        display.warn(msg);
+        projectStartupDiagnostic('warning', msg);
         bootLogger.child('vault').warn(msg);
       },
     );
@@ -2840,7 +2846,7 @@ export async function buildAgentRuntime(
     // watcher to keep the process alive only as long as the REPL does.
     process.on('exit', () => { try { soulWatcher.close(); } catch { /* noop */ } });
   } catch (err) {
-    display.warn(
+    projectStartupDiagnostic('warning',
       `SOUL.md watcher could not attach (${(err as Error).message}). ` +
       'Use `/reload-soul` to apply edits mid-session.',
     );
@@ -2892,7 +2898,7 @@ export async function buildAgentRuntime(
   if (spawnPauseBootStatus) {
     const s = spawnPauseBootStatus;
     const reasonSuffix = s.reason ? ` (reason: ${s.reason})` : '';
-    display.warn(
+    projectStartupDiagnostic('warning',
       `spawn_sub_agent / subagent_fanout are PAUSED${reasonSuffix}. ` +
       'Run /spawn-pause off to resume.',
     );
@@ -3611,7 +3617,7 @@ export async function buildAgentRuntime(
       });
     }
   } catch (err) {
-    display.dim(`(skill commands unavailable: ${(err as Error).message})`);
+    projectStartupDiagnostic('info', `(skill commands unavailable: ${(err as Error).message})`);
   }
 
   // ── Phase v4.1-1.1: CLI-side channel manager ──────────────────────
@@ -3672,15 +3678,17 @@ export async function buildAgentRuntime(
     }
 
     if (serverIsHosting) {
-      display.dim(
+      projectStartupDiagnostic('info',
         '[channels] aiden serve is running locally — channel adapters hosted there, /channel commands stay read-only.',
       );
     } else {
       // start() resolves quickly when no token is set (logs "Disabled" and
       // returns). Errors don't crash boot.
-      channelManager.startAll().catch((e: Error) =>
-        display.dim(`[channels] startAll error: ${e.message}`),
-      );
+      startupActions.push(async () => {
+        await channelManager.startAll().catch((error: Error) =>
+          projectStartupDiagnostic('info', `[channels] startAll error: ${error.message}`),
+        );
+      });
     }
   }
 
@@ -3715,6 +3723,11 @@ export async function buildAgentRuntime(
     // non-undefined instance (formerly dormant in Phase 13).
     contextCompressor,
     startupNotices,
+    startupIdentityRendered,
+    startupDiagnostics,
+    startupActions,
+    releaseStartupProjection: () => { startupProjectionReleased = true; },
+    projectStartupDiagnostic,
     commandRegistry,
     mcpClient,
     providerId,
@@ -3786,6 +3799,12 @@ export interface AgentRuntime {
   /** v4.11 preflight compression — production-wired (no longer dormant). */
   contextCompressor: ContextCompressor;
   startupNotices: StartupNotice[];
+  /** First-run setup already projected the canonical six-line identity. */
+  startupIdentityRendered: boolean;
+  startupDiagnostics: Array<{ severity: 'info' | 'warning'; text: string }>;
+  startupActions: Array<() => Promise<void>>;
+  releaseStartupProjection: () => void;
+  projectStartupDiagnostic: (severity: 'info' | 'warning', text: string) => void;
   commandRegistry: CommandRegistry;
   mcpClient: ReturnType<typeof setupMcpFromConfig> extends Promise<infer R>
     ? R extends { client: infer C }
@@ -4136,7 +4155,10 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
           { provider: runtime.providerId, model: runtime.modelId },
         );
         if (!ok) {
-          console.warn('[daemon] real-runner install returned false — placeholder still active');
+          runtime.projectStartupDiagnostic(
+            'warning',
+            '[daemon] real-runner install returned false — placeholder still active',
+          );
         }
       }
     }
@@ -4144,7 +4166,10 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
     // Fail-loud but non-fatal — install failure leaves the
     // placeholder runner active; the REPL still works and the
     // daemon's rails still serve triggers.
-    console.error('[daemon] install agent builder failed: ' + (e instanceof Error ? e.message : String(e)));
+    runtime.projectStartupDiagnostic(
+      'warning',
+      '[daemon] install agent builder failed: ' + (e instanceof Error ? e.message : String(e)),
+    );
   }
 
   const sessionOpts = {
@@ -4178,6 +4203,10 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
     personalityManager: runtime.personalityManager,
     pluginLoader: runtime.pluginLoader,
     startupNotices: runtime.startupNotices,
+    startupIdentityRendered: runtime.startupIdentityRendered,
+    startupDiagnostics: runtime.startupDiagnostics,
+    startupActions: runtime.startupActions,
+    releaseStartupProjection: runtime.releaseStartupProjection,
     // Phase 30.2.1 — boot card renders "model not configured" and
     // chat attempts get the friendly NotConfiguredError message.
     unconfigured: runtime.exploreMode,

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -144,7 +144,9 @@ import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 import { emitComposerReadyForTests } from './composerReadiness';
 import { requestTurnCancel } from './frame/interruptControls';
 import {
+  fitStartupLine,
   renderStartupDashboard,
+  renderStartupWidthRequirement,
   resolveStartupDashboardTier,
 } from './startupDashboard';
 import {
@@ -152,6 +154,7 @@ import {
   renderStartupNoticeLines,
   type StartupNotice,
 } from './startupNotices';
+import { AIDEN_BOOT_MIN_COLUMNS } from '../../core/v4/ui/identity';
 
 interface ChatTurnLifecycleContext {
   handle: DurableJobHandle;
@@ -381,6 +384,15 @@ export interface ChatSessionOptions {
 
   /** One-shot provider/model/plugin/MCP startup notices. */
   startupNotices?: readonly StartupNotice[];
+
+  /** Boot diagnostics held until the identity and structured notices render. */
+  startupDiagnostics?: readonly { severity: 'info' | 'warning'; text: string }[];
+  /** Interactive boot actions that must not take terminal ownership before identity. */
+  startupActions?: readonly (() => Promise<void>)[];
+  releaseStartupProjection?: () => void;
+
+  /** True only when first-run setup already projected the canonical identity. */
+  startupIdentityRendered?: boolean;
 
   /** Optional: resume an existing session id. */
   resumeSessionId?: string;
@@ -647,6 +659,7 @@ export class ChatSession implements ChatSessionLike {
    */
   private streamingDisabledWarned = false;
   private startupRendered = false;
+  private startupRenderPromise: Promise<void> | null = null;
 
   /**
    * Phase v4.1.2-memory-D:
@@ -3511,6 +3524,24 @@ export class ChatSession implements ChatSessionLike {
     // don't get scrollback chatter on stdout.
     if (!process.stdout.isTTY) return;
     if (this.startupRendered) return;
+    if (this.startupRenderPromise) return this.startupRenderPromise;
+    this.startupRenderPromise = this.renderStartupCardOnce();
+    try {
+      await this.startupRenderPromise;
+    } finally {
+      this.startupRenderPromise = null;
+    }
+  }
+
+  private async renderStartupCardOnce(): Promise<void> {
+    const display = this.opts.display;
+    if (!this.opts.startupIdentityRendered) {
+      await display.waitForTerminalColumns(
+        AIDEN_BOOT_MIN_COLUMNS,
+        renderStartupWidthRequirement(display.terminalColumns()),
+      );
+    }
+    if (this.startupRendered) return;
     this.startupRendered = true;
 
     // Channel summary — observable, not banner-essential, but kept so
@@ -3551,7 +3582,7 @@ export class ChatSession implements ChatSessionLike {
     const sourceLabel = bootSourceLabel(this.opts.initialBootSource);
     const dashboard = renderStartupDashboard({
       columns,
-      banner: display.banner(version),
+      includeIdentity: !this.opts.startupIdentityRendered,
       style: {
         brand: (value) => display.brand(value),
         muted: (value) => display.muted(value),
@@ -3597,10 +3628,23 @@ export class ChatSession implements ChatSessionLike {
         command: (value) => display.applyColors(value, 'accent'),
       },
     });
+    display.write(`\n${dashboard.lines.join('\n')}\n`);
     if (noticeLines.length > 0) {
       display.write(`\n${noticeLines.join('\n')}\n`);
     }
-    display.write(`\n${dashboard.lines.join('\n')}\n`);
+    for (const diagnostic of this.opts.startupDiagnostics ?? []) {
+      const text = fitStartupLine(diagnostic.text, Math.max(1, columns - 2));
+      if (diagnostic.severity === 'warning') display.warn(text);
+      else display.dim(text);
+    }
+    this.opts.releaseStartupProjection?.();
+    for (const action of this.opts.startupActions ?? []) {
+      try {
+        await action();
+      } catch {
+        display.warn('A startup action could not complete. Run /doctor for details.');
+      }
+    }
 
     // v4.6 Phase 3A — operator kill-switch indicator. Lands ABOVE
     // the blank-line + provider-source annotation so an operator

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -43,6 +43,7 @@ import type { CapabilityCardData } from '../../providers/v4/types';
 import type { TaskOutcomePresentation } from '../../core/v4/taskOutcomePresentation';
 import type { OperatorActivityState } from './operatorProjection';
 import { AIDEN_LOGO_LINES } from '../../core/v4/ui/identity';
+import { waitForStartupWidth } from './startupWidthGate';
 import {
   normalizeActivityPhase,
   phaseColorKind,
@@ -528,6 +529,16 @@ export class Display {
   /** Raw terminal width for geometry-sensitive, single-row surfaces. */
   terminalColumns(): number {
     return frameGetTerminalCols(this.out);
+  }
+
+  /** Hold interactive startup until the canonical boot identity can fit. */
+  async waitForTerminalColumns(minimum: number, requirementLines: readonly string[]): Promise<boolean> {
+    return waitForStartupWidth({
+      out: this.out,
+      minimum,
+      currentColumns: () => this.terminalColumns(),
+      requirementLines,
+    });
   }
 
   /**

--- a/cli/v4/onboarding/disclaimer.ts
+++ b/cli/v4/onboarding/disclaimer.ts
@@ -23,9 +23,12 @@
 
 import * as readline from 'node:readline';
 
-import { renderTitleLine } from '../../../core/v4/ui/banner';
+import { renderBanner } from '../../../core/v4/ui/banner';
+import { AIDEN_BOOT_MIN_COLUMNS } from '../../../core/v4/ui/identity';
 import { c, separator, termWidth } from '../../../core/v4/ui/theme';
 import { VERSION } from '../../../core/version';
+import { renderStartupWidthRequirement } from '../startupDashboard';
+import { waitForStartupWidth } from '../startupWidthGate';
 
 export interface DisclaimerResult {
   /** True when the user accepted (or stdin wasn't a TTY). */
@@ -107,9 +110,7 @@ function renderDisclaimerBody(version: string): string {
   const w = termWidth();
   const innerW = Math.min(w - 4, 70);
   const body: string[] = [];
-  // Fresh setup and the normal session run in the same process. Keep setup's
-  // identity compact so the canonical six-row startup wordmark has one owner.
-  body.push(`\n  ${renderTitleLine(version)}\n\n`);
+  body.push(renderBanner({ version, width: w, framed: false }));
 
   // Slice 10c framed-panel chrome. Orange bar at col 2; content + 2
   // inner spaces; muted `─` divider between sections.
@@ -173,6 +174,12 @@ export async function showDisclaimer(
   }
 
   clearScreen(out);
+  await waitForStartupWidth({
+    out,
+    minimum: AIDEN_BOOT_MIN_COLUMNS,
+    currentColumns: () => Number(out.columns) || termWidth(),
+    requirementLines: renderStartupWidthRequirement(Number(out.columns) || termWidth()),
+  });
   out.write(renderDisclaimerBody(version));
 
   const question =

--- a/cli/v4/startupDashboard.ts
+++ b/cli/v4/startupDashboard.ts
@@ -8,11 +8,17 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
 
+import {
+  AIDEN_BOOT_MIN_COLUMNS,
+  AIDEN_LOGO_INDENT,
+  AIDEN_LOGO_LINES,
+} from '../../core/v4/ui/identity';
+
 const ANSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const SAFE_MARGIN = 2;
 
 export type StartupDashboardTier = 'wide' | 'medium' | 'narrow' | 'minimal';
-export type StartupLogoTier = 'full' | 'compact' | 'plain';
+export type StartupLogoTier = 'full' | 'blocked';
 
 export interface StartupEnvironmentData {
   os?: string;
@@ -64,6 +70,8 @@ export interface RenderStartupDashboardOptions {
   data: StartupDashboardData;
   banner?: string;
   style?: StartupDashboardStyle;
+  /** First-run setup may already own the one canonical identity projection. */
+  includeIdentity?: boolean;
 }
 
 export interface RenderedStartupDashboard {
@@ -339,22 +347,20 @@ function renderProject(
 }
 
 export function resolveStartupLogoTier(columns: number, banner?: string): StartupLogoTier {
-  const tier = resolveStartupDashboardTier(columns);
-  if (tier === 'narrow' || tier === 'minimal') return 'plain';
-  if (tier === 'medium') return 'compact';
-  if (!banner) return 'plain';
-  const width = safeWidth(columns);
-  const lines = banner.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  return lines.length > 0 && lines.every((line) => startupVisibleWidth(line) <= width)
-    ? 'full'
-    : 'compact';
+  void banner;
+  const width = Number.isFinite(columns) ? Math.max(1, Math.floor(columns)) : 80;
+  return width >= AIDEN_BOOT_MIN_COLUMNS ? 'full' : 'blocked';
 }
 
-function normalizeBanner(banner: string | undefined, width: number): string[] {
-  if (!banner) return [];
-  const lines = banner.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  if (lines.some((line) => startupVisibleWidth(line) > width)) return [];
-  return lines;
+export function renderStartupWidthRequirement(columns: number): string[] {
+  const width = safeWidth(columns);
+  return [
+    ...wrapPlain(
+      `Aiden requires at least ${AIDEN_BOOT_MIN_COLUMNS} columns to display its boot interface.`,
+      width,
+    ),
+    ...wrapPlain('Widen the terminal to continue.', width),
+  ];
 }
 
 export function renderStartupDashboard(options: RenderStartupDashboardOptions): RenderedStartupDashboard {
@@ -364,16 +370,18 @@ export function renderStartupDashboard(options: RenderStartupDashboardOptions): 
   const data = options.data;
   const lines: string[] = [];
   const logoTier = resolveStartupLogoTier(options.columns, options.banner);
-  const bannerLines = logoTier === 'full' ? normalizeBanner(options.banner, width) : [];
 
-  if (bannerLines.length > 0) {
-    lines.push(...bannerLines, style.muted('Autonomous AI Engine'), '');
-  } else if (logoTier === 'compact') {
-    lines.push(style.brand('A I D E N'));
-    lines.push(style.muted('Autonomous AI Engine'));
-  } else {
-    lines.push(style.brand('AIDEN'));
-    lines.push(style.muted('Autonomous AI Engine'));
+  const includeIdentity = options.includeIdentity !== false;
+  if (includeIdentity && logoTier === 'blocked') {
+    return { tier, lines: renderStartupWidthRequirement(options.columns) };
+  }
+
+  if (includeIdentity) {
+    lines.push(
+      ...AIDEN_LOGO_LINES.map((line) => style.brand(`${AIDEN_LOGO_INDENT}${line}`)),
+      style.muted('Autonomous AI Engine'),
+      '',
+    );
   }
 
   lines.push(statusLine(data, style, tier, width));

--- a/cli/v4/startupWidthGate.ts
+++ b/cli/v4/startupWidthGate.ts
@@ -1,0 +1,28 @@
+/** One-shot width gate shared by interactive startup and first-run setup. */
+export async function waitForStartupWidth(options: {
+  out: NodeJS.WriteStream;
+  minimum: number;
+  currentColumns: () => number;
+  requirementLines: readonly string[];
+}): Promise<boolean> {
+  const { out, minimum, currentColumns, requirementLines } = options;
+  if (!out.isTTY || currentColumns() >= minimum) return false;
+
+  out.write(`\x1b[2J\x1b[H${requirementLines.join('\n')}\n`);
+  const keepAlive = setInterval(() => undefined, 60_000);
+  try {
+    await new Promise<void>((resolve) => {
+      const onResize = (): void => {
+        if (currentColumns() < minimum) return;
+        out.off('resize', onResize);
+        resolve();
+      };
+      out.on('resize', onResize);
+      onResize();
+    });
+  } finally {
+    clearInterval(keepAlive);
+  }
+  out.write('\x1b[2J\x1b[H');
+  return true;
+}

--- a/core/v4/ui/banner.ts
+++ b/core/v4/ui/banner.ts
@@ -27,21 +27,26 @@
  *
  *       Built solo · By Taracod · White Lotus
  *
- * Narrow (<60 cols): collapses to a single-line title.
+ * Below the canonical identity width, callers receive only the startup width
+ * requirement and wait for a resize before continuing.
  *
  * Pure renderer — returns the composed string. Callers own the write.
  * No stateful spinners / inquirer prompts here.
  */
 
 import { c, dim, termWidth, getColorDepth } from './theme';
-import { AIDEN_LOGO_LINES } from './identity';
+import {
+  AIDEN_BOOT_MIN_COLUMNS,
+  AIDEN_LOGO_CELL_WIDTH,
+  AIDEN_LOGO_LINES,
+} from './identity';
 
 /**
- * The canonical block-style AIDEN ASCII. Six rows, widest row = 36 cells.
+ * The canonical block-style AIDEN ASCII. Six rows, widest row = 37 cells.
  */
 const AIDEN_ART = AIDEN_LOGO_LINES;
 
-const ART_WIDTH = 36;
+const ART_WIDTH = AIDEN_LOGO_CELL_WIDTH;
 
 export interface BannerOptions {
   /** Aiden runtime version — rendered as `v{version}`. */
@@ -69,35 +74,22 @@ function rpad(s: string, n: number): string {
   return s + ' '.repeat(n - len);
 }
 
-/** Centre `s` within width `w` (no colour codes in `s`). */
-function centre(s: string, w: number): string {
-  if (s.length >= w) return s;
-  const total = w - s.length;
-  const left = Math.floor(total / 2);
-  return ' '.repeat(left) + s + ' '.repeat(total - left);
-}
-
 /**
  * Build the framed banner block as a single string with trailing
  * newline. Truecolor → 256 → 16 / mono all handled by `theme.c.*`.
  */
 export function renderBanner(opts: BannerOptions): string {
-  const w = Math.max(40, Math.min(opts.width ?? termWidth(), 80));
-  const narrow = w < 60;
+  const w = Math.max(1, Math.min(opts.width ?? termWidth(), 80));
   const tagline = opts.tagline ?? 'Autonomous AI Engine';
   const credits = opts.credits ?? 'Built solo · By Taracod · White Lotus';
   const versionLine = `${tagline} · Local-first · v${opts.version}`;
 
-  // Narrow layout: single-line title + tagline + credits.
-  if (narrow) {
-    const out: string[] = [];
-    out.push('');
-    out.push(centre(c.primary('A I D E N'), w));
-    out.push('');
-    out.push(centre(c.muted(versionLine), w));
-    out.push(centre(c.muted(credits), w));
-    out.push('');
-    return out.join('\n') + '\n';
+  if (w < AIDEN_BOOT_MIN_COLUMNS) {
+    return [
+      `Aiden requires at least ${AIDEN_BOOT_MIN_COLUMNS} columns to display its boot interface.`,
+      'Widen the terminal to continue.',
+      '',
+    ].join('\n');
   }
 
   // v4.8.0 Slice 10b — wide layout flows the AIDEN art without the

--- a/core/v4/ui/identity.ts
+++ b/core/v4/ui/identity.ts
@@ -16,3 +16,10 @@ export const AIDEN_LOGO_LINES = Object.freeze([
 ] as const);
 
 export const AIDEN_LOGO_TEXT = AIDEN_LOGO_LINES.join('\n');
+
+/** Terminal-cell geometry of the canonical interactive boot identity. */
+export const AIDEN_LOGO_CELL_WIDTH = 37;
+export const AIDEN_LOGO_INDENT = '  ';
+export const AIDEN_BOOT_SAFE_MARGIN = 2;
+export const AIDEN_BOOT_MIN_COLUMNS =
+  AIDEN_LOGO_CELL_WIDTH + AIDEN_LOGO_INDENT.length + AIDEN_BOOT_SAFE_MARGIN;

--- a/tests/v4/cli/canonicalIdentity.test.ts
+++ b/tests/v4/cli/canonicalIdentity.test.ts
@@ -8,10 +8,19 @@ import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { Writable } from 'node:stream';
 
-import { AIDEN_LOGO_LINES, AIDEN_LOGO_TEXT } from '../../../core/v4/ui/identity';
+import {
+  AIDEN_BOOT_MIN_COLUMNS,
+  AIDEN_BOOT_SAFE_MARGIN,
+  AIDEN_LOGO_CELL_WIDTH,
+  AIDEN_LOGO_INDENT,
+  AIDEN_LOGO_LINES,
+  AIDEN_LOGO_TEXT,
+} from '../../../core/v4/ui/identity';
 import { renderBanner } from '../../../core/v4/ui/banner';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
+
+const stringWidth: (value: string) => number = require('string-width');
 
 describe('canonical Aiden identity', () => {
   it('keeps the established six-line wordmark byte-for-byte stable', () => {
@@ -58,5 +67,26 @@ describe('canonical Aiden identity', () => {
       if (previous === undefined) delete process.env.NO_COLOR;
       else process.env.NO_COLOR = previous;
     }
+  });
+
+  it('derives the supported width from terminal display cells and intended indentation', () => {
+    expect(AIDEN_LOGO_LINES.map(stringWidth)).toEqual([37, 37, 37, 37, 37, 37]);
+    expect(AIDEN_LOGO_CELL_WIDTH).toBe(Math.max(...AIDEN_LOGO_LINES.map(stringWidth)));
+    expect(AIDEN_BOOT_MIN_COLUMNS).toBe(
+      AIDEN_LOGO_CELL_WIDTH + stringWidth(AIDEN_LOGO_INDENT) + AIDEN_BOOT_SAFE_MARGIN,
+    );
+  });
+
+  it('preserves the same six logical lines through LF and CRLF projection', () => {
+    const lf = AIDEN_LOGO_TEXT.split('\n');
+    const crlf = AIDEN_LOGO_TEXT.replace(/\n/g, '\r\n').split(/\r?\n/);
+    expect(lf).toEqual([...AIDEN_LOGO_LINES]);
+    expect(crlf).toEqual([...AIDEN_LOGO_LINES]);
+  });
+
+  it('never replaces the canonical identity with a spaced text wordmark', () => {
+    const rendered = renderBanner({ version: '4.18.0', width: 44 });
+    expect(rendered).not.toContain('A I D E N');
+    for (const line of AIDEN_LOGO_LINES) expect(rendered).toContain(line);
   });
 });

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -9,6 +9,8 @@ import { SkinEngine } from '../../../cli/v4/skinEngine';
 import { resolveConfiguredAutonomyLevel } from '../../../core/v4/config';
 import { ApprovalEngine } from '../../../moat/approvalEngine';
 import { resolveAutonomyPolicy, type AutonomyLevel } from '../../../moat/autonomy';
+import { AIDEN_LOGO_LINES } from '../../../core/v4/ui/identity';
+import type { StartupNotice } from '../../../cli/v4/startupNotices';
 
 const stringWidth: (value: string) => number = require('string-width');
 
@@ -44,8 +46,10 @@ function captureDisplay(columns: number): { display: Display; chunks: string[]; 
 function buildSession(
   level: AutonomyLevel,
   columns = 100,
-): { session: ChatSession; chunks: string[] } {
-  const { display, chunks } = captureDisplay(columns);
+  startupNotices: StartupNotice[] = [],
+  startupIdentityRendered = false,
+): { session: ChatSession; chunks: string[]; out: NodeJS.WriteStream } {
+  const { display, chunks, out } = captureDisplay(columns);
   const approvalEngine = new ApprovalEngine('smart', {});
   approvalEngine.setAutonomyPolicy(resolveAutonomyPolicy(level, {
     workspaceRoots: [process.cwd()],
@@ -67,8 +71,18 @@ function buildSession(
     initialModelId: 'llama-3.3-70b-versatile',
     memoryManager: {} as never,
     installSignalHandler: false,
+    startupNotices,
+    startupIdentityRendered,
   };
-  return { session: new ChatSession(options), chunks };
+  if (startupNotices.some((notice) => notice.source === 'plugin')) {
+    options.commandRegistry.register({
+      name: 'plugins',
+      description: 'plugins',
+      category: 'system',
+      handler: async () => undefined,
+    });
+  }
+  return { session: new ChatSession(options), chunks, out };
 }
 
 let priorStdoutTty: boolean | undefined;
@@ -167,14 +181,15 @@ describe('responsive startup dashboard integration', () => {
     { columns: 120, tier: 'wide', sections: true, frame: true },
     { columns: 80, tier: 'wide', sections: true, frame: true },
     { columns: 48, tier: 'narrow', sections: true, frame: true },
-    { columns: 20, tier: 'minimal', sections: false, frame: true },
+    { columns: 44, tier: 'narrow', sections: true, frame: true },
   ])('renders the $tier transcript once at $columns columns', async ({ columns, sections, frame }) => {
     const { session, chunks } = buildSession('Partner', columns);
     await session.renderStartupCard();
     const output = stripAnsi(chunks.join(''));
 
-    const logo = columns >= 44 ? /Autonomous AI Engine/g : /^AIDEN$/gm;
-    expect(output.match(logo)).toHaveLength(1);
+    expect(output.match(/Autonomous AI Engine/g)).toHaveLength(1);
+    for (const line of AIDEN_LOGO_LINES) expect(output).toContain(line);
+    expect(output).not.toContain('A I D E N');
     expect(output).toContain('Partner');
     expect(output).toContain('llama-3.3-70b-versatile'.slice(0, columns >= 48 ? 8 : 3));
     expect(output).toMatch(/built solo/i);
@@ -189,6 +204,59 @@ describe('responsive startup dashboard integration', () => {
     for (const line of output.split(/\r?\n/)) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(Math.max(1, columns - 2));
     }
+  });
+
+  it('renders startup notices only after the complete identity block', async () => {
+    const notice: StartupNotice = {
+      id: 'plugin:grant:test-plugin',
+      severity: 'action',
+      title: 'test-plugin plugin capability requires a grant',
+      command: '/plugins grant test-plugin',
+      source: 'plugin',
+      blocking: false,
+      dedupeKey: 'plugin:grant:test-plugin',
+    };
+    const { session, chunks } = buildSession('Partner', 100, [notice]);
+    await session.renderStartupCard();
+    const output = stripAnsi(chunks.join(''));
+    const finalLogoRow = output.indexOf(AIDEN_LOGO_LINES.at(-1)!);
+    const noticeRow = output.indexOf(notice.title);
+
+    expect(finalLogoRow).toBeGreaterThanOrEqual(0);
+    expect(noticeRow).toBeGreaterThan(finalLogoRow);
+  });
+
+  it('does not duplicate an identity already rendered by first-run setup', async () => {
+    const { session, chunks } = buildSession('Partner', 100, [], true);
+    chunks.push(`${AIDEN_LOGO_LINES.join('\n')}\n`);
+    await session.renderStartupCard();
+    const output = stripAnsi(chunks.join(''));
+
+    for (const line of AIDEN_LOGO_LINES) {
+      expect(output.match(new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(1);
+    }
+    expect(output.match(/Built solo/gi)).toHaveLength(1);
+  });
+
+  it('waits below the minimum width and renders startup exactly once after resize', async () => {
+    const { session, chunks, out } = buildSession('Partner', 40);
+    let settled = false;
+    const first = session.renderStartupCard().then(() => { settled = true; });
+    const second = session.renderStartupCard();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const narrowOutput = stripAnsi(chunks.join(''));
+    expect(settled).toBe(false);
+    expect(narrowOutput).toMatch(/Aiden requires at least \d+ columns/);
+    expect(narrowOutput).not.toContain('Autonomous AI Engine');
+
+    (out as unknown as { columns: number }).columns = 44;
+    out.emit('resize');
+    await Promise.all([first, second]);
+    const output = stripAnsi(chunks.join(''));
+    expect(output.match(/Autonomous AI Engine/g)).toHaveLength(1);
+    expect(output.match(/Built solo/gi)).toHaveLength(1);
+    for (const line of AIDEN_LOGO_LINES) expect(output.match(new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(1);
   });
 
   it('does not subscribe the completed startup transcript to resize events', async () => {

--- a/tests/v4/cli/startupDashboard.pty.test.ts
+++ b/tests/v4/cli/startupDashboard.pty.test.ts
@@ -7,15 +7,7 @@ import * as pty from 'node-pty';
 import { COMPOSER_READY_TOKEN, RESIZE_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
 import { TerminalScreen } from '../harness/terminalScreen';
-
-const CANONICAL_LOGO = [
-  '█████╗  ██╗██████╗ ███████╗███╗   ██╗',
-  '██╔══██╗██║██╔══██╗██╔════╝████╗  ██║',
-  '███████║██║██║  ██║█████╗  ██╔██╗ ██║',
-  '██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║',
-  '██║  ██║██║██████╔╝███████╗██║ ╚████║',
-  '╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝',
-] as const;
+import { AIDEN_LOGO_LINES as CANONICAL_LOGO } from '../../../core/v4/ui/identity';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const stringWidth: (value: string) => number = require('string-width');
@@ -55,7 +47,7 @@ async function waitFor(
   throw new Error(`startup PTY timeout:\n${diagnostic().slice(-8000)}`);
 }
 
-async function launch(columns: number, paused = false): Promise<{
+async function launch(columns: number, paused = false, promoteToColumns?: number): Promise<{
   child: RunningPty;
   raw: () => string;
   plain: () => string;
@@ -64,6 +56,7 @@ async function launch(columns: number, paused = false): Promise<{
   scrollbackHistory: () => string;
   reviewableHistory: () => string;
   activeComposerCount: () => number;
+  blockedProjection: () => string;
   resize: (columns: number, rows?: number) => Promise<void>;
 }> {
   const repoRoot = path.resolve(__dirname, '../../..');
@@ -149,6 +142,22 @@ async function launch(columns: number, paused = false): Promise<{
     dataSubscription,
     exitSubscription,
   });
+  let blockedProjection = '';
+  if (promoteToColumns !== undefined) {
+    await waitFor(
+      () => stripAnsi(output).includes('Widen the terminal to continue.'),
+      () => stripAnsi(output),
+    );
+    blockedProjection = stripAnsi(output);
+    pendingHostResize = { columns: promoteToColumns, rows: 50 };
+    hostResizeCapture = '';
+    child.resize(promoteToColumns, 50);
+    await fs.writeFile(
+      terminalSizeFile,
+      JSON.stringify({ columns: promoteToColumns, rows: 50 }),
+      'utf8',
+    );
+  }
   await waitFor(
     () => output.includes(COMPOSER_READY_TOKEN),
     () => stripAnsi(output),
@@ -170,6 +179,7 @@ async function launch(columns: number, paused = false): Promise<{
     scrollbackHistory: () => screen.scrollbackSnapshot(),
     reviewableHistory: () => screen.reviewableSnapshot(),
     activeComposerCount: () => screen.activeComposerSurfaces().length,
+    blockedProjection: () => blockedProjection,
     resize: async (nextColumns, nextRows = 50) => {
       const outputStart = output.length;
       pendingHostResize = { columns: nextColumns, rows: nextRows };
@@ -237,9 +247,7 @@ function expectCleanMainBuffer(startup: Awaited<ReturnType<typeof launch>>): voi
 
 function dashboardLines(output: string): string[] {
   const lines = output.split(/\r?\n/);
-  const start = lines.findIndex((line) => (
-    line.includes('█████╗') || /^\s*(?:A I D E N|AIDEN)\s*$/u.test(line)
-  ));
+  const start = lines.findIndex((line) => line.includes(CANONICAL_LOGO[0]));
   const end = lines.findIndex((line, index) => index >= start && line.startsWith('▲ You'));
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
@@ -290,6 +298,29 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     expect(physical).not.toMatch(/\x1b\[3[13]m/u);
   }, 30_000);
 
+  it('holds a too-narrow boot and renders one complete startup after widening', async () => {
+    provider = await startMockProvider({ modelId: 'custom-default' });
+    const startup = await launch(40, false, 44);
+    const blocked = startup.blockedProjection();
+    const logicalBlocked = blocked.replace(/\s+/gu, ' ');
+
+    expect(logicalBlocked).toContain('Aiden requires at least 41 columns to display its boot interface.');
+    expect(logicalBlocked).toContain('Widen the terminal to continue.');
+    expect(blocked).not.toContain('Autonomous AI Engine');
+    expect(blocked).not.toContain('A I D E N');
+    expect(blocked).not.toContain('Environment');
+
+    const projection = startup.plain();
+    for (const row of CANONICAL_LOGO) expect(projection.split(row)).toHaveLength(2);
+    expect(projection.match(/Autonomous AI Engine/gu) ?? []).toHaveLength(1);
+    expect(projection.match(/Built solo/giu) ?? []).toHaveLength(1);
+    expect(startup.activeComposerCount()).toBe(1);
+    await startup.resize(60);
+    await startup.resize(44);
+    expect(startup.reviewableHistory().match(/Autonomous AI Engine/gu) ?? []).toHaveLength(1);
+    expect(startup.activeComposerCount()).toBe(1);
+  }, 30_000);
+
   it('selects wide, medium, and narrow transcript tiers without resize duplication', async () => {
     provider = await startMockProvider({ modelId: 'custom-default' });
 
@@ -304,7 +335,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     expect(wideBeforeResize).toMatch(/\d+ loaded/);
     expect(wideBeforeResize).toContain('spawn-pause: ON');
     expect(wide.raw().split(COMPOSER_READY_TOKEN)).toHaveLength(2);
-    for (const line of dashboardLines(wideBeforeResize)) {
+    for (const line of dashboardLines(wide.plain())) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(118);
     }
 
@@ -320,27 +351,28 @@ describe.skipIf(process.platform !== 'win32')('built CLI responsive startup dash
     expect(mediumRendered).toContain('Environment');
     expect(mediumRendered).toContain('Capabilities');
     expect(mediumRendered).toContain('github.com/taracodlabs/aiden');
-    expect(dashboardLines(mediumRendered).join('\n')).toContain('╭');
+    expect(dashboardLines(medium.plain()).join('\n')).toContain('╭');
     expect(mediumRendered).toContain('GitHub:');
     expect(mediumRendered).toContain('Web:');
     expect(mediumRendered).toContain('Contact:');
-    for (const line of dashboardLines(mediumRendered)) {
+    for (const line of dashboardLines(medium.plain())) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(78);
     }
 
     const narrow = await launch(48);
     const narrowRendered = narrow.rendered();
-    expect(narrowRendered).toMatch(/^AIDEN$/mu);
-    expect(narrowRendered).not.toContain('█████╗');
+    const narrowProjection = narrow.plain();
+    for (const row of CANONICAL_LOGO) expect(narrowProjection).toContain(row);
+    expect(narrowProjection).not.toContain('A I D E N');
     expect(narrowRendered).toMatch(/◇\s+Assistant\s+·\s+◆\s+custom-default/i);
     expect(narrowRendered).toMatch(/built solo/i);
     expect(narrowRendered).toContain('Environment');
     expect(narrowRendered).toContain('Capabilities');
-    expect(dashboardLines(narrowRendered).join('\n')).toContain('╭');
+    expect(dashboardLines(narrow.plain()).join('\n')).toContain('╭');
     expect(narrowRendered).toContain('GitHub:');
     expect(narrowRendered).toContain('Web:');
     expect(narrowRendered).toContain('Contact:');
-    for (const line of dashboardLines(narrowRendered)) {
+    for (const line of dashboardLines(narrow.plain())) {
       expect(stringWidth(line), line).toBeLessThanOrEqual(46);
     }
     const narrowRows = narrowRendered.split('\n');

--- a/tests/v4/cli/startupDashboard.test.ts
+++ b/tests/v4/cli/startupDashboard.test.ts
@@ -8,6 +8,7 @@ import {
   type StartupDashboardData,
 } from '../../../cli/v4/startupDashboard';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { AIDEN_LOGO_LINES } from '../../../core/v4/ui/identity';
 
 const base: StartupDashboardData = {
   trust: 'Partner',
@@ -39,14 +40,7 @@ const base: StartupDashboardData = {
   helper: 'Type your message · /help for commands · /skills to add more',
 };
 
-const banner = [
-  '█████╗  ██╗██████╗ ███████╗███╗   ██╗',
-  '██╔══██╗██║██╔══██╗██╔════╝████╗  ██║',
-  '███████║██║██║  ██║█████╗  ██╔██╗ ██║',
-  '██╔══██║██║██║  ██║██╔══╝  ██║╚██╗██║',
-  '██║  ██║██║██████╔╝███████╗██║ ╚████║',
-  '╚═╝  ╚═╝╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝',
-].join('\n');
+const banner = AIDEN_LOGO_LINES.join('\n');
 
 function render(columns: number, data: StartupDashboardData = base): string[] {
   return renderStartupDashboard({ columns, data, banner }).lines;
@@ -59,10 +53,10 @@ function assertBounded(lines: string[], columns: number): void {
 }
 
 describe('responsive startup dashboard', () => {
-  it('selects full, compact, and plain startup identities without wrapping', () => {
+  it('preserves the full canonical startup identity at every supported width', () => {
     expect(resolveStartupLogoTier(100, banner)).toBe('full');
-    expect(resolveStartupLogoTier(60, banner)).toBe('compact');
-    expect(resolveStartupLogoTier(44, banner)).toBe('plain');
+    expect(resolveStartupLogoTier(60, banner)).toBe('full');
+    expect(resolveStartupLogoTier(44, banner)).toBe('full');
   });
 
   it.each([
@@ -108,11 +102,11 @@ describe('responsive startup dashboard', () => {
     assertBounded(lines, 80);
   });
 
-  it('keeps the compact narrow layout, full project details, and bounded card', () => {
+  it('keeps the full identity, narrow layout, project details, and bounded card', () => {
     const lines = render(48);
     const text = lines.join('\n');
-    expect(text).toContain('AIDEN');
-    expect(text).not.toContain(banner.split('\n')[0]);
+    expect(AIDEN_LOGO_LINES.every((line) => text.includes(line))).toBe(true);
+    expect(text).not.toContain('A I D E N');
     expect(text).toContain('Partner');
     expect(text).toContain('gpt-5.6-sol');
     expect(text).toContain('Built solo');
@@ -169,10 +163,9 @@ describe('responsive startup dashboard', () => {
     (columns) => {
       const lines = render(columns);
       const text = lines.join('\n');
-      const logoTier = resolveStartupLogoTier(columns, banner);
-      expect(text).toContain(
-        logoTier === 'full' ? banner.split('\n')[0] : logoTier === 'compact' ? 'A I D E N' : 'AIDEN',
-      );
+      expect(resolveStartupLogoTier(columns, banner)).toBe('full');
+      for (const logoLine of AIDEN_LOGO_LINES) expect(text).toContain(logoLine);
+      expect(text).not.toContain('A I D E N');
       expect(text).toContain('Autonomous AI Engine');
       expect(text).toContain('Built solo');
       expect(text).toContain('GitHub:');
@@ -214,17 +207,19 @@ describe('responsive startup dashboard', () => {
         },
       }).lines;
       const plainLines = lines.map((line) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/gu, ''));
-      for (const logoLine of banner.split('\n')) expect(plainLines).toContain(logoLine);
+      for (const logoLine of banner.split('\n')) {
+        expect(plainLines.some((line) => line.endsWith(logoLine))).toBe(true);
+      }
       const logo = lines.slice(0, banner.split('\n').length).join('\n');
       expect(logo).toContain('\x1b[38;2;255;107;53m');
     },
   );
 
-  it.each([60, 44])('never wraps the startup identity at %i columns', (columns) => {
+  it.each([60, 44])('never wraps or replaces the startup identity at %i columns', (columns) => {
     const lines = render(columns);
-    expect(lines.join('\n')).not.toContain(banner.split('\n')[0]);
-    const identity = columns === 60 ? 'A I D E N' : 'AIDEN';
-    expect(lines.filter((line) => line.includes(identity))).toHaveLength(1);
+    const text = lines.join('\n');
+    for (const logoLine of AIDEN_LOGO_LINES) expect(text).toContain(logoLine);
+    expect(text).not.toContain('A I D E N');
     assertBounded(lines, columns);
   });
 
@@ -262,11 +257,16 @@ describe('responsive startup dashboard', () => {
     },
   );
 
-  it('is safe at minimal widths and never creates negative padding or broken borders', () => {
+  it('blocks normal startup below the canonical identity width', () => {
     const lines = render(20);
-    expect(lines.join('\n')).toContain('AIDEN');
-    expect(lines.join('\n')).not.toMatch(/undefined|null|NaN/);
-    expect(lines.join('\n')).toContain('╭');
+    const text = lines.join('\n');
+    const logicalText = text.replace(/\s+/g, ' ');
+    expect(logicalText).toMatch(/Aiden requires at least \d+ columns to display its boot interface\./);
+    expect(logicalText).toContain('Widen the terminal to continue.');
+    expect(text).not.toContain('A I D E N');
+    expect(text).not.toContain('Autonomous AI Engine');
+    expect(text).not.toContain('Environment');
+    expect(text).not.toContain('Built solo');
     assertBounded(lines, 20);
   });
 

--- a/tests/v4/cli/startupIdentity.test.ts
+++ b/tests/v4/cli/startupIdentity.test.ts
@@ -1,0 +1,58 @@
+import { PassThrough, Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import { showDisclaimer } from '../../../cli/v4/onboarding/disclaimer';
+import { AIDEN_LOGO_LINES } from '../../../core/v4/ui/identity';
+
+function startupStreams(columns: number): {
+  input: NodeJS.ReadStream;
+  output: NodeJS.WriteStream;
+  chunks: string[];
+} {
+  const chunks: string[] = [];
+  const input = new PassThrough() as unknown as NodeJS.ReadStream;
+  const output = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  }) as unknown as NodeJS.WriteStream;
+  Object.assign(input, { isTTY: true });
+  Object.assign(output, { isTTY: true, columns });
+  return { input, output, chunks };
+}
+
+describe('first-run startup identity', () => {
+  it('renders the canonical identity before setup copy', async () => {
+    const { input, output, chunks } = startupStreams(80);
+    const pending = showDisclaimer({ in: input, out: output, version: '4.18.0' });
+    (input as unknown as PassThrough).write('\n');
+    const result = await pending;
+    const rendered = chunks.join('').replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+
+    expect(result.ok).toBe(true);
+    for (const line of AIDEN_LOGO_LINES) expect(rendered).toContain(line);
+    expect(rendered).not.toContain('A I D E N');
+    expect(rendered.indexOf(AIDEN_LOGO_LINES.at(-1)!)).toBeLessThan(rendered.indexOf('Aiden can:'));
+  });
+
+  it('waits at a narrow width before rendering the first-run identity', async () => {
+    const { input, output, chunks } = startupStreams(40);
+    let settled = false;
+    const pending = showDisclaimer({ in: input, out: output, version: '4.18.0' })
+      .then((value) => { settled = true; return value; });
+    await new Promise((resolve) => setImmediate(resolve));
+    const blocked = chunks.join('').replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+    expect(settled).toBe(false);
+    expect(blocked).toContain('Aiden requires at least 41 columns');
+    expect(blocked).not.toContain('A I D E N');
+    expect(blocked).not.toContain(AIDEN_LOGO_LINES[0]);
+
+    (output as unknown as { columns: number }).columns = 44;
+    output.emit('resize');
+    (input as unknown as PassThrough).write('\n');
+    await pending;
+    const rendered = chunks.join('').replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+    for (const line of AIDEN_LOGO_LINES) expect(rendered.split(line)).toHaveLength(2);
+  });
+});

--- a/tests/v4/core/logger/factoryReplSacred.test.ts
+++ b/tests/v4/core/logger/factoryReplSacred.test.ts
@@ -153,25 +153,25 @@ describe('markReplActive — defense-in-depth flag', () => {
   });
 });
 
-// ─── Source-contract guard on the user-visible warn migration ─────────
+// ─── Source contract for the owned interactive startup projection ─────
 
-describe('aidenCLI source contract — spawn-pause warn migrated to display.warn', () => {
-  it('uses display.warn (not bootLogger.warn) for the user-visible spawn-pause notice', async () => {
+describe('aidenCLI source contract — spawn-pause warning uses owned startup projection', () => {
+  it('projects the interactive warning without using bootLogger.warn', async () => {
     const src = await fs.readFile(
       path.resolve(__dirname, '../../../../cli/v4/aidenCLI.ts'),
       'utf8',
     );
-    // The 10-line region around the spawn-pause boot block MUST
-    // contain display.warn and MUST NOT contain bootLogger.warn —
-    // because under Slice 10.7a bootLogger no longer routes warn to
-    // the TTY in cli-interactive.
+    // Bound the contract to the exact startup block so unrelated logging or
+    // projection calls elsewhere cannot satisfy these assertions.
     const region = src.match(
-      /v4\.6 Phase 3A — startup probe for the spawn-pause[\s\S]{0,2000}/,
+      /if \(spawnPauseBootStatus\) \{[\s\S]*?\n  \}\r?\n\r?\n  \/\/ ── Phase v4\.1-subagent/,
     );
     expect(region, 'spawn-pause block not found in expected shape').not.toBeNull();
-    expect(region![0]).toMatch(/display\.warn\(/);
-    // Tolerate `bootLogger.info(...)` for the structured-context
-    // record but reject `bootLogger.warn(` which is the regressed call.
-    expect(region![0]).not.toMatch(/bootLogger\.warn\(/);
+    const block = region![0];
+    expect(block).toMatch(/projectStartupDiagnostic\s*\(\s*['"]warning['"]\s*,/);
+    expect(block).toMatch(/bootLogger\.info\s*\(/);
+    expect(block).not.toMatch(/bootLogger\.warn\s*\(/);
+    expect(block).not.toMatch(/process\.(?:stdout|stderr)\.write\s*\(/);
+    expect(block).not.toMatch(/console\.(?:warn|error)\s*\(/);
   });
 });

--- a/tests/v4/daemon/api/runsTraceAdoption.test.ts
+++ b/tests/v4/daemon/api/runsTraceAdoption.test.ts
@@ -12,7 +12,8 @@ import os from 'node:os';
 import path from 'node:path';
 import http from 'node:http';
 
-import { spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import express from 'express';
 import {
   bootstrapDaemonFoundation,
@@ -36,6 +37,8 @@ let aidenHome: string;
 let prev: Record<string, string | undefined>;
 let basePort: number;
 let apiServer: http.Server | null = null;
+
+const execFileAsync = promisify(execFile);
 
 interface PostOptions {
   body:    Record<string, unknown>;
@@ -210,20 +213,18 @@ describe('Slice 7 inbound trace adoption + 7 captured smoke scenarios', () => {
       daemonId: dmn, incarnationId: inc, runId: rid, traceId: tid, spanId: sid,
       source: 'cli' as const, attempt: 1,
     };
-    await runWithContext(ctx, () => {
+    await runWithContext(ctx, async () => {
       const ambient = currentContext()!;
       const env = spawnEnvWithContext(ambient, {});
-      const child = spawn(process.execPath, ['-e', 'console.log(process.env.AIDEN_RUN_ID + "|" + process.env.AIDEN_PARENT_SPAN_ID)'], { env });
-      let out = '';
-      child.stdout.on('data', (b: Buffer) => { out += b.toString(); });
-      return new Promise<void>((resolve) => {
-        child.on('exit', () => {
-          console.log(`[smoke 6] child env: ${out.trim()}`);
-          expect(out).toContain(rid);
-          expect(out).toContain(sid);
-          resolve();
-        });
-      });
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        ['-e', 'console.log(process.env.AIDEN_RUN_ID + "|" + process.env.AIDEN_PARENT_SPAN_ID)'],
+        { env, encoding: 'utf8' },
+      );
+      console.log(`[smoke 6] child env: ${stdout.trim()}`);
+      expect(stderr).toBe('');
+      expect(stdout).toContain(rid);
+      expect(stdout).toContain(sid);
     });
   });
 

--- a/tests/v4/daemon/kernelFailureInjection.test.ts
+++ b/tests/v4/daemon/kernelFailureInjection.test.ts
@@ -418,7 +418,7 @@ describe('kernel deterministic failure boundaries', () => {
     expect(engine.projection.cursor('lost-ui', admitted.jobId)).toBe(0);
     expect(engine.projection.read('lost-ui', admitted.jobId).map((event) => event.jobSequence))
       .toEqual(engine.listEvents(admitted.jobId).map((event) => event.jobSequence));
-  });
+  }, 60_000);
 
   it('keeps an unsafe network Effect unknown after a real loopback disconnect', async () => {
     const path = databasePath();


### PR DESCRIPTION
## Summary

- preserves the canonical six-line AIDEN identity at every supported interactive width
- holds startup below the required width and continues once the terminal is wide enough
- renders structured startup notices only after the complete identity block
- shares one identity definition across returning-user, first-run, source, built, and packed paths

## Validation

- focused and neighboring startup, display, and theme tests: 325 passed, 13 skipped
- Windows startup and built CLI PTY matrix: 26 passed
- manual Windows PowerShell observation passed: full six-line identity, one render, no compact fallback, usable startup
- focused startup-warning logger contract: 12 passed
- Stage 1 identity regression matrix: 68 passed
- typecheck passed
- production build passed
- package dry run and isolated tarball install passed
- installed package version and help passed
- scope, NUL, secret, attribution, and diff scans passed

## CI correction

The startup warning source contract now checks the owned interactive startup projection instead of requiring the removed direct display write. It continues to reject `bootLogger.warn` and direct terminal output while allowing structured `bootLogger.info` context. This correction changes tests only.

## Scope

This is Stage 1 boot-identity preservation only. It does not change activity rendering, activity-to-answer spacing, renderer coordination, terminal ownership, or package version.

## Acceptance

Manual Windows PowerShell visual acceptance and the focused local regression gates are complete. Replacement CI is pending.