### PR TITLE
fix(runtime): complete v4.19 hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ Expected output:
 4.19.0
 ```
 
+Both public commands, `aiden` and `aiden-runtime`, start the same standalone
+local runtime. The separate desktop/API client is an internal build artifact
+for connecting to an already-running service and is not included as an npm
+command.
+
 Verify the stable release without a permanent installation:
 
 ```bash

--- a/cli/aiden.ts
+++ b/cli/aiden.ts
@@ -21,6 +21,7 @@ import { COMMANDS, COMMAND_DETAIL, getCatalog }             from './commandCatal
 import type { CmdDetail }                                    from './commandCatalog'
 import * as commandCatalog                                   from './commandCatalog'
 import { TOOL_DESCRIPTIONS }                                 from '../core/toolRegistry'
+import { resolveDesktopApiClientLocalCommand }                from './desktopApiClientArgs'
 
 // ── Constants ────────────────────────────────────────────────────────────────────
 
@@ -6263,6 +6264,11 @@ async function resolveSessionArgs(): Promise<void> {
 // ── Main ──────────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
+  const localCommand = resolveDesktopApiClientLocalCommand(process.argv.slice(2), VERSION)
+  if (localCommand !== null) {
+    process.stdout.write(localCommand)
+    return
+  }
   // ── Windows VT / ANSI init ──────────────────────────────────────────────────
   if (process.platform === 'win32') {
     try {

--- a/cli/desktopApiClientArgs.ts
+++ b/cli/desktopApiClientArgs.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+export function resolveDesktopApiClientLocalCommand(
+  args: readonly string[],
+  version: string,
+): string | null {
+  if (args.includes('--version') || args.includes('-v')) return `${version}\n`;
+  if (args.includes('--help') || args.includes('-h')) {
+    return [
+      `Aiden desktop/API client ${version}`,
+      '',
+      'Connects to an already-running Aiden API service.',
+      'Set AIDEN_API to override the default http://localhost:4200 endpoint.',
+      '',
+      'The public aiden and aiden-runtime commands use the standalone local runtime.',
+      '',
+    ].join('\n');
+  }
+  return null;
+}

--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -1,6 +1,7 @@
 /** Central lifecycle owner for live CLI tool activity rows. */
 import type { LiveActivityRowHandle, ToolRowHandle } from './display';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
+import { runtimeTrace } from '../../core/v4/runtimeTrace';
 import type {
   ToolActivityPhase,
   ToolActivityTiming,
@@ -387,9 +388,5 @@ function cloneUpdate(update: ToolActivityUpdate): ToolActivityUpdate {
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {
-  if (process.env.AIDEN_P2A_DIAG !== '1') return;
-  try {
-    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
-  } catch { /* diagnostics must never affect activity lifecycle */ }
+  runtimeTrace('activity', event, data);
 }

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -2877,7 +2877,7 @@ export async function buildAgentRuntime(
   installReplCrashHandlers({
     log: (level, msg, meta) => bootLogger.child('crash')[level](msg, meta),
     notify: (line) => {
-      try { process.stderr.write(`\n${line}\n`); } catch { /* stderr torn down */ }
+      try { display.writeError(`\n${line}\n`); } catch { /* display torn down */ }
     },
   });
   // Wire the gateway singleton's logger BEFORE registering its processor

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Display } from './display';
+import { runtimeTrace } from '../../core/v4/runtimeTrace';
 import { ActivityRegistry, type ModalActivityOptions } from './activityRegistry';
 import { boxBottom, boxLine, boxTopTitled, truncateVisible, visibleLength } from './box';
 import type {
@@ -939,11 +940,7 @@ Reply with ONE word: safe, caution, or dangerous.`;
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {
-  if (process.env.AIDEN_P2A_DIAG !== '1') return;
-  try {
-    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
-  } catch { /* diagnostics must never affect callbacks */ }
+  runtimeTrace('callbacks', event, data);
 }
 
 // Tier-3.1 (v4.1-tier3.1): replaced 🟢/🟡/🔴 emoji badges with

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -331,19 +331,14 @@ export class CliCallbacks {
   }
 
   async withModalActivity<T>(run: () => Promise<T>, options?: ModalActivityOptions<T>): Promise<T> {
-    this.display.pauseComposerSurface();
-    try {
+    return this.display.withModalLease('approval', async () => {
       return await this.activities.runModal(run, {
         ...options,
         beforeActivityResume: () => {
-          this.display.resumeComposerSurface();
           options?.beforeActivityResume?.();
         },
       });
-    } finally {
-      // Idempotent fallback for a defensive failure before runModal's finally.
-      this.display.resumeComposerSurface();
-    }
+    });
   }
 
   completeActivityTurn(): void {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -2844,7 +2844,7 @@ export class ChatSession implements ChatSessionLike {
           turnId,
           durationMs: Date.now() - settlementStartedAt,
         });
-        runtimeTrace('turn', 'final_frame.accepted', { turnId, mode: 'streaming' });
+        runtimeTrace('turn', 'final_frame.queued', { turnId, mode: 'streaming' });
       }
 
       this.history = result.messages;
@@ -3195,7 +3195,7 @@ export class ChatSession implements ChatSessionLike {
           turnId,
           durationMs: Date.now() - settlementStartedAt,
         });
-        runtimeTrace('turn', 'final_frame.accepted', { turnId, mode: 'complete' });
+        runtimeTrace('turn', 'final_frame.queued', { turnId, mode: 'complete' });
       }
 
       if (streamingActive && durableEvidenceForDisplay.length > 0) {
@@ -3256,6 +3256,8 @@ export class ChatSession implements ChatSessionLike {
         );
       }
 
+      await this.opts.display.awaitTerminalSettled();
+      runtimeTrace('turn', 'final_frame.accepted', { turnId });
       this.setStatusState({ kind: 'ready' });
       this.lastTurnElapsedMs = Date.now() - turnStartedAt;
       // v4.8.0 Slice 7 — record per-turn outcome for the status dot.
@@ -3283,6 +3285,7 @@ export class ChatSession implements ChatSessionLike {
       // — matches the `\n\n` blank already below `▎ Aiden` header.
       this.opts.display.write(`\n  ${this.opts.display.rule()}\n`);
       this.renderStatusLine();
+      runtimeTrace('turn', 'ready_prompt.emitted', { turnId });
       runtimeTrace('turn', 'stable_ready', {
         turnId,
         durationMs: this.lastTurnElapsedMs,

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -20,6 +20,7 @@
  */
 
 import type { AidenAgent } from '../../core/v4/aidenAgent';
+import { runtimeTrace } from '../../core/v4/runtimeTrace';
 import { buildTurnRuntimeContext } from '../../core/v4/turnRuntimeContext';
 import { computeTaskFinalization } from '../../core/v4/taskVerification';
 import {
@@ -1105,14 +1106,7 @@ export class ChatSession implements ChatSessionLike {
       // summarizing so the user knows where to look for missing data.
       exitHandler = () => {
         if (!this.summarized) {
-          // Best-effort one-liner — stderr because stdout may be torn
-          // down already.
-          try {
-            process.stderr.write(
-              '[aiden] process exiting without session summary — ' +
-              'distillation file not written for this session.\n',
-            );
-          } catch { /* nothing to do */ }
+          runtimeTrace('session', 'summary.missing', { sessionId: this.sessionId });
         }
       };
       process.on('exit', exitHandler);
@@ -2573,11 +2567,7 @@ export class ChatSession implements ChatSessionLike {
 
     const p2aDiagEnabled = process.env.AIDEN_P2A_DIAG === '1';
     const emitP2aDiag = (event: string, data: Record<string, unknown>): void => {
-      if (!p2aDiagEnabled) return;
-      try {
-        const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-        process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, turnId, ...data })}\n`);
-      } catch { /* diagnostics must never affect the turn */ }
+      if (p2aDiagEnabled) runtimeTrace('turn', event, { turnId, ...data });
     };
     let lastHeartbeatAt = Number(process.hrtime.bigint() / 1_000_000n);
     const p2aHeartbeat = p2aDiagEnabled
@@ -2789,6 +2779,7 @@ export class ChatSession implements ChatSessionLike {
                   // implementation; cast to any to avoid widening
                   // the public Display surface for one-shot use.
                   (this.opts.display as unknown as { skin: import('./skinEngine').SkinEngine }).skin,
+                  this.opts.display.progressProjection(`turn-${turnId}`),
                 );
               }
               progressBar.update(outputTokens, maxTokens);
@@ -3838,6 +3829,7 @@ export class ChatSession implements ChatSessionLike {
             'verifying installed version',
             'complete',
           ],
+          projection: this.opts.display.progressProjection('runtime-update'),
         });
         const controller = new AbortController();
         const cancel = (): void => controller.abort();

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -2206,6 +2206,22 @@ export class ChatSession implements ChatSessionLike {
     // = exactly one blank row between user input and Aiden header,
     // matching the rhythm Shiva flagged in smoke.
     const turnStartedAt = Date.now();
+    runtimeTrace('turn', 'input.accepted', {
+      turnId,
+      inputChars: userInput.length,
+      persistedInput: inputAlreadyPersisted,
+    });
+    runtimeTrace('turn', 'planning.start', { turnId });
+    let planningSettled = false;
+    const settlePlanning = (reason: 'first_token' | 'tool' | 'provider_complete'): void => {
+      if (planningSettled) return;
+      planningSettled = true;
+      runtimeTrace('turn', 'planning.end', {
+        turnId,
+        reason,
+        durationMs: Date.now() - turnStartedAt,
+      });
+    };
     const userMsg: Message = { role: 'user', content: userInput };
 
     // Apply any queued system prompts (from skill slash commands) by
@@ -2667,6 +2683,11 @@ export class ChatSession implements ChatSessionLike {
         turnContext,
         onFirstDelta: streamingEnabled
           ? wrapTurnId(() => {
+              settlePlanning('first_token');
+              runtimeTrace('turn', 'first_token', {
+                turnId,
+                durationMs: Date.now() - turnStartedAt,
+              });
               stopIndicatorOnce();
               streamingActive = true;
               // v4.11 Slice 1 — a new stream segment is starting (this
@@ -2726,6 +2747,7 @@ export class ChatSession implements ChatSessionLike {
           : undefined,
         onToolCallStart: streamingEnabled
           ? wrapTurnId((call: import('../../providers/v4/types').ToolCallRequest) => {
+              settlePlanning('tool');
               // v4.11 Slice 1 — segment boundary: flush buffered prose
               // before the tool indicator paints, preserving order.
               flushStreamDeltas();
@@ -2787,6 +2809,12 @@ export class ChatSession implements ChatSessionLike {
           : undefined,
       }));
       const result = await runAgent();
+      settlePlanning('provider_complete');
+      runtimeTrace('turn', 'final_stream.complete', {
+        turnId,
+        finishReason: result.finishReason,
+        durationMs: Date.now() - turnStartedAt,
+      });
       if (jobEngine && replTaskId && jobAttemptId && jobGeneration !== null && replRunId !== null) {
         currentProviderAttemptLedger()?.reconcileJobLinkage({
           taskId: replTaskId,
@@ -2807,7 +2835,17 @@ export class ChatSession implements ChatSessionLike {
       // Hide the progress bar before any post-stream content
       // (statusFooter, the next prompt) lands on its line.
       progressBar?.hide();
-      if (streamingActive) { flushStreamDeltas(); this.opts.display.streamComplete(); }
+      if (streamingActive) {
+        flushStreamDeltas();
+        const settlementStartedAt = Date.now();
+        runtimeTrace('turn', 'markdown_settlement.start', { turnId });
+        this.opts.display.streamComplete();
+        runtimeTrace('turn', 'markdown_settlement.end', {
+          turnId,
+          durationMs: Date.now() - settlementStartedAt,
+        });
+        runtimeTrace('turn', 'final_frame.accepted', { turnId, mode: 'streaming' });
+      }
 
       this.history = result.messages;
       this.compressionCount = result.compressionEvents;
@@ -3150,7 +3188,14 @@ export class ChatSession implements ChatSessionLike {
         // the one-shot reply lands. Idempotent + tool-gated by
         // the shared separator gate.
         const activityDivider = takeToolReplySeparator();
+        const settlementStartedAt = Date.now();
+        runtimeTrace('turn', 'markdown_settlement.start', { turnId });
         this.opts.display.write(this.opts.display.agentTurn(result.finalContent, { activityDivider }));
+        runtimeTrace('turn', 'markdown_settlement.end', {
+          turnId,
+          durationMs: Date.now() - settlementStartedAt,
+        });
+        runtimeTrace('turn', 'final_frame.accepted', { turnId, mode: 'complete' });
       }
 
       if (streamingActive && durableEvidenceForDisplay.length > 0) {
@@ -3238,6 +3283,10 @@ export class ChatSession implements ChatSessionLike {
       // — matches the `\n\n` blank already below `▎ Aiden` header.
       this.opts.display.write(`\n  ${this.opts.display.rule()}\n`);
       this.renderStatusLine();
+      runtimeTrace('turn', 'stable_ready', {
+        turnId,
+        durationMs: this.lastTurnElapsedMs,
+      });
       // v4.1.5+ Path A — finalize the loop trace. No-op if the env
       // var is unset OR if the turn didn't trip any threshold. When
       // it DOES emit, the snapshot path goes to a dim status line so

--- a/cli/v4/commands/model.ts
+++ b/cli/v4/commands/model.ts
@@ -11,13 +11,12 @@
  * provider/model. Empty args opens the interactive picker (also reused by
  * `aiden model`). Spec form is parsed via Phase 5's ModelSwitcher.
  */
-import path from 'node:path';
-import fs from 'node:fs';
-
 import type { SlashCommand, SlashCommandContext } from '../commandRegistry';
 import { ModelSwitcher } from '../../../providers/v4/modelSwitch';
 import { runModelPicker } from './modelPicker';
 import { PROVIDER_REGISTRY } from '../../../providers/v4/registry';
+import { loadTokens, isExpired } from '../../../core/v4/auth/tokenStore';
+import type { ProviderAccessState } from './modelPicker';
 
 /**
  * Sync auth-state probe used by the Phase 22 picker. Single source of
@@ -28,24 +27,33 @@ import { PROVIDER_REGISTRY } from '../../../providers/v4/registry';
  *     exist. Token validity is the runtime resolver's concern.
  *   - env-var providers — process.env[apiKeyEnvVar] must be non-empty.
  */
-function makeAuthProbe(rootPath: string | undefined): (id: string) => boolean {
-  return (providerId: string): boolean => {
+export function makeProviderAccessProbe(ctx: SlashCommandContext): (id: string) => Promise<ProviderAccessState> {
+  return async (providerId: string): Promise<ProviderAccessState> => {
     const entry = PROVIDER_REGISTRY[providerId];
-    if (!entry) return false;
-    if (entry.tier === 'local') return true;
-    if (entry.oauth && rootPath) {
-      try {
-        fs.accessSync(path.join(rootPath, 'auth', `${entry.oauth.providerId}.json`));
-        return true;
-      } catch {
-        return false;
+    if (!entry) return 'not_configured';
+    const readiness = ctx.config?.getValue<{ state?: string }>(`providers.${providerId}.readiness`);
+    const readinessState = (): ProviderAccessState | null => {
+      if (readiness?.state === 'complete') return 'readiness_verified';
+      if (readiness?.state === 'failed_retryable' || readiness?.state === 'failed_requires_user_action') {
+        return 'readiness_failed';
       }
+      return null;
+    };
+    if (entry.tier === 'local') return readinessState() ?? (readiness ? 'authentication_valid' : 'not_configured');
+    if (entry.oauth) {
+      if (!ctx.paths) return 'authentication_missing';
+      const tokens = await loadTokens(ctx.paths, entry.oauth.providerId);
+      if (!tokens) return 'authentication_missing';
+      if (isExpired(tokens)) return 'authentication_expired';
+      return readinessState() ?? 'authentication_valid';
     }
     if (entry.apiKeyEnvVar) {
       const v = process.env[entry.apiKeyEnvVar];
-      return typeof v === 'string' && v.length > 0;
+      if (typeof v === 'string' && v.trim().length > 0) return readinessState() ?? 'authentication_valid';
+      const configured = ctx.config?.get(`providers.${providerId}.apiKey`);
+      return configured?.trim() ? readinessState() ?? 'authentication_valid' : 'authentication_missing';
     }
-    return false;
+    return 'not_configured';
   };
 }
 
@@ -81,12 +89,12 @@ export const model: SlashCommand = {
         return {};
       }
     } else {
-      const picked = await runModelPicker({
+      const picked = await ctx.display.withModalLease('model-picker', () => runModelPicker({
         resolver: ctx.resolver,
         currentProviderId: ctx.session?.getCurrentProvider(),
         currentModelId: ctx.session?.getCurrentModel(),
-        isProviderAuthed: makeAuthProbe(ctx.paths?.root),
-      });
+        isProviderAuthed: makeProviderAccessProbe(ctx),
+      }));
       if (!picked) {
         ctx.display.dim('Model unchanged.');
         return {};

--- a/cli/v4/commands/modelPicker.ts
+++ b/cli/v4/commands/modelPicker.ts
@@ -35,6 +35,13 @@ import type { FetchModelsResult } from '../../../core/v4/providers/modelFetch';
 import { termWidth } from '../../../core/v4/ui/theme';
 
 export type ProviderTier = 'pro' | 'free' | 'paid' | 'local' | 'subscription';
+export type ProviderAccessState =
+  | 'not_configured'
+  | 'authentication_missing'
+  | 'authentication_expired'
+  | 'authentication_valid'
+  | 'readiness_verified'
+  | 'readiness_failed';
 
 export interface ModelPickerOptions {
   resolver: RuntimeResolver;
@@ -58,7 +65,7 @@ export interface ModelPickerOptions {
    * "everyone is authed" when omitted, which keeps existing tests
    * and the `aiden model` CLI path working without extra plumbing.
    */
-  isProviderAuthed?: (providerId: string) => boolean;
+  isProviderAuthed?: (providerId: string) => boolean | ProviderAccessState | Promise<boolean | ProviderAccessState>;
   /** Live local-inventory seam. Production uses global fetch. */
   fetchImpl?: typeof fetch;
   ollamaBaseUrl?: string;
@@ -91,27 +98,31 @@ const CANCEL_VALUE = '__cancel__';
 const OLLAMA_UNAVAILABLE_VALUE = '__ollama_unavailable__';
 
 /** Auth badge rendered into stage-1 provider rows. */
-function authBadge(entry: ProviderRegistryEntry, authed: boolean): string {
-  if (authed) {
-    // OAuth providers note that authed-state means a stored token, not
-    // an env-var key — useful for users debugging "where did my creds
-    // come from".
-    return entry.oauth ? '✓ authed (OAuth)' : '✓ authed';
+function authBadge(entry: ProviderRegistryEntry, access: boolean | ProviderAccessState): string {
+  const state: ProviderAccessState = typeof access === 'boolean'
+    ? access ? 'authentication_valid' : 'authentication_missing'
+    : access;
+  switch (state) {
+    case 'readiness_verified': return '✓ ready';
+    case 'readiness_failed': return '⚠ readiness failed';
+    case 'authentication_expired': return '⚠ authentication expired';
+    case 'authentication_valid': return entry.oauth ? '✓ auth valid (OAuth)' : '✓ auth valid';
+    case 'not_configured': return '⚠ not configured';
+    case 'authentication_missing':
+      if (entry.tier === 'local') return '⚠ no daemon';
+      return entry.oauth ? '⚠ authentication missing' : '⚠ no API key';
   }
-  if (entry.tier === 'local') return '⚠ no daemon';
-  if (entry.oauth) return '⚠ not signed in';
-  return '⚠ no API key';
 }
 
 /** Map a provider entry to a stage-1 picker row. */
 function providerChoice(
   entry: ProviderRegistryEntry,
   modelCount: number,
-  authed: boolean,
+  access: boolean | ProviderAccessState,
   isCurrent: boolean,
 ): { name: string; value: string; description?: string } {
   const badge = TIER_BADGE[entry.tier] ?? entry.tier;
-  const ab = authBadge(entry, authed);
+  const ab = authBadge(entry, access);
   const count = `(${modelCount} model${modelCount === 1 ? '' : 's'})`;
   const current = isCurrent ? '  ← current' : '';
   return {
@@ -307,7 +318,7 @@ export async function runModelPicker(
         ? `⚙ Model Picker — Select Provider · ${hintParts.join(' · ')}`
         : '⚙ Model Picker — Select Provider';
 
-    const providerChoices = providerEntries.map((e) => {
+    const providerChoices = await Promise.all(providerEntries.map(async (e) => {
       const localModels = e.id === 'ollama' && ollamaInventory
         ? ollamaInventory.models
         : null;
@@ -319,10 +330,10 @@ export async function runModelPicker(
       return providerChoice(
         e,
         localModels?.length ?? listModelsForProvider(e.id).length,
-        isAuthed(e.id),
+        await isAuthed(e.id),
         e.id === currentProviderId && currentInstalled,
       );
-    });
+    }));
     providerChoices.push({ name: 'Cancel', value: CANCEL_VALUE });
 
     let providerId: string;

--- a/cli/v4/commands/setup.ts
+++ b/cli/v4/commands/setup.ts
@@ -12,14 +12,13 @@
  * "Skip — explore Aiden first" branch) where the user has decided
  * they want to actually configure a provider after looking around.
  *
- * After the wizard returns, we tell the user to restart Aiden so
- * the new provider/model is picked up — hot-swapping the provider
- * adapter inside an in-flight session is v4.1 territory and would
- * require rebuilding the AidenAgent's provider field, the fallback
- * chain, and the chatSession's currentProviderId in lockstep.
+ * After the wizard returns, the session rebuilds the selected provider
+ * adapter before swapping it in. A failed rebuild leaves the prior working
+ * provider untouched.
  */
 import type { SlashCommand } from '../commandRegistry';
 import { runSetupWizard } from '../setupWizard';
+import { runtimeTrace } from '../../../core/v4/runtimeTrace';
 
 export const setup: SlashCommand = {
   name: 'setup',
@@ -34,16 +33,42 @@ export const setup: SlashCommand = {
       );
       return;
     }
-    const result = await runSetupWizard({
-      paths: ctx.paths,
+    const result = await ctx.display.withModalLease('setup', () => runSetupWizard({
+      paths: ctx.paths!,
       display: ctx.display,
       force: true,
-    });
+    }));
     if (result.status === 'configured' && result.ran) {
-      ctx.display.write(
-        '\nProvider configured. ' +
-          'Restart Aiden (`/quit` then re-run `aiden`) to pick up the new provider.\n\n',
-      );
+      const providerId = result.config?.model.provider;
+      const modelId = result.config?.model.modelId;
+      runtimeTrace('provider', 'setup.completed', {
+        providerId: providerId ?? null,
+        modelId: modelId ?? null,
+        readiness: result.readiness?.state ?? null,
+      });
+      if (!providerId || !modelId || !ctx.session) {
+        ctx.display.printError(
+          'Provider was saved but could not activate in this session.',
+          'The previous provider remains active; run /model to retry activation.',
+        );
+        return;
+      }
+      try {
+        await ctx.session.setProvider(providerId, modelId);
+        runtimeTrace('provider', 'adapter.rebuilt', { providerId, modelId, activated: true });
+        ctx.display.write(`\nProvider configured and active: ${providerId}:${modelId}.\n\n`);
+      } catch (error) {
+        runtimeTrace('provider', 'adapter.rebuilt', {
+          providerId,
+          modelId,
+          activated: false,
+          errorKind: error instanceof Error ? error.name : 'unknown',
+        });
+        ctx.display.printError(
+          'Provider was configured but could not activate in this session.',
+          'The previous provider remains active; check readiness and run /model to retry.',
+        );
+      }
     } else if (result.status === 'skipped') {
       ctx.display.write(
         '\nStill in explore mode. Run /setup again whenever you\'re ready.\n\n',

--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -530,8 +530,9 @@ export class BottomRegion {
 
   /** Move the transcript viewport away from or toward the live tail. */
   scrollTranscript(deltaRows: number): void {
+    const maximum = this.maxTranscriptScrollOffset(this.surface());
     this.projection = reduceOperatorProjection(this.projection, {
-      type: 'viewport.scroll', delta: deltaRows,
+      type: 'viewport.scroll', delta: deltaRows, maxOffset: maximum,
     });
     if (this.active) this.paintAll(true);
   }
@@ -741,6 +742,23 @@ export class BottomRegion {
     return `${sequence}${ESC}[${cursorRow};${cursorCol}H${SAVE_TRANSCRIPT}`;
   }
 
+  private maxTranscriptScrollOffset(surface: RenderedSurface): number {
+    const bottom = Math.max(0, this.sink.rows() - surface.laneRows);
+    const source = visibleTranscriptSource(this.projection);
+    const width = Math.max(1, this.sink.cols() - 1);
+    const rows = wrapTranscriptText(source, width);
+    const capacity = Math.max(0, bottom - (source.endsWith('\n') ? 1 : 0));
+    return Math.max(0, rows.length - capacity);
+  }
+
+  private clampTranscriptScrollOffset(surface: RenderedSurface): void {
+    this.projection = reduceOperatorProjection(this.projection, {
+      type: 'viewport.scroll',
+      delta: 0,
+      maxOffset: this.maxTranscriptScrollOffset(surface),
+    });
+  }
+
   private clearOwnedRows(count: number): string {
     let sequence = '';
     for (let offset = Math.max(1, count) - 1; offset >= 0; offset -= 1) {
@@ -870,6 +888,7 @@ export class BottomRegion {
       type: 'viewport.measure', width: this.sink.cols(), height: this.sink.rows(),
     });
     const surface = this.surface();
+    this.clampTranscriptScrollOffset(surface);
     const frame = surface.lines.join('\n');
     const geometry = this.establishGeometry(surface.laneRows);
     if (!geometry && frame === this.lastFrame && !rebuildTranscript) {
@@ -897,6 +916,7 @@ export class BottomRegion {
       type: 'viewport.measure', width: this.sink.cols(), height: this.sink.rows(),
     });
     const surface = this.surface();
+    this.clampTranscriptScrollOffset(surface);
     this.laneRows = surface.laneRows;
     this.geometry = {
       rows: this.sink.rows(),
@@ -959,6 +979,7 @@ export class BottomRegion {
       type: 'viewport.measure', width: this.sink.cols(), height: this.sink.rows(),
     });
     const surface = this.surface();
+    this.clampTranscriptScrollOffset(surface);
     this.laneRows = surface.laneRows;
     const nextGeometry: SurfaceGeometry = {
       rows: this.sink.rows(),

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -2958,7 +2958,6 @@ export class Display {
       this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
       this.streamProjectionHeaderPending = true;
       this.streamProjectionActivityDividerPending = projectedOwner !== null && activityDivider;
-      this.uiEventsFiredThisTurn = false;
       // agentHeader emits trailing `\n\n`; cursor is at col 0 of a fresh
       // line, so the very next chunk needs the leading indent.
       this.streamLastEndedNewline = true;
@@ -3082,14 +3081,6 @@ export class Display {
     if (!this.out.isTTY) return;
     if (process.env.AIDEN_NO_REFORMAT === '1') return;
     if (lines === 0) return;
-    // v4.8.0 Phase 2.3 fix — when ui_* events painted this turn, skip the
-    // cursor-up + erase-to-end-of-screen rerender. The eraser wipes
-    // anything below where the stream started, including our event rows.
-    // Tradeoff: assistant text on a ui-event turn stays raw (no in-place
-    // markdown beautification). Acceptable — when the model is using
-    // structured ui events, it's signalling state, not relying on prose
-    // formatting.
-    if (this.uiEventsFiredThisTurn) return;
     // Cheap structural heuristic — only re-render when formatting
     // actually helps. Plain prose chunks stay raw (no flicker).
     //
@@ -3253,7 +3244,6 @@ export class Display {
       this.streamHeaderShown = false;
       this.streamLastEndedNewline = false;
       this.streamProjectionHeaderPending = false;
-      this.uiEventsFiredThisTurn = false;
       return;
     }
     if (!this.streamLastEndedNewline) {
@@ -3270,8 +3260,6 @@ export class Display {
     this.streamLineCount = 0;
     this.streamHeaderShown = false;
     this.streamLastEndedNewline = false;
-    // v4.8.0 Phase 2.3 fix — turn ends; clear the ui-fired flag.
-    this.uiEventsFiredThisTurn = false;
   }
 
   /**
@@ -3315,12 +3303,6 @@ export class Display {
   private uiTaskTerminalIds = new Set<string>();
   private structuredActivityIds = new Set<string>();
 
-  // v4.8.0 Phase 2.3 fix — set true by renderUiEvent; tryRerenderInPlace
-  // early-returns when set so the cursor-up + erase-to-end-of-screen
-  // sequence can't wipe our ui_* rows. Reset at stream lifecycle
-  // boundaries (streamPartial first-delta init + streamComplete).
-  private uiEventsFiredThisTurn = false;
-
   /** Render semantic ui_* events. Stable task IDs replace active cards in place. */
   /**
    * v4.8.0 Phase 2.3 fix-2 — reset the per-turn ui-event flag. Called
@@ -3331,19 +3313,11 @@ export class Display {
    * authoritative reset for turn-start.
    */
   resetUiTurnState(): void {
-    this.uiEventsFiredThisTurn = false;
     this.structuredActivityIds.clear();
   }
 
   renderUiEvent(name: string, args: Record<string, unknown>): void {
     if (!this.out.isTTY) return;
-    // v4.8.0 Phase 2.3 fix — Option C. The post-stream markdown rerender
-    // (`tryRerenderInPlace`) does `cursor-up-N + erase-to-end-of-screen`,
-    // which wipes anything painted between stream start and stream end —
-    // including our ui_* rows. Mark the turn so the rerender skips this
-    // turn entirely. Resets when the next streaming turn begins (see
-    // streamPartial header init) and on streamComplete cleanup.
-    this.uiEventsFiredThisTurn = true;
     if (name === 'ui_task_update')      { this.renderUiTaskUpdate(args);      return; }
     if (name === 'ui_task_done')        { this.renderUiTaskDone(args);        return; }
     if (name === 'ui_command_result')   { this.renderUiCommandResult(args);   return; }

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -110,6 +110,7 @@ import {
   type LaneSink,
 } from './composerLane';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
+import { runtimeTrace } from '../../core/v4/runtimeTrace';
 import type { ActivitySnapshot } from './activityRegistry';
 import { projectFileEffect, projectRepositoryState } from './effectPresentation';
 import { terminalStateSymbol, terminalSupportsUnicode } from './terminalSymbols';
@@ -455,6 +456,9 @@ export class Display {
   // Modal prompts need the full terminal surface while they own stdin. This
   // depth pauses only composer painting and retains the exact draft/hint.
   private composerSurfacePauseDepth = 0;
+  private nextModalLeaseId = 0;
+  private activeModalLeases = new Set<number>();
+  private semanticDocumentRevision = 0;
   private nextLiveRowIdentity = 0;
   private activityPresentationMode: ActivityPresentationMode = 'summary';
 
@@ -2334,6 +2338,7 @@ export class Display {
 
   /** Write modal-only chrome without adding it to transcript projection. */
   writeTransient(text: string): void {
+    this.traceTerminalWrite('modal', text, 'stdout');
     this.out.write(text);
   }
 
@@ -2346,6 +2351,7 @@ export class Display {
       this.composerLane.writeAfterCursor(text);
       return;
     }
+    this.traceTerminalWrite('after-composer-cursor', text, 'stdout');
     this.out.write(text);
   }
 
@@ -2354,16 +2360,32 @@ export class Display {
       this.composerLane.writeAbove(text);
       return;
     }
+    this.traceTerminalWrite('error', text, 'stderr');
     this.err.write(text);
   }
 
   /** Route flowing output through the fixed-region owner while it is active. */
   private writeOutput(text: string): void {
+    this.traceTerminalWrite('display', text, 'stdout');
     if (this.composerLane) {
       this.composerLane.writeAbove(text);
       return;
     }
     this.out.write(text);
+  }
+
+  private traceTerminalWrite(writer: string, text: string, target: 'stdout' | 'stderr'): void {
+    this.semanticDocumentRevision += 1;
+    runtimeTrace('display', 'terminal.write', {
+      writer,
+      target,
+      revision: this.semanticDocumentRevision,
+      width: this.out.columns ?? null,
+      height: this.out.rows ?? null,
+      emittedRows: text.length === 0 ? 0 : text.split('\n').length,
+      clearOperations: (text.match(/\x1b\[(?:2K|J|[0-9]+M)/g) ?? []).length,
+      controlSequence: /\x1b\[/.test(text),
+    });
   }
 
   // ── v4.12.1 Pillar 4 Slice 2c — live composer surface ────────────────────
@@ -2559,7 +2581,7 @@ export class Display {
       off?: (e: string, fn: () => void) => unknown;
     };
     return {
-      write: (s) => { this.out.write(s); },
+      write: (s) => { this.traceTerminalWrite('composer-lane', s, 'stdout'); this.out.write(s); },
       rows: () => (typeof this.out.rows === 'number' && this.out.rows >= 1 ? this.out.rows : 24),
       cols: () => (typeof this.out.columns === 'number' && this.out.columns >= 1 ? this.out.columns : 80),
       onResize: (fn) => { stream.on?.('resize', fn); return () => { stream.off?.('resize', fn); }; },
@@ -2809,6 +2831,8 @@ export class Display {
   // — the post-stream pass clears it via cursor-up + erase-line and
   // reprints the formatted output.
   private streamBuffer = '';
+  /** Complete raw assistant source for the current projected turn. */
+  private streamDocumentBuffer = '';
   private streamLineCount = 0;
   private streamProjectionSequence = 0;
   private streamProjectionId = '';
@@ -2838,6 +2862,58 @@ export class Display {
 
   removeDurableActivity(id: string): void {
     this.composerLane?.removeLiveRow(`durable:${id}`);
+  }
+
+  /** Acquire exclusive ownership for an interactive modal prompt. */
+  acquireModalLease(owner: string): { release: () => void } {
+    const id = ++this.nextModalLeaseId;
+    this.activeModalLeases.add(id);
+    runtimeTrace('display', 'modal.acquire', {
+      owner,
+      leaseId: id,
+      width: this.out.columns ?? null,
+      height: this.out.rows ?? null,
+    });
+    this.pauseComposerSurface();
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        this.activeModalLeases.delete(id);
+        runtimeTrace('display', 'modal.release', {
+          owner,
+          leaseId: id,
+          width: this.out.columns ?? null,
+          height: this.out.rows ?? null,
+        });
+        this.resumeComposerSurface();
+      },
+    };
+  }
+
+  /** Run a modal while preserving and restoring the single owned surface. */
+  async withModalLease<T>(owner: string, run: () => Promise<T>): Promise<T> {
+    const lease = this.acquireModalLease(owner);
+    try {
+      return await run();
+    } finally {
+      lease.release();
+    }
+  }
+
+  /** Resolve only after all preceding terminal writes have been accepted. */
+  async awaitTerminalSettled(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      if (this.out.destroyed) {
+        resolve();
+        return;
+      }
+      this.out.write('', (error?: Error | null) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
   }
 
   progressProjection(id: string): {
@@ -2874,11 +2950,15 @@ export class Display {
       this.composerLane.clearViewport();
       return;
     }
-    if (this.out.isTTY) this.out.write('\x1b[3J\x1b[2J\x1b[H');
+    if (this.out.isTTY) {
+      const clear = '\x1b[3J\x1b[2J\x1b[H';
+      this.traceTerminalWrite('display-clear', clear, 'stdout');
+      this.out.write(clear);
+    }
   }
 
   private projectedStreamText(formatted: boolean): string {
-    let body = this.streamBuffer;
+    let body = this.streamDocumentBuffer;
     if (formatted && body) {
       try {
         body = this.applyFrameToRendered(this.markdown(body).trimEnd());
@@ -2893,14 +2973,17 @@ export class Display {
   }
 
   private settleProjectedStream(owner: ComposerLane): void {
-    if (this.streamBuffer) {
-      owner.settleLiveRow(this.streamProjectionId, this.projectedStreamText(true));
+    if (this.streamDocumentBuffer) {
+      const projectionId = this.streamProjectionId;
+      owner.removeLiveRow(projectionId, true);
+      owner.writeAbove(`${this.projectedStreamText(true)}\n`, `assistant-terminal:${projectionId}`);
       this.streamProjectionHeaderPending = false;
       this.streamProjectionActivityDividerPending = false;
     } else {
       owner.removeLiveRow(this.streamProjectionId, true);
     }
     this.streamBuffer = '';
+    this.streamDocumentBuffer = '';
     this.streamLineCount = 0;
     this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
   }
@@ -2954,6 +3037,7 @@ export class Display {
       }
       this.streamHeaderShown = true;
       this.streamBuffer = '';
+      this.streamDocumentBuffer = '';
       this.streamLineCount = 0;
       this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
       this.streamProjectionHeaderPending = true;
@@ -2964,6 +3048,7 @@ export class Display {
     }
     if (projectedOwner) {
       this.streamBuffer += text;
+      this.streamDocumentBuffer += text;
       this.streamLastEndedNewline = text.endsWith('\n');
       projectedOwner.setLiveRow(this.streamProjectionId, this.projectedStreamText(false));
       return;
@@ -2985,6 +3070,7 @@ export class Display {
     // Phase v4.1-reply-formatting: track buffer + line count for the
     // post-stream re-render.
     this.streamBuffer += text;
+    this.streamDocumentBuffer += text;
     // v4.1.4 reply-quality polish — F-B1 wrap-aware row count.
     //
     // Prior counter just `streamLineCount += text.match(/\n/g)?.length`
@@ -3157,7 +3243,8 @@ export class Display {
     if (!this.streamHeaderShown) return;
     const projectedOwner = this.projectedStreamOwner();
     if (projectedOwner) {
-      this.settleProjectedStream(projectedOwner);
+      projectedOwner.removeLiveRow(this.streamProjectionId);
+      this.streamProjectionId = `assistant-stream:${++this.streamProjectionSequence}`;
       this.streamLastEndedNewline = true;
       return;
     }
@@ -3257,6 +3344,7 @@ export class Display {
     // user-visible body in well-behaved turns.
     this.tryRerenderInPlace(this.streamBuffer, this.streamLineCount);
     this.streamBuffer = '';
+    this.streamDocumentBuffer = '';
     this.streamLineCount = 0;
     this.streamHeaderShown = false;
     this.streamLastEndedNewline = false;

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -2350,6 +2350,10 @@ export class Display {
   }
 
   writeError(text: string): void {
+    if (this.composerSurfacePauseDepth === 0 && this.composerLane?.isActive()) {
+      this.composerLane.writeAbove(text);
+      return;
+    }
     this.err.write(text);
   }
 
@@ -2834,6 +2838,34 @@ export class Display {
 
   removeDurableActivity(id: string): void {
     this.composerLane?.removeLiveRow(`durable:${id}`);
+  }
+
+  progressProjection(id: string): {
+    update(line: string): boolean;
+    clear(): boolean;
+    settle(line: string): boolean;
+  } {
+    const rowId = `progress:${id}`;
+    return {
+      update: (line) => {
+        const owner = this.projectedStreamOwner();
+        if (!owner) return false;
+        owner.setLiveRow(rowId, line);
+        return true;
+      },
+      clear: () => {
+        const owner = this.projectedStreamOwner();
+        if (!owner) return false;
+        owner.removeLiveRow(rowId);
+        return true;
+      },
+      settle: (line) => {
+        const owner = this.projectedStreamOwner();
+        if (!owner) return false;
+        owner.settleLiveRow(rowId, line);
+        return true;
+      },
+    };
   }
 
   /** Clear the visual transcript while retaining composer and status state. */

--- a/cli/v4/display/progressBar.ts
+++ b/cli/v4/display/progressBar.ts
@@ -69,6 +69,12 @@ export interface ProgressBarHandle {
   getTokens(): { output: number; max: number | undefined };
 }
 
+export interface ProgressProjection {
+  update(line: string): boolean;
+  clear(): boolean;
+  settle(line: string): boolean;
+}
+
 /**
  * Number of bar cells. 10 cells gives clean fractions (every 10% of
  * fill ratio == one cell). Wider bars feel noisy at the standard
@@ -106,6 +112,7 @@ const EMPTY  = '░';
 export function createProgressBar(
   out:  NodeJS.WriteStream,
   skin: SkinEngine,
+  projection?: ProgressProjection,
 ): ProgressBarHandle {
   const isTty = !!out.isTTY;
 
@@ -114,6 +121,8 @@ export function createProgressBar(
   let printed     = false;
   let hidden      = false;
   let lastPaintTokens = -1;
+  let projected = false;
+  let rawPrinted = false;
 
   const buildLine = (): string => {
     // Fill ratio: 0..1, then snap to a cell count 0..BAR_CELLS.
@@ -149,23 +158,32 @@ export function createProgressBar(
 
   const paint = (): void => {
     if (!isTty || hidden) return;
-    if (printed) {
+    const line = buildLine();
+    if (projection?.update(line)) {
+      printed = true;
+      projected = true;
+      lastPaintTokens = outputTokens;
+      return;
+    }
+    if (rawPrinted) {
       // Subsequent paint: walk up to the bar's row, clear it, rewrite,
       // drop a newline so the cursor lands on the row BELOW the bar.
-      out.write(`${ANSI_UP_ERASE}${buildLine()}\n`);
+      out.write(`${ANSI_UP_ERASE}${line}\n`);
     } else {
       // First paint: just write the bar + `\n`. Cursor moves to the
       // row below, ready for subsequent walk-up-and-erase ticks.
-      out.write(`${buildLine()}\n`);
+      out.write(`${line}\n`);
       printed = true;
+      rawPrinted = true;
     }
     lastPaintTokens = outputTokens;
   };
 
   const erase = (): void => {
+    if (projected && projection?.clear()) return;
     // Walk up to the bar's row and clear it. No trailing `\n` — the
     // caller will write content here and include its own newline.
-    if (isTty && printed) out.write(ANSI_UP_ERASE);
+    if (isTty && rawPrinted) out.write(ANSI_UP_ERASE);
   };
 
   return {

--- a/cli/v4/inputAuthority.ts
+++ b/cli/v4/inputAuthority.ts
@@ -5,6 +5,7 @@
 /** Render-free exclusive-input lease for prompts that run during a turn. */
 import type { TurnKey } from './turnInputListener';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
+import { runtimeTrace } from '../../core/v4/runtimeTrace';
 
 export type RawKeyHandler = (str: string | undefined, key: TurnKey) => void;
 export type InputOwner = 'during_turn' | 'approval' | 'skill_prompt' | 'clarify';
@@ -361,9 +362,5 @@ function defaultEmitKeypress(stdin: RawStdinLike): void {
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {
-  if (process.env.AIDEN_P2A_DIAG !== '1') return;
-  try {
-    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
-  } catch { /* diagnostics must never affect input ownership */ }
+  runtimeTrace('input', event, data);
 }

--- a/cli/v4/operatorProjection.ts
+++ b/cli/v4/operatorProjection.ts
@@ -61,7 +61,7 @@ export type OperatorProjectionEvent =
       'succeeded' | 'failed' | 'denied' | 'interrupted' | 'cancelled' | 'timed_out' | 'unknown' | 'stale'>;
       summary: string; endedAt: number }
   | { type: 'activity.remove'; id: string }
-  | { type: 'viewport.scroll'; delta: number }
+  | { type: 'viewport.scroll'; delta: number; maxOffset?: number }
   | { type: 'viewport.follow' }
   | { type: 'viewport.measure'; width: number; height: number };
 
@@ -175,7 +175,13 @@ export function reduceOperatorProjection(
       return { ...state, eventSequence: nextSequence, activities };
     }
     case 'viewport.scroll': {
-      const scrollOffset = Math.max(0, state.viewport.scrollOffset + event.delta);
+      const maximum = event.maxOffset === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, Math.floor(event.maxOffset));
+      const scrollOffset = Math.min(
+        maximum,
+        Math.max(0, state.viewport.scrollOffset + event.delta),
+      );
       return {
         ...state,
         viewport: {

--- a/cli/v4/semanticActivity.ts
+++ b/cli/v4/semanticActivity.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 
 import type { ColorKind } from './skinEngine';
+import { filterPowerShellProgressClixml } from '../../core/v4/powerShellClixml';
+export { filterPowerShellProgressClixml } from '../../core/v4/powerShellClixml';
 
 export type ActivityPresentationMode = 'summary' | 'full';
 
@@ -260,11 +262,6 @@ export function relativizeActivityText(
   return replaced.replace(/\\/gu, '/');
 }
 
-function isPowerShellProgressClixml(value: string): boolean {
-  const text = value.trim();
-  return /^#< CLIXML\s*<Objs\b[\s\S]*<Obj\b[^>]*\bS="progress"[\s\S]*<PR\b[\s\S]*<\/Objs>$/u.test(text);
-}
-
 function isGitLineEndingNotice(value: string): boolean {
   const text = value.trim();
   if (!text) return false;
@@ -289,14 +286,16 @@ export interface CommandPresentation {
 
 export function projectCommandPresentation(input: CommandPresentationInput): CommandPresentation {
   const command = input.command.trim() || 'command';
-  const details = [input.stdout, input.stderr].filter(Boolean).join('\n');
-  const progressNoise = input.exitCode === 0 && isPowerShellProgressClixml(input.stderr);
-  const lineEndingNoise = input.exitCode === 0 && isGitLineEndingNotice(input.stderr);
+  const progress = filterPowerShellProgressClixml(input.stderr);
+  const stderr = progress.stderr;
+  const details = [input.stdout, stderr].filter(Boolean).join('\n');
+  const progressNoise = progress.removedProgress;
+  const lineEndingNoise = input.exitCode === 0 && isGitLineEndingNotice(stderr);
 
   if (input.mode === 'full') {
     const lines = [`${input.exitCode === 0 ? '✓' : '✕'} ${command} — ${input.exitCode === 0 ? 'completed' : 'failed'}`];
     if (input.stdout) lines.push(...input.stdout.split(/\r?\n/u));
-    if (input.stderr) lines.push(...input.stderr.split(/\r?\n/u));
+    if (stderr) lines.push(...stderr.split(/\r?\n/u));
     if (input.exitCode !== 0) lines.push(`exit ${input.exitCode}`);
     return { lines, details, outcome: input.exitCode === 0 ? 'success' : 'failure' };
   }
@@ -305,14 +304,14 @@ export function projectCommandPresentation(input: CommandPresentationInput): Com
     const lines = [`✓ ${command} — completed`];
     if (progressNoise) lines.push('! PowerShell emitted progress metadata; ignored');
     else if (lineEndingNoise) lines.push('! Git line-ending notice available');
-    else if (input.stderr.trim()) lines.push(...input.stderr.split(/\r?\n/u).slice(0, 5));
+    else if (stderr.trim()) lines.push(...stderr.split(/\r?\n/u).slice(0, 5));
     if (/^git\s+diff\b/iu.test(command) && input.stdout.trim()) lines.push(...compactDiffLines(input.stdout));
-    return { lines, details, outcome: progressNoise || lineEndingNoise || input.stderr.trim() ? 'warning' : 'success' };
+    return { lines, details, outcome: progressNoise || lineEndingNoise || stderr.trim() ? 'warning' : 'success' };
   }
 
   const diagnostics = [
     ...input.stdout.split(/\r?\n/u).filter(Boolean).slice(0, 5),
-    ...input.stderr.split(/\r?\n/u).filter(Boolean).slice(0, 5),
+    ...stderr.split(/\r?\n/u).filter(Boolean).slice(0, 5),
   ];
   return {
     lines: [`✕ ${command} — failed`, ...diagnostics, `exit ${input.exitCode}`],

--- a/cli/v4/turnIdleDiagnostics.ts
+++ b/cli/v4/turnIdleDiagnostics.ts
@@ -27,10 +27,6 @@ export function turnIdleDiagnostic(event: string, data: Record<string, unknown> 
       ...data,
     })}\n`;
     const diagnosticFile = process.env.AIDEN_TEST_TURN_IDLE_DIAG_FILE;
-    if (diagnosticFile) {
-      appendFileSync(diagnosticFile, line, 'utf8');
-    } else {
-      process.stderr.write(line);
-    }
+    if (diagnosticFile) appendFileSync(diagnosticFile, line, 'utf8');
   } catch { /* test diagnostics must not affect the terminal lifecycle */ }
 }

--- a/cli/v4/ui/progressBar.ts
+++ b/cli/v4/ui/progressBar.ts
@@ -12,6 +12,7 @@
  */
 
 import { Writable } from 'node:stream';
+import type { ProgressProjection } from '../display/progressBar';
 
 export interface ProgressBarOptions {
   /** Top-line label, e.g. "Installing aiden-runtime v4.9.1...". */
@@ -28,6 +29,7 @@ export interface ProgressBarOptions {
   env?:     NodeJS.ProcessEnv;
   /** Render-tick interval (ms). Default 100. */
   tickMs?:  number;
+  projection?: ProgressProjection;
 }
 
 export interface ProgressBar {
@@ -126,28 +128,39 @@ export function startProgressBar(opts: ProgressBarOptions): ProgressBar {
   let phase   = opts.phases[0] ?? '';
   let percent = 0;
   let painted = false;
+  let projected = false;
   let closed  = false;
 
   const write = (s: string): void => {
     try { out.write(s); } catch { /* swallow — never break caller */ }
   };
+  const update = (s: string): boolean => opts.projection?.update(s) ?? false;
+  const settle = (s: string): boolean => opts.projection?.settle(s) ?? false;
 
   // SIGINT: restore cursor + clear the partial line before bubbling.
   const onSigint = (): void => {
-    try { write(ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR); } catch { /* noop */ }
+    if (!projected) {
+      try { write(ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR); } catch { /* noop */ }
+    }
   };
   if (mode.animated) {
     try { process.once('SIGINT', onSigint); } catch { /* noop */ }
   }
 
   // Label line paints once, immediately.
-  write(`${mode.color ? ANSI_MUTED : ''}${opts.label}${mode.color ? ANSI_RESET : ''}\n`);
+  const label = `${mode.color ? ANSI_MUTED : ''}${opts.label}${mode.color ? ANSI_RESET : ''}`;
+  if (!update(label)) write(`${label}\n`);
 
   const paint = (): void => {
     if (closed) return;
     const elapsedMs = Date.now() - startedAt;
     if (elapsedMs < PAINT_AFTER_MS) return;
     const line = renderLine({ width, percent, phase, elapsedMs, mode });
+    if (update(line)) {
+      painted = true;
+      projected = true;
+      return;
+    }
     if (mode.animated) {
       if (!painted) { write(ANSI_HIDE_CURSOR); painted = true; }
       write(ANSI_CLEAR_LINE + line);
@@ -169,9 +182,10 @@ export function startProgressBar(opts: ProgressBarOptions): ProgressBar {
     const finalLine = mode.color
       ? `${color}${icon}${ANSI_RESET} ${message}`
       : `${icon} ${message}`;
-    if (mode.animated && painted) write(ANSI_CLEAR_LINE);
+    if (settle(finalLine)) return;
+    if (mode.animated && painted && !projected) write(ANSI_CLEAR_LINE);
     write(finalLine + '\n');
-    if (mode.animated) write(ANSI_SHOW_CURSOR);
+    if (mode.animated && !projected) write(ANSI_SHOW_CURSOR);
   };
 
   return {
@@ -198,11 +212,14 @@ export function startPhaseIndicator(opts: ProgressBarOptions): PhaseIndicator {
   let frame = 0;
   let phase = opts.phases[0] ?? 'working';
   let painted = false;
+  let projected = false;
   let closed = false;
 
   const write = (value: string): void => {
     try { out.write(value); } catch { /* output failure must not break update */ }
   };
+  const update = (value: string): boolean => opts.projection?.update(value) ?? false;
+  const settle = (value: string): boolean => opts.projection?.settle(value) ?? false;
   const format = (): string => {
     const elapsed = `${((Date.now() - startedAt) / 1_000).toFixed(1)}s`;
     const glyph = frames[frame++ % frames.length];
@@ -213,6 +230,11 @@ export function startPhaseIndicator(opts: ProgressBarOptions): PhaseIndicator {
   const paint = (): void => {
     if (closed) return;
     const line = format();
+    if (update(line)) {
+      painted = true;
+      projected = true;
+      return;
+    }
     if (mode.animated) {
       if (!painted) {
         write(ANSI_HIDE_CURSOR);
@@ -224,11 +246,12 @@ export function startPhaseIndicator(opts: ProgressBarOptions): PhaseIndicator {
     }
   };
   const onSigint = (): void => {
-    if (mode.animated && painted) write(ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR);
+    if (mode.animated && painted && !projected) write(ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR);
   };
   if (mode.animated) process.once('SIGINT', onSigint);
 
-  write(`${mode.color ? ANSI_MUTED : ''}${opts.label}${mode.color ? ANSI_RESET : ''}\n`);
+  const label = `${mode.color ? ANSI_MUTED : ''}${opts.label}${mode.color ? ANSI_RESET : ''}`;
+  if (!update(label)) write(`${label}\n`);
   paint();
   const timer = mode.animated ? setInterval(paint, tickMs) : null;
   timer?.unref?.();
@@ -238,12 +261,13 @@ export function startPhaseIndicator(opts: ProgressBarOptions): PhaseIndicator {
     closed = true;
     if (timer) clearInterval(timer);
     process.removeListener('SIGINT', onSigint);
-    if (mode.animated && painted) write(ANSI_CLEAR_LINE);
+    if (mode.animated && painted && !projected) write(ANSI_CLEAR_LINE);
     const line = mode.color
       ? `${color}${icon}${ANSI_RESET} ${message}`
       : `${icon} ${message}`;
+    if (settle(line)) return;
     write(line + '\n');
-    if (mode.animated) write(ANSI_SHOW_CURSOR);
+    if (mode.animated && !projected) write(ANSI_SHOW_CURSOR);
   };
 
   return {

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -1420,13 +1420,8 @@ export class AidenAgent {
     const failureClassifier = buildDefaultClassifier();
     let toolLoopCard: AidenAgentResult['toolLoopCard'] = undefined;
 
-    // v4.11 perf — opt-in per-iteration timing. Zero-overhead when the
-    // env var is unset (one `process.env` read per iteration entry).
-    // Stderr bypasses any frame/display guards; format `[perf:...]`
-    // greps cleanly out of the test runner / smoke logs.
-    const _perfDiag = process.env.AIDEN_PERF_DIAG === '1';
+    // Phase timings use the optional file-only runtime trace sink.
     while (true) {
-      const _iterStartedAt = _perfDiag ? Date.now() : 0;
       // v4.6 prep — between-iteration cooperative-cancellation check.
       // When the caller passed an AbortSignal that has aborted, exit
       // immediately with `finishReason: 'interrupted'`. Delta accumulation
@@ -1573,7 +1568,13 @@ export class AidenAgent {
       const providerRunOptions = deferApprovalStream
         ? { ...runOptions, onFirstDelta: undefined, onDelta: undefined }
         : runOptions;
-      const _llmStartedAt = _perfDiag ? Date.now() : 0;
+      const _llmStartedAt = Date.now();
+      runtimeTrace('performance', 'provider.request', {
+        iteration: turnCount,
+        provider: this.providerId ?? 'unknown',
+        model: this.modelId ?? 'unknown',
+        messageCount: messages.length,
+      });
       p2aDiag('provider.continuation.start', {
         iteration: turnCount,
         continuation: turnCount > 1,
@@ -1626,19 +1627,13 @@ export class AidenAgent {
           finishReason: output.finishReason,
           aborted: runOptions.signal?.aborted === true,
         });
-        if (_perfDiag) {
-          const llmMs = Date.now() - _llmStartedAt;
-          const tokIn = output.usage?.inputTokens ?? 0;
-          const tokOut = output.usage?.outputTokens ?? 0;
-          const nTools = output.toolCalls?.length ?? 0;
-          runtimeTrace('performance', 'provider.complete', {
-            iteration: turnCount + 1,
-            durationMs: llmMs,
-            inputTokens: tokIn,
-            outputTokens: tokOut,
-            toolCallCount: nTools,
-          });
-        }
+        runtimeTrace('performance', 'provider.complete', {
+          iteration: turnCount,
+          durationMs: Date.now() - _llmStartedAt,
+          inputTokens: output.usage?.inputTokens ?? 0,
+          outputTokens: output.usage?.outputTokens ?? 0,
+          toolCallCount: output.toolCalls?.length ?? 0,
+        });
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         // v4.6 prep — external abort takes priority over fallback. An
@@ -1938,10 +1933,21 @@ export class AidenAgent {
         let attemptNo = 0;
         let aggregateTiming: ToolActivityTiming | undefined;
         let afterFired = false;
+        runtimeTrace('performance', 'tool.admitted', {
+          iteration: turnCount,
+          toolCallId: call.id,
+          tool: call.name,
+        });
         try {
           for (;;) {
             attemptNo += 1;
-            const _toolStartedAt = _perfDiag ? Date.now() : 0;
+            const _toolStartedAt = Date.now();
+            runtimeTrace('performance', 'tool.start', {
+              iteration: turnCount,
+              toolCallId: call.id,
+              tool: call.name,
+              attempt: attemptNo,
+            });
             if (blockedByRequiredClarification) {
               const question = this.pendingRequiredClarification?.question ?? 'required information';
               result = {
@@ -1976,24 +1982,26 @@ export class AidenAgent {
             }
             aggregateTiming = mergeActivityTiming(aggregateTiming, result.activityTiming);
             if (aggregateTiming) result.activityTiming = aggregateTiming;
-            if (_perfDiag) {
-              const toolMs = Date.now() - _toolStartedAt;
-              const ok = result.error == null;
-              const src = attemptNo === 1 && _preComputed ? 'parallel' : 'live';
-              runtimeTrace('performance', 'tool.complete', {
-                iteration: turnCount + 1,
-                tool: call.name,
-                durationMs: toolMs,
-                source: src,
-                ok,
-                attempt: attemptNo,
-              });
-            }
+            runtimeTrace('performance', 'tool.complete', {
+              iteration: turnCount,
+              toolCallId: call.id,
+              tool: call.name,
+              durationMs: Date.now() - _toolStartedAt,
+              source: attemptNo === 1 && _preComputed ? 'parallel' : 'live',
+              ok: result.error == null,
+              attempt: attemptNo,
+            });
             // v4.11 Slice 1 (verifier→honesty bridge) — compute the
             // per-tool verification ALWAYS (pure/synchronous) so the
             // post-loop honesty footer reflects real outcomes independent
             // of whether TCE/recovery is active.
             const verificationStartedAt = Date.now();
+            runtimeTrace('performance', 'verification.start', {
+              iteration: turnCount,
+              toolCallId: call.id,
+              tool: call.name,
+              attempt: attemptNo,
+            });
             if (aggregateTiming) {
               aggregateTiming.verificationStartedAt = verificationStartedAt;
               try {
@@ -2018,6 +2026,14 @@ export class AidenAgent {
               recordDurableToolVerification(call.id, verification);
             }
             const verificationEndedAt = Date.now();
+            runtimeTrace('performance', 'verification.end', {
+              iteration: turnCount,
+              toolCallId: call.id,
+              tool: call.name,
+              attempt: attemptNo,
+              durationMs: verificationEndedAt - verificationStartedAt,
+              verified: verification?.ok ?? null,
+            });
             if (aggregateTiming) {
               aggregateTiming.verificationEndedAt = verificationEndedAt;
               aggregateTiming.verificationDurationMs =

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -1,3 +1,5 @@
+import { runtimeTrace } from './runtimeTrace';
+
 /**
  * Aiden v4 — local-first AI agent
  * Copyright (C) 2026 Shiva Deore (Taracod)
@@ -1629,9 +1631,13 @@ export class AidenAgent {
           const tokIn = output.usage?.inputTokens ?? 0;
           const tokOut = output.usage?.outputTokens ?? 0;
           const nTools = output.toolCalls?.length ?? 0;
-          process.stderr.write(
-            `[perf:iter=${turnCount + 1} llm=${llmMs}ms tokens_in=${tokIn} tokens_out=${tokOut} toolCalls=${nTools}]\n`,
-          );
+          runtimeTrace('performance', 'provider.complete', {
+            iteration: turnCount + 1,
+            durationMs: llmMs,
+            inputTokens: tokIn,
+            outputTokens: tokOut,
+            toolCallCount: nTools,
+          });
         }
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
@@ -1974,9 +1980,14 @@ export class AidenAgent {
               const toolMs = Date.now() - _toolStartedAt;
               const ok = result.error == null;
               const src = attemptNo === 1 && _preComputed ? 'parallel' : 'live';
-              process.stderr.write(
-                `[perf:iter=${turnCount + 1} tool=${call.name} ms=${toolMs} src=${src} ok=${ok} attempt=${attemptNo}]\n`,
-              );
+              runtimeTrace('performance', 'tool.complete', {
+                iteration: turnCount + 1,
+                tool: call.name,
+                durationMs: toolMs,
+                source: src,
+                ok,
+                attempt: attemptNo,
+              });
             }
             // v4.11 Slice 1 (verifier→honesty bridge) — compute the
             // per-tool verification ALWAYS (pure/synchronous) so the
@@ -2810,11 +2821,7 @@ function lastUserMessageContent(history: Message[]): string {
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {
-  if (process.env.AIDEN_P2A_DIAG !== '1') return;
-  try {
-    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
-  } catch { /* diagnostics must never affect the agent loop */ }
+  runtimeTrace('agent-loop', event, data);
 }
 
 function resolvesPendingClarification(content: string): boolean {

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -1,4 +1,4 @@
-import { runtimeTrace } from './runtimeTrace';
+import { runtimeTrace, writeNonInteractiveDiagnostic } from './runtimeTrace';
 
 /**
  * Aiden v4 — local-first AI agent
@@ -1627,13 +1627,19 @@ export class AidenAgent {
           finishReason: output.finishReason,
           aborted: runOptions.signal?.aborted === true,
         });
+        const llmMs = Date.now() - _llmStartedAt;
         runtimeTrace('performance', 'provider.complete', {
           iteration: turnCount,
-          durationMs: Date.now() - _llmStartedAt,
+          durationMs: llmMs,
           inputTokens: output.usage?.inputTokens ?? 0,
           outputTokens: output.usage?.outputTokens ?? 0,
           toolCallCount: output.toolCalls?.length ?? 0,
         });
+        if (process.env.AIDEN_PERF_DIAG === '1') {
+          writeNonInteractiveDiagnostic(
+            `[perf:iter=${turnCount + 1} llm=${llmMs}ms tokens_in=${output.usage?.inputTokens ?? 0} tokens_out=${output.usage?.outputTokens ?? 0} toolCalls=${output.toolCalls?.length ?? 0}]`,
+          );
+        }
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         // v4.6 prep — external abort takes priority over fallback. An
@@ -1982,15 +1988,22 @@ export class AidenAgent {
             }
             aggregateTiming = mergeActivityTiming(aggregateTiming, result.activityTiming);
             if (aggregateTiming) result.activityTiming = aggregateTiming;
+            const toolMs = Date.now() - _toolStartedAt;
+            const source = attemptNo === 1 && _preComputed ? 'parallel' : 'live';
             runtimeTrace('performance', 'tool.complete', {
               iteration: turnCount,
               toolCallId: call.id,
               tool: call.name,
-              durationMs: Date.now() - _toolStartedAt,
-              source: attemptNo === 1 && _preComputed ? 'parallel' : 'live',
+              durationMs: toolMs,
+              source,
               ok: result.error == null,
               attempt: attemptNo,
             });
+            if (process.env.AIDEN_PERF_DIAG === '1') {
+              writeNonInteractiveDiagnostic(
+                `[perf:iter=${turnCount + 1} tool=${call.name} ms=${toolMs} src=${source} ok=${result.error == null} attempt=${attemptNo}]`,
+              );
+            }
             // v4.11 Slice 1 (verifier→honesty bridge) — compute the
             // per-tool verification ALWAYS (pure/synchronous) so the
             // post-loop honesty footer reflects real outcomes independent

--- a/core/v4/daemon/db/migrations.ts
+++ b/core/v4/daemon/db/migrations.ts
@@ -2288,6 +2288,13 @@ function applyV41(db: Database.Database): void {
   ]);
 }
 
+/** Exact durable Effect bindings for proof Claims. */
+function applyV42(db: Database.Database): void {
+  addMissingColumns(db, 'job_claims', [
+    ['effect_ids_json', "TEXT NOT NULL DEFAULT '[]'"],
+  ]);
+}
+
 const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 1, name: 'phase 1 — daemon foundation',                  sql: V1_SQL },
   { version: 2, name: 'phase 2 — file watcher observations',          sql: V2_SQL },
@@ -2330,6 +2337,7 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
   { version: 39, name: 'Worker provider restart and reconciliation', apply: applyV39 },
   { version: 40, name: 'bounded parallel read-only Worker groups', apply: applyV40 },
   { version: 41, name: 'durable TriggerBus claim fencing', apply: applyV41 },
+  { version: 42, name: 'exact Claim Effect bindings', apply: applyV42 },
 ];
 
 export const LATEST_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1].version;

--- a/core/v4/daemon/dispatcher/agentRunner.ts
+++ b/core/v4/daemon/dispatcher/agentRunner.ts
@@ -114,6 +114,7 @@ export interface DaemonAgentResult {
 /** The function-shaped agent invocation seam. */
 export interface DaemonAgentRunner {
   invoke(input: DaemonAgentInput): Promise<DaemonAgentResult>;
+  dispose?(reason?: string): Promise<void>;
 }
 
 // ── Pure helpers ───────────────────────────────────────────────────────────

--- a/core/v4/daemon/dispatcher/dispatcher.ts
+++ b/core/v4/daemon/dispatcher/dispatcher.ts
@@ -489,13 +489,22 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
         clearTimeout(_pollTimer);
         _pollTimer = null;
       }
-      // Race in-flight drain against the timeout.
+      // The runner owns canonical lifecycle timers and cancellation. Dispose it
+      // before durable stores close, then wait for every claimed event to drain.
       const drain = Promise.allSettled([..._workerPromises]);
-      const deadline = new Promise<void>((resolve) => {
-        const t = setTimeout(() => resolve(), timeoutMs);
-        if (typeof t.unref === 'function') t.unref();
+      const runnerDisposal = runner?.dispose?.('dispatcher shutdown') ?? Promise.resolve();
+      let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+      const deadline = new Promise<never>((_resolve, reject) => {
+        deadlineTimer = setTimeout(() => reject(new Error(
+          `Dispatcher shutdown timed out with ${_workerPromises.size} lifecycle task(s) still active`,
+        )), timeoutMs);
+        deadlineTimer.unref?.();
       });
-      await Promise.race([drain, deadline]);
+      try {
+        await Promise.race([Promise.all([drain, runnerDisposal]), deadline]);
+      } finally {
+        if (deadlineTimer) clearTimeout(deadlineTimer);
+      }
       log('info', `[dispatcher] stopped — inflight=${_inflight.size} processed=${_stats.claimed}`);
     },
     inflight() {
@@ -505,6 +514,7 @@ export function createDispatcher(opts: CreateDispatcherOptions): Dispatcher {
       return { ..._stats };
     },
     async _pumpOnce() {
+      if (_stopping) return null;
       if (!runner) runner = opts.runnerFactory();
       const event = opts.triggerBus.claim({ ownerId: opts.ownerId, leaseMs });
       if (!event) return null;

--- a/core/v4/daemon/dispatcher/realAgentRunner.ts
+++ b/core/v4/daemon/dispatcher/realAgentRunner.ts
@@ -81,7 +81,12 @@ import { emitArtifactVerified, emitCostUpdated, type PillarEventSink } from '../
 import type { TaskStore } from '../taskStore';
 import type { JobEngine } from '../jobEngine';
 import { createJobControlAuthority, type JobControlAuthority } from '../jobControlAuthority';
-import { executeDurableJob, type DurableJobHandle } from '../jobLifecycle';
+import {
+  createDurableJobLifecycleScope,
+  executeDurableJob,
+  type DurableJobHandle,
+  type DurableJobLifecycleScope,
+} from '../jobLifecycle';
 import {
   resolveDaemonModel,
 } from './resolveModel';
@@ -170,6 +175,8 @@ export interface CreateRealAgentRunnerOptions {
   jobControlAuthority?: JobControlAuthority;
   /** Canonical Attempt cancellation signal supplied to the execution adapter. */
   executionSignal?: AbortSignal;
+  /** Optional owner that drains canonical lifecycle work before durable stores close. */
+  lifecycleScope?: DurableJobLifecycleScope;
 }
 
 // ── Implementation ─────────────────────────────────────────────────────────
@@ -196,9 +203,11 @@ export function createRealAgentRunner(
     : null);
 
   if (opts.jobEngine && jobControls) {
-    const durableOptions = { ...opts, jobEngine: opts.jobEngine };
+    const lifecycleScope = opts.lifecycleScope ?? createDurableJobLifecycleScope();
+    const durableOptions = { ...opts, jobEngine: opts.jobEngine, lifecycleScope };
     return {
       invoke: (input) => invokeDurableDaemon(input, durableOptions, jobControls),
+      dispose: (reason) => lifecycleScope.dispose(reason),
     };
   }
 
@@ -686,6 +695,7 @@ async function invokeDurableDaemon(
   try {
     const execution = await executeDurableJob({
       engine: opts.jobEngine,
+      lifecycleScope: opts.lifecycleScope,
       ownerId: input.instanceId,
       leaseTtlMs: 60_000,
       admission,

--- a/core/v4/daemon/jobLifecycle.ts
+++ b/core/v4/daemon/jobLifecycle.ts
@@ -117,6 +117,72 @@ export class DurableJobBudgetExceededError extends DurableJobLifecycleError {
   }
 }
 
+export class DurableJobLifecycleDisposedError extends DurableJobLifecycleError {
+  constructor(message = 'Durable lifecycle scope was disposed', handle?: Partial<DurableJobHandle>) {
+    super(message, handle);
+    this.name = 'DurableJobLifecycleDisposedError';
+  }
+}
+
+interface DurableJobLifecycleRegistration {
+  dispose(reason: string): void;
+  done: Promise<void>;
+}
+
+class DurableJobLifecycleDisposalError extends Error {
+  constructor(readonly causes: unknown[]) {
+    super('Durable lifecycle disposal failed');
+    this.name = 'DurableJobLifecycleDisposalError';
+  }
+}
+
+export class DurableJobLifecycleScope {
+  private readonly registrations = new Set<DurableJobLifecycleRegistration>();
+  private disposal: Promise<void> | null = null;
+  private disposedState = false;
+
+  get disposed(): boolean {
+    return this.disposedState;
+  }
+
+  get activeCount(): number {
+    return this.registrations.size;
+  }
+
+  assertActive(): void {
+    if (this.disposedState) throw new DurableJobLifecycleDisposedError();
+  }
+
+  register(registration: DurableJobLifecycleRegistration): () => void {
+    this.assertActive();
+    this.registrations.add(registration);
+    return () => this.registrations.delete(registration);
+  }
+
+  dispose(reason = 'Durable lifecycle scope disposed'): Promise<void> {
+    if (this.disposal) return this.disposal;
+    this.disposedState = true;
+    const registrations = [...this.registrations];
+    const disposalErrors: unknown[] = [];
+    for (const registration of registrations) {
+      try {
+        registration.dispose(reason);
+      } catch (error) {
+        disposalErrors.push(error);
+      }
+    }
+    this.disposal = Promise.allSettled(registrations.map((registration) => registration.done)).then(() => {
+      if (disposalErrors.length === 1) throw disposalErrors[0];
+      if (disposalErrors.length > 1) throw new DurableJobLifecycleDisposalError(disposalErrors);
+    });
+    return this.disposal;
+  }
+}
+
+export function createDurableJobLifecycleScope(): DurableJobLifecycleScope {
+  return new DurableJobLifecycleScope();
+}
+
 export interface ExecuteDurableJobOptions<T> {
   engine: JobEngine;
   ownerId: string;
@@ -134,6 +200,7 @@ export interface ExecuteDurableJobOptions<T> {
   controlPollMs?: number;
   onLeaseLost?: (error: DurableJobLifecycleError) => void;
   onPhase?: (event: DurableJobLifecyclePhaseEvent) => void;
+  lifecycleScope?: DurableJobLifecycleScope;
 }
 
 function isExistingAdmission(admission: DurableJobAdmission): admission is ExistingDurableJobAdmission {
@@ -257,6 +324,7 @@ function notifyPhase(
 export async function executeDurableJob<T>(
   options: ExecuteDurableJobOptions<T>,
 ): Promise<DurableJobExecutionResult<T>> {
+  options.lifecycleScope?.assertActive();
   const producer = producerFor(options.admission);
   const admitted = admitDurableJob(options.engine, options.admission);
   notifyPhase(options.onPhase, 'admitted', admitted);
@@ -334,6 +402,7 @@ export async function executeDurableJob<T>(
   let controlWatcher: ReturnType<typeof setInterval> | null = null;
   let runtimeBudgetTimer: ReturnType<typeof setTimeout> | null = null;
   let runtimeBudgetExpired = false;
+  let disposalError: DurableJobLifecycleDisposedError | null = null;
   const executionStartedAt = Date.now();
 
   const stopHeartbeat = (): void => {
@@ -344,6 +413,7 @@ export async function executeDurableJob<T>(
   const startHeartbeat = (): void => {
     stopHeartbeat();
     heartbeat = setInterval(() => {
+      if (disposalError) return;
       const renewed = options.engine.renewAttemptLease({
         attemptId: handle.attemptId,
         ownerId: options.ownerId,
@@ -365,6 +435,40 @@ export async function executeDurableJob<T>(
     }, Math.max(1_000, Math.floor(leaseTtlMs / 3)));
     heartbeat.unref?.();
   };
+
+  const stopAsyncResources = (): void => {
+    if (runtimeBudgetTimer) clearTimeout(runtimeBudgetTimer);
+    runtimeBudgetTimer = null;
+    stopHeartbeat();
+    if (controlWatcher) clearInterval(controlWatcher);
+    controlWatcher = null;
+    detachRuntime?.();
+    detachRuntime = null;
+  };
+
+  let resolveLifecycleDone!: () => void;
+  const lifecycleDone = new Promise<void>((resolve) => { resolveLifecycleDone = resolve; });
+  const unregisterScope = options.lifecycleScope?.register({
+    done: lifecycleDone,
+    dispose(reason) {
+      if (disposalError) return;
+      disposalError = new DurableJobLifecycleDisposedError(reason, handle);
+      stopAsyncResources();
+      let persistenceError: unknown = null;
+      try {
+        options.engine.cancelJob({
+          jobId: handle.jobId,
+          reason,
+          producer,
+          eventIdempotencyKey: `lifecycle-dispose:${handle.attemptId}:${handle.generation}`,
+        });
+      } catch (error) {
+        persistenceError = error;
+      }
+      leaseAbort.abort(disposalError);
+      if (persistenceError) throw persistenceError;
+    },
+  }) ?? null;
 
   Object.defineProperties(handle, {
     pauseAtBoundary: {
@@ -556,6 +660,7 @@ export async function executeDurableJob<T>(
     if (runtimeBudget?.limit !== null && runtimeBudget !== undefined) {
       const remaining = Math.max(0, runtimeBudget.limit - runtimeBudget.used);
       runtimeBudgetTimer = setTimeout(() => {
+        if (disposalError) return;
         try {
           options.engine.workerProviderCalls.recordInterruptionForAttempt({
             childJobId: handle.jobId,
@@ -580,7 +685,7 @@ export async function executeDurableJob<T>(
     }
 
     controlWatcher = setInterval(() => {
-      if (leaseAbort.signal.aborted) return;
+      if (disposalError || leaseAbort.signal.aborted) return;
       const status = options.engine.getJob(handle.jobId)?.status;
       if (status === 'cancelled' || status === 'cancelling') {
         leaseAbort.abort(new Error('Durable Job cancellation requested'));
@@ -591,6 +696,7 @@ export async function executeDurableJob<T>(
     notifyPhase(options.onPhase, 'running', handle, handle.generation);
     notifyPhase(options.onPhase, 'executing', handle, handle.generation);
     const value = await runWithJobExecutionContext(executionContext, () => options.execute(handle));
+    if (disposalError) throw disposalError;
     if (runtimeBudgetExpired) throw new DurableJobBudgetExceededError('runtime_ms', handle);
     if (leaseLost) throw leaseLost;
     assertAuthority(options.engine, handle);
@@ -606,6 +712,7 @@ export async function executeDurableJob<T>(
     notifyPhase(options.onPhase, 'settled', handle, handle.generation);
     return Object.assign(handle, { value });
   } catch (error) {
+    if (disposalError) throw disposalError;
     if (leaseLost || error instanceof DurableJobAuthorityLostError) throw error;
     const attempt = options.engine.getAttempt(handle.attemptId);
     const job = options.engine.getJob(handle.jobId);
@@ -629,29 +736,28 @@ export async function executeDurableJob<T>(
     }
     throw error;
   } finally {
-    if (runtimeBudgetTimer) clearTimeout(runtimeBudgetTimer);
-    runtimeBudgetTimer = null;
-    if (options.engine.resources.getBudgets(handle.jobId).some((budget) => budget.kind === 'runtime_ms')) {
-      try {
-        options.engine.resources.debit({
-          jobId: handle.jobId,
-          attemptId: handle.attemptId,
-          generation: handle.generation,
-          fenceToken: handle.fenceToken,
-          kind: 'runtime_ms',
-          amount: Math.max(0, Date.now() - executionStartedAt),
-          certainty: 'confirmed',
-          idempotencyKey: `runtime:${handle.attemptId}:${handle.generation}`,
-          enforceLimit: false,
-        });
-      } catch { /* stale authority cannot spend after replacement */ }
+    stopAsyncResources();
+    try {
+      if (!disposalError && options.engine.resources.getBudgets(handle.jobId).some((budget) => budget.kind === 'runtime_ms')) {
+        try {
+          options.engine.resources.debit({
+            jobId: handle.jobId,
+            attemptId: handle.attemptId,
+            generation: handle.generation,
+            fenceToken: handle.fenceToken,
+            kind: 'runtime_ms',
+            amount: Math.max(0, Date.now() - executionStartedAt),
+            certainty: 'confirmed',
+            idempotencyKey: `runtime:${handle.attemptId}:${handle.generation}`,
+            enforceLimit: false,
+          });
+        } catch { /* stale authority cannot spend after replacement */ }
+      }
+      if (!disposalError) notifyPhase(options.onPhase, 'cleanup', handle, handle.generation);
+    } finally {
+      unregisterScope?.();
+      resolveLifecycleDone();
     }
-    stopHeartbeat();
-    if (controlWatcher) clearInterval(controlWatcher);
-    controlWatcher = null;
-    detachRuntime?.();
-    detachRuntime = null;
-    notifyPhase(options.onPhase, 'cleanup', handle, handle.generation);
   }
 }
 

--- a/core/v4/daemon/jobProofAuthority.ts
+++ b/core/v4/daemon/jobProofAuthority.ts
@@ -6,6 +6,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 
 import type { Db } from './db/connection';
+import { runtimeTrace } from '../runtimeTrace';
 
 export type ClaimCategory = 'contract' | 'observed' | 'courtesy';
 export type ClaimState = 'unverified' | 'verified' | 'partial' | 'failed' | 'unknown';
@@ -297,6 +298,17 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
           `INSERT INTO proof_reviews (job_id, evidence_id, reason, created_at) VALUES (?, ?, 'late evidence', ?)`,
         ).run(command.jobId, evidenceId, now);
       }).immediate();
+      runtimeTrace('proof', 'evidence.recorded', {
+        jobId: command.jobId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        evidenceId,
+        effectId: command.effectId ?? null,
+        source: command.source,
+        coverage: command.coverage,
+        verificationResult: command.verificationResult,
+        late,
+      });
       return authority.listEvidence(command.jobId).find((evidence) => evidence.evidenceId === evidenceId)!;
     },
     checkClaim(command) {
@@ -305,6 +317,15 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       if (getVerdict(claim.job_id)) throw new Error('Final verdict is immutable');
       assertAttempt(claim.job_id, command.attemptId, command.generation);
       const now = command.now ?? Date.now();
+      const verificationStartedAt = Date.now();
+      runtimeTrace('proof', 'claim_verification.start', {
+        jobId: claim.job_id,
+        claimId: command.claimId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        evidenceCount: command.evidenceIds.length,
+        requestedState: command.state,
+      });
       db.transaction(() => {
         const linkedEvidence: EvidenceRow[] = [];
         const requiredEffectIds = JSON.parse(claim.effect_ids_json) as string[];
@@ -380,6 +401,14 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
         db.prepare('UPDATE job_claims SET state = ?, attempt_id = ?, generation = ?, checked_at = ? WHERE claim_id = ?')
           .run(command.state, command.attemptId, command.generation, now, command.claimId);
       }).immediate();
+      runtimeTrace('proof', 'claim_verification.end', {
+        jobId: claim.job_id,
+        claimId: command.claimId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        state: command.state,
+        durationMs: Date.now() - verificationStartedAt,
+      });
       return authority.listClaims(claim.job_id).find((item) => item.claimId === command.claimId)!;
     },
     listClaims,
@@ -408,10 +437,23 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       else verdict = 'unknown';
       const now = command.now ?? Date.now();
       const summary = { requiredClaims: claims.length, verifiedClaims: verifiedCount, failedClaims: failedCount, unknownClaims: unknownCount };
+      runtimeTrace('proof', 'verdict.computed', {
+        jobId: command.jobId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        verdict,
+        ...summary,
+      });
       db.prepare(
         `INSERT INTO job_verdicts (job_id, attempt_id, generation, verdict, summary_json, finalized_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
       ).run(command.jobId, command.attemptId, command.generation, verdict, JSON.stringify(summary), now);
+      runtimeTrace('proof', 'proof.persisted', {
+        jobId: command.jobId,
+        attemptId: command.attemptId,
+        generation: command.generation,
+        verdict,
+      });
       return getVerdict(command.jobId)!;
     },
     getVerdict,

--- a/core/v4/daemon/jobProofAuthority.ts
+++ b/core/v4/daemon/jobProofAuthority.ts
@@ -36,6 +36,7 @@ export interface ClaimRecord {
   sourceReferences: ClaimSourceReference[];
   requiredValidation: ClaimValidationRequirement[];
   requiredEvidenceCategories: string[];
+  effectIds: string[];
 }
 
 export interface EvidenceRecord {
@@ -74,6 +75,7 @@ export interface JobProofAuthority {
     sourceReferences?: ClaimSourceReference[];
     requiredValidation?: ClaimValidationRequirement[];
     requiredEvidenceCategories?: string[];
+    effectIds?: string[];
   }): ClaimRecord;
   recordEvidence(command: {
     jobId: string; attemptId: string; generation: number; fenceToken: string;
@@ -104,6 +106,7 @@ type ClaimRow = {
   category: ClaimCategory; statement: string; required: number; state: ClaimState;
   repository_snapshot_id: string | null; source_references_json: string;
   required_validation_json: string; required_evidence_categories_json: string;
+  effect_ids_json: string;
 };
 type EvidenceRow = {
   evidence_id: string; job_id: string; attempt_id: string; generation: number; effect_id: string | null;
@@ -122,6 +125,7 @@ const mapClaim = (row: ClaimRow): ClaimRecord => ({
   sourceReferences: JSON.parse(row.source_references_json) as ClaimSourceReference[],
   requiredValidation: JSON.parse(row.required_validation_json) as ClaimValidationRequirement[],
   requiredEvidenceCategories: JSON.parse(row.required_evidence_categories_json) as string[],
+  effectIds: JSON.parse(row.effect_ids_json) as string[],
 });
 const mapEvidence = (row: EvidenceRow): EvidenceRecord => ({
   evidenceId: row.evidence_id, jobId: row.job_id, attemptId: row.attempt_id,
@@ -196,18 +200,31 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       const sourceReferences = validateSourceReferences(command.jobId, repositorySnapshotId, command.sourceReferences ?? []);
       const requiredValidation = command.requiredValidation ?? [];
       const requiredEvidenceCategories = [...new Set(command.requiredEvidenceCategories ?? [])].sort();
+      const effectIds = [...new Set(command.effectIds ?? [])].sort();
+      for (const effectId of effectIds) {
+        const effect = db.prepare(
+          `SELECT job_id, attempt_id, generation FROM side_effect_ledger WHERE key = ?`,
+        ).get(effectId) as { job_id: string; attempt_id: string; generation: number } | undefined;
+        if (!effect || effect.job_id !== command.jobId) {
+          throw new Error('Claim Effect does not belong to the Job');
+        }
+        if (command.attemptId && command.generation !== null && command.generation !== undefined
+          && (effect.attempt_id !== command.attemptId || effect.generation !== command.generation)) {
+          throw new Error('Claim Effect does not match the bound Attempt');
+        }
+      }
       const claimId = id('claim');
       db.prepare(
         `INSERT INTO job_claims
            (claim_id, job_id, attempt_id, generation, category, statement, required, state,
             repository_snapshot_id,source_references_json,required_validation_json,
-            required_evidence_categories_json,created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, 'unverified', ?, ?, ?, ?, ?)`,
+            required_evidence_categories_json,effect_ids_json,created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'unverified', ?, ?, ?, ?, ?, ?)`,
       ).run(
         claimId, command.jobId, command.attemptId ?? null, command.generation ?? null,
         command.category, command.statement, command.required === true ? 1 : 0,
         repositorySnapshotId, JSON.stringify(sourceReferences), JSON.stringify(requiredValidation),
-        JSON.stringify(requiredEvidenceCategories), command.now ?? Date.now(),
+        JSON.stringify(requiredEvidenceCategories), JSON.stringify(effectIds), command.now ?? Date.now(),
       );
       return authority.listClaims(command.jobId).find((claim) => claim.claimId === claimId)!;
     },
@@ -290,6 +307,17 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       const now = command.now ?? Date.now();
       db.transaction(() => {
         const linkedEvidence: EvidenceRow[] = [];
+        const requiredEffectIds = JSON.parse(claim.effect_ids_json) as string[];
+        const requiredEffects = new Set(requiredEffectIds);
+        for (const effectId of requiredEffectIds) {
+          const effect = db.prepare(
+            `SELECT job_id, attempt_id, generation FROM side_effect_ledger WHERE key = ?`,
+          ).get(effectId) as { job_id: string; attempt_id: string; generation: number } | undefined;
+          if (!effect || effect.job_id !== claim.job_id
+            || effect.attempt_id !== command.attemptId || effect.generation !== command.generation) {
+            throw new Error('Claim Effect authority no longer matches the proving Attempt');
+          }
+        }
         for (const evidenceId of command.evidenceIds) {
           const evidence = db.prepare('SELECT * FROM job_evidence WHERE evidence_id = ?').get(evidenceId) as EvidenceRow | undefined;
           if (!evidence || evidence.job_id !== claim.job_id || evidence.attempt_id !== command.attemptId || evidence.generation !== command.generation) {
@@ -299,6 +327,9 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
             throw new Error('Evidence snapshot does not match the source-bound Claim');
           }
           if (evidence.fresh_until !== null && evidence.fresh_until < now) throw new Error('Stale evidence cannot prove a claim');
+          if (requiredEffects.size > 0 && (!evidence.effect_id || !requiredEffects.has(evidence.effect_id))) {
+            throw new Error('Evidence does not match a required Claim Effect');
+          }
           linkedEvidence.push(evidence);
           db.prepare('INSERT OR IGNORE INTO claim_evidence (claim_id, evidence_id, created_at) VALUES (?, ?, ?)')
             .run(command.claimId, evidenceId, now);
@@ -306,6 +337,7 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
         if (command.state === 'verified' && (
           linkedEvidence.length === 0
           || linkedEvidence.some((item) => item.verification_result !== 'verified' || item.coverage !== 'full')
+          || requiredEffectIds.some((effectId) => !linkedEvidence.some((item) => item.effect_id === effectId))
         )) {
           throw new Error('Verified claims require complete verified evidence');
         }
@@ -361,9 +393,6 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       if (existing) return existing;
       assertAttempt(command.jobId, command.attemptId, command.generation, command.fenceToken);
       const claims = listClaims(command.jobId).filter((claim) => claim.category === 'contract' && claim.required);
-      const evidence = listEvidence(command.jobId).filter(
-        (item) => item.attemptId === command.attemptId && item.generation === command.generation && !item.late,
-      );
       const unresolvedEffect = db.prepare(
         `SELECT 1 FROM side_effect_ledger WHERE job_id = ?
           AND effect_state IN ('unknown','partial','started') LIMIT 1`,
@@ -371,10 +400,9 @@ export function createJobProofAuthority(db: Db): JobProofAuthority {
       const verifiedCount = claims.filter((claim) => claim.state === 'verified').length;
       const failedCount = claims.filter((claim) => claim.state === 'failed').length;
       const unknownCount = claims.filter((claim) => claim.state === 'unknown' || claim.state === 'unverified' || claim.state === 'partial').length;
-      const incompleteCoverage = evidence.some((item) => item.coverage !== 'full' || item.verificationResult === 'unknown');
       let verdict: FinalVerdict;
       if (command.cancelled) verdict = 'cancelled';
-      else if (unresolvedEffect || unknownCount > 0 || incompleteCoverage) verdict = verifiedCount > 0 ? 'partially_verified' : 'unknown';
+      else if (unresolvedEffect || unknownCount > 0) verdict = verifiedCount > 0 ? 'partially_verified' : 'unknown';
       else if (failedCount > 0) verdict = verifiedCount > 0 ? 'partially_verified' : 'failed';
       else if (claims.length > 0 && verifiedCount === claims.length) verdict = 'verified';
       else verdict = 'unknown';

--- a/core/v4/powerShellClixml.ts
+++ b/core/v4/powerShellClixml.ts
@@ -1,0 +1,14 @@
+/** Remove only structured PowerShell progress objects from a CLIXML document. */
+export function filterPowerShellProgressClixml(value: string): { stderr: string; removedProgress: boolean } {
+  const text = value.trim();
+  const document = /^(#< CLIXML\s*)(<Objs\b[^>]*>)([\s\S]*)(<\/Objs>)$/u.exec(text);
+  if (!document) return { stderr: value, removedProgress: false };
+  const body = document[3] ?? '';
+  const filtered = body.replace(/<Obj\b(?=[^>]*\bS="progress")[^>]*>[\s\S]*?<\/Obj>/gu, '');
+  if (filtered === body) return { stderr: value, removedProgress: false };
+  if (!filtered.trim()) return { stderr: '', removedProgress: true };
+  return {
+    stderr: `${document[1] ?? '#< CLIXML\n'}${document[2] ?? '<Objs>'}${filtered}${document[4] ?? '</Objs>'}`,
+    removedProgress: true,
+  };
+}

--- a/core/v4/runtimeTrace.ts
+++ b/core/v4/runtimeTrace.ts
@@ -20,3 +20,29 @@ export function runtimeTrace(
     // Diagnostics cannot affect runtime execution.
   }
 }
+
+/** Preserve opt-in script diagnostics without writing into an owned terminal. */
+export function writeNonInteractiveDiagnostic(
+  message: string,
+  interactive = Boolean(process.stdout.isTTY),
+): void {
+  if (interactive) return;
+  try {
+    process.stderr.write(message.endsWith('\n') ? message : `${message}\n`);
+  } catch {
+    // Diagnostics cannot affect runtime execution.
+  }
+}
+
+/** Preserve warning diagnostics for redirected and non-interactive callers. */
+export function warnNonInteractiveDiagnostic(
+  message: string,
+  interactive = Boolean(process.stdout.isTTY),
+): void {
+  if (interactive) return;
+  try {
+    console.warn(message);
+  } catch {
+    // Diagnostics cannot affect runtime execution.
+  }
+}

--- a/core/v4/runtimeTrace.ts
+++ b/core/v4/runtimeTrace.ts
@@ -1,0 +1,22 @@
+import { appendFileSync } from 'node:fs';
+
+export function runtimeTrace(
+  scope: string,
+  event: string,
+  data: Record<string, unknown> = {},
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const target = env.AIDEN_RUNTIME_TRACE_FILE
+    ?? (env.AIDEN_P2A_DIAG === '1' ? env.AIDEN_P2A_DIAG_FILE : undefined);
+  if (!target) return;
+  try {
+    appendFileSync(target, `${JSON.stringify({
+      monoMs: Number(process.hrtime.bigint() / 1_000_000n),
+      scope,
+      event,
+      ...data,
+    })}\n`, 'utf8');
+  } catch {
+    // Diagnostics cannot affect runtime execution.
+  }
+}

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -59,7 +59,7 @@ import type { SnapshotObservation } from './temporalEvidence';
 import type { SSRFProtection } from '../../moat/ssrfProtection';
 import type { TirithScanner } from '../../moat/tirithScanner';
 import type { MemoryGuard } from '../../moat/memoryGuard';
-import { classifyCommand, isReadOnlyCommand } from '../../moat/dangerousPatterns';
+import { analyzeCommandIntent, isReadOnlyCommand } from '../../moat/dangerousPatterns';
 import { classifyBrowserAction } from './browserState';
 import { pwBrowserStatus, pwDialogPendingTier } from '../playwrightBridge';
 import type { SkillLoader } from './skillLoader';
@@ -656,6 +656,9 @@ export class ToolRegistry {
         call.name === 'shell_exec' &&
         typeof args.command === 'string' &&
         isReadOnlyCommand(args.command);
+      const shellIntent = call.name === 'shell_exec' && typeof args.command === 'string'
+        ? analyzeCommandIntent(args.command, context.cwd ?? process.cwd())
+        : undefined;
       // Fail closed: a tool must EXPLICITLY declare `mutates: false` to skip the
       // approval gate. An unknown / undeclared `mutates` (e.g. a dynamically
       // registered tool that never set it) is ASSUMED to mutate and is gated —
@@ -813,7 +816,7 @@ export class ToolRegistry {
             toolCallId: call.id,
             toolName: call.name,
             args,
-            riskTier: handler.riskTier ?? 'caution',
+            riskTier: shellIntent?.tier ?? handler.riskTier ?? 'caution',
             mutates: true,
             effect: effectDescriptor,
             approvalState: approvalGated ? 'pending' : 'not_required',
@@ -855,9 +858,8 @@ export class ToolRegistry {
         let riskTier: 'safe' | 'caution' | 'dangerous' | undefined;
         let reason: string | undefined;
         if (call.name === 'shell_exec' && typeof args.command === 'string') {
-          const c = classifyCommand(args.command);
-          riskTier = c.tier;
-          reason = c.reason;
+          riskTier = shellIntent?.tier;
+          reason = shellIntent?.reason;
         } else if (
           call.name === 'browser_click' || call.name === 'browser_type' ||
           call.name === 'browser_fill' || call.name === 'browser_navigate'
@@ -891,8 +893,10 @@ export class ToolRegistry {
         // Effective tier is the handler annotation (Phase 1 floor)
         // OR the classifier escalation above (whichever is higher).
         let preview: unknown;
-        const effectiveTier = (riskTier === 'dangerous' || handler.riskTier === 'dangerous')
-          ? 'dangerous' : (riskTier ?? handler.riskTier);
+        const effectiveTier = call.name === 'shell_exec'
+          ? (riskTier ?? 'dangerous')
+          : (riskTier === 'dangerous' || handler.riskTier === 'dangerous')
+            ? 'dangerous' : (riskTier ?? handler.riskTier);
         if (effectiveTier === 'dangerous' && typeof handler.buildPreview === 'function') {
           try {
             preview = await handler.buildPreview(args, context);

--- a/moat/dangerousPatterns.ts
+++ b/moat/dangerousPatterns.ts
@@ -24,6 +24,17 @@
 
 export type RiskTier = 'safe' | 'caution' | 'dangerous';
 
+export interface CommandIntentAnalysis {
+  operation: string;
+  effect: 'read_only' | 'mutating' | 'external' | 'unknown';
+  network: boolean;
+  reversible: boolean;
+  scope: 'process' | 'repository' | 'working_directory' | 'external' | 'unknown';
+  confidence: 'high' | 'medium' | 'low';
+  tier: RiskTier;
+  reason?: string;
+}
+
 export interface DangerPattern {
   /** Stable identifier (used in logs / approval keys). */
   name: string;
@@ -106,6 +117,37 @@ export function classifyCommand(input: string): {
   const tier = highestTier(matches);
   const reason = matches[0]?.description;
   return { tier, matches, reason };
+}
+
+/** Bounded intent analysis. Recognized operations are precise; unknown input
+ * remains dangerous and approval-gated. */
+export function analyzeCommandIntent(command: string, _cwd = process.cwd()): CommandIntentAnalysis {
+  const raw = command.trim();
+  const pattern = classifyCommand(raw);
+  if (pattern.tier !== 'safe') {
+    return {
+      operation: pattern.matches[0]?.name ?? 'dangerous_command', effect: 'mutating',
+      network: /\b(?:curl|wget|invoke-webrequest|npm\s+publish)\b/iu.test(raw),
+      reversible: false, scope: 'unknown', confidence: 'high', tier: pattern.tier,
+      ...(pattern.reason ? { reason: pattern.reason } : {}),
+    };
+  }
+  if (/^(?:[^\s]*[\\/])?node(?:\.exe)?\s+(?:--version|-v)\s*$/iu.test(raw)) {
+    return { operation: 'inspect_runtime_version', effect: 'read_only', network: false, reversible: true, scope: 'process', confidence: 'high', tier: 'safe' };
+  }
+  if (/^git(?:\.exe)?\s+/iu.test(raw) && isReadOnlyCommand(raw)) {
+    return { operation: 'inspect_repository', effect: 'read_only', network: false, reversible: true, scope: 'repository', confidence: 'high', tier: 'safe' };
+  }
+  if (isReadOnlyCommand(raw)) {
+    return { operation: 'inspect_local_state', effect: 'read_only', network: false, reversible: true, scope: 'working_directory', confidence: 'high', tier: 'safe' };
+  }
+  if (/^node(?:\.exe)?\s+(?!-)[^\s]+(?:\s|$)/iu.test(raw)) {
+    return { operation: 'execute_local_script', effect: 'mutating', network: false, reversible: false, scope: 'working_directory', confidence: 'medium', tier: 'caution', reason: 'Local script execution may change working-directory state.' };
+  }
+  if (/^(?:npm|pnpm|yarn)\s+(?:publish|unpublish|deprecate)\b/iu.test(raw)) {
+    return { operation: 'publish_package', effect: 'external', network: true, reversible: false, scope: 'external', confidence: 'high', tier: 'dangerous', reason: 'Publishes or changes a remote package.' };
+  }
+  return { operation: 'unknown_command', effect: 'unknown', network: false, reversible: false, scope: 'unknown', confidence: 'low', tier: 'dangerous', reason: 'Command intent could not be proven safe.' };
 }
 
 // ── Read-only command allowlist (v4.14.6) ────────────────────────────────────
@@ -228,6 +270,7 @@ function isReadOnlyGit(stage: string): boolean {
 export function isReadOnlyCommand(command: string): boolean {
   const raw = command.trim();
   if (!raw) return false;
+  if (/^(?:[^\s]*[\\/])?node(?:\.exe)?\s+(?:--version|-v)\s*$/iu.test(raw)) return true;
   const bare = stripLiterals(raw);
   if (UNSAFE_META.test(bare)) return false;               // redirect / chain / subst / background
   if (classifyCommand(raw).tier !== 'safe') return false; // any dangerous/caution pattern

--- a/providers/v4/responseStreamAdapter.ts
+++ b/providers/v4/responseStreamAdapter.ts
@@ -1,3 +1,5 @@
+import { runtimeTrace } from '../../core/v4/runtimeTrace';
+
 /**
  * Aiden v4 — local-first AI agent
  * Copyright (C) 2026 Shiva Deore (Taracod)
@@ -518,11 +520,7 @@ export class ResponseStreamAdapter implements ProviderAdapter {
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {
-  if (process.env.AIDEN_P2A_DIAG !== '1') return;
-  try {
-    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
-  } catch { /* diagnostics must never affect provider calls */ }
+  runtimeTrace('response-stream', event, data);
 }
 
 // ── Encoders ────────────────────────────────────────────────────────────
@@ -718,11 +716,7 @@ function parseToolArgs(s: string): Record<string, unknown> {
       ? (v as Record<string, unknown>)
       : {};
   } catch {
-    // eslint-disable-next-line no-console
-    console.warn(
-      '[responseStreamAdapter] function_call.arguments is not valid JSON; ' +
-      'falling back to {}',
-    );
+    runtimeTrace('response-stream', 'tool.arguments.invalid', {});
     return {};
   }
 }
@@ -938,8 +932,7 @@ function handleSseEvent(
 
     default:
       if (debug) {
-        // eslint-disable-next-line no-console
-        console.warn(`[responseStreamAdapter] unknown SSE event: ${type}`);
+        runtimeTrace('response-stream', 'event.unknown', { type });
       }
   }
 }

--- a/providers/v4/responseStreamAdapter.ts
+++ b/providers/v4/responseStreamAdapter.ts
@@ -1,4 +1,4 @@
-import { runtimeTrace } from '../../core/v4/runtimeTrace';
+import { runtimeTrace, warnNonInteractiveDiagnostic } from '../../core/v4/runtimeTrace';
 
 /**
  * Aiden v4 — local-first AI agent
@@ -933,6 +933,7 @@ function handleSseEvent(
     default:
       if (debug) {
         runtimeTrace('response-stream', 'event.unknown', { type });
+        warnNonInteractiveDiagnostic(`[responseStreamAdapter] unknown SSE event: ${type}`);
       }
   }
 }

--- a/scripts/acceptance/native-runtime-preflight.mjs
+++ b/scripts/acceptance/native-runtime-preflight.mjs
@@ -1,0 +1,35 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const root = resolve(option('--root') ?? process.cwd());
+const requireFromRoot = createRequire(resolve(root, 'package.json'));
+const lockfile = resolve(root, 'package-lock.json');
+const report = {
+  version: process.version,
+  abi: process.versions.modules,
+  execPath: process.execPath,
+  lockfileSha256: createHash('sha256').update(readFileSync(lockfile)).digest('hex').toUpperCase(),
+  betterSqlite3: requireFromRoot.resolve('better-sqlite3'),
+  query: null,
+};
+
+try {
+  const Database = requireFromRoot('better-sqlite3');
+  const db = new Database(':memory:');
+  try {
+    report.query = db.prepare('SELECT 1 AS ok').get();
+  } finally {
+    db.close();
+  }
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+} catch (error) {
+  process.stderr.write(`${JSON.stringify({ ...report, error: error instanceof Error ? error.message : String(error) })}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/acceptance/repository-baseline.mjs
+++ b/scripts/acceptance/repository-baseline.mjs
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function normalize(value) {
+  return value.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+const root = resolve(option('--root') ?? process.cwd());
+const allowedUntracked = new Set(
+  process.argv.flatMap((value, index) => value === '--allow-untracked' ? [process.argv[index + 1]] : [])
+    .filter(Boolean)
+    .map(normalize),
+);
+const protectedSpec = option('--protected');
+const status = spawnSync('git', ['status', '--porcelain=v1', '-z', '--untracked-files=all'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+if (status.status !== 0) {
+  process.stderr.write(status.stderr || 'Unable to inspect repository baseline.\n');
+  process.exit(2);
+}
+
+const entries = status.stdout.split('\0').filter(Boolean).map((entry) => ({
+  status: entry.slice(0, 2),
+  path: normalize(entry.slice(3)),
+}));
+const trackedDirty = entries.filter((entry) => entry.status !== '??');
+const unexpectedUntracked = entries.filter(
+  (entry) => entry.status === '??' && !allowedUntracked.has(entry.path),
+);
+let protectedFile = null;
+if (protectedSpec) {
+  const split = protectedSpec.lastIndexOf('=');
+  if (split <= 0) throw new Error('--protected expects relative-path=SHA256');
+  const path = normalize(protectedSpec.slice(0, split));
+  const expectedSha256 = protectedSpec.slice(split + 1).toUpperCase();
+  const sha256 = createHash('sha256').update(readFileSync(resolve(root, path))).digest('hex').toUpperCase();
+  protectedFile = { path, expectedSha256, sha256, matches: sha256 === expectedSha256 };
+}
+const clean = trackedDirty.length === 0
+  && unexpectedUntracked.length === 0
+  && (protectedFile?.matches ?? true);
+process.stdout.write(`${JSON.stringify({
+  root,
+  clean,
+  trackedDirty,
+  allowedUntracked: entries.filter((entry) => entry.status === '??' && allowedUntracked.has(entry.path)),
+  unexpectedUntracked,
+  protectedFile,
+})}\n`);
+process.exitCode = clean ? 0 : 1;

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -642,6 +642,28 @@ describe('settled activity row spacing', () => {
     expectActivityAnswerBoundary(screen, ['completed', 'second.ts'], 'Streamed activity answer.', false);
   });
 
+  it('settles split markdown atomically after resize and activity projection', async () => {
+    const { display, screen, stream } = createDisplay(80, 24);
+    display.setStatusFooter('provider · runtime · ready');
+    display.setIdleComposer('', 'Type your message');
+
+    display.streamPartial('# Before resize\n```');
+    stream.resize(44, 24);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    display.streamPartial('ts\nconst value = 1;\n```\n');
+    display.renderUiEvent('ui_toast', { kind: 'info', message: 'Evidence recorded' });
+    display.streamPartial('## Final result\n- Run `npm test`\n- Unicode 世界\n');
+    display.streamComplete();
+
+    const rendered = screen.snapshot();
+    expect(rendered.match(/FINAL RESULT/giu)).toHaveLength(1);
+    expect(rendered.match(/Evidence recorded/gu)).toHaveLength(1);
+    expect(rendered.match(/npm test/gu)).toHaveLength(1);
+    expect(rendered).not.toContain('```');
+    expect(rendered.match(/▲ You/gu)).toHaveLength(1);
+    expect(rendered.match(/provider · runtime/gu)).toHaveLength(1);
+  });
+
   it('keeps the activity-to-answer transition bounded at narrow width', () => {
     const { display, screen } = prepare(44);
     display.toolRow('file_read', { path: 'src/narrow-transition.ts' }).ok(12);

--- a/tests/v4/cli/bottomRegion.test.ts
+++ b/tests/v4/cli/bottomRegion.test.ts
@@ -4,7 +4,7 @@
  *
  * Aiden — local-first agent.
  */
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Writable } from 'node:stream';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
@@ -655,13 +655,38 @@ describe('settled activity row spacing', () => {
     display.streamPartial('## Final result\n- Run `npm test`\n- Unicode 世界\n');
     display.streamComplete();
 
-    const rendered = screen.snapshot();
+    const rendered = screen.bufferSnapshot();
     expect(rendered.match(/FINAL RESULT/giu)).toHaveLength(1);
     expect(rendered.match(/Evidence recorded/gu)).toHaveLength(1);
     expect(rendered.match(/npm test/gu)).toHaveLength(1);
     expect(rendered).not.toContain('```');
     expect(rendered.match(/▲ You/gu)).toHaveLength(1);
     expect(rendered.match(/provider · runtime/gu)).toHaveLength(1);
+  });
+
+  it('parses one complete assistant document after an activity interrupts a split fence', () => {
+    const { display, screen } = createDisplay(80, 30);
+    display.setStatusFooter('provider runtime ready');
+    display.setIdleComposer('', 'Type your message');
+    const markdown = vi.spyOn(display, 'markdown');
+    const first = '# Verified result\n\n```';
+    const second = 'json\n{"verified":true,"exitCode":0}\n```\n\n- Fresh readback complete\n';
+
+    display.streamPartial(first);
+    display.toolRow('file_read', { path: 'result.json' }).ok(12);
+    display.streamPartial(second);
+    display.streamComplete();
+
+    expect(markdown).toHaveBeenCalledTimes(1);
+    expect(markdown).toHaveBeenCalledWith(first + second);
+    const rendered = screen.snapshot();
+    expect(rendered.match(/result\.json/gu)).toHaveLength(1);
+    expect(rendered).toContain('verified');
+    expect(rendered).toContain('exitCode');
+    expect(rendered).toContain('Fresh readback complete');
+    expect(rendered).not.toContain('```');
+    expect(rendered.match(/You/gu)).toHaveLength(1);
+    expect(rendered.match(/provider runtime/gu)).toHaveLength(1);
   });
 
   it('keeps the activity-to-answer transition bounded at narrow width', () => {

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { TerminalScreen } from '../harness/terminalScreen';
@@ -75,7 +76,7 @@ function bottomDraft(content: string[]): string {
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   await new Promise((resolve) => setTimeout(resolve, 750));

--- a/tests/v4/cli/compactTranscript.pty.test.ts
+++ b/tests/v4/cli/compactTranscript.pty.test.ts
@@ -11,6 +11,7 @@ import * as pty from 'node-pty';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { TerminalScreen } from '../harness/terminalScreen';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 
 type RunningPty = ReturnType<typeof pty.spawn>;
 let child: RunningPty | null = null;
@@ -41,7 +42,7 @@ function semanticGap(frame: string, before: string, after: string): number {
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   await new Promise((resolve) => setTimeout(resolve, 500));
@@ -101,6 +102,7 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
       let timeout: ReturnType<typeof setTimeout> | null = null;
       let exitProbe: ReturnType<typeof setInterval> | null = null;
       let settled = false;
+      let observedProcessExitAt: number | null = null;
       let dataSubscription: { dispose(): void } | null = null;
       let exitSubscription: { dispose(): void } | null = null;
       const childPid = child!.pid;
@@ -123,8 +125,13 @@ describe.skipIf(process.platform !== 'win32')('built CLI compact hybrid transcri
         exitProbe = setInterval(() => {
           try {
             if (processTableContains(childPid)) return;
-            if (raw.includes('Goodbye.')) finish();
-            else finish(new Error('compact transcript process exited before clean CLI shutdown'));
+            if (raw.includes('Goodbye.')) {
+              finish();
+              return;
+            }
+            observedProcessExitAt ??= Date.now();
+            if (Date.now() - observedProcessExitAt < 1_500) return;
+            finish(new Error('compact transcript process exited before clean CLI shutdown output drained'));
           } catch (error) {
             finish(error as Error);
           }

--- a/tests/v4/cli/composerHandoff.pty.test.ts
+++ b/tests/v4/cli/composerHandoff.pty.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 import { startMockProvider, type MockProvider, type MockProviderTurn } from '../harness/mockProvider';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 
@@ -95,7 +96,7 @@ function stripAnsi(value: string): string {
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   if (provider) {

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -206,6 +206,44 @@ describe('ComposerLane — lifecycle', () => {
     });
   });
 
+  it('clamps repeated PageUp at the oldest retained wrapped transcript row', () => {
+    const s = mockSink(12, 80);
+    const lane = new ComposerLane(s);
+    lane.activate({ draft: '', mode: 'idle' }, 'provider · model · ready');
+    lane.writeAbove(Array.from({ length: 20 }, (_, index) => `retained row ${index + 1}`).join('\n') + '\n');
+
+    lane.scrollTranscript(10_000);
+
+    expect(lane.viewportSnapshot()).toMatchObject({
+      retainedTranscriptRows: 20,
+      scrollOffset: 15,
+      stickyTail: false,
+    });
+  });
+
+  it('reclamps a scrolled viewport when wider wrapping increases visible capacity', async () => {
+    const s = mockSink(12, 44);
+    const lane = new ComposerLane(s);
+    lane.activate({ draft: '', mode: 'idle' }, 'provider · model · ready');
+    const transcript = Array.from(
+      { length: 10 },
+      (_, index) => `row ${index + 1} ${'x'.repeat(50)}`,
+    ).join('\n') + '\n';
+    lane.writeAbove(transcript);
+    lane.scrollTranscript(10_000);
+    expect(lane.viewportSnapshot().scrollOffset).toBeGreaterThan(5);
+
+    s.setCols(80);
+    s.fireResize(12);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(lane.viewportSnapshot()).toMatchObject({
+      retainedTranscriptRows: 10,
+      scrollOffset: 5,
+      stickyTail: false,
+    });
+  });
+
   it('discards a trailing resize repaint captured before the viewport epoch changed', async () => {
     const s = mockSink(24, 80);
     const lane = new ComposerLane(s);

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -773,6 +773,21 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     expect(stripAnsi(totalAtCompletion).toLowerCase()).toContain('chunk 3');
   });
 
+  it('settles final markdown after an activity event interrupts the stream', () => {
+    const { d, chunks } = captureDisplay({ tty: true });
+    d.streamPartial('# Before activity\n- first item\n');
+    d.renderUiEvent('ui_toast', { kind: 'info', message: 'Activity recorded' });
+    d.streamPartial('# After activity\n- final item\n');
+    chunks.length = 0;
+
+    d.streamComplete();
+
+    const completion = chunks.join('');
+    expect(completion).toMatch(/\x1b\[\d+F\x1b\[2K/);
+    expect(stripAnsi(completion).toLowerCase()).toContain('after activity');
+    expect(stripAnsi(completion)).toContain('final item');
+  });
+
   it('plain prose (no structure): no eraser fires on tool interrupt or streamComplete', () => {
     const { d, chunks } = captureDisplay({ tty: true });
     // No headers, lists, fences, blockquotes — heuristic should bail.

--- a/tests/v4/cli/displayComposer.test.ts
+++ b/tests/v4/cli/displayComposer.test.ts
@@ -9,7 +9,7 @@
  * setComposer paints the draft + mode label, tool calls do not swallow the
  * input surface, and clearing removes it without stray writes.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Writable } from 'node:stream';
 import { Display } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
@@ -248,5 +248,43 @@ describe('Display composer — fixed bottom surface compatibility opt-out', () =
     expect(painted).not.toContain('cleanup draft');
     expect(painted).not.toContain('provider \u00b7 model');
     expect(painted).not.toContain('â–² You');
+  });
+
+  it('restores the owned surface exactly once when an exclusive modal lease releases', async () => {
+    const { d, chunks } = makeDisplay();
+    d.setBusyHint('queue');
+    d.setComposer('draft survives', 'queue');
+    chunks.length = 0;
+
+    await d.withModalLease('model-picker', async () => {
+      expect(chunks.join('')).toContain('\x1b[r');
+    });
+
+    const restored = stripAnsi(chunks.join(''));
+    expect(restored.match(/draft survives/g)).toHaveLength(1);
+    d.clearComposer();
+  });
+
+  it('waits for preceding terminal writes before accepting the final frame', async () => {
+    const callbacks: Array<() => void> = [];
+    const out = new Writable({
+      write(_chunk, _enc, cb) { callbacks.push(cb); },
+    }) as Writable & { isTTY?: boolean; columns?: number };
+    out.isTTY = false;
+    out.columns = 80;
+    const d = new Display({ stdout: out as unknown as NodeJS.WriteStream, skin: new SkinEngine({ forceMono: true }) });
+    const settled = vi.fn();
+
+    d.write('authoritative proof\n');
+    const barrier = d.awaitTerminalSettled().then(settled);
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    callbacks.shift()?.();
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+    callbacks.shift()?.();
+    await barrier;
+    expect(settled).toHaveBeenCalledOnce();
   });
 });

--- a/tests/v4/cli/entrypointContract.test.ts
+++ b/tests/v4/cli/entrypointContract.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveDesktopApiClientLocalCommand } from '../../../cli/desktopApiClientArgs';
+
+const root = path.resolve(__dirname, '../../..');
+
+describe('CLI entrypoint contract', () => {
+  it('maps both public commands to the standalone local runtime only', () => {
+    const manifest = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8')) as {
+      bin: Record<string, string>;
+      files: string[];
+    };
+    expect(manifest.bin).toEqual({
+      aiden: './dist/cli/v4/aidenCLI.js',
+      'aiden-runtime': './dist/cli/v4/aidenCLI.js',
+    });
+    expect(manifest.files).not.toContain('dist-bundle/');
+    expect(manifest.files).not.toContain('packages/aiden-os/');
+    expect(manifest.files).not.toContain('release-notes-v4.16.0.md');
+  });
+
+  it('answers desktop/API client version and help without a server', () => {
+    expect(resolveDesktopApiClientLocalCommand(['--version'], '4.19.0')).toBe('4.19.0\n');
+    expect(resolveDesktopApiClientLocalCommand(['-v'], '4.19.0')).toBe('4.19.0\n');
+    expect(resolveDesktopApiClientLocalCommand(['--help'], '4.19.0')).toContain('desktop/API client');
+    expect(resolveDesktopApiClientLocalCommand(['-h'], '4.19.0')).toContain('AIDEN_API');
+    expect(resolveDesktopApiClientLocalCommand([], '4.19.0')).toBeNull();
+  });
+
+  it('dispatches local informational flags before the desktop/API health request', () => {
+    const source = readFileSync(path.join(root, 'cli/aiden.ts'), 'utf8');
+    const localDispatch = source.indexOf('resolveDesktopApiClientLocalCommand(process.argv.slice(2), VERSION)');
+    const healthRequest = source.indexOf("apiFetch<any>('/api/health', null)");
+    expect(localDispatch).toBeGreaterThanOrEqual(0);
+    expect(healthRequest).toBeGreaterThan(localDispatch);
+  });
+});

--- a/tests/v4/cli/fullRuntimeInput.pty.test.ts
+++ b/tests/v4/cli/fullRuntimeInput.pty.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 
 type RunningPty = ReturnType<typeof pty.spawn>;
@@ -33,7 +34,7 @@ function stripAnsi(value: string): string {
 
 afterEach(async () => {
   for (const child of children) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
   }
   children.clear();
   await new Promise((resolve) => setTimeout(resolve, 300));

--- a/tests/v4/cli/inputAuthority.pty.test.ts
+++ b/tests/v4/cli/inputAuthority.pty.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 
 type RunningPty = ReturnType<typeof pty.spawn>;
 
@@ -9,7 +10,7 @@ const children = new Set<RunningPty>();
 
 afterEach(async () => {
   for (const child of children) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
   }
   children.clear();
   await new Promise((resolve) => setTimeout(resolve, 500));

--- a/tests/v4/cli/interactionDecision.pty.test.ts
+++ b/tests/v4/cli/interactionDecision.pty.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 
@@ -41,7 +42,7 @@ function currentTurn(output: string, prompt: string): string {
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   if (provider) {

--- a/tests/v4/cli/interactiveOutputOwnership.test.ts
+++ b/tests/v4/cli/interactiveOutputOwnership.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = join(__dirname, '..', '..', '..');
+
+function source(path: string): string {
+  return readFileSync(join(root, path), 'utf8');
+}
+
+describe('interactive output ownership', () => {
+  it('routes provider progress through the active display projection', () => {
+    const text = source('cli/v4/chatSession.ts');
+    const start = text.indexOf('onProgress: streamingEnabled');
+    const end = text.indexOf('const result = await runAgent()', start);
+    const block = text.slice(start, end);
+
+    expect(block).toContain('progressProjection(');
+    expect(block).toContain('createProgressBar(');
+  });
+
+  it('projects interactive crash notices instead of writing to stderr', () => {
+    const text = source('cli/v4/aidenCLI.ts');
+    const start = text.indexOf('installReplCrashHandlers({');
+    const end = text.indexOf('gateway.attachLogger', start);
+    const block = text.slice(start, end);
+
+    expect(block).toContain('display.writeError(');
+    expect(block).not.toContain('process.stderr.write');
+  });
+
+  it('keeps optional runtime diagnostics off interactive stdout and stderr', () => {
+    const files = [
+      'cli/v4/activityRegistry.ts',
+      'cli/v4/callbacks.ts',
+      'cli/v4/chatSession.ts',
+      'cli/v4/inputAuthority.ts',
+      'core/v4/aidenAgent.ts',
+      'providers/v4/responseStreamAdapter.ts',
+      'tools/v4/clarify/clarifyTool.ts',
+    ];
+    for (const file of files) {
+      const text = source(file);
+      const diagnosticWrites = text.match(
+        /AIDEN_P2A_DIAG[\s\S]{0,900}?process\.(?:stdout|stderr)\.write/g,
+      ) ?? [];
+      expect(diagnosticWrites, file).toEqual([]);
+    }
+  });
+});

--- a/tests/v4/cli/interactiveWriterAuthority.test.ts
+++ b/tests/v4/cli/interactiveWriterAuthority.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(__dirname, '../../..');
+const interactiveAdapters = [
+  'cli/v4/chatSession.ts',
+  'cli/v4/callbacks.ts',
+  'cli/v4/display/progressBar.ts',
+  'cli/v4/commands/modelPicker.ts',
+  'cli/v4/frame/runtime.ts',
+];
+const unownedWriter = /process\.(?:stdout|stderr)\.write|console\.(?:log|warn|error)|\.(?:cursorTo|moveCursor|clearLine|clearScreenDown)\s*\(/u;
+
+describe('interactive terminal writer authority', () => {
+  it('keeps session, progress, callback, picker and frame adapters free of direct terminal writers', () => {
+    for (const relative of interactiveAdapters) {
+      const source = readFileSync(resolve(root, relative), 'utf8');
+      expect(source, relative).not.toMatch(unownedWriter);
+    }
+  });
+
+  it('routes setup and picker through named exclusive modal leases', () => {
+    const setup = readFileSync(resolve(root, 'cli/v4/commands/setup.ts'), 'utf8');
+    const model = readFileSync(resolve(root, 'cli/v4/commands/model.ts'), 'utf8');
+    const callbacks = readFileSync(resolve(root, 'cli/v4/callbacks.ts'), 'utf8');
+    expect(setup).toContain("withModalLease('setup'");
+    expect(model).toContain("withModalLease('model-picker'");
+    expect(callbacks).toContain("withModalLease('approval'");
+  });
+});

--- a/tests/v4/cli/modelAccessState.test.ts
+++ b/tests/v4/cli/modelAccessState.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { makeProviderAccessProbe } from '../../../cli/v4/commands/model';
+import { resolveAidenPaths } from '../../../core/v4/paths';
+import { saveTokens } from '../../../core/v4/auth/tokenStore';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function context(root: string, readinessState: string) {
+  return {
+    paths: resolveAidenPaths({ rootOverride: root }),
+    config: {
+      getValue: () => ({ state: readinessState }),
+      get: () => undefined,
+    },
+  } as never;
+}
+
+describe('model picker provider access truth', () => {
+  it('does not report verified readiness when the persisted OAuth token is expired', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'aiden-auth-state-'));
+    roots.push(root);
+    const paths = resolveAidenPaths({ rootOverride: root });
+    const ctx = context(root, 'complete');
+    await saveTokens(paths, {
+      provider: 'chatgpt-plus',
+      accessToken: 'fixture-token',
+      expiresAtMs: Date.now() - 1,
+    });
+
+    await expect(makeProviderAccessProbe(ctx)('chatgpt-plus')).resolves.toBe('authentication_expired');
+  });
+
+  it('distinguishes valid authentication from verified and failed readiness', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'aiden-auth-state-'));
+    roots.push(root);
+    const paths = resolveAidenPaths({ rootOverride: root });
+    await saveTokens(paths, {
+      provider: 'chatgpt-plus',
+      accessToken: 'fixture-token',
+      expiresAtMs: Date.now() + 60_000,
+    });
+    const make = (state: string) => makeProviderAccessProbe({
+      paths,
+      config: { getValue: () => ({ state }), get: () => undefined },
+    } as never)('chatgpt-plus');
+
+    await expect(make('credential_verified')).resolves.toBe('authentication_valid');
+    await expect(make('complete')).resolves.toBe('readiness_verified');
+    await expect(make('failed_requires_user_action')).resolves.toBe('readiness_failed');
+  });
+});

--- a/tests/v4/cli/modelPicker.test.ts
+++ b/tests/v4/cli/modelPicker.test.ts
@@ -301,7 +301,7 @@ describe('runModelPicker', () => {
     expect(anthropicRow).toMatch(/\(\d+ model[s]?\)/);
   });
 
-  it('stage-1 shows ✓ authed for providers reporting credentials', async () => {
+  it('stage-1 distinguishes authentication and readiness states truthfully', async () => {
     const seen: string[] = [];
     const select = vi.fn(async (opts: any) => {
       if (isStage1(opts.message)) {
@@ -313,12 +313,21 @@ describe('runModelPicker', () => {
     await runModelPicker({
       resolver: realResolver(),
       promptModule: { select },
-      isProviderAuthed: (id) => id === 'anthropic',
+      isProviderAuthed: (id) => id === 'anthropic'
+        ? 'readiness_verified'
+        : id === 'chatgpt-plus'
+          ? 'authentication_expired'
+          : id === 'groq'
+            ? 'readiness_failed'
+            : 'authentication_missing',
     });
     const anthropicRow = seen.find((s) => s.startsWith('Anthropic'))!;
+    const chatgptRow = seen.find((s) => s.startsWith('ChatGPT Plus'))!;
     const groqRow = seen.find((s) => s.startsWith('Groq'))!;
-    expect(anthropicRow).toMatch(/✓ authed/);
-    expect(groqRow).toMatch(/⚠ no API key/);
+    expect(anthropicRow).toMatch(/✓ ready/);
+    expect(chatgptRow).toMatch(/authentication expired/);
+    expect(chatgptRow).not.toMatch(/authed/);
+    expect(groqRow).toMatch(/readiness failed/);
   });
 
   it('stage-1 marks the current provider with ← current and stage-2 the current model', async () => {

--- a/tests/v4/cli/ollamaModelPicker.pty.test.ts
+++ b/tests/v4/cli/ollamaModelPicker.pty.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 
 type RunningPty = ReturnType<typeof pty.spawn>;
 let child: RunningPty | null = null;
@@ -17,7 +18,7 @@ function plain(value: string): string {
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   await new Promise((resolve) => setTimeout(resolve, 300));

--- a/tests/v4/cli/progressBar.test.ts
+++ b/tests/v4/cli/progressBar.test.ts
@@ -124,6 +124,27 @@ describe('createProgressBar (v4.1.4 Part 1.6)', () => {
     expect(chunks.length).toBeGreaterThan(after100);
   });
 
+  it('routes owned interactive updates without writing cursor controls to the stream', () => {
+    const { out, chunks } = makeStream(true);
+    const projected: string[] = [];
+    let cleared = 0;
+    const skin = new SkinEngine({ forceMono: true });
+    const bar = createProgressBar(out, skin, {
+      update: (line) => { projected.push(line); return true; },
+      clear: () => { cleared += 1; return true; },
+      settle: () => false,
+    });
+
+    bar.update(100, 1_000);
+    bar.update(200, 1_000);
+    bar.hide();
+
+    expect(projected).toHaveLength(2);
+    expect(stripAnsi(projected.at(-1)!)).toContain('200/1K tokens');
+    expect(cleared).toBe(1);
+    expect(chunks).toEqual([]);
+  });
+
   it('Non-TTY: completely silent — no writes regardless of updates', () => {
     const { out, chunks } = makeStream(false);
     const skin = new SkinEngine({ forceMono: true });

--- a/tests/v4/cli/semanticActivity.test.ts
+++ b/tests/v4/cli/semanticActivity.test.ts
@@ -8,6 +8,7 @@ import {
   projectCommandPresentation,
   projectEvidenceLines,
   projectSkillInvocation,
+  filterPowerShellProgressClixml,
   relativizeActivityText,
   shouldDeferActivityTransition,
   type SemanticActivityPhase,
@@ -139,6 +140,23 @@ describe('compact command and evidence projection', () => {
     expect(projected.lines).toContain('! Git line-ending notice available');
     expect(projected.lines.join('\n')).not.toContain('failed');
     expect(projected.details).toContain('LF will be replaced');
+  });
+
+  it('removes only PowerShell progress records and preserves genuine errors', () => {
+    const progress = '<Obj S="progress"><MS><PR N="Record"><AV>Working</AV></PR></MS></Obj>';
+    const error = '<Obj S="Error"><MS><S N="Message">Access denied</S></MS></Obj>';
+    expect(filterPowerShellProgressClixml(`#< CLIXML\n<Objs>${progress}</Objs>`)).toEqual({
+      stderr: '', removedProgress: true,
+    });
+    expect(filterPowerShellProgressClixml(`#< CLIXML\n<Objs>${progress}${error}</Objs>`)).toEqual({
+      stderr: `#< CLIXML\n<Objs>${error}</Objs>`, removedProgress: true,
+    });
+    expect(filterPowerShellProgressClixml('#< CLIXML\nnot xml')).toEqual({
+      stderr: '#< CLIXML\nnot xml', removedProgress: false,
+    });
+    expect(filterPowerShellProgressClixml('native stderr')).toEqual({
+      stderr: 'native stderr', removedProgress: false,
+    });
   });
 
   it('uses repository-relative text in summary mode and exact paths in full mode', () => {

--- a/tests/v4/cli/setupCommand.test.ts
+++ b/tests/v4/cli/setupCommand.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const runSetupWizard = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../cli/v4/setupWizard', () => ({ runSetupWizard }));
+
+import { setup } from '../../../cli/v4/commands/setup';
+
+describe('/setup live provider lifecycle', () => {
+  it('rebuilds the active provider after successful setup without requiring restart', async () => {
+    runSetupWizard.mockResolvedValue({
+      status: 'configured',
+      ran: true,
+      config: { model: { provider: 'groq', modelId: 'openai/gpt-oss-120b' } },
+      readiness: { state: 'complete' },
+    });
+    const write = vi.fn();
+    const printError = vi.fn();
+    const setProvider = vi.fn().mockResolvedValue(undefined);
+    const withModalLease = vi.fn(async (_owner: string, run: () => Promise<unknown>) => run());
+
+    await setup.handler({
+      paths: { root: 'C:\\aiden-home' },
+      display: { write, printError, withModalLease },
+      session: { setProvider },
+    } as never);
+
+    expect(setProvider).toHaveBeenCalledWith('groq', 'openai/gpt-oss-120b');
+    expect(withModalLease).toHaveBeenCalledWith('setup', expect.any(Function));
+    expect(write).not.toHaveBeenCalledWith(expect.stringMatching(/restart|\/quit/iu));
+    expect(printError).not.toHaveBeenCalled();
+  });
+
+  it('preserves the prior live provider when rebuilding the configured adapter fails', async () => {
+    runSetupWizard.mockResolvedValue({
+      status: 'configured',
+      ran: true,
+      config: { model: { provider: 'groq', modelId: 'openai/gpt-oss-120b' } },
+      readiness: { state: 'complete' },
+    });
+    const write = vi.fn();
+    const printError = vi.fn();
+    const setProvider = vi.fn().mockRejectedValue(new Error('readiness failed'));
+    const withModalLease = vi.fn(async (_owner: string, run: () => Promise<unknown>) => run());
+
+    await setup.handler({
+      paths: { root: 'C:\\aiden-home' },
+      display: { write, printError, withModalLease },
+      session: { setProvider },
+    } as never);
+
+    expect(printError).toHaveBeenCalledWith(
+      expect.stringMatching(/configured.*could not activate/iu),
+      expect.stringMatching(/previous provider/iu),
+    );
+    expect(write).not.toHaveBeenCalledWith(expect.stringMatching(/restart/iu));
+  });
+});

--- a/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
+++ b/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 
 import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
@@ -38,7 +39,7 @@ function submit(terminal: RunningPty, text: string): void {
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   if (provider) {

--- a/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
+++ b/tests/v4/cli/tokenEfficiencyAcceptance.pty.test.ts
@@ -25,16 +25,9 @@ function plain(value: string): string {
 }
 
 function submit(terminal: RunningPty, text: string): void {
-  let index = 0;
-  const next = (): void => {
-    if (index < text.length) {
-      terminal.write(text[index++]!);
-      setTimeout(next, 5);
-      return;
-    }
-    setTimeout(() => terminal.write('\r'), 100);
-  };
-  next();
+  // This acceptance test owns accounting behavior, while keyboard pacing has
+  // dedicated coverage. One deferred write avoids timer-fragmented input loss.
+  setImmediate(() => terminal.write(`${text}\r`));
 }
 
 afterEach(async () => {

--- a/tests/v4/cli/ui/progressBar.test.ts
+++ b/tests/v4/cli/ui/progressBar.test.ts
@@ -152,6 +152,32 @@ describe('startProgressBar â€” stream behavior', () => {
 });
 
 describe('startPhaseIndicator â€” truthful indeterminate updater status', () => {
+  it('uses the owned projection for interactive updates and settlement', () => {
+    const cap = captureStream();
+    const projected: string[] = [];
+    const settled: string[] = [];
+    const indicator = startPhaseIndicator({
+      label: 'Updating',
+      phases: ['installing', 'verifying'],
+      out: cap.stream,
+      isTTY: true,
+      env: { NO_COLOR: '1' },
+      tickMs: 60_000,
+      projection: {
+        update: (line) => { projected.push(line); return true; },
+        clear: () => true,
+        settle: (line) => { settled.push(line); return true; },
+      },
+    });
+
+    indicator.setPhase('verifying');
+    indicator.complete('Update verified.');
+
+    expect(projected.join('\n')).toContain('verifying');
+    expect(settled).toEqual(['✓ Update verified.']);
+    expect(cap.chunks).toEqual([]);
+  });
+
   it('renders phases without a fabricated numeric percentage', () => {
     const cap = captureStream();
     const indicator = startPhaseIndicator({

--- a/tests/v4/cli/viewportEpoch.pty.test.ts
+++ b/tests/v4/cli/viewportEpoch.pty.test.ts
@@ -7,6 +7,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import * as pty from 'node-pty';
+import { killPtyIfRunning } from '../harness/ptyProcessLifecycle';
 
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 import { startMockProvider, type MockProvider } from '../harness/mockProvider';
@@ -47,7 +48,7 @@ function assertClearedFrame(screen: TerminalScreen, oldRows: readonly string[]):
 
 afterEach(async () => {
   if (child) {
-    try { child.kill(); } catch { /* already exited */ }
+    try { killPtyIfRunning(child); } catch { /* already exited */ }
     child = null;
   }
   await new Promise((resolve) => setTimeout(resolve, 500));

--- a/tests/v4/codebase/repositorySnapshotMigration.test.ts
+++ b/tests/v4/codebase/repositorySnapshotMigration.test.ts
@@ -31,7 +31,7 @@ describe('repository snapshot migration v32', () => {
       migration.apply!(db!);
       db!.prepare('INSERT OR REPLACE INTO schema_version (id,version,applied_at) VALUES (1,32,?)').run(Date.now());
     }).immediate();
-    expect(LATEST_SCHEMA_VERSION).toBe(41);
+    expect(LATEST_SCHEMA_VERSION).toBe(42);
     expect(db.prepare('SELECT id,status,repository_snapshot_id FROM tasks WHERE id=?').get('job')).toEqual({ id: 'job', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare('SELECT attempt_id,status,repository_snapshot_id FROM runs WHERE attempt_id=?').get('attempt')).toEqual({ attempt_id: 'attempt', status: 'queued', repository_snapshot_id: null });
     expect(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'repository_%' ORDER BY name").all()).toEqual([

--- a/tests/v4/core/runtimeTrace.test.ts
+++ b/tests/v4/core/runtimeTrace.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runtimeTrace } from '../../../core/v4/runtimeTrace';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('runtime trace sink', () => {
+  it('writes structured records only to the configured file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'aiden-runtime-trace-'));
+    roots.push(root);
+    const target = join(root, 'trace.jsonl');
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    runtimeTrace('turn', 'accepted', { turnId: 7 }, {
+      AIDEN_RUNTIME_TRACE_FILE: target,
+    });
+
+    const record = JSON.parse(readFileSync(target, 'utf8')) as Record<string, unknown>;
+    expect(record).toMatchObject({ scope: 'turn', event: 'accepted', turnId: 7 });
+    expect(record.monoMs).toEqual(expect.any(Number));
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when no file sink is configured', () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    runtimeTrace('turn', 'accepted', {}, { AIDEN_P2A_DIAG: '1' });
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+  });
+});

--- a/tests/v4/core/runtimeTrace.test.ts
+++ b/tests/v4/core/runtimeTrace.test.ts
@@ -37,4 +37,24 @@ describe('runtime trace sink', () => {
     expect(stdout).not.toHaveBeenCalled();
     expect(stderr).not.toHaveBeenCalled();
   });
+
+  it('covers the complete turn, tool, proof, and render phase boundary', () => {
+    const root = join(__dirname, '../../..');
+    const session = readFileSync(join(root, 'cli/v4/chatSession.ts'), 'utf8');
+    const agent = readFileSync(join(root, 'core/v4/aidenAgent.ts'), 'utf8');
+    const proof = readFileSync(join(root, 'core/v4/daemon/jobProofAuthority.ts'), 'utf8');
+    for (const event of [
+      'input.accepted', 'planning.start', 'planning.end', 'first_token',
+      'final_stream.complete', 'markdown_settlement.start', 'markdown_settlement.end',
+      'final_frame.accepted', 'stable_ready',
+    ]) expect(session).toContain(`'${event}'`);
+    for (const event of [
+      'provider.request', 'provider.complete', 'tool.admitted', 'tool.start',
+      'tool.complete', 'verification.start', 'verification.end',
+    ]) expect(agent).toContain(`'${event}'`);
+    for (const event of [
+      'evidence.recorded', 'claim_verification.start', 'claim_verification.end',
+      'verdict.computed', 'proof.persisted',
+    ]) expect(proof).toContain(`'${event}'`);
+  });
 });

--- a/tests/v4/core/runtimeTrace.test.ts
+++ b/tests/v4/core/runtimeTrace.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { runtimeTrace } from '../../../core/v4/runtimeTrace';
+import {
+  runtimeTrace,
+  warnNonInteractiveDiagnostic,
+  writeNonInteractiveDiagnostic,
+} from '../../../core/v4/runtimeTrace';
 
 const roots: string[] = [];
 
@@ -36,6 +40,21 @@ describe('runtime trace sink', () => {
 
     expect(stdout).not.toHaveBeenCalled();
     expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('preserves redirected diagnostics without writing into interactive output', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    writeNonInteractiveDiagnostic('redirected', false);
+    warnNonInteractiveDiagnostic('warning', false);
+    writeNonInteractiveDiagnostic('hidden', true);
+    warnNonInteractiveDiagnostic('hidden warning', true);
+
+    expect(stderr).toHaveBeenCalledOnce();
+    expect(stderr).toHaveBeenCalledWith('redirected\n');
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith('warning');
   });
 
   it('covers the complete turn, tool, proof, and render phase boundary', () => {

--- a/tests/v4/core/runtimeTrace.test.ts
+++ b/tests/v4/core/runtimeTrace.test.ts
@@ -76,4 +76,17 @@ describe('runtime trace sink', () => {
       'verdict.computed', 'proof.persisted',
     ]) expect(proof).toContain(`'${event}'`);
   });
+
+  it('accepts the final frame before projecting the stable ready state', () => {
+    const root = join(__dirname, '../../..');
+    const session = readFileSync(join(root, 'cli/v4/chatSession.ts'), 'utf8');
+    const barrier = session.indexOf('await this.opts.display.awaitTerminalSettled()');
+    const accepted = session.indexOf("runtimeTrace('turn', 'final_frame.accepted'", barrier);
+    const ready = session.indexOf("this.setStatusState({ kind: 'ready' })", accepted);
+    const readyPrompt = session.indexOf("runtimeTrace('turn', 'ready_prompt.emitted'", ready);
+    expect(barrier).toBeGreaterThan(0);
+    expect(accepted).toBeGreaterThan(barrier);
+    expect(ready).toBeGreaterThan(accepted);
+    expect(readyPrompt).toBeGreaterThan(ready);
+  });
 });

--- a/tests/v4/daemon/db/kernelMigration.test.ts
+++ b/tests/v4/daemon/db/kernelMigration.test.ts
@@ -44,6 +44,29 @@ function tempDb(): { root: string; path: string } {
 }
 
 describe('kernel migration compatibility', () => {
+  it('adds empty Effect bindings to existing Claims without changing their truth', () => {
+    const db = new Database(':memory:');
+    applyThrough(db, 41);
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO job_claims
+         (claim_id, job_id, category, statement, required, state, created_at)
+       VALUES ('claim_legacy', 'job_legacy', 'contract', 'legacy claim', 1, 'verified', 1)`,
+    ).run();
+    db.pragma('foreign_keys = ON');
+
+    expect(runMigrations(db)).toEqual({ from: 41, to: LATEST_SCHEMA_VERSION });
+    expect(db.prepare(
+      `SELECT statement, required, state, effect_ids_json FROM job_claims WHERE claim_id='claim_legacy'`,
+    ).get()).toEqual({
+      statement: 'legacy claim',
+      required: 1,
+      state: 'verified',
+      effect_ids_json: '[]',
+    });
+    db.close();
+  });
+
   it('opens a populated v4.16-era database without changing terminal truth or queued input', () => {
     const location = tempDb();
     const legacy = new Database(location.path);

--- a/tests/v4/daemon/db/migrations.test.ts
+++ b/tests/v4/daemon/db/migrations.test.ts
@@ -114,7 +114,7 @@ describe('runMigrations', () => {
        VALUES ('manual','preserved','{"value":1}','claimed',1,'legacy-owner',?,?,?)`,
     ).run(now + 60_000, now, now);
 
-    expect(runMigrations(db)).toEqual({ from: 40, to: 41 });
+    expect(runMigrations(db)).toEqual({ from: 40, to: LATEST_SCHEMA_VERSION });
     expect(db.prepare(
       'SELECT source_key,payload_json,status,claim_owner,claim_token FROM trigger_events WHERE source_key=?',
     ).get('preserved')).toEqual({

--- a/tests/v4/daemon/dispatcher/lifecycle.test.ts
+++ b/tests/v4/daemon/dispatcher/lifecycle.test.ts
@@ -43,6 +43,7 @@ afterEach(() => { try { db.close(); } catch { /* noop */ } });
 // Helper: build a dispatcher that records every invocation in `calls`.
 function build(opts: {
   invoke: (input: DaemonAgentInput) => Promise<DaemonAgentResult>;
+  dispose?: (reason?: string) => Promise<void>;
   maxAttempts?: number;
 }): { dispatcher: Dispatcher; calls: DaemonAgentInput[] } {
   const calls: DaemonAgentInput[] = [];
@@ -56,9 +57,12 @@ function build(opts: {
     leaseMs:    60_000,
     renewMs:    30_000,
     maxAttempts: opts.maxAttempts ?? 3,
-    runnerFactory: () => makeRunner(async (input) => {
-      calls.push(input);
-      return opts.invoke(input);
+    runnerFactory: () => ({
+      ...makeRunner(async (input) => {
+        calls.push(input);
+        return opts.invoke(input);
+      }),
+      ...(opts.dispose ? { dispose: opts.dispose } : {}),
     }),
   });
   return { dispatcher, calls };
@@ -194,5 +198,34 @@ describe('dispatcher — workerCount=1 boundedness', () => {
     await dispatcher.stop(2_000);
     // Dispatcher exited cleanly.
     expect(dispatcher.inflight().length).toBe(0);
+  });
+
+  it('stop() awaits runner lifecycle disposal before resolving', async () => {
+    let resolveDisposal!: () => void;
+    const disposal = new Promise<void>((resolve) => { resolveDisposal = resolve; });
+    const { dispatcher } = build({
+      invoke: async () => ({ runId: 0, finishReason: 'stop' }),
+      dispose: async () => disposal,
+    });
+    dispatcher.start();
+
+    let stopped = false;
+    const stopping = dispatcher.stop(2_000).then(() => { stopped = true; });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(stopped).toBe(false);
+
+    resolveDisposal();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
+  it('stop() rejects instead of permitting storage teardown when lifecycle disposal misses its deadline', async () => {
+    const { dispatcher } = build({
+      invoke: async () => ({ runId: 0, finishReason: 'stop' }),
+      dispose: async () => new Promise<void>(() => { /* intentionally unresolved */ }),
+    });
+    dispatcher.start();
+
+    await expect(dispatcher.stop(10)).rejects.toThrow(/shutdown timed out/i);
   });
 });

--- a/tests/v4/daemon/jobLifecycle.test.ts
+++ b/tests/v4/daemon/jobLifecycle.test.ts
@@ -8,7 +8,11 @@ import Database from 'better-sqlite3';
 
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 import { createJobEngine, type JobEngine } from '../../../core/v4/daemon/jobEngine';
-import { executeDurableJob } from '../../../core/v4/daemon/jobLifecycle';
+import {
+  createDurableJobLifecycleScope,
+  DurableJobLifecycleDisposedError,
+  executeDurableJob,
+} from '../../../core/v4/daemon/jobLifecycle';
 import { currentJobExecutionContext } from '../../../core/v4/daemon/jobExecutionContext';
 import { createJobControlAuthority } from '../../../core/v4/daemon/jobControlAuthority';
 
@@ -408,6 +412,103 @@ describe('executeDurableJob', () => {
     expect(sawAbort).toBe(true);
     expect(engine.getJob(active.jobId)?.status).toBe('cancelled');
     expect(controlAuthority.runtime.isAttached(active.attemptId)).toBe(false);
+  });
+
+  it('disposes and drains a running lifecycle before durable storage closes', async () => {
+    const scope = createDurableJobLifecycleScope();
+    let enteredExecution = false;
+    let readsAfterDisposal = 0;
+    const scopedEngine: JobEngine = {
+      ...engine,
+      getJob(jobId) {
+        if (scope.disposed) readsAfterDisposal += 1;
+        return engine.getJob(jobId);
+      },
+    };
+
+    const running = executeDurableJob({
+      engine: scopedEngine,
+      lifecycleScope: scope,
+      ownerId: 'instance_lifecycle',
+      controlPollMs: 25,
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_dispose',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_dispose', requestFingerprint: 'fingerprint_dispose', goal: 'dispose work',
+      },
+      execute: async (handle) => {
+        enteredExecution = true;
+        await new Promise<void>((_resolve, reject) => {
+          handle.signal.addEventListener('abort', () => reject(handle.signal.reason), { once: true });
+        });
+        return 'unreachable';
+      },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    });
+
+    while (!enteredExecution) await new Promise((resolve) => setTimeout(resolve, 0));
+    await scope.dispose('test shutdown');
+    await expect(running).rejects.toBeInstanceOf(DurableJobLifecycleDisposedError);
+
+    expect(scope.activeCount).toBe(0);
+    expect(readsAfterDisposal).toBe(0);
+    expect(engine.listJobs({ sessionId: 'session_dispose' })[0]?.status).toBe('cancelled');
+
+    db.close();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(readsAfterDisposal).toBe(0);
+    db = new Database(':memory:');
+  });
+
+  it('makes lifecycle disposal idempotent and fences late admission', async () => {
+    const scope = createDurableJobLifecycleScope();
+
+    await scope.dispose('first shutdown');
+    await scope.dispose('second shutdown');
+
+    expect(scope.activeCount).toBe(0);
+    await expect(executeDurableJob({
+      engine,
+      lifecycleScope: scope,
+      ownerId: 'instance_lifecycle',
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_late',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_late', requestFingerprint: 'fingerprint_late', goal: 'late work',
+      },
+      execute: async () => 'unreachable',
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    })).rejects.toBeInstanceOf(DurableJobLifecycleDisposedError);
+    expect(engine.listJobs({ sessionId: 'session_late' })).toEqual([]);
+  });
+
+  it('releases lifecycle ownership after an execution error', async () => {
+    const scope = createDurableJobLifecycleScope();
+
+    await expect(executeDurableJob({
+      engine,
+      lifecycleScope: scope,
+      ownerId: 'instance_lifecycle',
+      controlPollMs: 25,
+      admission: {
+        entryPoint: 'test', source: 'test', sessionId: 'session_error_cleanup',
+        instanceId: 'instance_lifecycle', idempotencyNamespace: 'lifecycle',
+        idempotencyKey: 'request_error_cleanup', requestFingerprint: 'fingerprint_error_cleanup', goal: 'fail safely',
+      },
+      execute: async () => { throw new Error('expected execution failure'); },
+      finalize: () => ({
+        status: 'completed', outcome: 'completed', finishReason: 'stop', evidence: {},
+      }),
+    })).rejects.toThrow('expected execution failure');
+
+    expect(scope.activeCount).toBe(0);
+    await scope.dispose('post-error shutdown');
+    expect(scope.activeCount).toBe(0);
+    expect(engine.listJobs({ sessionId: 'session_error_cleanup' })[0]?.status).toBe('failed');
   });
 
   it('emits one ordered phase trace and finalizes once', async () => {

--- a/tests/v4/daemon/jobProofAuthority.test.ts
+++ b/tests/v4/daemon/jobProofAuthority.test.ts
@@ -185,6 +185,103 @@ describe('JobProofAuthority', () => {
     }).verdict).toBe('verified');
   });
 
+  it('does not let incomplete optional capture poison independently verified required claims', () => {
+    const job = activeJob('optional-capture');
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'required output is exact', required: true,
+      requiredEvidenceCategories: ['filesystem.readback'],
+    });
+    jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'optional.capture', producer: 'test', observedAt: 410, coverage: 'unknown',
+      verificationResult: 'unknown', payload: { captured: false }, now: 411,
+    });
+    const required = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'filesystem.readback', producer: 'test', observedAt: 412, coverage: 'full',
+      verificationResult: 'verified', payload: { exact: true }, now: 413,
+    });
+    jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [required.evidenceId], state: 'verified', now: 414,
+    });
+
+    expect(jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation,
+      fenceToken: job.fenceToken, now: 415,
+    }).verdict).toBe('verified');
+  });
+
+  it('rejects evidence linked to a different durable Effect', () => {
+    const job = activeJob('effect-binding');
+    db.prepare(
+      `INSERT INTO side_effect_ledger
+         (key, task_id, step, tool, args_hash, status, attempted_at, job_id, attempt_id,
+          generation, effect_state)
+       VALUES (?, ?, ?, 'shell_exec', ?, 'confirmed', ?, ?, ?, ?, 'committed')`,
+    ).run('effect_expected', job.jobId, 0, 'digest-a', 420, job.jobId, job.attemptId, job.generation);
+    db.prepare(
+      `INSERT INTO side_effect_ledger
+         (key, task_id, step, tool, args_hash, status, attempted_at, job_id, attempt_id,
+          generation, effect_state)
+       VALUES (?, ?, ?, 'shell_exec', ?, 'confirmed', ?, ?, ?, ?, 'committed')`,
+    ).run('effect_other', job.jobId, 1, 'digest-b', 421, job.jobId, job.attemptId, job.generation);
+    const claim = jobs.proof.createClaim({
+      jobId: job.jobId, category: 'contract', statement: 'expected Effect is verified', required: true,
+      effectIds: ['effect_expected'],
+    });
+    const unrelated = jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      effectId: 'effect_other', source: 'effect.readback', producer: 'test', observedAt: 422,
+      coverage: 'full', verificationResult: 'verified', payload: { exact: true }, now: 423,
+    });
+
+    expect(() => jobs.proof.checkClaim({
+      claimId: claim.claimId, attemptId: job.attemptId, generation: job.generation,
+      evidenceIds: [unrelated.evidenceId], state: 'verified', now: 424,
+    })).toThrow(/Effect/);
+  });
+
+  it('verifies the complete file, hash, and repository acceptance workflow', () => {
+    const job = activeJob('acceptance-workflow');
+    const definitions = [
+      ['input.txt has exact content', 'filesystem.readback', { path: 'input.txt', content: 'Aiden proof input' }],
+      ['result.json has exact content', 'filesystem.readback', { path: 'result.json', exact: true }],
+      ['input.txt SHA-256 matches', 'filesystem.sha256', { path: 'input.txt', sha256: 'expected-sha256' }],
+      ['repository remains unchanged', 'repository.diff', { changed: [] }],
+    ] as const;
+    const claims = definitions.map(([statement, source]) => jobs.proof.createClaim({
+      jobId: job.jobId,
+      category: 'contract',
+      statement,
+      required: true,
+      requiredEvidenceCategories: [source],
+    }));
+    jobs.proof.recordEvidence({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+      source: 'optional.capture', producer: 'test', observedAt: 430, coverage: 'partial',
+      verificationResult: 'unknown', payload: { helper: 'unavailable' }, now: 431,
+    });
+    definitions.forEach(([_, source, payload], index) => {
+      const evidence = jobs.proof.recordEvidence({
+        jobId: job.jobId, attemptId: job.attemptId, generation: job.generation, fenceToken: job.fenceToken,
+        source, producer: 'test', observedAt: 432 + index, coverage: 'full',
+        verificationResult: 'verified', payload, now: 440 + index,
+      });
+      jobs.proof.checkClaim({
+        claimId: claims[index]!.claimId, attemptId: job.attemptId, generation: job.generation,
+        evidenceIds: [evidence.evidenceId], state: 'verified', now: 450 + index,
+      });
+    });
+
+    const verdict = jobs.proof.finalize({
+      jobId: job.jobId, attemptId: job.attemptId, generation: job.generation,
+      fenceToken: job.fenceToken, now: 460,
+    });
+    expect(verdict.verdict).toBe('verified');
+    expect(verdict.summary).toMatchObject({ requiredClaims: 4, verifiedClaims: 4 });
+  });
+
   it('keeps an unresolved unsafe Effect from producing a verified verdict', () => {
     const job = activeJob('unsafe-unknown');
     const claim = jobs.proof.createClaim({

--- a/tests/v4/harness/aidenTerm.ts
+++ b/tests/v4/harness/aidenTerm.ts
@@ -36,6 +36,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+import { killPtyIfRunning } from './ptyProcessLifecycle';
 
 export interface SpawnAidenTermOptions {
   /** Columns. Default 120 — wide enough for full-density status footer. */
@@ -264,7 +265,7 @@ export async function spawnAidenTerm(
       return await waitForExit(waitOpts);
     },
     kill: () => {
-      try { child.kill(); } catch { /* best-effort */ }
+      try { killPtyIfRunning(child); } catch { /* best-effort */ }
     },
     isAlive: () => exitCode === null,
     pid:     () => child.pid,

--- a/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
+++ b/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
@@ -2,6 +2,7 @@
 
 const path = require('node:path');
 const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
 
 const repoRoot = process.env.AIDEN_TEST_REPO_ROOT;
 const installRoot = process.env.AIDEN_TEST_INSTALLED_ROOT;
@@ -24,18 +25,66 @@ function plain(value) {
 
 function submit(terminal, value, onComplete) {
   let index = 0;
+  let stopped = false;
+  let immediate;
+  const timers = new Set();
+  const schedule = (callback, delay) => {
+    const timer = setTimeout(() => {
+      timers.delete(timer);
+      if (!stopped) callback();
+    }, delay);
+    timers.add(timer);
+  };
   const writeNext = () => {
     if (index < value.length) {
       terminal.write(value[index++]);
-      setTimeout(writeNext, 10);
-    } else {
-      setTimeout(() => {
-        terminal.write('\r');
-        onComplete();
-      }, 100);
+      schedule(writeNext, 10);
+      return;
     }
+    schedule(() => {
+      terminal.write('\r');
+      onComplete();
+    }, 100);
   };
-  writeNext();
+  immediate = setImmediate(() => {
+    immediate = undefined;
+    if (!stopped) writeNext();
+  });
+  return () => {
+    stopped = true;
+    if (immediate) clearImmediate(immediate);
+    for (const timer of timers) clearTimeout(timer);
+    timers.clear();
+  };
+}
+
+function terminateForFailure(terminal) {
+  if (process.platform === 'win32') {
+    spawnSync('taskkill.exe', ['/PID', String(terminal.pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    return;
+  }
+  terminal.kill();
+}
+
+async function releaseExitedPty(terminal) {
+  if (process.platform !== 'win32') return;
+  const agent = terminal._agent;
+  agent?.inSocket?.destroy();
+  agent?.outSocket?.destroy();
+  const worker = agent?._conoutSocketWorker?._worker;
+  if (worker && typeof worker.terminate === 'function') {
+    await worker.terminate();
+  }
+}
+
+function activeSmokeHandles() {
+  const standardHandles = new Set([process.stdin, process.stdout, process.stderr]);
+  return process._getActiveHandles()
+    .filter((handle) => !standardHandles.has(handle))
+    .map((handle) => handle?.constructor?.name ?? typeof handle);
 }
 
 function runFirstSession() {
@@ -50,19 +99,35 @@ function runFirstSession() {
     let state = 'boot';
     let historyTurns = 0;
     let historyReadyTarget = 0;
+    let compressionReadyTarget = 0;
     let submitting = false;
+    let settled = false;
+    let dataSubscription;
+    let exitSubscription;
+    let cancelSubmission;
     const send = (value, afterSent) => {
       submitting = true;
-      submit(terminal, value, () => {
+      cancelSubmission = submit(terminal, value, () => {
+        cancelSubmission = undefined;
         submitting = false;
         afterSent?.();
       });
     };
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      cancelSubmission?.();
+      dataSubscription?.dispose();
+      exitSubscription?.dispose();
+      if (error) reject(error);
+      else resolve(value);
+    };
     const timeout = setTimeout(() => {
-      terminal.kill();
-      reject(new Error(`First packaged interactive session timed out (${state}):\n${plain(output).slice(-12_000)}`));
+      terminateForFailure(terminal);
+      finish(new Error(`First packaged interactive session timed out (${state}):\n${plain(output).slice(-12_000)}`));
     }, 90_000);
-    terminal.onData((chunk) => {
+    dataSubscription = terminal.onData((chunk) => {
       output += chunk;
       if (submitting) return;
       const text = plain(output);
@@ -101,18 +166,29 @@ function runFirstSession() {
         if (!text.includes('Providers and models') || !text.includes('Purposes')) {
           throw new Error('Detailed usage output omitted required sections.');
         }
-        state = 'compress'; send('/compress');
-      } else if (state === 'compress' && /Compressed \d+ .* \d+ messages/.test(text)) {
+        state = 'compress';
+        send('/compress', () => {
+          compressionReadyTarget = output.split(readyToken).length;
+        });
+      } else if (state === 'compress'
+          && /Compressed \d+ .* \d+ messages/.test(text)
+          && readyCount >= compressionReadyTarget) {
         state = 'quit'; send('/quit');
       }
     });
-    terminal.onExit(({ exitCode }) => {
-      clearTimeout(timeout);
+    exitSubscription = terminal.onExit(({ exitCode }) => {
       if (state !== 'quit' || exitCode !== 0) {
-        reject(new Error(`First packaged interactive session exited ${exitCode} (${state}):\n${plain(output).slice(-12_000)}`));
+        finish(new Error(`First packaged interactive session exited ${exitCode} (${state}):\n${plain(output).slice(-12_000)}`));
         return;
       }
-      resolve(output);
+      dataSubscription?.dispose();
+      exitSubscription?.dispose();
+      dataSubscription = undefined;
+      exitSubscription = undefined;
+      void releaseExitedPty(terminal).then(
+        () => finish(null, output),
+        (error) => finish(error),
+      );
     });
   });
 }
@@ -128,15 +204,32 @@ function runRestartSession() {
     let output = '';
     let state = 'boot';
     let submitting = false;
+    let settled = false;
+    let dataSubscription;
+    let exitSubscription;
+    let cancelSubmission;
     const send = (value) => {
       submitting = true;
-      submit(terminal, value, () => { submitting = false; });
+      cancelSubmission = submit(terminal, value, () => {
+        cancelSubmission = undefined;
+        submitting = false;
+      });
+    };
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      cancelSubmission?.();
+      dataSubscription?.dispose();
+      exitSubscription?.dispose();
+      if (error) reject(error);
+      else resolve(value);
     };
     const timeout = setTimeout(() => {
-      terminal.kill();
-      reject(new Error(`Restarted packaged session timed out (${state}):\n${plain(output).slice(-12_000)}\nRequest trace:\n${requestTrace()}`));
+      terminateForFailure(terminal);
+      finish(new Error(`Restarted packaged session timed out (${state}):\n${plain(output).slice(-12_000)}\nRequest trace:\n${requestTrace()}`));
     }, 60_000);
-    terminal.onData((chunk) => {
+    dataSubscription = terminal.onData((chunk) => {
       output += chunk;
       if (submitting) return;
       const text = plain(output);
@@ -149,13 +242,19 @@ function runRestartSession() {
         state = 'quit'; send('/quit');
       }
     });
-    terminal.onExit(({ exitCode }) => {
-      clearTimeout(timeout);
+    exitSubscription = terminal.onExit(({ exitCode }) => {
       if (state !== 'quit' || exitCode !== 0) {
-        reject(new Error(`Restarted packaged session exited ${exitCode} (${state}):\n${plain(output).slice(-12_000)}`));
+        finish(new Error(`Restarted packaged session exited ${exitCode} (${state}):\n${plain(output).slice(-12_000)}`));
         return;
       }
-      resolve(output);
+      dataSubscription?.dispose();
+      exitSubscription?.dispose();
+      dataSubscription = undefined;
+      exitSubscription = undefined;
+      void releaseExitedPty(terminal).then(
+        () => finish(null, output),
+        (error) => finish(error),
+      );
     });
   });
 }
@@ -174,6 +273,11 @@ function runRestartSession() {
     if (!combined.includes(expected)) throw new Error(`Missing packaged interactive evidence: ${expected}`);
   }
   if (combined.includes('controlled-package-value')) throw new Error('Credential sentinel leaked into interactive output.');
+  await new Promise((resolve) => setImmediate(resolve));
+  const activeHandles = activeSmokeHandles();
+  if (activeHandles.length > 0) {
+    throw new Error(`Packaged interactive smoke leaked active handles: ${activeHandles.join(', ')}`);
+  }
   process.stdout.write(JSON.stringify({
     economy: 'PASS',
     budgetWarning: 'PASS',
@@ -183,8 +287,7 @@ function runRestartSession() {
     compression: 'PASS',
     restartResume: 'PASS',
   }) + '\n');
-  process.exit(0);
 })().catch((error) => {
   process.stderr.write(`${error.stack ?? error}\n`);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
+++ b/tests/v4/harness/packagedInteractiveTokenSmoke.cjs
@@ -24,37 +24,23 @@ function plain(value) {
 }
 
 function submit(terminal, value, onComplete) {
-  let index = 0;
   let stopped = false;
-  let immediate;
-  const timers = new Set();
-  const schedule = (callback, delay) => {
-    const timer = setTimeout(() => {
-      timers.delete(timer);
-      if (!stopped) callback();
-    }, delay);
-    timers.add(timer);
-  };
-  const writeNext = () => {
-    if (index < value.length) {
-      terminal.write(value[index++]);
-      schedule(writeNext, 10);
-      return;
-    }
-    schedule(() => {
+  let enterTimer;
+  let immediate = setImmediate(() => {
+    immediate = undefined;
+    if (stopped) return;
+    terminal.write(value);
+    enterTimer = setTimeout(() => {
+      enterTimer = undefined;
+      if (stopped) return;
       terminal.write('\r');
       onComplete();
     }, 100);
-  };
-  immediate = setImmediate(() => {
-    immediate = undefined;
-    if (!stopped) writeNext();
   });
   return () => {
     stopped = true;
     if (immediate) clearImmediate(immediate);
-    for (const timer of timers) clearTimeout(timer);
-    timers.clear();
+    if (enterTimer) clearTimeout(enterTimer);
   };
 }
 
@@ -98,19 +84,18 @@ function runFirstSession() {
     let output = '';
     let state = 'boot';
     let historyTurns = 0;
-    let historyReadyTarget = 0;
-    let compressionReadyTarget = 0;
+    let commandReadyTarget = 0;
     let submitting = false;
     let settled = false;
     let dataSubscription;
     let exitSubscription;
     let cancelSubmission;
-    const send = (value, afterSent) => {
+    const send = (value) => {
+      commandReadyTarget = output.split(readyToken).length;
       submitting = true;
       cancelSubmission = submit(terminal, value, () => {
         cancelSubmission = undefined;
         submitting = false;
-        afterSent?.();
       });
     };
     const finish = (error, value) => {
@@ -134,45 +119,38 @@ function runFirstSession() {
       const readyCount = output.split(readyToken).length - 1;
       if (state === 'boot' && readyCount >= 1) {
         state = 'mode'; send('/mode economy');
-      } else if (state === 'mode' && text.includes('Usage mode: economy')) {
+      } else if (state === 'mode' && text.includes('Usage mode: economy') && readyCount >= commandReadyTarget) {
         state = 'budget-set'; send('/budget 120');
-      } else if (state === 'budget-set' && text.includes('Session token cap set')) {
+      } else if (state === 'budget-set' && text.includes('Session token cap set') && readyCount >= commandReadyTarget) {
         state = 'first-turn'; send('package history turn 1');
-      } else if (state === 'first-turn' && text.includes('PACKAGED SIMPLE PASS') && readyCount >= 4) {
+      } else if (state === 'first-turn' && text.includes('PACKAGED SIMPLE PASS') && readyCount >= commandReadyTarget) {
         state = 'budget-warning'; send('/budget');
-      } else if (state === 'budget-warning' && text.includes('Budget warning.')) {
+      } else if (state === 'budget-warning' && text.includes('Budget warning.') && readyCount >= commandReadyTarget) {
         state = 'budget-expand'; send('/budget 100000');
-      } else if (state === 'budget-expand' && text.includes('Session token cap set to 100,000')) {
+      } else if (state === 'budget-expand' && text.includes('Session token cap set to 100,000') && readyCount >= commandReadyTarget) {
         historyTurns = 1;
         state = 'history';
-        send(`use a tool for package history ${historyTurns}`, () => {
-          historyReadyTarget = output.split(readyToken).length;
-        });
-      } else if (state === 'history' && readyCount >= historyReadyTarget) {
+        send(`use a tool for package history ${historyTurns}`);
+      } else if (state === 'history' && readyCount >= commandReadyTarget) {
         if (historyTurns < 4) {
           historyTurns += 1;
-          send(`use a tool for package history ${historyTurns}`, () => {
-            historyReadyTarget = output.split(readyToken).length;
-          });
+          send(`use a tool for package history ${historyTurns}`);
         } else {
           state = 'usage-json'; send('/usage --json');
         }
-      } else if (state === 'usage-json' && text.includes('"physicalAttempts":9')) {
+      } else if (state === 'usage-json' && text.includes('"physicalAttempts":9') && readyCount >= commandReadyTarget) {
         state = 'usage-human'; send('/usage');
-      } else if (state === 'usage-human' && text.includes('Usage — Current session')) {
+      } else if (state === 'usage-human' && text.includes('Usage — Current session') && readyCount >= commandReadyTarget) {
         if (!text.includes('cumulative exposures')) throw new Error('Human usage summary omitted schema exposure context.');
         state = 'usage-details'; send('/usage details');
-      } else if (state === 'usage-details' && text.includes('Usage details — Current session')) {
+      } else if (state === 'usage-details' && text.includes('Usage details — Current session') && readyCount >= commandReadyTarget) {
         if (!text.includes('Providers and models') || !text.includes('Purposes')) {
           throw new Error('Detailed usage output omitted required sections.');
         }
-        state = 'compress';
-        send('/compress', () => {
-          compressionReadyTarget = output.split(readyToken).length;
-        });
+        state = 'compress'; send('/compress');
       } else if (state === 'compress'
           && /Compressed \d+ .* \d+ messages/.test(text)
-          && readyCount >= compressionReadyTarget) {
+          && readyCount >= commandReadyTarget) {
         state = 'quit'; send('/quit');
       }
     });
@@ -203,12 +181,14 @@ function runRestartSession() {
     });
     let output = '';
     let state = 'boot';
+    let commandReadyTarget = 0;
     let submitting = false;
     let settled = false;
     let dataSubscription;
     let exitSubscription;
     let cancelSubmission;
     const send = (value) => {
+      commandReadyTarget = output.split(readyToken).length;
       submitting = true;
       cancelSubmission = submit(terminal, value, () => {
         cancelSubmission = undefined;
@@ -236,9 +216,11 @@ function runRestartSession() {
       const readyCount = output.split(readyToken).length - 1;
       if (state === 'boot' && readyCount >= 1) {
         state = 'usage'; send('/usage --json');
-      } else if (state === 'usage' && text.includes('"compression":{"physicalAttempts":1')) {
+      } else if (state === 'usage'
+          && text.includes('"compression":{"physicalAttempts":1')
+          && readyCount >= commandReadyTarget) {
         state = 'turn'; send('RESTART');
-      } else if (state === 'turn' && text.includes('PACKAGED RESTART PASS') && readyCount >= 3) {
+      } else if (state === 'turn' && text.includes('PACKAGED RESTART PASS') && readyCount >= commandReadyTarget) {
         state = 'quit'; send('/quit');
       }
     });

--- a/tests/v4/harness/ptyProcessLifecycle.test.ts
+++ b/tests/v4/harness/ptyProcessLifecycle.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+import { isProcessRunning, killPtyIfRunning } from './ptyProcessLifecycle';
+
+describe('PTY process cleanup', () => {
+  it('does not invoke PTY cleanup after the child has exited', () => {
+    const kill = vi.fn();
+    expect(killPtyIfRunning({ pid: 2_147_483_647, kill })).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('does not kill during PTY output drain after native process exit', () => {
+    const kill = vi.fn();
+    expect(killPtyIfRunning({
+      pid: process.pid,
+      kill,
+      _agent: { exitCode: 0 },
+    })).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('recognizes the current process as running', () => {
+    expect(isProcessRunning(process.pid)).toBe(true);
+  });
+
+  it.runIf(process.platform === 'win32')('terminates only the recorded Windows process tree', async () => {
+    const processUnderTest = spawn(process.execPath, [
+      '-e',
+      'setInterval(() => {}, 1000)',
+    ], { windowsHide: true });
+    await once(processUnderTest, 'spawn');
+    const exited = once(processUnderTest, 'exit');
+    const fallbackKill = vi.fn();
+
+    expect(killPtyIfRunning({ pid: processUnderTest.pid!, kill: fallbackKill })).toBe(true);
+    await exited;
+    expect(fallbackKill).not.toHaveBeenCalled();
+    expect(isProcessRunning(processUnderTest.pid!)).toBe(false);
+  });
+});

--- a/tests/v4/harness/ptyProcessLifecycle.ts
+++ b/tests/v4/harness/ptyProcessLifecycle.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+export interface KillablePtyProcess {
+  pid: number;
+  kill(): void;
+  /** The PTY records native process exit before its output-drain event fires. */
+  _agent?: {
+    exitCode?: number;
+  };
+}
+
+export function isProcessRunning(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Avoid asking node-pty to enumerate a console that already disappeared. */
+export function killPtyIfRunning(child: KillablePtyProcess): boolean {
+  if (child._agent?.exitCode !== undefined) return false;
+  if (!isProcessRunning(child.pid)) return false;
+  if (process.platform === 'win32') {
+    const result = spawnSync('taskkill.exe', [
+      '/PID', String(child.pid), '/T', '/F',
+    ], { stdio: 'ignore', windowsHide: true });
+    return result.status === 0;
+  }
+  child.kill();
+  return true;
+}

--- a/tests/v4/harness/runPackagedTokenEfficiencySmoke.cjs
+++ b/tests/v4/harness/runPackagedTokenEfficiencySmoke.cjs
@@ -59,7 +59,13 @@ function run(executable, args, options = {}) {
     timeout: options.timeout ?? 180_000,
     windowsHide: true,
   });
-  if (result.error) throw result.error;
+  if (result.error) {
+    throw new Error([
+      result.error.message,
+      result.stdout,
+      result.stderr,
+    ].join('\n'));
+  }
   if (result.status !== 0) {
     throw new Error([
       `${path.basename(executable)} ${args.join(' ')} exited ${result.status}`,

--- a/tests/v4/moat/dangerousPatterns.test.ts
+++ b/tests/v4/moat/dangerousPatterns.test.ts
@@ -4,6 +4,7 @@ import {
   detectDangerousPatterns,
   highestTier,
   classifyCommand,
+  analyzeCommandIntent,
 } from '../../../moat/dangerousPatterns';
 
 describe('dangerousPatterns — individual detections', () => {
@@ -98,6 +99,36 @@ describe('dangerousPatterns — individual detections', () => {
     expect(classifyCommand('Remove-Item -Recurse C:\\Users\\victim').tier).toBe(
       'dangerous',
     );
+  });
+});
+
+describe('bounded command intent analysis', () => {
+  it('classifies proven metadata commands as low-risk reads', () => {
+    expect(analyzeCommandIntent('node --version', 'C:\\work')).toMatchObject({
+      operation: 'inspect_runtime_version', effect: 'read_only', network: false,
+      reversible: true, scope: 'process', confidence: 'high', tier: 'safe',
+    });
+    expect(analyzeCommandIntent('git status --short', 'C:\\work')).toMatchObject({
+      operation: 'inspect_repository', effect: 'read_only', network: false,
+      reversible: true, scope: 'repository', confidence: 'high', tier: 'safe',
+    });
+  });
+
+  it('keeps a local Node script approval-gated without calling it dangerous', () => {
+    expect(analyzeCommandIntent('node verify.js', 'C:\\scratch')).toMatchObject({
+      operation: 'execute_local_script', effect: 'mutating', network: false,
+      scope: 'working_directory', confidence: 'medium', tier: 'caution',
+    });
+  });
+
+  it('keeps publication, deletion and unknown commands conservative', () => {
+    expect(analyzeCommandIntent('npm publish', 'C:\\work')).toMatchObject({
+      effect: 'external', network: true, reversible: false, tier: 'dangerous',
+    });
+    expect(analyzeCommandIntent('Remove-Item -Recurse C:\\Users\\victim', 'C:\\work').tier).toBe('dangerous');
+    expect(analyzeCommandIntent('custom-runner --do-work', 'C:\\work')).toMatchObject({
+      effect: 'unknown', confidence: 'low', tier: 'dangerous',
+    });
   });
 });
 

--- a/tests/v4/responseStreamAdapter.test.ts
+++ b/tests/v4/responseStreamAdapter.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ResponseStreamAdapter } from '../../providers/v4/responseStreamAdapter';
 import { ProviderError, ProviderRateLimitError } from '../../providers/v4/errors';
 import type { Message } from '../../providers/v4/types';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 function makeResponse(
   body: unknown,
@@ -31,6 +34,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
   vi.useRealTimers();
 });
 
@@ -140,7 +144,10 @@ describe('ResponseStreamAdapter', () => {
     expect(result.finishReason).toBe('tool_use');
   });
 
-  it('4. malformed function_call arguments fall back to {} with warn', async () => {
+  it('4. malformed function_call arguments fall back to {} with a file diagnostic', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'aiden-response-trace-'));
+    const trace = join(root, 'trace.jsonl');
+    vi.stubEnv('AIDEN_RUNTIME_TRACE_FILE', trace);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     fetchMock.mockResolvedValueOnce(
       makeResponse({
@@ -161,8 +168,10 @@ describe('ResponseStreamAdapter', () => {
       tools: [],
     });
     expect(result.toolCalls[0].arguments).toEqual({});
-    expect(warn).toHaveBeenCalled();
+    expect(readFileSync(trace, 'utf8')).toContain('tool.arguments.invalid');
+    expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
+    rmSync(root, { recursive: true, force: true });
   });
 
   it('5. empty output[] with output_text backfills a synthetic message', async () => {

--- a/tests/v4/toolRegistry.test.ts
+++ b/tests/v4/toolRegistry.test.ts
@@ -196,6 +196,39 @@ describe('ToolRegistry', () => {
     expect(result.activityTiming?.terminalClassification).toBe('blocked');
   });
 
+  it('passes bounded shell intent tiers to approval without weakening unknown commands', async () => {
+    const execute = vi.fn(async () => ({ ok: true }));
+    registry.register(makeHandler('shell_exec', {
+      category: 'execute',
+      mutates: true,
+      riskTier: 'dangerous',
+      execute,
+    }));
+    const seen: Array<{ command: unknown; riskTier: unknown }> = [];
+    const approvalEngine = new ApprovalEngine('manual', {
+      promptUser: async (request) => {
+        seen.push({ command: request.args.command, riskTier: request.riskTier });
+        return 'deny';
+      },
+    });
+    const exec = registry.buildExecutor({ ...makeContext(), approvalEngine });
+
+    const version = await exec(call('shell_exec', { command: 'node --version' }));
+    const verify = await exec(call('shell_exec', { command: 'node verify.js' }));
+    const publish = await exec(call('shell_exec', { command: 'npm publish' }));
+    const unknown = await exec(call('shell_exec', { command: 'custom-runner task' }));
+
+    expect(version.error).toBeUndefined();
+    expect(seen).toEqual([
+      { command: 'node verify.js', riskTier: 'caution' },
+      { command: 'npm publish', riskTier: 'dangerous' },
+      { command: 'custom-runner task', riskTier: 'dangerous' },
+    ]);
+    expect(verify.approvalDecision?.state).toBe('denied');
+    expect(publish.approvalDecision?.state).toBe('denied');
+    expect(unknown.approvalDecision?.state).toBe('denied');
+  });
+
   it('cancellation during handler retains elapsed execution once', async () => {
     let now = 0;
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);

--- a/tests/v4/tools/terminal.test.ts
+++ b/tests/v4/tools/terminal.test.ts
@@ -40,12 +40,14 @@ describe('shell_exec — schema', () => {
 });
 
 describe('localBackend', () => {
-  it('preserves PowerShell source exactly at the process boundary', () => {
+  it('preserves PowerShell source while suppressing progress at the process boundary', () => {
     const source = `Write-Output '$env:TEMP'; Write-Output \"quoted\"; Write-Output \`tick; Write-Output '₹ $ literal'`;
     const invocation = buildLocalShellInvocation(source, 'win32');
     expect(invocation.executable).toBe('powershell.exe');
     expect(invocation.args.slice(0, 3)).toEqual(['-NoProfile', '-NonInteractive', '-EncodedCommand']);
-    expect(Buffer.from(invocation.args[3], 'base64').toString('utf16le')).toBe(source);
+    const decoded = Buffer.from(invocation.args[3], 'base64').toString('utf16le');
+    expect(decoded).toContain("$ProgressPreference='SilentlyContinue';");
+    expect(decoded.endsWith(source)).toBe(true);
   });
 
   it('keeps an explicit nested PowerShell command out of an outer PowerShell parser', () => {
@@ -57,8 +59,9 @@ describe('localBackend', () => {
         detached: false,
       });
       const invocation = buildLocalShellInvocation(command, 'win32');
-      expect(Buffer.from(invocation.args.at(-1)!, 'base64').toString('utf16le'))
-        .toBe('$env:TEMP; $env:LOCALAPPDATA');
+      const decoded = Buffer.from(invocation.args.at(-1)!, 'base64').toString('utf16le');
+      expect(decoded).toContain("$ProgressPreference='SilentlyContinue';");
+      expect(decoded.endsWith('$env:TEMP; $env:LOCALAPPDATA')).toBe(true);
     }
   });
 
@@ -82,8 +85,9 @@ describe('localBackend', () => {
       'win32',
     );
     expect(invocation.executable).toBe('powershell.exe');
-    expect(Buffer.from(invocation.args[invocation.args.length - 1]!, 'base64').toString('utf16le'))
-      .toBe('$marker = 1; Write-Output $marker');
+    const decoded = Buffer.from(invocation.args[invocation.args.length - 1]!, 'base64').toString('utf16le');
+    expect(decoded).toContain("$ProgressPreference='SilentlyContinue';");
+    expect(decoded.endsWith('$marker = 1; Write-Output $marker')).toBe(true);
   });
 
   it.runIf(isWin)('executes direct environment lookups and special characters on Windows', async () => {

--- a/tests/v4/tools/traceQuery.test.ts
+++ b/tests/v4/tools/traceQuery.test.ts
@@ -12,7 +12,7 @@
  * tested separately in tests/v4/cli/chatSessionUiPersist.test.ts so
  * a future regression in either layer fails the right test.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -22,26 +22,44 @@ import { createRunStore, type RunStore } from '../../../core/v4/daemon/runStore'
 import { makeTraceQueryTool } from '../../../tools/v4/trace/traceQuery';
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
 
+let root: string;
+let templatePath: string;
 let tmp: string;
 let db: Database.Database;
 let store: RunStore;
+let fixtureSequence = 0;
 
-beforeEach(async () => {
-  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-trace-query-'));
-  db = new Database(path.join(tmp, 'daemon.db'));
-  runMigrations(db);
-  store = createRunStore({ db });
+beforeAll(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-trace-query-'));
+  templatePath = path.join(root, 'template.db');
+  const template = new Database(templatePath);
+  runMigrations(template);
   // Seed a daemon_instances row so the runs FK is satisfied.
-  db.prepare(
+  template.prepare(
     `INSERT OR IGNORE INTO daemon_instances
        (instance_id, pid, hostname, started_at, last_heartbeat, version)
      VALUES (?, ?, ?, ?, ?, ?)`,
   ).run('test-inst', process.pid, 'localhost', Date.now(), Date.now(), '4.10.0-test');
+  template.close();
+});
+
+beforeEach(async () => {
+  fixtureSequence += 1;
+  tmp = path.join(root, `case-${fixtureSequence}`);
+  await fs.mkdir(tmp);
+  const databasePath = path.join(tmp, 'daemon.db');
+  await fs.copyFile(templatePath, databasePath);
+  db = new Database(databasePath);
+  store = createRunStore({ db });
 });
 
 afterEach(async () => {
   db.close();
   await fs.rm(tmp, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  await fs.rm(root, { recursive: true, force: true });
 });
 
 // ─── listEventsForSession ─────────────────────────────────────────────

--- a/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
@@ -10,11 +10,12 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { runMigrations } from '../../../core/v4/daemon/db/migrations';
-import { createDispatcher } from '../../../core/v4/daemon/dispatcher/dispatcher';
+import { createDispatcher, type Dispatcher } from '../../../core/v4/daemon/dispatcher/dispatcher';
 import { createRealAgentRunner, type AgentBuilder } from '../../../core/v4/daemon/dispatcher/realAgentRunner';
 import { createJobEngine } from '../../../core/v4/daemon/jobEngine';
 import { createRunStore } from '../../../core/v4/daemon/runStore';
 import { createTriggerBus } from '../../../core/v4/daemon/triggerBus';
+import { createDurableJobLifecycleScope } from '../../../core/v4/daemon/jobLifecycle';
 import { resolveAidenPaths } from '../../../core/v4/paths';
 import { ProviderAttemptLedger } from '../../../core/v4/usageLedger';
 import {
@@ -32,7 +33,13 @@ describe('read-only repository Worker durable dispatcher path', () => {
   const cleanup: string[] = [];
   const databases: Database.Database[] = [];
   let ledger: ProviderAttemptLedger | null = null;
+  let lifecycleScope: ReturnType<typeof createDurableJobLifecycleScope> | null = null;
+  let dispatcher: Dispatcher | null = null;
   afterEach(async () => {
+    await dispatcher?.stop(5_000);
+    dispatcher = null;
+    await lifecycleScope?.dispose('test teardown');
+    lifecycleScope = null;
     setProviderAttemptLedger(null);
     ledger?.close();
     ledger = null;
@@ -43,6 +50,7 @@ describe('read-only repository Worker durable dispatcher path', () => {
   });
 
   it('delivers the child through TriggerBus and the canonical daemon lifecycle exactly once', async () => {
+    lifecycleScope = createDurableJobLifecycleScope();
     const root = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-e2e-'));
     const home = await mkdtemp(path.join(os.tmpdir(), 'aiden-worker-e2e-home-'));
     cleanup.push(root, home);
@@ -154,15 +162,16 @@ describe('read-only repository Worker durable dispatcher path', () => {
         endpointReference: binding.endpointReference,
       };
     };
-    const runner = createRealAgentRunner({
+    const realRunner = createRealAgentRunner({
       db, runStore, jobEngine: engine, agentBuilder: builder,
+      lifecycleScope,
       persistedDefault: { provider: 'different-provider', model: 'different-model' },
       dailyBudget: null,
     });
-    const dispatcher = createDispatcher({
+    dispatcher = createDispatcher({
       triggerBus: bus, runStore, db, jobEngine: engine,
       ownerId: 'worker-instance', instanceId: 'worker-instance', workerCount: 1,
-      runnerFactory: () => runner, initialRunnerKind: 'real',
+      runnerFactory: () => realRunner, initialRunnerKind: 'real',
     });
 
     expect(await dispatcher._pumpOnce()).toBe(admission.triggerEvent.id);
@@ -190,6 +199,20 @@ describe('read-only repository Worker durable dispatcher path', () => {
     const parentEvidenceId = verification.evidence[0].evidenceId;
     expect(childEvidenceId).not.toBe(parentEvidenceId);
     expect(await readFile(path.join(root, 'source.ts'), 'utf8')).toBe(sourceBytes);
+
+    const jobsBeforeLateDelivery = engine.listJobs({ limit: 1_000 }).length;
+    await dispatcher.stop(5_000);
+    const late = bus.insert({
+      source: 'manual',
+      sourceKey: 'late-delivery',
+      idempotencyKey: 'late-delivery',
+      payload: { request: 'must remain fenced' },
+    });
+    expect(await dispatcher._pumpOnce()).toBeNull();
+    expect(bus.get(late.id)).toMatchObject({ status: 'pending', attempts: 0 });
+    expect(engine.listJobs({ limit: 1_000 })).toHaveLength(jobsBeforeLateDelivery);
+    expect(calls).toBe(2);
+
     db.close();
 
     const reopenedDb = new Database(dbPath);
@@ -217,5 +240,5 @@ describe('read-only repository Worker durable dispatcher path', () => {
     expect(reopened.proof.getVerdict(parent.jobId)).toBeNull();
     expect(await readFile(path.join(root, 'source.ts'), 'utf8')).toBe(sourceBytes);
     reopenedDb.close();
-  }, 30_000);
+  }, 45_000);
 });

--- a/tests/v4/worker/workerMigration.test.ts
+++ b/tests/v4/worker/workerMigration.test.ts
@@ -84,7 +84,7 @@ describe('Worker persistence migration', () => {
     db.pragma('foreign_keys = ON');
     const before = new Set(tables());
     expect(runMigrations(db)).toEqual({ from: 38, to: LATEST_SCHEMA_VERSION });
-    expect(LATEST_SCHEMA_VERSION).toBe(41);
+    expect(LATEST_SCHEMA_VERSION).toBe(42);
     expect(tables().filter((table) => !before.has(table))).toEqual([
       'job_budget_reservation_reconciliations',
       'worker_group_members',
@@ -156,7 +156,7 @@ describe('Worker persistence migration', () => {
   it('is idempotent when the latest schema is already installed', () => {
     expect(runMigrations(db)).toEqual({ from: 0, to: LATEST_SCHEMA_VERSION });
     expect(runMigrations(db)).toEqual({ from: LATEST_SCHEMA_VERSION, to: LATEST_SCHEMA_VERSION });
-    expect(LATEST_SCHEMA_VERSION).toBe(41);
+    expect(LATEST_SCHEMA_VERSION).toBe(42);
     expect(tables()).toEqual(expect.arrayContaining([
       'worker_groups', 'worker_group_members', 'worker_provider_concurrency_reservations',
     ]));

--- a/tools/v4/backends/local.ts
+++ b/tools/v4/backends/local.ts
@@ -88,6 +88,10 @@ function stripMatchingQuotes(value: string): string {
   return trimmed;
 }
 
+function controlledPowerShellScript(script: string): string {
+  return `$ProgressPreference='SilentlyContinue'; ${script}`;
+}
+
 function buildExplicitPowerShellInvocation(match: RegExpMatchArray): LocalShellInvocation {
   const executable = match[1]!;
   const rest = match[2] ?? '';
@@ -95,7 +99,7 @@ function buildExplicitPowerShellInvocation(match: RegExpMatchArray): LocalShellI
   if (commandToken) {
     const prefix = rest.slice(0, commandToken.index).trim();
     const script = stripMatchingQuotes(rest.slice(commandToken.index + commandToken[0].length));
-    const encoded = Buffer.from(script, 'utf16le').toString('base64');
+    const encoded = Buffer.from(controlledPowerShellScript(script), 'utf16le').toString('base64');
     return {
       executable,
       args: [...splitWindowsArguments(prefix), '-EncodedCommand', encoded],
@@ -125,7 +129,7 @@ export function buildLocalShellInvocation(
   if (explicitPowerShell) return buildExplicitPowerShellInvocation(explicitPowerShell);
   // EncodedCommand preserves quotes, Unicode, backticks, semicolons, and
   // literal dollar signs across the native process boundary.
-  const encoded = Buffer.from(command, 'utf16le').toString('base64');
+  const encoded = Buffer.from(controlledPowerShellScript(command), 'utf16le').toString('base64');
   return {
     executable: 'powershell.exe',
     args: ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],

--- a/tools/v4/clarify/clarifyTool.ts
+++ b/tools/v4/clarify/clarifyTool.ts
@@ -1,3 +1,5 @@
+import { runtimeTrace } from '../../../core/v4/runtimeTrace';
+
 /**
  * Copyright (c) 2026 Shiva Deore (Taracod).
  * Licensed under AGPL-3.0. See LICENSE for details.
@@ -125,9 +127,5 @@ export function makeClarifyTool(): ToolHandler {
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {
-  if (process.env.AIDEN_P2A_DIAG !== '1') return;
-  try {
-    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
-    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
-  } catch { /* diagnostics must never affect clarify */ }
+  runtimeTrace('clarify', event, data);
 }

--- a/tools/v4/terminal/shellExec.ts
+++ b/tools/v4/terminal/shellExec.ts
@@ -39,6 +39,8 @@ import {
   dockerSessionExec,
 } from '../../../core/v4/dockerSession';
 import { getSandboxConfig } from '../../../core/v4/sandboxConfig';
+import { filterPowerShellProgressClixml } from '../../../core/v4/powerShellClixml';
+import { analyzeCommandIntent } from '../../../moat/dangerousPatterns';
 
 // v4.14.6 — grep-family tools exit 1 to mean "no matches found" — a successful
 // empty search, not a failure. Reporting it as failure made the model re-issue
@@ -83,6 +85,7 @@ export const shellExecTool: ToolHandler = {
     const userOverride = ctx.terminalBackend;
     const effective: 'local' | 'docker' =
       userOverride ?? (config.enabled ? config.defaultBackend : 'local');
+    const intent = analyzeCommandIntent(command, cwd);
     // Lightweight risk hints — same patterns ApprovalEngine uses
     // in smart mode. Kept inline to avoid pulling moat/ into the
     // tool layer.
@@ -97,7 +100,7 @@ export const shellExecTool: ToolHandler = {
     return {
       tool: 'shell_exec',
       args,
-      riskTier: 'dangerous',
+      riskTier: intent.tier,
       sideEffects: [{ type: 'shell_command', command, cwd, backend: effective }],
       detectedRisks: risks,
       summary: `Would run \`${command.length > 80 ? command.slice(0, 80) + '…' : command}\` via ${effective} backend in ${cwd}`,
@@ -157,7 +160,8 @@ export const shellExecTool: ToolHandler = {
     // v4.12 TOC.1 — cap output at the boundary (head40/tail60 + marker, ANSI
     // strip, secret-redact-after-truncation). Under cap → byte-identical.
     const outCap = capToolOutput(result.stdout ?? '');
-    const errCap = capToolOutput(result.stderr ?? '');
+    const filteredStderr = filterPowerShellProgressClixml(result.stderr ?? '').stderr;
+    const errCap = capToolOutput(filteredStderr);
     const omitted = outCap.omittedChars + errCap.omittedChars;
     return attachRawValidationOutput({
       success: result.exitCode === 0 || isGrepNoMatchExit(command, result.exitCode),


### PR DESCRIPTION
## Scope

Final v4.19 runtime hardening focused on terminal ownership, complete final-response settlement, provider activation, truthful access state, shell safety, Windows output filtering, native-runtime preflight, and release-acceptance guards.

## Root causes corrected

- Transcript scroll offset could advance past retained wrapped content.
- Interactive progress could bypass the owned composer output path.
- Activity could divide a streamed Markdown document before final parsing.
- Ready state could appear before the terminal accepted the final frame.
- Setup persisted a provider but required a restart before the live session used it.
- Authentication and readiness states could be presented as equivalent.
- Modal prompts could release and restore the composer through overlapping paths.
- Shell commands lacked a bounded effect and risk classification.
- PowerShell progress CLIXML could leak into compact activity output.
- Required effects could inherit verification from unrelated evidence.
- Windows terminal cleanup could leave an output worker alive after child exit.
- Packaged interactive commands could advance before the next composer-ready boundary.

## Focused commits

- `1bbdfeb3` clamp transcript viewport offset
- `4da34a64` serialize interactive progress output
- `167fbc8c` settle final Markdown after activity
- `e3e23217` bind proof to required effects
- `445f9f6c` clarify runtime entrypoint contracts
- `68f8dd75` add opt-in turn phase tracing
- `e133a0a2` harden Windows terminal cleanup
- `85cd90b5` preserve redirected diagnostics
- `c62bd086` stabilize terminal command injection
- `22474da5` harden packaged interactive smoke cleanup
- `4335b248` synchronize packaged command handoffs
- `9a72f559` reuse one migrated trace-query template while preserving a unique database per test
- `a7f64ade` complete final runtime and terminal hardening

## Final automated validation

- Changed-file focused matrix, Node 20: 249 passed, 1 skipped
- Changed-file focused matrix, Node 22: 249 passed, 1 skipped
- Windows Node 20 deterministic non-network suite: 7,582 passed, 48 skipped
- Windows Node 22 deterministic non-network suite: 7,582 passed, 48 skipped
- Windows PTY Node 20: 45/45
- Windows PTY Node 22: 45/45
- Integration: 37 passed, 9 credential-dependent skipped
- Typecheck: passed on Node 20 and Node 22
- Production build: passed on Node 20 and Node 22
- Native database preflight: Node 20 ABI 115 and Node 22 ABI 127 passed
- Diff, secret, NUL, attribution, and package-scope scans: passed
- Attributable child-process cleanup: passed

## Physical Windows PowerShell acceptance

Passed on Node 20 and Node 22:

- provider hot reload worked without restart;
- final Markdown and fenced JSON rendered completely;
- wide to narrow to wide resize remained stable;
- PageUp and PageDown remained bounded;
- activity and Evidence rows appeared once;
- no PowerShell CLIXML leaked;
- composer and footer appeared once;
- ready appeared only after final settlement;
- denied approval caused no filesystem effect;
- quit restored the terminal and left no attributable processes.

## Package dry-run

- Package: `aiden-runtime@4.19.0`
- Public commands: `aiden` and `aiden-runtime`
- Filename: `aiden-runtime-4.19.0.tgz`
- Packed size: 2,404,411 bytes
- Unpacked size: 9,160,463 bytes
- Files: 1,076
- Protected notes, stale launcher workspace, tests, acceptance scripts, databases, logs, and private references: excluded

No package was published, no tag was created, and no GitHub Release was created by this PR.
## Lifecycle teardown correction

The Windows Node 22 timeout left canonical lifecycle work active while test teardown closed SQLite. Lifecycle timers previously had no externally awaited disposal boundary; the surviving cancellation watcher then read Job state from the closed database.

The correction:

- gives canonical lifecycle work an idempotent scope that fences late admission, clears owned timers, persists cancellation before abort, and awaits active work;
- makes the real daemon runner expose awaited disposal;
- makes dispatcher shutdown stop new claims, dispose the runner, drain claimed work, and fail loudly instead of reporting a safe stop after its deadline;
- orders the Worker E2E fixture teardown before ledger, database, and temporary-file cleanup;
- keeps the exact TriggerBus delivery and persistence assertions, adds late-delivery fencing, and uses a measured test-local 45-second ceiling.

The original hosted log proves the lifecycle was still inside execution when the 30-second test budget expired, but does not identify a single inner await. Local monotonic measurements completed the full scenario in 0.95 seconds during the complete deterministic suite and 1.61 seconds under concurrent SQLite load. Fresh-process stress completed 20/20 on Node 20 and 50/50 on Node 22. This evidence supports hosted-runner descheduling as a contributor without treating it as the teardown root cause.

Additional validation:

- lifecycle/dispatcher RED-to-GREEN contracts: 16 lifecycle tests and 9 dispatcher lifecycle tests passed;
- Worker/lifecycle/TriggerBus/recovery matrix: 116/116 on Node 20 and Node 22;
- deterministic non-network suite: 7,587 passed, 48 skipped on Node 20 and Node 22;
- Windows PTY: 45/45 on Node 20 and Node 22;
- typecheck and production build: passed;
- no attributable child process, lifecycle timer, or closed-database callback remained.