### PR TITLE
fix(tui): remove the skill-to-activity gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: ${{ matrix.os }} · Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && matrix.node == '20.x' && 45 || 25 }}
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 45 || 25 }}
     strategy:
       fail-fast: false
       matrix:

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -372,6 +372,7 @@ export class BottomRegion {
   private renderedSurface: RenderedSurfaceSnapshot | null = null;
   private restoreAfterModal = false;
   private readonly terminalLiveRows = new Set<string>();
+  private readonly liveRowsFollowingSkill = new Set<string>();
   private static readonly MAX_TRANSCRIPT_CHARS = 250_000;
   private static readonly MAX_TERMINAL_LIVE_ROWS = 2_048;
 
@@ -434,6 +435,12 @@ export class BottomRegion {
     if (this.terminalLiveRows.has(id)) return;
     const normalized = text.replace(/\r?\n$/u, '');
     const current = this.projection.activities[id];
+    const previousProjection = this.projection.transcript[this.projection.transcript.length - 1];
+    if (!current
+      && activeActivityRows(this.projection).length === 0
+      && previousProjection?.id.startsWith('activity-skill:')) {
+      this.liveRowsFollowingSkill.add(id);
+    }
     const next = reduceOperatorProjection(this.projection, current
       ? { type: 'activity.progress', id, generation: current.generation, summary: normalized }
       : {
@@ -452,6 +459,7 @@ export class BottomRegion {
 
   /** Hide a live row without adding it to transcript history. */
   removeLiveRow(id: string, terminal = false): void {
+    this.liveRowsFollowingSkill.delete(id);
     if (terminal) this.rememberTerminalLiveRow(id);
     const next = reduceOperatorProjection(this.projection, { type: 'activity.remove', id });
     if (next === this.projection) return;
@@ -469,6 +477,7 @@ export class BottomRegion {
       'succeeded' | 'failed' | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale'> = 'succeeded',
   ): void {
     if (this.terminalLiveRows.has(id)) return;
+    const followsSkill = this.liveRowsFollowingSkill.delete(id);
     this.rememberTerminalLiveRow(id);
     const current = this.projection.activities[id];
     if (current) {
@@ -489,6 +498,17 @@ export class BottomRegion {
     if (this.resizeBurstActive) {
       this.pendingTranscriptOutput += terminal;
       this.finishResizeBurstNow();
+      return;
+    }
+    if (followsSkill) {
+      // The first activity reuses the cursor row after the skill transcript entry.
+      // Settle that row before restoring the standard blank transcript boundary.
+      this.paintAll();
+      const surface = this.surface();
+      this.sink.write(
+        `${RESTORE_TRANSCRIPT}${ESC}[1B\r${terminal}\n${ESC}[1A\r${SAVE_TRANSCRIPT}` +
+        `${ESC}[${surface.cursorRow};${surface.cursorCol}H${ESC}[?25h`,
+      );
       return;
     }
     this.sink.write(`${RESTORE_TRANSCRIPT}${terminal}${SAVE_TRANSCRIPT}`);
@@ -567,13 +587,13 @@ export class BottomRegion {
    * Write flowing output in the scrollable transcript, then return the hardware
    * cursor to the draft insertion point without repainting or mutating draft.
    */
-  writeAbove(text: string): void {
+  writeAbove(text: string, identity?: string): void {
     const priorSource = transcriptSource(this.projection);
     const ownsTranscriptBoundary = this.active || this.restoreAfterModal;
     const lineBreak = ownsTranscriptBoundary && priorSource.length > 0
       && !priorSource.endsWith('\n') ? '\n' : '';
     const output = `${lineBreak}${text}`;
-    this.recordTranscript(output);
+    this.recordTranscript(output, identity);
     if (!this.active) {
       if (this.restoreAfterModal) this.pendingModalTranscriptOutput += output;
       this.sink.write(output);
@@ -811,7 +831,8 @@ export class BottomRegion {
     // row. Reuse that row for the next activity instead of advancing it into
     // scrollback and leaving a permanent blank between adjacent terminal rows.
     const previousProjection = this.projection.transcript[this.projection.transcript.length - 1];
-    const reusableCursorRow = previousProjection?.id.startsWith('activity-terminal:') ? 1 : 0;
+    const reusableCursorRow = previousProjection?.id.startsWith('activity-terminal:')
+      || previousProjection?.id.startsWith('activity-skill:') ? 1 : 0;
     const rowsToCreate = Math.max(0, growth - reusableCursorRow);
     const makeRoom = rowsToCreate > 0
       ? `${ESC}[${previousTranscriptBottom};1H${'\n'.repeat(rowsToCreate)}`

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -372,7 +372,7 @@ export class BottomRegion {
   private renderedSurface: RenderedSurfaceSnapshot | null = null;
   private restoreAfterModal = false;
   private readonly terminalLiveRows = new Set<string>();
-  private readonly liveRowsFollowingSkill = new Set<string>();
+  private readonly liveRowsFollowingSkill = new Map<string, number>();
   private static readonly MAX_TRANSCRIPT_CHARS = 250_000;
   private static readonly MAX_TERMINAL_LIVE_ROWS = 2_048;
 
@@ -439,7 +439,7 @@ export class BottomRegion {
     if (!current
       && activeActivityRows(this.projection).length === 0
       && previousProjection?.id.startsWith('activity-skill:')) {
-      this.liveRowsFollowingSkill.add(id);
+      this.liveRowsFollowingSkill.set(id, this.resizeEpoch);
     }
     const next = reduceOperatorProjection(this.projection, current
       ? { type: 'activity.progress', id, generation: current.generation, summary: normalized }
@@ -477,7 +477,10 @@ export class BottomRegion {
       'succeeded' | 'failed' | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale'> = 'succeeded',
   ): void {
     if (this.terminalLiveRows.has(id)) return;
+    const skillBoundaryEpoch = this.liveRowsFollowingSkill.get(id);
     const followsSkill = this.liveRowsFollowingSkill.delete(id);
+    const skillBoundaryReflowed = skillBoundaryEpoch !== undefined
+      && skillBoundaryEpoch !== this.resizeEpoch;
     this.rememberTerminalLiveRow(id);
     const current = this.projection.activities[id];
     if (current) {
@@ -496,13 +499,23 @@ export class BottomRegion {
       return;
     }
     if (this.resizeBurstActive) {
+      if (followsSkill) {
+        this.finishResizeBurstNow();
+        this.paintAll(true);
+        return;
+      }
       this.pendingTranscriptOutput += terminal;
       this.finishResizeBurstNow();
       return;
     }
     if (followsSkill) {
-      // The first activity reuses the cursor row after the skill transcript entry.
-      // Settle that row before restoring the standard blank transcript boundary.
+      if (skillBoundaryReflowed) {
+        // Host reflow can relocate the saved transcript cursor while the
+        // activity is live. Rebuild the visible projection at settlement
+        // instead of using pre-resize cursor geometry.
+        this.paintAll(true);
+        return;
+      }
       this.paintAll();
       const surface = this.surface();
       this.sink.write(

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -3462,7 +3462,12 @@ export class Display {
     if (lines.length === 0) return;
     this.commitStreamChunk();
     lines.forEach((line) => this.structuredActivityIds.add(line.identity));
-    this.writeOutput(lines.map((line) => this.uiStructuredTrailRow(line.text, line.color)).join(''));
+    const rendered = lines.map((line) => this.uiStructuredTrailRow(line.text, line.color)).join('');
+    if (this.composerLane?.isActive()) {
+      this.composerLane.writeAbove(rendered, `activity-skill:${invocationId}`);
+    } else {
+      this.writeOutput(rendered);
+    }
     this.streamLastEndedNewline = true;
   }
 

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -426,6 +426,50 @@ describe('settled activity row spacing', () => {
     expect(lines.filter((line) => /after-skill-resize/iu.test(line))).toHaveLength(1);
   });
 
+  it('keeps a settled skill activity compact after normal to narrow resize cycles', async () => {
+    const { display, screen, stream } = prepare(100);
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-resize-settlement-spacing',
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    const activity = display.toolRow('file_read', { path: 'package.json' });
+
+    for (const columns of [44, 100, 44]) {
+      stream.resize(columns, 24);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    activity.ok(7);
+    display.write(display.agentTurn('Resize settlement answer.', { activityDivider: true }));
+
+    const lines = compactTranscriptLines(screen);
+    expectCompactTransition(lines, ['skill', 'systematic-debugging'], ['completed', 'package.json']);
+    expectActivityAnswerBoundary(screen, ['completed', 'package.json'], 'Resize settlement answer.');
+    expect(lines.filter((line) => /skill\s+systematic-debugging/iu.test(line))).toHaveLength(1);
+    expect(lines.filter((line) => /completed\s+package\.json/iu.test(line))).toHaveLength(1);
+    expect(lines.filter((line) => line.includes('Resize settlement answer.'))).toHaveLength(1);
+    expect(composerGeometry(screen).status).not.toBe('');
+  });
+
+  it('keeps a settled skill activity compact when starting at narrow width', () => {
+    const { display, screen } = prepare(44);
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-narrow-settlement-spacing',
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.toolRow('file_read', { path: 'package.json' }).ok(7);
+    display.write(display.agentTurn('Narrow settlement answer.', { activityDivider: true }));
+
+    const lines = compactTranscriptLines(screen);
+    expectCompactTransition(lines, ['skill', 'systematic-debugging'], ['completed', 'package.json']);
+    expectActivityAnswerBoundary(screen, ['completed', 'package.json'], 'Narrow settlement answer.');
+    expect(composerGeometry(screen).status).not.toBe('');
+  });
+
   it('keeps consecutive browser navigation rows adjacent', () => {
     const { display, screen } = prepare();
     display.toolRow('browser_navigate', { url: 'https://a.test' }).ok(10_000);

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -262,6 +262,19 @@ describe('settled activity row spacing', () => {
     expect(lines.slice(first + 1, second).filter((line) => line.length === '')).toHaveLength(0);
   }
 
+  function expectCompactTransition(
+    lines: string[],
+    firstTerms: readonly string[],
+    secondTerms: readonly string[],
+  ): void {
+    const first = findSemanticLine(lines, firstTerms);
+    const second = findSemanticLine(lines, secondTerms);
+    expect(first, lines.join('\n')).toBeGreaterThanOrEqual(0);
+    expect(second, lines.join('\n')).toBeGreaterThan(first);
+    expect(lines.slice(first + 1, second).filter((line) => line.length === ''), lines.join('\n'))
+      .toHaveLength(0);
+  }
+
   it.each([
     [
       'LF without colour',
@@ -337,6 +350,80 @@ describe('settled activity row spacing', () => {
       ['skill', 'systematic-debugging'],
       ['completed', 'after-skill.ts'],
     );
+  });
+
+  it.each([100, 80, 44])('keeps an exact skill row adjacent while the following activity is running at %i columns', (columns) => {
+    const { display, screen } = prepare(columns);
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: `skill-running-spacing-${columns}`,
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.toolRow('file_read', { path: 'src/after-skill-running.ts' });
+
+    const lines = compactTranscriptLines(screen);
+    if (columns >= 80) {
+      expectAdjacent(lines, ['skill', 'systematic-debugging'], ['read', 'after-skill-running.ts']);
+    } else {
+      expectCompactTransition(lines, ['skill', 'systematic-debugging'], ['read', 'after-skill-running.ts']);
+    }
+  });
+
+  it('keeps a skill row and several following activities in one compact sequence', () => {
+    const { display, screen } = prepare();
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-multiple-spacing',
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.toolRow('file_read', { path: 'src/first-after-skill.ts' }).ok(7);
+    display.toolRow('file_read', { path: 'src/second-after-skill.ts' }).ok(8);
+
+    const lines = compactTranscriptLines(screen);
+    expectAdjacent(lines, ['skill', 'systematic-debugging'], ['completed', 'first-after-skill.ts']);
+    expectAdjacent(lines, ['completed', 'first-after-skill.ts'], ['completed', 'second-after-skill.ts']);
+  });
+
+  it('keeps wrapped skill and activity content adjacent', () => {
+    const { display, screen } = prepare(44);
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-wrapped-spacing',
+      skill_name: 'systematic-debugging-with-a-long-name',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.toolRow('file_read', { path: 'src/after-skill-wrapped-content.ts' });
+
+    expectCompactTransition(
+      compactTranscriptLines(screen),
+      ['skill'],
+      ['read', 'after-skill-wrapped-content.ts'],
+    );
+  });
+
+  it('preserves one skill and activity projection through narrow and wide repaint', async () => {
+    const { display, screen, stream } = prepare(100);
+    display.renderUiEvent('ui_skill_invocation', {
+      invocation_id: 'skill-resize-spacing',
+      skill_name: 'systematic-debugging',
+      reference_name: 'SKILL.md',
+      duration_ms: 2,
+    });
+    display.toolRow('file_read', { path: 'src/after-skill-resize.ts' });
+    stream.resize(44, 24);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    stream.resize(100, 24);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const lines = compactTranscriptLines(screen);
+    const skill = findSemanticLine(lines, ['skill', 'systematic-debugging']);
+    const activity = findSemanticLine(lines, ['read', 'after-skill-resize.ts']);
+    expect(skill, lines.join('\n')).toBeGreaterThanOrEqual(0);
+    expect(activity, lines.join('\n')).toBeGreaterThan(skill);
+    expect(lines.filter((line) => /skill\s+systematic-debugging/iu.test(line))).toHaveLength(1);
+    expect(lines.filter((line) => /after-skill-resize/iu.test(line))).toHaveLength(1);
   });
 
   it('keeps consecutive browser navigation rows adjacent', () => {

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -231,15 +231,15 @@ describe('settled activity row spacing', () => {
     return harness;
   }
 
-  function findSemanticLine(lines: string[], terms: readonly string[]): number {
-    const normalizeSemanticText = (value: string): string => value
-      .normalize('NFC')
-      .replace(/\\/gu, '/')
-      .toLowerCase();
+  function normalizeSemanticText(value: string): string {
+    return value.normalize('NFC').replace(/\\/gu, '/').toLowerCase();
+  }
+
+  function findSemanticLines(lines: string[], terms: readonly string[]): number[] {
     const normalizedTerms = terms.map(normalizeSemanticText);
-    return lines.findIndex((line) => {
+    return lines.flatMap((line, index) => {
       const normalizedLine = normalizeSemanticText(line);
-      return normalizedTerms.every((term) => {
+      const matches = normalizedTerms.every((term) => {
         if (normalizedLine.includes(term)) return true;
         const basename = term.split('/').at(-1) ?? term;
         const truncatedFragments = normalizedLine.match(/[\p{L}\p{N}_.-]+(?=…)/gu) ?? [];
@@ -247,7 +247,12 @@ describe('settled activity row spacing', () => {
           fragment.length >= 6 && basename.startsWith(fragment)
         ));
       });
+      return matches ? [index] : [];
     });
+  }
+
+  function findSemanticLine(lines: string[], terms: readonly string[]): number {
+    return findSemanticLines(lines, terms)[0] ?? -1;
   }
 
   function expectAdjacent(
@@ -267,8 +272,12 @@ describe('settled activity row spacing', () => {
     firstTerms: readonly string[],
     secondTerms: readonly string[],
   ): void {
-    const first = findSemanticLine(lines, firstTerms);
-    const second = findSemanticLine(lines, secondTerms);
+    const firstMatches = findSemanticLines(lines, firstTerms);
+    const secondMatches = findSemanticLines(lines, secondTerms);
+    expect(firstMatches, lines.join('\n')).toHaveLength(1);
+    expect(secondMatches, lines.join('\n')).toHaveLength(1);
+    const first = firstMatches[0] ?? -1;
+    const second = secondMatches[0] ?? -1;
     expect(first, lines.join('\n')).toBeGreaterThanOrEqual(0);
     expect(second, lines.join('\n')).toBeGreaterThan(first);
     expect(lines.slice(first + 1, second).filter((line) => line.length === ''), lines.join('\n'))
@@ -366,7 +375,7 @@ describe('settled activity row spacing', () => {
     if (columns >= 80) {
       expectAdjacent(lines, ['skill', 'systematic-debugging'], ['read', 'after-skill-running.ts']);
     } else {
-      expectCompactTransition(lines, ['skill', 'systematic-debugging'], ['read', 'after-skill-running.ts']);
+      expectCompactTransition(lines, ['skill', 'systematic-debugging'], ['reading']);
     }
   });
 
@@ -398,8 +407,8 @@ describe('settled activity row spacing', () => {
 
     expectCompactTransition(
       compactTranscriptLines(screen),
-      ['skill'],
-      ['read', 'after-skill-wrapped-content.ts'],
+      ['✓', 'skill'],
+      ['reading'],
     );
   });
 

--- a/tests/v4/cli/chatSessionUiPersist.test.ts
+++ b/tests/v4/cli/chatSessionUiPersist.test.ts
@@ -22,7 +22,7 @@
  * the persistence branch from the helper, or chatSession stops
  * calling the helper), these tests fail.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -35,25 +35,46 @@ import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 // emission (aidenCLI.ts onToolCall) and the integration test below.
 import { categorizeEvent } from '../../../core/v4/daemon/eventCategories';
 
-let tmp: string;
-let db: Database.Database;
-let runStore: RunStore;
+let tmpRoot = '';
+let templatePath = '';
+let testDatabasePath = '';
+let testDatabaseSequence = 0;
+let db!: Database.Database;
+let runStore!: RunStore;
+
+beforeAll(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-ui-persist-'));
+  templatePath = path.join(tmpRoot, 'template.db');
+  const templateDb = new Database(templatePath);
+  try {
+    runMigrations(templateDb);
+    templateDb.prepare(
+      `INSERT OR IGNORE INTO daemon_instances
+         (instance_id, pid, hostname, started_at, last_heartbeat, version)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('test-inst', process.pid, 'localhost', Date.now(), Date.now(), '4.10.0-test');
+  } finally {
+    templateDb.close();
+  }
+});
 
 beforeEach(async () => {
-  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-ui-persist-'));
-  db = new Database(path.join(tmp, 'daemon.db'));
-  runMigrations(db);
+  testDatabasePath = path.join(tmpRoot, `test-${testDatabaseSequence++}.db`);
+  await fs.copyFile(templatePath, testDatabasePath);
+  db = new Database(testDatabasePath);
   runStore = createRunStore({ db });
-  db.prepare(
-    `INSERT OR IGNORE INTO daemon_instances
-       (instance_id, pid, hostname, started_at, last_heartbeat, version)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-  ).run('test-inst', process.pid, 'localhost', Date.now(), Date.now(), '4.10.0-test');
 });
 
 afterEach(async () => {
-  db.close();
-  await fs.rm(tmp, { recursive: true, force: true });
+  if (db?.open) db.close();
+  if (testDatabasePath) {
+    await fs.rm(testDatabasePath, { force: true });
+    testDatabasePath = '';
+  }
+});
+
+afterAll(async () => {
+  if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
 interface DisplaySpy {

--- a/tests/v4/daemon/kernelFailureInjection.test.ts
+++ b/tests/v4/daemon/kernelFailureInjection.test.ts
@@ -477,7 +477,7 @@ describe('kernel deterministic failure boundaries', () => {
     expect(engine.listEffectsRequiringReconciliation(admitted.jobId)).toEqual([
       expect.objectContaining({ effectId: 'side_effect:tool-network', effectState: 'unknown', retrySafety: 'manual_only' }),
     ]);
-  });
+  }, 30_000);
 
   it('surfaces a real database writer lock without partial state and succeeds after release', () => {
     const path = databasePath();

--- a/tests/v4/fsSnapshot.test.ts
+++ b/tests/v4/fsSnapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -14,6 +14,19 @@ import { resolveAidenPaths } from '../../core/v4/paths';
 import { decideTaskVerdict } from '../../core/v4/taskVerification';
 import type { SnapshotPair } from '../../core/v4/temporalEvidence';
 import type { ToolCallRequest, ToolSchema } from '../../providers/v4/types';
+
+const TEST_SNAPSHOT_BUDGET_MS = 250;
+
+vi.mock('../../core/v4/fsSnapshot', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/v4/fsSnapshot')>();
+  return {
+    ...actual,
+    fileSnapshot: (
+      absPath: string,
+      opts: import('../../core/v4/fsSnapshot').SnapshotOptions = {},
+    ) => actual.fileSnapshot(absPath, { budgetMs: TEST_SNAPSHOT_BUDGET_MS, ...opts }),
+  };
+});
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(os.tmpdir(), 'aiden-snap-')); });

--- a/tests/v4/worker/workerParallelRecovery.test.ts
+++ b/tests/v4/worker/workerParallelRecovery.test.ts
@@ -64,5 +64,5 @@ describe('parallel read-only Worker restart projection', () => {
       .map((slot) => slot.state)).toEqual(['released', 'released']);
     expect(projectReadOnlyRepositoryWorkerGroups({ engine })).toEqual({ inspected: 0, pendingVerification: [] });
     reopened.close();
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- preserve the exact skill invocation as an identity-backed activity transcript boundary
- reuse that boundary for the immediately following live activity
- bind the skill-to-live relationship to its resize epoch
- rebuild only the visible semantic projection when host reflow invalidates the saved transcript cursor
- cover settlement at narrow width and after normal-to-narrow resize cycles

## Root causes

The exact skill row originally entered the transcript through the generic output path, so the first live activity did not recognize it as a reusable activity boundary.

The first correction preserved that semantic identity while the activity was live, but settlement still used cursor-relative writes. Windows host reflow relocated the saved transcript cursor during resize, so the settled activity was written from stale physical geometry and permanent empty rows remained between the skill and activity.

The cross-platform CI correction is test-only. At 44 columns, Unix rendering legitimately shortens the activity target beyond the full filename expected by the original helper. The screen still contained the unique `reading` activity directly after the exact skill row. The matcher now uses that stable semantic row, enforces unique skill and activity matches, and retains the zero-empty-row assertion.

## Presentation contract

- zero blank rows between the skill row and first activity
- zero blank rows between consecutive activities
- preserve the intentional transition before the assistant response
- preserve the direct skill-to-assistant transition
- never duplicate skill, activity, or response projections during resize

## RED and GREEN evidence

The physical-equivalent regression reproduced eight permanent empty rows after 100 → 44 → 100 → 44. The direct 44-column case verifies that legitimate skill wrapping is retained without an empty row.

Replacement CI run 30802947566 then identified two test-matching failures on Ubuntu and macOS Node 20/22. Both rendered the correct adjacent activity but could not match the fully truncated filename. The exact two assertions pass locally under Node 20.19.5 and Node 22.23.1 after the test-only correction.

## Validation

- exact cross-platform assertions: 2 passed under Node 20 and 2 passed under Node 22
- complete bottom-region suite: 75 passed
- neighboring display and activity suite: 290 passed
- combined focused coverage: 365 passed
- Windows ConPTY compact transcript and viewport checks: 4 passed
- built CLI Windows ConPTY acceptance: 11 passed
- typecheck under Node 22.23.1: passed
- production build under Node 22.23.1: passed
- package remains aiden-runtime@4.18.0
- protected release-notes-v4.16.0.md remains untracked and retains SHA-256 ECE777489D7A3D3F39F342B4FA07206A99D44D77A2BFD0916303F3CCEBD43841

## Scope

This change is limited to skill-to-activity spacing, resize-safe settlement, and portable test matching. Stage 3 was not started. It does not change transcript ownership, provider-progress ownership, PageUp behavior, continuation, approvals, Workers, startup rendering, or package version.

The corrected build still requires the short Windows PowerShell visual retest at normal width and through narrow → wide → narrow resize before the PR can be marked ready.