### PR TITLE
release: prepare v4.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ Give Aiden a goal. It can work across your files, terminal, browser, supported a
 ![Built solo](https://img.shields.io/badge/Built-solo-B8A893?style=flat-square)
 ![By Taracod](https://img.shields.io/badge/By-Taracod-FF6B35?style=flat-square)
 ![White Lotus](https://img.shields.io/badge/Brand-White_Lotus-FFB088?style=flat-square)
-![Stable](https://img.shields.io/badge/Stable-v4.18.0-4ADE80?style=flat-square)
-![Release candidate](https://img.shields.io/badge/Release_candidate-v4.19.0--rc.1-F59E0B?style=flat-square)
+![Stable](https://img.shields.io/badge/Stable-v4.19.0-4ADE80?style=flat-square)
 
 </details>
 
@@ -184,10 +183,10 @@ Research this topic, compare the strongest findings, and save a structured Markd
 > [!IMPORTANT]
 > **Release channels**
 >
-> - **Stable:** `v4.18.0` through npm `latest`
-> - **Release candidate:** `v4.19.0-rc.1` through npm `beta`
+> - **Stable:** `v4.19.0` through npm `latest`
+> - **Archived RC:** [`v4.19.0-rc.1`](https://github.com/taracodlabs/aiden/releases/tag/v4.19.0-rc.1)
 
-### Stable — v4.18.0
+### Stable — v4.19.0
 
 ```bash
 npm install -g aiden-runtime
@@ -199,7 +198,7 @@ That’s it. The first launch opens Aiden’s current setup flow, checks the sel
 Stable channel:
 
 ```text
-npm latest → 4.18.0
+npm latest → 4.19.0
 ```
 
 Without permanent installation:
@@ -208,40 +207,7 @@ Without permanent installation:
 npx aiden-runtime@latest
 ```
 
-### Release candidate — v4.19.0-rc.1
-
-The release candidate is available through npm’s `beta` channel for testing
-the next Worker and Model Bridge capabilities.
-
-```bash
-npm install -g aiden-runtime@beta
-aiden
-```
-
-Exact-version installation:
-
-```bash
-npm install -g aiden-runtime@4.19.0-rc.1
-aiden
-```
-
-Without permanent installation:
-
-```bash
-npx aiden-runtime@beta
-```
-
-Exact version without permanent installation:
-
-```bash
-npx aiden-runtime@4.19.0-rc.1
-```
-
-Release-candidate channel:
-
-```text
-npm beta → 4.19.0-rc.1
-```
+The [v4.19.0-rc.1 release candidate](https://github.com/taracodlabs/aiden/releases/tag/v4.19.0-rc.1) is archived.
 
 ### Verify the installed version
 
@@ -249,21 +215,17 @@ npm beta → 4.19.0-rc.1
 aiden --version
 ```
 
-Expected output depends on the installed channel:
+Expected output:
 
 ```text
-Stable:            4.18.0
-Release candidate: 4.19.0-rc.1
+4.19.0
 ```
 
-Verify the release candidate without a permanent installation:
+Verify the stable release without a permanent installation:
 
 ```bash
-npx aiden-runtime@beta --version
+npx aiden-runtime@latest --version
 ```
-
-The stable command installs and runs the stable channel; it does not install
-the release candidate.
 
 **Want Aiden to react to files, schedules, email, or webhooks? Enable autonomous triggers:**
 
@@ -281,11 +243,9 @@ https://github.com/user-attachments/assets/7a66bc19-8b17-4b01-be85-3aa5945a1b3b
 
 <br>
 
-## What's new in v4.19.0-rc.1
+## What's new in v4.19.0
 
-**Release candidate:** v4.19.0-rc.1 extends Aiden’s durable Worker and Model
-Bridge foundations. It is available through npm `beta` for validation before
-the next stable release.
+**Aiden v4.19.0 is the stable Worker and Model Bridge release.**
 
 - **Durable Worker contracts.** Read-only repository Workers use explicit parent and child execution authority.
 - **Immutable model binding.** Each Worker keeps its provider and model binding fixed for the admitted execution.
@@ -301,9 +261,9 @@ artifacts. Investigation found no duplicate tool execution, duplicate mutating
 effect, durable-state corruption, approval corruption, lost input, or crash.
 This is tracked as a P2 cosmetic issue.
 
-### RC feedback
+### Feedback
 
-Please report release-candidate feedback through [GitHub Issues](https://github.com/taracodlabs/aiden/issues)
+Please report feedback through [GitHub Issues](https://github.com/taracodlabs/aiden/issues)
 or the [Aiden Discord community](https://discord.gg/CU5wshJW4F). Include:
 
 - operating system;
@@ -319,7 +279,7 @@ Do not include API keys, tokens, secrets, or private repository content.
 
 This GitHub README update does not change the README captured on the already-
 published npm package page. Updating that page would require publishing a new
-version, which is outside this release-candidate documentation change.
+version.
 
 ## What's new in v4.18.0
 

--- a/RELEASE-NOTES-v4.19.0.md
+++ b/RELEASE-NOTES-v4.19.0.md
@@ -1,0 +1,41 @@
+# Aiden v4.19.0
+
+Aiden v4.19.0 is the stable Worker and Model Bridge release for
+`aiden-runtime`.
+
+## Highlights
+
+- Durable Worker contracts and read-only repository Workers.
+- Parent and child execution authority with immutable provider and model binding.
+- Separate logical provider-call and physical-attempt accounting.
+- Durable token and usage accounting, budget reservation, and pre-send enforcement.
+- Bounded retries and provider fallback.
+- Cancellation during provider work and rejection of late provider results.
+- Worker restart and reopen.
+- Child Evidence with parent Verification.
+- Parallel Worker admission and reservations.
+- Stable joins and deterministic reconciliation.
+
+## Validation
+
+The release candidate evidence was accepted across the supported runtime and
+integration gates:
+
+- Windows Node 20 non-PTY: 7,533 passed, 48 skipped.
+- Windows Node 22 non-PTY: 7,533 passed, 48 skipped.
+- Windows PTY Node 20: 45 passed.
+- Windows PTY Node 22: 45 passed.
+- Built CLI ConPTY: 11 passed.
+- Worker/recovery/cancellation: 122/122.
+- Focused lifecycle: 50/50.
+- Integration: 39 passed, 7 credential-dependent skipped.
+- Two-hour soak: 1,414 cycles, 4,548 provider calls, 0 failures, 0 crashes,
+  0 hangs, 0 database locks, 0 duplicate effects, and 0 process leaks.
+
+## Known issue
+
+Aggressive terminal resizing may produce cosmetic activity-row projection
+artifacts. Investigation found no duplicate tool execution, duplicate mutating
+effect, durable-state corruption, approval corruption, lost input, or crash.
+This remains classified as a P2 cosmetic issue and is not a correctness
+failure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-runtime",
-  "version": "4.19.0-rc.1",
+  "version": "4.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-runtime",
-      "version": "4.19.0-rc.1",
+      "version": "4.19.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-runtime",
-  "version": "4.19.0-rc.1",
+  "version": "4.19.0",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/v4/daemon/taskStore.test.ts
+++ b/tests/v4/daemon/taskStore.test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
   db = new Database(path.join(tmp, 'daemon.db'));
   runMigrations(db);
   store = createTaskStore({ db });
-});
+}, 60_000);
 
 afterEach(async () => {
   db.close();


### PR DESCRIPTION
## Summary\n\nPrepares the stable runtime-only Aiden v4.19.0 release from the guarded main commit.\n\n## Scope\n\n- README.md\n- RELEASE-NOTES-v4.19.0.md\n- package.json root runtime version 4.19.0\n- package-lock.json root metadata only\n- no production code changes\n- the obsolete workspace launcher remains at 4.18.0 and outside public scope\n- no publication, tag, release, or npm dist-tag change\n\n## Validation\n\n- focused release metadata tests: 2 passed\n- TaskStore exact suite under Node 20: 20/20 runs, 25/25 tests each; setup remained approximately 8 seconds per run\n- TaskStore exact suite under Node 22: 25/25 passed\n- neighboring SQLite/daemon recovery matrix: 53/53 passed under Node 20 and 53/53 under Node 22\n- typecheck: passed\n- production build: passed\n- local Node 22 deterministic run: 7,540 passed, 39 skipped; two existing Windows-sensitive tests remain for the CI matrix gate\n- package: aiden-runtime@4.19.0\n- packed file count: 1,073\n- packed size: 2,401,638 bytes\n- unpacked size: 9,141,083 bytes\n- SHA-1: 4118DACBD7A0202BDA904976386733900B034257\n- SHA-256: 3AA825C8FEB648814C6031D216F65474C42522846421C94F911728B03C57A73C\n- isolated Node 22 tarball installation: both declared CLI entrypoints reported 4.19.0\n- protected release-notes-v4.16.0.md remained untracked and unchanged\n\n## Windows Node 20 CI correction\n\nThe hosted non-PTY failure was limited to the TaskStore setup hook exceeding Vitest's default 30-second hook budget under the fully loaded Windows matrix. The test body did not fail, and no lock, leak, or assertion defect reproduced in isolation or in the neighboring SQLite matrix. The correction is test-only: the TaskStore setup hook has an explicit 60-second timeout. Global test timeouts, assertions, retries, skips, and production code are unchanged.\n\nNothing has been published, tagged, released, or moved to npm latest. This PR is draft and requires the full supported CI matrix before review or merge.