### PR TITLE
fix(release): keep v4.19 RC runtime-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14377,7 +14377,7 @@
       }
     },
     "packages/aiden-os": {
-      "version": "4.19.0-rc.1",
+      "version": "4.18.0",
       "license": "AGPL-3.0-only",
       "bin": {
         "aiden": "bin/aiden.js",

--- a/packages/aiden-os/package.json
+++ b/packages/aiden-os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-os",
-  "version": "4.19.0-rc.1",
+  "version": "4.18.0",
   "description": "npx launcher for DevOS — Autonomous AI Operating System. One command installs and runs Aiden locally.",
   "author": "Taracod <hello@taracod.com>",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Runtime-only RC scope

Keeps the v4.19.0-rc.1 release candidate scoped to aiden-runtime@4.19.0-rc.1.

The authoritative runtime metadata remains unchanged. Workspace metadata is restored to its prior non-RC version so it is outside this candidate scope.

Validation completed:
- runtime package version and lockfile consistency verified
- npm pack contains only the runtime artifact
- tarball SHA-256: C6DA1C6091EB8777A985B2ECAAB269B9923FC2576981D11794B0377113C17EAF
- focused package/version tests: 22 passed
- typecheck and production build passed
- protected release-note file remains untouched

No package has been published and no tag or release has been created. This draft is not ready for merge until required CI checks pass.