### PR TITLE
fix(cli): harden v4.19.1 startup and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## v4.19.1 — 2026-08-06
+
+### Startup and update reliability
+
+- Both public commands now enter a dependency-light bootstrap before the full
+  runtime or native modules load.
+- Incomplete packages, missing entrypoints, unsupported Node versions, native
+  load failures, and Node ABI mismatches produce concise repair guidance instead
+  of raw startup stacks.
+- Interactive startup performs a cached, fail-open update check with stable,
+  beta, off, Later, and per-version Skip behavior.
+- `aiden update`, `aiden update --check`, `aiden update --yes`, and exact-version
+  updates operate without loading the full runtime.
+- Updates run through an external temporary helper, target the npm prefix that
+  owns the running installation, verify the package, command version, and native
+  runtime, and verify rollback before reporting restoration.
+- A successful update is reported only after all verification gates pass; user
+  data remains outside the replaceable npm package.
+
+### Runtime support
+
+- Supported Node versions are Node 20 and Node 22.
+- Node 24 reaches the bootstrap and receives an actionable compatibility message
+  without loading native runtime dependencies.
+
+### Upgrade instructions
+
+```bash
+npm uninstall -g aiden-runtime
+npm install -g aiden-runtime@latest
+```
+
+The uninstall step repairs already-incomplete v4.19.0 installations without
+removing Aiden's user-data home.
+
+---
+
 ## v4.17.0 — 2026-07-29
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Give Aiden a goal. It can work across your files, terminal, browser, supported a
 <!-- Language & runtime -->
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?style=flat-square&logo=typescript&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-ES2022-F7DF1E?style=flat-square&logo=javascript&logoColor=black)
-![Node.js](https://img.shields.io/badge/Node.js-≥18-339933?style=flat-square&logo=node.js&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-20_or_22-339933?style=flat-square&logo=node.js&logoColor=white)
 ![ESM](https://img.shields.io/badge/Modules-ESM-FFB088?style=flat-square)
 ![esbuild](https://img.shields.io/badge/Bundler-esbuild-FFCF00?style=flat-square&logo=esbuild&logoColor=black)
 ![npm](https://img.shields.io/badge/Registry-npm-CB3837?style=flat-square&logo=npm&logoColor=white)
@@ -104,7 +104,7 @@ Give Aiden a goal. It can work across your files, terminal, browser, supported a
 ![Built solo](https://img.shields.io/badge/Built-solo-B8A893?style=flat-square)
 ![By Taracod](https://img.shields.io/badge/By-Taracod-FF6B35?style=flat-square)
 ![White Lotus](https://img.shields.io/badge/Brand-White_Lotus-FFB088?style=flat-square)
-![Stable](https://img.shields.io/badge/Stable-v4.19.0-4ADE80?style=flat-square)
+![Stable](https://img.shields.io/badge/Stable-v4.19.1-4ADE80?style=flat-square)
 
 </details>
 
@@ -183,10 +183,10 @@ Research this topic, compare the strongest findings, and save a structured Markd
 > [!IMPORTANT]
 > **Release channels**
 >
-> - **Stable:** `v4.19.0` through npm `latest`
+> - **Stable:** `v4.19.1` through npm `latest`
 > - **Archived RC:** [`v4.19.0-rc.1`](https://github.com/taracodlabs/aiden/releases/tag/v4.19.0-rc.1)
 
-### Stable — v4.19.0
+### Stable — v4.19.1
 
 ```bash
 npm install -g aiden-runtime
@@ -198,7 +198,7 @@ That’s it. The first launch opens Aiden’s current setup flow, checks the sel
 Stable channel:
 
 ```text
-npm latest → 4.19.0
+npm latest → 4.19.1
 ```
 
 Without permanent installation:
@@ -218,7 +218,7 @@ aiden --version
 Expected output:
 
 ```text
-4.19.0
+4.19.1
 ```
 
 Both public commands, `aiden` and `aiden-runtime`, start the same standalone
@@ -530,13 +530,35 @@ npx aiden-runtime@latest
 npm install -g aiden-runtime@latest
 ```
 
-Or, from inside a running session:
+The permanent bootstrap checks for stable updates before the full runtime loads.
+When an update is available, choose Update, Later, or Skip. You can also use:
+
+```bash
+aiden update --check
+aiden update
+aiden update --yes
+aiden update --version 4.19.1
+```
+
+The default channel is npm `latest`. Set `AIDEN_UPDATE_CHANNEL=beta` to follow
+npm `beta`, or `AIDEN_UPDATE_CHANNEL=off` to disable bootstrap checks.
+
+The existing in-session command remains available:
 
 ```text
 /update install
 ```
 
-Aiden also prompts you on boot when a newer version is available. Use `/update auto off` to silence automatic update notices.
+Aiden supports Node 20 and Node 22. If an older 4.19.0 installation cannot
+start, repair it once under the Node version you intend to use:
+
+```bash
+npm uninstall -g aiden-runtime
+npm install -g aiden-runtime@latest
+```
+
+Reinstalling the global package does not remove Aiden's workspaces, settings,
+history, Jobs, Evidence, or provider configuration from the Aiden data home.
 
 ### Uninstall
 
@@ -781,7 +803,7 @@ Quick reference:
 - **An old setup screen appears** — remove stale global binaries and reinstall with `npm install -g aiden-runtime@latest`
 - **`/help` does not list a command** — some commands require an active session or capability
 - **npm permission errors on Windows** — use a user-writable npm prefix and install into a normal directory rather than a drive root
-- **Native module version mismatch** — run Aiden under the Node version used to install its native dependencies, or reinstall dependencies under the active Node version
+- **Native module version mismatch** — switch to Node 20 or Node 22, then reinstall `aiden-runtime` under that active Node version
 
 <br>
 

--- a/RELEASE-NOTES-v4.19.1.md
+++ b/RELEASE-NOTES-v4.19.1.md
@@ -1,0 +1,68 @@
+# Aiden v4.19.1
+
+Aiden v4.19.1 is a startup and update reliability patch for `aiden-runtime`.
+
+## Highlights
+
+- A permanent dependency-light bootstrap starts before the full CLI and native
+  modules.
+- Missing or incomplete package files, unsupported Node versions, native-load
+  failures, and Node ABI mismatches now produce concise repair guidance.
+- Interactive startup checks the configured npm channel with a short timeout,
+  a 24-hour cache, and Update, Later, or Skip choices.
+- Manual commands support update checks, unattended installation, and validated
+  exact versions without loading the full runtime.
+- A temporary external updater installs into the prefix that owns the running
+  package and uses the npm CLI associated with the active Node runtime.
+- Installation success requires package, entrypoint, command-version, and native
+  runtime verification. Failed verification attempts a verified rollback.
+- Update checks fail open when the registry is unavailable and never block
+  non-interactive use for input.
+
+## Supported runtimes
+
+Aiden v4.19.1 supports Node 20 and Node 22. Node 24 is not claimed as a supported
+runtime; the bootstrap provides a compatibility message before native modules
+load.
+
+## Upgrade
+
+Healthy installations can run:
+
+```bash
+aiden update
+```
+
+If an existing v4.19.0 command cannot start because its installation is missing
+files or was installed under a different Node runtime, repair it once with:
+
+```bash
+npm uninstall -g aiden-runtime
+npm install -g aiden-runtime@latest
+```
+
+Aiden workspaces, settings, history, Jobs, Attempts, Evidence, Proof, and provider
+configuration remain in the Aiden data home and are not removed by reinstalling
+the global npm package.
+
+## Manual update commands
+
+```bash
+aiden update --check
+aiden update
+aiden update --yes
+aiden update --version 4.19.1
+```
+
+The default channel is npm `latest`. Use `AIDEN_UPDATE_CHANNEL=beta` for npm
+`beta`, or `AIDEN_UPDATE_CHANNEL=off` to disable bootstrap checks.
+
+## Rollback
+
+```bash
+npm uninstall -g aiden-runtime
+npm install -g aiden-runtime@4.19.0
+```
+
+Rollback changes the installed runtime package only. It does not delete the
+Aiden data home.

--- a/bin/aiden-bootstrap.cjs
+++ b/bin/aiden-bootstrap.cjs
@@ -1,0 +1,785 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+const PACKAGE_NAME = 'aiden-runtime';
+const SUPPORTED_NODE_MAJORS = Object.freeze([20, 22]);
+const DEFAULT_CHANNEL = 'stable';
+const DEFAULT_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_REMIND_DELAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_NETWORK_TIMEOUT_MS = 2_000;
+const REAL_CLI = path.join('dist', 'cli', 'v4', 'aidenCLI.js');
+const REQUIRED_RUNTIME = path.join('dist', 'core', 'version.js');
+const STATE_FILE = '.update_check.json';
+const REGISTRY_URL = 'https://registry.npmjs.org/aiden-runtime';
+
+function parseVersion(value) {
+  if (typeof value !== 'string') return null;
+  const match = value.trim().match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+  return {
+    raw: value.trim(),
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+  };
+}
+
+function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  if (!a || !b) throw new Error('Invalid semantic version.');
+  for (let i = 0; i < 3; i += 1) {
+    if (a.core[i] !== b.core[i]) return a.core[i] - b.core[i];
+  }
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let i = 0; i < length; i += 1) {
+    if (a.prerelease[i] === undefined) return -1;
+    if (b.prerelease[i] === undefined) return 1;
+    const av = a.prerelease[i];
+    const bv = b.prerelease[i];
+    if (av === bv) continue;
+    const an = /^\d+$/.test(av) ? Number(av) : null;
+    const bn = /^\d+$/.test(bv) ? Number(bv) : null;
+    if (an !== null && bn !== null) return an - bn;
+    if (an !== null) return -1;
+    if (bn !== null) return 1;
+    return av.localeCompare(bv);
+  }
+  return 0;
+}
+
+function resolveAidenDataRoot(env = process.env, platform = process.platform, home = os.homedir()) {
+  if (typeof env.AIDEN_HOME === 'string' && env.AIDEN_HOME.trim()) {
+    return path.resolve(stripOuterQuotes(env.AIDEN_HOME.trim()));
+  }
+  if (platform === 'win32') {
+    return path.join(env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'aiden');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'aiden');
+  }
+  const xdg = typeof env.XDG_CONFIG_HOME === 'string' && env.XDG_CONFIG_HOME.trim()
+    ? path.resolve(stripOuterQuotes(env.XDG_CONFIG_HOME.trim()))
+    : path.join(home, '.config');
+  const preferred = path.join(xdg, 'aiden');
+  const legacy = path.join(home, '.aiden');
+  try {
+    if (fs.existsSync(legacy) && !fs.existsSync(preferred)) return legacy;
+  } catch {}
+  return preferred;
+}
+
+function stripOuterQuotes(value) {
+  return value.replace(/^["']+/, '').replace(/["']+$/, '').trim();
+}
+
+function checkPackageHealth(options) {
+  const packageRoot = options.packageRoot;
+  const nodeVersion = options.nodeVersion || process.versions.node;
+  const major = Number.parseInt(String(nodeVersion).split('.')[0], 10);
+  if (!SUPPORTED_NODE_MAJORS.includes(major)) {
+    return { ok: false, kind: 'unsupported-node' };
+  }
+  if (!packageRoot || !fs.existsSync(packageRoot)) {
+    return { ok: false, kind: 'missing-package' };
+  }
+  const manifestPath = path.join(packageRoot, 'package.json');
+  if (!fs.existsSync(manifestPath)) {
+    return { ok: false, kind: 'missing-package-json' };
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return { ok: false, kind: 'malformed-package' };
+  }
+  if (manifest.name !== PACKAGE_NAME || typeof manifest.version !== 'string' || !parseVersion(manifest.version)) {
+    return { ok: false, kind: 'inconsistent-package', version: manifest.version };
+  }
+  if (!fs.existsSync(path.join(packageRoot, REAL_CLI))) {
+    return { ok: false, kind: 'missing-cli', version: manifest.version };
+  }
+  if (!fs.existsSync(path.join(packageRoot, REQUIRED_RUNTIME))) {
+    return { ok: false, kind: 'missing-runtime', version: manifest.version };
+  }
+  if (!fs.existsSync(path.join(packageRoot, 'bin', 'aiden-updater.cjs'))) {
+    return { ok: false, kind: 'missing-updater', version: manifest.version };
+  }
+  return { ok: true, version: manifest.version };
+}
+
+function valueToDiagnostic(value) {
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}${value.stack ? `\n${value.stack}` : ''}`;
+  }
+  if (value && typeof value === 'object') {
+    const code = typeof value.code === 'string' ? value.code : '';
+    const message = typeof value.message === 'string' ? value.message : String(value);
+    return `${code}\n${message}`;
+  }
+  return String(value || '');
+}
+
+function classifyStartupFailure(value) {
+  const text = valueToDiagnostic(value);
+  const abi = text.match(/NODE_MODULE_VERSION\s+(\d+)[\s\S]*?(?:requires|using)\s+NODE_MODULE_VERSION\s+(\d+)/i);
+  if (abi) {
+    return { kind: 'native-abi', installedAbi: abi[1], requiredAbi: abi[2] };
+  }
+  const reverseAbi = text.match(/requires\s+NODE_MODULE_VERSION\s+(\d+)[\s\S]*?NODE_MODULE_VERSION\s+(\d+)/i);
+  if (reverseAbi) {
+    return { kind: 'native-abi', installedAbi: reverseAbi[2], requiredAbi: reverseAbi[1] };
+  }
+  if (/\bERR_DLOPEN_FAILED\b|invalid win32 application|wrong elf class|file too short|bad native image/i.test(text)) {
+    return { kind: 'native-load' };
+  }
+  if (/\bMODULE_NOT_FOUND\b|\bERR_MODULE_NOT_FOUND\b|cannot find module|cannot find package/i.test(text)) {
+    return { kind: 'missing-module' };
+  }
+  return { kind: 'unknown' };
+}
+
+function diagnosticId(detail) {
+  return crypto.createHash('sha256').update(String(detail || 'unknown')).digest('hex').slice(0, 10).toUpperCase();
+}
+
+function formatStartupFailure(failure, context, options = {}) {
+  const repair = [
+    'Repair Aiden using the currently active Node version:',
+    '',
+    'npm uninstall -g aiden-runtime',
+    'npm install -g aiden-runtime@latest',
+    '',
+    'Your Aiden workspaces, settings and history will not be deleted.',
+  ];
+  let lines;
+  if (failure.kind === 'unsupported-node') {
+    lines = [
+      'Aiden cannot start with this Node version.',
+      '',
+      `Current runtime: Node ${context.nodeVersion} · ABI ${context.nodeAbi}`,
+      'Supported runtimes: Node 20 and Node 22',
+      '',
+      'Switch to Node 20 or Node 22, then reinstall Aiden with that active Node version:',
+      '',
+      'npm uninstall -g aiden-runtime',
+      'npm install -g aiden-runtime@latest',
+    ];
+  } else if (failure.kind === 'native-abi') {
+    lines = [
+      'Aiden was installed using a different Node version.',
+      '',
+      `Installed version: ${context.installedVersion || 'unknown'}`,
+      `Current runtime:   Node ${context.nodeVersion} · ABI ${context.nodeAbi}`,
+      failure.installedAbi ? `Installed native module: ABI ${failure.installedAbi}` : '',
+      '',
+      ...repair,
+    ].filter(Boolean);
+  } else if (failure.kind === 'native-load') {
+    lines = [
+      'Aiden could not load a required native component.',
+      '',
+      `Installed version: ${context.installedVersion || 'unknown'}`,
+      `Current runtime:   Node ${context.nodeVersion} · ABI ${context.nodeAbi}`,
+      '',
+      ...repair,
+    ];
+  } else if (failure.kind === 'missing-cli' || failure.kind === 'missing-runtime' || failure.kind === 'missing-updater' || failure.kind === 'missing-package' || failure.kind === 'missing-package-json' || failure.kind === 'malformed-package' || failure.kind === 'inconsistent-package' || failure.kind === 'missing-module') {
+    lines = [
+      'Aiden could not start because its installation is incomplete.',
+      '',
+      `Installed version: ${context.installedVersion || 'unknown'}`,
+      `Node version:      ${context.nodeVersion}`,
+      '',
+      ...repair,
+    ];
+  } else {
+    const id = diagnosticId(options.detail);
+    lines = [
+      'Aiden could not complete startup.',
+      '',
+      `Diagnostic: ${id}`,
+      `Installed version: ${context.installedVersion || 'unknown'}`,
+      `Node version:      ${context.nodeVersion}`,
+      '',
+      'Run `aiden doctor` after repairing the installation, or retry with AIDEN_BOOTSTRAP_DEBUG=1 for technical details.',
+    ];
+  }
+  if (options.debug && options.detail) {
+    lines.push('', 'Technical details:', String(options.detail));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function normalizeUpdateState(value) {
+  const input = value && typeof value === 'object' ? value : {};
+  const channel = input.channel === 'beta' || input.channel === 'off' || input.channel === 'stable'
+    ? input.channel
+    : DEFAULT_CHANNEL;
+  return {
+    ...input,
+    enabled: typeof input.enabled === 'boolean' ? input.enabled : channel !== 'off',
+    channel,
+    ts: Number.isFinite(input.ts) ? input.ts : 0,
+    latest: typeof input.latest === 'string' ? input.latest : null,
+    beta: typeof input.beta === 'string' ? input.beta : null,
+    installed: typeof input.installed === 'string' ? input.installed : '',
+    skippedVersion: typeof input.skippedVersion === 'string' ? input.skippedVersion : undefined,
+    remindAfter: Number.isFinite(input.remindAfter) ? input.remindAfter : undefined,
+  };
+}
+
+function readUpdateState(file) {
+  try {
+    return normalizeUpdateState(JSON.parse(fs.readFileSync(file, 'utf8')));
+  } catch {
+    return normalizeUpdateState(null);
+  }
+}
+
+function atomicWriteJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const temporary = `${file}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
+  fs.writeFileSync(temporary, JSON.stringify(value), { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(temporary, file);
+}
+
+function selectUpdateCandidate(options) {
+  if (options.channel === 'off') return null;
+  const candidate = options.channel === 'beta' ? options.beta : options.latest;
+  if (!candidate || !parseVersion(candidate)) return null;
+  const parsed = parseVersion(candidate);
+  if (options.channel === 'stable' && parsed.prerelease.length > 0) return null;
+  return compareVersions(candidate, options.installed) > 0 ? candidate : null;
+}
+
+function shouldOfferUpdate(options) {
+  if (!options.candidate || !parseVersion(options.candidate)) return false;
+  if (compareVersions(options.candidate, options.installed) <= 0) return false;
+  const state = normalizeUpdateState(options.state);
+  if (!state.enabled || state.channel === 'off') return false;
+  if (state.skippedVersion === options.candidate) return false;
+  if (state.remindAfter && options.now < state.remindAfter) return false;
+  return true;
+}
+
+function parseUpdateArgs(args) {
+  if (args[0] !== 'update') return { mode: 'none', assumeYes: false };
+  let mode = 'install';
+  let assumeYes = false;
+  let version;
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--check') mode = 'check';
+    else if (arg === '--yes' || arg === '-y') assumeYes = true;
+    else if (arg === '--version') {
+      version = args[i + 1];
+      i += 1;
+      if (!parseVersion(version)) return { mode, assumeYes, error: 'A valid exact version is required.' };
+    } else {
+      return { mode, assumeYes, error: `Unknown update option: ${arg}` };
+    }
+  }
+  return { mode, assumeYes, ...(version ? { version } : {}) };
+}
+
+function requestJson(url, timeoutMs = DEFAULT_NETWORK_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    const transport = parsed.protocol === 'http:' ? http : https;
+    let deadline = null;
+    const request = transport.get(parsed, {
+      headers: { Accept: 'application/json', 'User-Agent': 'aiden-runtime bootstrap' },
+    }, (response) => {
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Registry returned HTTP ${response.statusCode || 0}.`));
+        return;
+      }
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        if (body.length < 1_000_000) body += chunk;
+      });
+      response.on('end', () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          reject(new Error('Registry returned invalid JSON.'));
+        }
+      });
+    });
+    deadline = setTimeout(() => request.destroy(new Error('Registry request timed out.')), timeoutMs);
+    request.once('close', () => {
+      if (deadline) clearTimeout(deadline);
+      deadline = null;
+    });
+    request.on('error', reject);
+  });
+}
+
+async function checkRegistry(options) {
+  const state = readUpdateState(options.stateFile);
+  if (options.env.AIDEN_UPDATE_CHANNEL === 'stable' || options.env.AIDEN_UPDATE_CHANNEL === 'beta' || options.env.AIDEN_UPDATE_CHANNEL === 'off') {
+    state.channel = options.env.AIDEN_UPDATE_CHANNEL;
+    state.enabled = state.channel !== 'off';
+  }
+  const now = typeof options.now === 'function'
+    ? options.now()
+    : (Number.isFinite(options.now) ? options.now : Date.now());
+  const interval = options.checkIntervalMs || DEFAULT_CHECK_INTERVAL_MS;
+  const force = options.force === true;
+  if (!state.enabled || state.channel === 'off' || options.env.AIDEN_NO_UPDATE_CHECK === '1') {
+    return { state, candidate: null, checked: false, offline: false };
+  }
+  if (!force && state.ts > 0 && now - state.ts < interval && state.installed === options.installed) {
+    return {
+      state,
+      candidate: selectUpdateCandidate({ installed: options.installed, latest: state.latest, beta: state.beta, channel: state.channel }),
+      checked: false,
+      offline: false,
+    };
+  }
+  try {
+    const metadata = await requestJson(options.registryUrl || REGISTRY_URL, options.timeoutMs || DEFAULT_NETWORK_TIMEOUT_MS);
+    const tags = metadata && typeof metadata === 'object' && metadata['dist-tags'] && typeof metadata['dist-tags'] === 'object'
+      ? metadata['dist-tags']
+      : {};
+    const next = normalizeUpdateState({
+      ...state,
+      ts: now,
+      installed: options.installed,
+      latest: typeof tags.latest === 'string' ? tags.latest : null,
+      beta: typeof tags.beta === 'string' ? tags.beta : null,
+    });
+    try { atomicWriteJson(options.stateFile, next); } catch {}
+    return {
+      state: next,
+      candidate: selectUpdateCandidate({ installed: options.installed, latest: next.latest, beta: next.beta, channel: next.channel }),
+      checked: true,
+      offline: false,
+      versions: metadata.versions && typeof metadata.versions === 'object' ? Object.keys(metadata.versions) : [],
+    };
+  } catch (error) {
+    const next = normalizeUpdateState({
+      ...state,
+      ts: now,
+      installed: options.installed,
+    });
+    try { atomicWriteJson(options.stateFile, next); } catch {}
+    return { state: next, candidate: null, checked: true, offline: true, error: error.message };
+  }
+}
+
+function renderUpdateOffer(installed, candidate) {
+  return [
+    '',
+    'A new Aiden update is available',
+    '',
+    `Current version: ${installed}`,
+    `New version:     ${candidate}`,
+    '',
+    "What's new:",
+    '- Reliable startup and repair guidance',
+    '- Built-in updates',
+    '- Improved Node compatibility diagnostics',
+    '',
+    '[U] Update now',
+    '[L] Later',
+    '[S] Skip this version',
+    '',
+  ].join('\n');
+}
+
+function promptForUpdate(options) {
+  if (!options.stdin.isTTY || !options.stdout.isTTY) return Promise.resolve('later');
+  options.stdout.write(renderUpdateOffer(options.installed, options.candidate));
+  const stdin = options.stdin;
+  const wasRaw = stdin.isRaw === true;
+  const wasPaused = typeof stdin.isPaused === 'function' ? stdin.isPaused() : false;
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer = null;
+    const finish = (choice) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      stdin.removeListener('data', onData);
+      stdin.removeListener('end', onEnd);
+      stdin.removeListener('close', onEnd);
+      try { if (!wasRaw && stdin.setRawMode) stdin.setRawMode(false); } catch {}
+      try { if (stdin.pause) stdin.pause(); } catch {}
+      resolve(choice);
+    };
+    const onData = (chunk) => {
+      const key = String(chunk || '').trim().toLowerCase();
+      if (key === '\u0003') finish('cancel');
+      else if (key === 'u') finish('update');
+      else if (key === 's') finish('skip');
+      else finish('later');
+    };
+    const onEnd = () => finish('later');
+    try {
+      if (!wasRaw && stdin.setRawMode) stdin.setRawMode(true);
+      if (wasPaused && stdin.resume) stdin.resume();
+      stdin.on('data', onData);
+      stdin.once('end', onEnd);
+      stdin.once('close', onEnd);
+    } catch {
+      finish('later');
+      return;
+    }
+    timer = setTimeout(() => finish('later'), options.timeoutMs || 8_000);
+    if (timer.unref) timer.unref();
+  });
+}
+
+function findNpmCli(nodeExecutable = process.execPath, env = process.env) {
+  const candidates = [];
+  if (typeof env.npm_execpath === 'string') candidates.push(env.npm_execpath);
+  const nodeDir = path.dirname(nodeExecutable);
+  candidates.push(
+    path.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.resolve(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  );
+  for (const candidate of candidates) {
+    try {
+      if (path.basename(candidate).toLowerCase() === 'npm-cli.js' && fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    } catch {}
+  }
+  return null;
+}
+
+function runNpmQuery(nodeExecutable, npmCli, args, env) {
+  const result = spawnSync(nodeExecutable, [npmCli, ...args], {
+    env,
+    encoding: 'utf8',
+    shell: false,
+    windowsHide: true,
+    timeout: 10_000,
+  });
+  if (result.status !== 0) return null;
+  const value = String(result.stdout || '').trim().split(/\r?\n/).pop();
+  return value || null;
+}
+
+function inferOwningPrefix(packageRoot, platform = process.platform) {
+  if (!packageRoot) return null;
+  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  const modulesRoot = pathApi.dirname(packageRoot);
+  if (pathApi.basename(modulesRoot).toLowerCase() !== 'node_modules') return null;
+  const parent = pathApi.dirname(modulesRoot);
+  if (platform !== 'win32' && pathApi.basename(parent) === 'lib') return pathApi.dirname(parent);
+  return parent;
+}
+
+function readInstallReceipt(packageRoot) {
+  if (!packageRoot) return null;
+  try {
+    const receipt = JSON.parse(fs.readFileSync(path.join(packageRoot, '.aiden-install.json'), 'utf8'));
+    if (!receipt || receipt.schemaVersion !== 1) return null;
+    return receipt;
+  } catch {
+    return null;
+  }
+}
+
+function isInside(parent, child) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function resolveNpmEnvironment(options = {}) {
+  const nodeExecutable = options.nodeExecutable || process.execPath;
+  const env = options.env || process.env;
+  const npmCli = findNpmCli(nodeExecutable, env);
+  if (!npmCli) return { ok: false, reason: 'npm-unavailable', nodeExecutable };
+  if (env.npm_command === 'exec' || /[\\/]_npx[\\/]/i.test(options.packageRoot || '')) {
+    return { ok: false, reason: 'temporary-package-runner', nodeExecutable, npmCli };
+  }
+  const configuredPrefix = runNpmQuery(nodeExecutable, npmCli, ['prefix', '-g'], env);
+  const configuredRoot = runNpmQuery(nodeExecutable, npmCli, ['root', '-g'], env);
+  const receipt = readInstallReceipt(options.packageRoot);
+  if (receipt && receipt.global === false) {
+    return { ok: false, reason: 'local-install', nodeExecutable, npmCli };
+  }
+  const recordedPrefix = typeof receipt?.prefix === 'string' && receipt.prefix.trim()
+    ? path.resolve(receipt.prefix)
+    : null;
+  const inferredPrefix = inferOwningPrefix(options.packageRoot);
+  const globalRoot = options.packageRoot ? path.dirname(options.packageRoot) : configuredRoot;
+  const packagePath = options.packageRoot || (globalRoot ? path.join(globalRoot, PACKAGE_NAME) : null);
+  if (recordedPrefix && packagePath && !isInside(recordedPrefix, packagePath)) {
+    return { ok: false, reason: 'install-receipt-mismatch', nodeExecutable, npmCli };
+  }
+  if (
+    options.packageRoot &&
+    !receipt &&
+    configuredRoot &&
+    path.resolve(configuredRoot) !== path.resolve(globalRoot)
+  ) {
+    return { ok: false, reason: 'unverified-install-prefix', nodeExecutable, npmCli };
+  }
+  const prefix = recordedPrefix || inferredPrefix || configuredPrefix;
+  if (!prefix || !globalRoot || !packagePath) {
+    return { ok: false, reason: 'npm-environment', nodeExecutable, npmCli };
+  }
+  return { ok: true, nodeExecutable, npmCli, prefix, globalRoot, packagePath };
+}
+
+function scheduleUpdater(options) {
+  const source = path.join(options.packageRoot, 'bin', 'aiden-updater.cjs');
+  if (!fs.existsSync(source)) throw new Error('The packaged update helper is missing.');
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'aiden-update-'));
+  const helper = path.join(directory, 'aiden-updater.cjs');
+  const statePath = path.join(directory, 'state.json');
+  fs.copyFileSync(source, helper);
+  atomicWriteJson(statePath, {
+    targetVersion: options.targetVersion,
+    previousVersion: options.previousVersion,
+    packageName: PACKAGE_NAME,
+    nodeExecutable: options.npmEnvironment.nodeExecutable,
+    npmCli: options.npmEnvironment.npmCli,
+    prefix: options.npmEnvironment.prefix,
+    globalRoot: options.npmEnvironment.globalRoot,
+    packagePath: options.npmEnvironment.packagePath,
+    tempDir: directory,
+    tty: Boolean(process.stdout.isTTY),
+    color: Boolean(process.stdout.isTTY && !process.env.NO_COLOR),
+  });
+  const child = spawn(options.npmEnvironment.nodeExecutable, [helper, statePath], {
+    stdio: 'inherit',
+    env: { ...process.env, AIDEN_BOOTSTRAP_SKIP_UPDATE: '1' },
+    shell: false,
+    windowsHide: false,
+  });
+  return new Promise((resolve) => {
+    child.once('error', (error) => resolve({ code: 1, error }));
+    child.once('exit', (code, signal) => resolve({ code: code ?? (signal ? 1 : 0), signal }));
+  });
+}
+
+async function handleUpdateCommand(options) {
+  const parsed = parseUpdateArgs(options.args);
+  if (parsed.error) {
+    options.stderr.write(`${parsed.error}\n`);
+    return 2;
+  }
+  const status = await checkRegistry({
+    stateFile: options.stateFile,
+    installed: options.installed,
+    env: options.env,
+    force: true,
+    registryUrl: options.env.AIDEN_UPDATE_REGISTRY_URL,
+  });
+  if (status.offline) {
+    options.stderr.write('Aiden could not reach the package registry. The current installation was not changed.\n');
+    return 1;
+  }
+  if (parsed.mode === 'check') {
+    options.stdout.write(`Installed: ${options.installed}\nLatest:    ${status.state.latest || 'unknown'}\n`);
+    if (status.candidate) options.stdout.write(`Update available: ${status.candidate}\n`);
+    else options.stdout.write('Aiden is up to date.\n');
+    return 0;
+  }
+  let target = parsed.version || status.candidate;
+  if (!target) {
+    options.stdout.write('Aiden is up to date.\n');
+    return 0;
+  }
+  const targetParsed = parseVersion(target);
+  if (!targetParsed || (status.state.channel === 'stable' && targetParsed.prerelease.length > 0)) {
+    options.stderr.write('The requested version is not valid for the configured update channel.\n');
+    return 2;
+  }
+  if (Array.isArray(status.versions) && status.versions.length > 0 && !status.versions.includes(target)) {
+    options.stderr.write(`aiden-runtime ${target} is not available from the configured registry.\n`);
+    return 1;
+  }
+  if (!parsed.assumeYes) {
+    if (!options.stdin.isTTY || !options.stdout.isTTY) {
+      options.stderr.write('Use `aiden update --yes` for a non-interactive installation.\n');
+      return 2;
+    }
+    const choice = await promptForUpdate({ stdin: options.stdin, stdout: options.stdout, installed: options.installed, candidate: target });
+    if (choice === 'cancel') return 130;
+    if (choice !== 'update') return 0;
+  }
+  const npmEnvironment = resolveNpmEnvironment({ env: options.env, packageRoot: options.packageRoot });
+  if (!npmEnvironment.ok) {
+    options.stderr.write('Aiden could not locate npm for the active Node installation. No update was installed.\n');
+    return 1;
+  }
+  const result = await scheduleUpdater({
+    packageRoot: options.packageRoot,
+    targetVersion: target,
+    previousVersion: options.installed,
+    npmEnvironment,
+  });
+  return result.code;
+}
+
+function spawnRealCli(options) {
+  return new Promise((resolve) => {
+    const child = spawn(options.nodeExecutable || process.execPath, [options.cliPath, ...options.args], {
+      cwd: options.cwd || process.cwd(),
+      env: { ...options.env, AIDEN_BOOTSTRAP_UPDATE_CHECKED: '1' },
+      stdio: ['inherit', 'inherit', 'pipe', 'ipc'],
+      shell: false,
+      windowsHide: false,
+    });
+    let ready = false;
+    let buffered = '';
+    const limit = 512 * 1024;
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString();
+      if (ready) process.stderr.write(text);
+      else if (buffered.length < limit) buffered += text.slice(0, limit - buffered.length);
+    });
+    child.on('message', (message) => {
+      if (!message || message.type !== 'aiden-bootstrap-ready' || ready) return;
+      ready = true;
+      if (buffered) process.stderr.write(buffered);
+      buffered = '';
+    });
+    child.once('error', (error) => resolve({ code: 1, ready, stderr: `${buffered}\n${valueToDiagnostic(error)}` }));
+    child.once('exit', (code, signal) => {
+      if (ready && buffered) process.stderr.write(buffered);
+      resolve({ code: code ?? (signal ? 1 : 0), signal, ready, stderr: buffered });
+    });
+  });
+}
+
+async function runBootstrap(options = {}) {
+  const packageRoot = options.packageRoot || path.resolve(__dirname, '..');
+  const args = options.args || process.argv.slice(2);
+  const env = options.env || process.env;
+  const stdout = options.stdout || process.stdout;
+  const stderr = options.stderr || process.stderr;
+  const context = { nodeVersion: process.versions.node, nodeAbi: process.versions.modules };
+  const health = checkPackageHealth({ packageRoot, nodeVersion: context.nodeVersion, nodeAbi: context.nodeAbi });
+  if (!health.ok) {
+    stderr.write(formatStartupFailure({ kind: health.kind }, { ...context, installedVersion: health.version }, {
+      debug: env.AIDEN_BOOTSTRAP_DEBUG === '1',
+      detail: health.kind,
+    }));
+    return 1;
+  }
+  context.installedVersion = health.version;
+  const dataRoot = resolveAidenDataRoot(env);
+  const stateFile = path.join(dataRoot, STATE_FILE);
+  const updateArgs = parseUpdateArgs(args);
+  if (updateArgs.mode !== 'none') {
+    return handleUpdateCommand({ args, env, stdin: options.stdin || process.stdin, stdout, stderr, packageRoot, stateFile, installed: health.version });
+  }
+
+  const interactiveStartup = args.length === 0 && (options.stdin || process.stdin).isTTY && stdout.isTTY;
+  if (interactiveStartup && env.AIDEN_BOOTSTRAP_SKIP_UPDATE !== '1') {
+    const status = await checkRegistry({
+      stateFile,
+      installed: health.version,
+      env,
+      force: false,
+      registryUrl: env.AIDEN_UPDATE_REGISTRY_URL,
+    });
+    if (shouldOfferUpdate({ installed: health.version, candidate: status.candidate, state: status.state, now: Date.now() })) {
+      const choice = await promptForUpdate({
+        stdin: options.stdin || process.stdin,
+        stdout,
+        installed: health.version,
+        candidate: status.candidate,
+      });
+      if (choice === 'skip') {
+        try { atomicWriteJson(stateFile, { ...status.state, skippedVersion: status.candidate, remindAfter: undefined }); } catch {}
+      } else if (choice === 'later') {
+        try { atomicWriteJson(stateFile, { ...status.state, remindAfter: Date.now() + DEFAULT_REMIND_DELAY_MS }); } catch {}
+      } else if (choice === 'update') {
+        const npmEnvironment = resolveNpmEnvironment({ env, packageRoot });
+        if (!npmEnvironment.ok) {
+          stderr.write('Aiden could not locate npm for the active Node installation. Starting the current version.\n');
+        } else {
+          const result = await scheduleUpdater({ packageRoot, targetVersion: status.candidate, previousVersion: health.version, npmEnvironment });
+          return result.code;
+        }
+      } else if (choice === 'cancel') {
+        return 130;
+      }
+    }
+  }
+
+  const result = await spawnRealCli({
+    cliPath: path.join(packageRoot, REAL_CLI),
+    args,
+    env,
+    cwd: options.cwd || process.cwd(),
+  });
+  if (result.code !== 0 && !result.ready && result.stderr.trim()) {
+    const failure = classifyStartupFailure(result.stderr);
+    stderr.write(formatStartupFailure(failure, context, {
+      debug: env.AIDEN_BOOTSTRAP_DEBUG === '1',
+      detail: result.stderr,
+    }));
+  } else if (!result.ready && result.stderr) {
+    stderr.write(result.stderr);
+  }
+  return result.code;
+}
+
+module.exports = {
+  SUPPORTED_NODE_MAJORS,
+  atomicWriteJson,
+  checkPackageHealth,
+  checkRegistry,
+  classifyStartupFailure,
+  compareVersions,
+  findNpmCli,
+  formatStartupFailure,
+  handleUpdateCommand,
+  normalizeUpdateState,
+  inferOwningPrefix,
+  readInstallReceipt,
+  isInside,
+  parseUpdateArgs,
+  promptForUpdate,
+  resolveAidenDataRoot,
+  resolveNpmEnvironment,
+  runBootstrap,
+  scheduleUpdater,
+  selectUpdateCandidate,
+  shouldOfferUpdate,
+  spawnRealCli,
+};
+
+if (require.main === module) {
+  runBootstrap().then(
+    (code) => { process.exitCode = code; },
+    (error) => {
+      process.stderr.write(formatStartupFailure(classifyStartupFailure(error), {
+        nodeVersion: process.versions.node,
+        nodeAbi: process.versions.modules,
+      }, {
+        debug: process.env.AIDEN_BOOTSTRAP_DEBUG === '1',
+        detail: valueToDiagnostic(error),
+      }));
+      process.exitCode = 1;
+    },
+  );
+}

--- a/bin/aiden-updater.cjs
+++ b/bin/aiden-updater.cjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+function isExactVersion(value) {
+  return typeof value === 'string' && /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(value);
+}
+
+function withActiveNodeOnPath(env, nodeExecutable) {
+  const next = { ...env };
+  const pathKey = Object.keys(next).find((key) => key.toLowerCase() === 'path') || 'PATH';
+  const existing = typeof next[pathKey] === 'string' ? next[pathKey] : '';
+  next[pathKey] = [path.dirname(nodeExecutable), existing].filter(Boolean).join(path.delimiter);
+  return next;
+}
+
+function safeReadJson(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+function classifyInstallFailure(text, code) {
+  const value = String(text || '').toLowerCase();
+  if (code === 'ENOENT') return 'npm-unavailable';
+  if (/(eacces|eperm|permission denied|operation not permitted|access is denied)/.test(value)) return 'permission';
+  if (/(etarget|no matching version|version not found)/.test(value)) return 'version-not-found';
+  if (/(econnreset|econnrefused|enotfound|etimedout|network request|socket hang up|dns lookup failed)/.test(value)) return 'network';
+  if (/(node-gyp|gyp err!|prebuild-install|native build|build failed)/.test(value)) return 'native-build';
+  if (/(registry|http (401|403|404|429|5\d\d)|npm err! code e40[134])/.test(value)) return 'registry';
+  return 'package-manager';
+}
+
+function requiresBootstrap(version) {
+  if (!isExactVersion(version)) return true;
+  const core = version.split('-')[0].split('.').map(Number);
+  if (core[0] !== 4) return core[0] > 4;
+  if (core[1] !== 19) return core[1] > 19;
+  return core[2] >= 1;
+}
+
+function createRenderer(options = {}) {
+  const output = options.output || process.stdout;
+  const tty = options.tty !== undefined ? options.tty : Boolean(output.isTTY);
+  const color = options.color !== undefined ? options.color : Boolean(tty && !process.env.NO_COLOR);
+  const animated = Boolean(tty && color && options.motion !== false && process.env.AIDEN_REDUCED_MOTION !== '1');
+  const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+  let timer = null;
+  let index = 0;
+  let active = false;
+  let label = '';
+  let lastSettled = null;
+  const paint = (code, text) => color ? `\x1b[${code}m${text}\x1b[0m` : text;
+  const clear = () => {
+    if (animated) output.write('\r\x1b[2K');
+  };
+  const draw = () => {
+    if (!active || !animated) return;
+    clear();
+    output.write(`${paint('38;5;208', frames[index % frames.length])} ${label}`);
+    index += 1;
+  };
+  return {
+    start(nextLabel) {
+      this.stop(false);
+      label = nextLabel;
+      lastSettled = null;
+      active = true;
+      if (!animated) {
+        output.write(`${nextLabel}\n`);
+        return;
+      }
+      draw();
+      timer = setInterval(draw, 90);
+    },
+    settle(nextLabel, success = true) {
+      this.stop(false);
+      if (lastSettled === nextLabel) return;
+      lastSettled = nextLabel;
+      output.write(`${paint(success ? '32' : '31', success ? '✓' : '×')} ${nextLabel}\n`);
+    },
+    stop(restore = true) {
+      if (timer) clearInterval(timer);
+      timer = null;
+      if (active && animated) clear();
+      active = false;
+      if (restore && animated) output.write('\x1b[?25h');
+    },
+    hasTimer() { return timer !== null; },
+  };
+}
+
+function runChild(command, args, options = {}) {
+  return new Promise((resolve) => {
+    const child = (options.spawnImpl || spawn)(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    const limit = options.outputLimit || 1_000_000;
+    child.stdout?.on('data', (chunk) => {
+      if (stdout.length < limit) stdout += chunk.toString().slice(0, limit - stdout.length);
+    });
+    child.stderr?.on('data', (chunk) => {
+      if (stderr.length < limit) stderr += chunk.toString().slice(0, limit - stderr.length);
+    });
+    let timer = null;
+    let settled = false;
+    const terminate = () => {
+      try {
+        if (process.platform === 'win32' && child.pid) {
+          spawnSync('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore', windowsHide: true, timeout: 5_000 });
+        } else {
+          child.kill('SIGTERM');
+        }
+      } catch {}
+    };
+    const onAbort = () => terminate();
+    if (options.signal) {
+      if (options.signal.aborted) onAbort();
+      else options.signal.addEventListener('abort', onAbort, { once: true });
+    }
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (options.signal) options.signal.removeEventListener('abort', onAbort);
+      resolve({ ...value, stdout, stderr, child });
+    };
+    child.once('error', (error) => finish({ code: -1, error }));
+    child.once('exit', (code, signal) => finish({ code: code ?? (signal ? -1 : 0), signal }));
+    if (options.timeoutMs) {
+      timer = setTimeout(() => {
+        terminate();
+        finish({ code: -1, timeout: true });
+      }, options.timeoutMs);
+    }
+  });
+}
+
+function verifyFiles(state) {
+  const manifest = safeReadJson(path.join(state.packagePath, 'package.json'));
+  if (!manifest || manifest.name !== state.packageName || manifest.version !== state.targetVersion) {
+    return { ok: false, kind: 'version-verification' };
+  }
+  const required = [
+    path.join(state.packagePath, 'dist', 'cli', 'v4', 'aidenCLI.js'),
+    path.join(state.packagePath, 'dist', 'core', 'version.js'),
+  ];
+  if (requiresBootstrap(state.targetVersion)) {
+    required.push(
+      path.join(state.packagePath, 'bin', 'aiden-bootstrap.cjs'),
+      path.join(state.packagePath, 'bin', 'aiden-updater.cjs'),
+    );
+  }
+  if (required.some((file) => !fs.existsSync(file))) return { ok: false, kind: 'file-verification' };
+  return { ok: true, manifest };
+}
+
+async function verifyInstalledPackage(state) {
+  const files = verifyFiles(state);
+  if (!files.ok) return files;
+  const bootstrap = path.join(state.packagePath, 'bin', 'aiden-bootstrap.cjs');
+  const realCli = path.join(state.packagePath, 'dist', 'cli', 'v4', 'aidenCLI.js');
+  const commandEntry = fs.existsSync(bootstrap) ? bootstrap : realCli;
+  const versionResult = await runChild(state.nodeExecutable, [commandEntry, '--version'], {
+    env: { ...process.env, AIDEN_BOOTSTRAP_SKIP_UPDATE: '1', AIDEN_NO_UPDATE_CHECK: '1' },
+    timeoutMs: 20_000,
+  });
+  if (versionResult.code !== 0 || versionResult.stdout.trim() !== state.targetVersion) {
+    return { ok: false, kind: 'command-verification', detail: versionResult.stderr };
+  }
+  const nativeRoot = path.join(state.packagePath, 'node_modules', 'better-sqlite3');
+  const nativeScript = [
+    "const Database=require(process.argv[1]);",
+    "const db=new Database(':memory:');",
+    "db.prepare('select 1 as ok').get();",
+    'db.close();',
+  ].join('');
+  const nativeResult = await runChild(state.nodeExecutable, ['-e', nativeScript, nativeRoot], {
+    env: { ...process.env, AIDEN_BOOTSTRAP_SKIP_UPDATE: '1', AIDEN_NO_UPDATE_CHECK: '1' },
+    timeoutMs: 20_000,
+  });
+  if (nativeResult.code !== 0) {
+    return { ok: false, kind: 'native-verification', detail: nativeResult.stderr };
+  }
+  return { ok: true };
+}
+
+async function installVersion(state, version, options = {}) {
+  if (!isExactVersion(version)) return { ok: false, kind: 'invalid-version' };
+  const args = [
+    state.npmCli,
+    'install',
+    '--global',
+    '--prefix',
+    state.prefix,
+    `${state.packageName}@${version}`,
+    '--no-audit',
+    '--no-fund',
+  ];
+  const outcome = await runChild(state.nodeExecutable, args, {
+    env: withActiveNodeOnPath(
+      { ...process.env, ...options.env, AIDEN_BOOTSTRAP_SKIP_UPDATE: '1' },
+      state.nodeExecutable,
+    ),
+    timeoutMs: 180_000,
+    signal: options.signal,
+  });
+  if (outcome.timeout) return { ok: false, kind: 'timeout', detail: outcome.stderr };
+  if (outcome.code !== 0) {
+    return {
+      ok: false,
+      kind: classifyInstallFailure(`${outcome.stderr}\n${outcome.stdout}`, outcome.error?.code),
+      detail: outcome.stderr,
+    };
+  }
+  return { ok: true };
+}
+
+function repairText(state) {
+  return [
+    'Aiden could not complete the update.',
+    '',
+    'Your workspaces, settings and history were not deleted.',
+    '',
+    'Repair:',
+    'npm uninstall -g aiden-runtime',
+    'npm install -g aiden-runtime@latest',
+    '',
+  ].join('\n');
+}
+
+async function runUpdater(state, options = {}) {
+  const output = options.output || process.stdout;
+  const renderer = options.renderer || createRenderer({ output, tty: state.tty, color: state.color });
+  const install = options.installVersion || installVersion;
+  const verify = options.verifyInstalledPackage || verifyInstalledPackage;
+  let interrupted = false;
+  const controller = new AbortController();
+  const onInterrupt = () => {
+    interrupted = true;
+    controller.abort();
+    renderer.stop();
+  };
+  process.once('SIGINT', onInterrupt);
+  process.once('SIGTERM', onInterrupt);
+  const restorePrevious = async () => {
+    output.write('Attempting to restore the previous public version...\n');
+    const restored = await install(state, state.previousVersion, { signal: controller.signal });
+    const restoredVerification = restored.ok
+      ? await verify({ ...state, targetVersion: state.previousVersion })
+      : { ok: false };
+    if (restored.ok && restoredVerification.ok) {
+      output.write(`✓ Aiden ${state.previousVersion} was restored and verified.\n`);
+      return true;
+    }
+    output.write('The previous version could not be verified.\n');
+    return false;
+  };
+  try {
+    if (!isExactVersion(state.targetVersion) || !isExactVersion(state.previousVersion)) {
+      renderer.settle('Update request rejected.', false);
+      return 2;
+    }
+    output.write(`\nUpdating Aiden to v${state.targetVersion}...\n\n`);
+    renderer.start('Checking installation');
+    if (!fs.existsSync(state.npmCli) || !fs.existsSync(state.nodeExecutable)) {
+      renderer.settle('Checking failed', false);
+      output.write(repairText(state));
+      return 1;
+    }
+    renderer.settle('Checking complete');
+    if (interrupted) return 130;
+
+    renderer.start('Installing package');
+    const installed = await install(state, state.targetVersion, { signal: controller.signal });
+    if (!installed.ok || interrupted) {
+      renderer.settle(interrupted ? 'Update cancelled' : `Installation failed (${installed.kind})`, false);
+      if (!interrupted) {
+        await restorePrevious();
+        output.write(repairText(state));
+      }
+      return interrupted ? 130 : 1;
+    }
+    renderer.settle('Installation complete');
+
+    renderer.start('Verifying installation');
+    const verified = await verify(state);
+    if (!verified.ok || interrupted) {
+      renderer.settle(interrupted ? 'Update cancelled' : `Verification failed (${verified.kind})`, false);
+      if (!interrupted) {
+        await restorePrevious();
+        output.write(repairText(state));
+      }
+      return interrupted ? 130 : 1;
+    }
+    renderer.settle('Verification complete');
+    output.write([
+      '',
+      '✓ Aiden was updated successfully',
+      `✓ Installed version: ${state.targetVersion}`,
+      '✓ Installation verified',
+      '',
+      'Restart Aiden to use the updated version:',
+      '',
+      'aiden',
+      '',
+    ].join('\n'));
+    return 0;
+  } finally {
+    renderer.stop();
+    process.removeListener('SIGINT', onInterrupt);
+    process.removeListener('SIGTERM', onInterrupt);
+  }
+}
+
+function cleanupTemporary(directory) {
+  try { fs.rmSync(directory, { recursive: true, force: true }); } catch {}
+}
+
+module.exports = {
+  classifyInstallFailure,
+  createRenderer,
+  installVersion,
+  isExactVersion,
+  requiresBootstrap,
+  runChild,
+  runUpdater,
+  verifyFiles,
+  verifyInstalledPackage,
+  withActiveNodeOnPath,
+};
+
+if (require.main === module) {
+  const statePath = process.argv[2];
+  const state = statePath ? safeReadJson(statePath) : null;
+  if (!state || !state.tempDir || path.dirname(statePath) !== state.tempDir) {
+    process.stderr.write('Aiden update state is invalid. No installation was changed.\n');
+    process.exitCode = 2;
+  } else {
+    runUpdater(state).then(
+      (code) => {
+        process.exitCode = code;
+        cleanupTemporary(state.tempDir);
+      },
+      () => {
+        process.stderr.write(repairText(state));
+        process.exitCode = 1;
+        cleanupTemporary(state.tempDir);
+      },
+    );
+  }
+}

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -1853,16 +1853,18 @@ export async function buildAgentRuntime(
   // Pre-warm the registry probe so the cache is fresh by the time
   // the prompt asks — same non-blocking pattern, same opt-out
   // semantics, no user-visible output from this call.
-  setImmediate(async () => {
-    try {
-      const { checkForUpdate } = await import('../../core/v4/update/checkUpdate');
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const pkg = require('../../package.json') as { version: string };
-      await checkForUpdate({ paths, installedVersion: pkg.version });
-    } catch {
-      /* silent — update check is best-effort */
-    }
-  });
+  if (process.env.AIDEN_BOOTSTRAP_UPDATE_CHECKED !== '1') {
+    setImmediate(async () => {
+      try {
+        const { checkForUpdate } = await import('../../core/v4/update/checkUpdate');
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const pkg = require('../../package.json') as { version: string };
+        await checkForUpdate({ paths, installedVersion: pkg.version });
+      } catch {
+        /* silent — update check is best-effort */
+      }
+    });
+  }
 
   // ── Phase 9 moat (stateless / wraps memory) ──────────────────────────
   const memoryGuard = new MemoryGuard(memoryManager);
@@ -4248,6 +4250,12 @@ async function runInteractiveChat(cliOpts: any, opts: MainOptions): Promise<void
   };
 
   try {
+    if (
+      process.env.AIDEN_BOOTSTRAP_UPDATE_CHECKED === '1' &&
+      typeof process.send === 'function'
+    ) {
+      process.send({ type: 'aiden-bootstrap-ready' });
+    }
     if (cliOpts.tui) {
       await runTuiMode({
         sessionOpts: sessionOpts as any,

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -3816,6 +3816,7 @@ export class ChatSession implements ChatSessionLike {
    * sessions constructed without paths wired) don't pay the cost.
    */
   private async maybeShowBootUpdatePrompt(): Promise<void> {
+    if (process.env.AIDEN_BOOTSTRAP_UPDATE_CHECKED === '1') return;
     if (!this.opts.paths) return;
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cu = require('../../core/v4/update/checkUpdate') as typeof import('../../core/v4/update/checkUpdate');

--- a/core/v4/update/checkUpdate.ts
+++ b/core/v4/update/checkUpdate.ts
@@ -72,6 +72,14 @@ export interface UpdateCacheShape {
   failedVersion?: string;
   failureCount?: number;
   retryAfter?: number;
+  /** Bootstrap-owned automatic update preference. */
+  enabled?: boolean;
+  /** Selected public update channel. */
+  channel?: 'stable' | 'beta' | 'off';
+  /** npm beta dist-tag observed by the dependency-light bootstrap. */
+  beta?: string | null;
+  /** Epoch ms before which the bootstrap should not prompt again. */
+  remindAfter?: number;
 }
 
 export interface UpdateStatus {
@@ -327,6 +335,10 @@ export async function checkForUpdate(opts: CheckUpdateOptions): Promise<UpdateSt
     failedVersion:  cached?.failedVersion,
     failureCount:   cached?.failureCount,
     retryAfter:     cached?.retryAfter,
+    enabled:        cached?.enabled,
+    channel:        cached?.channel,
+    beta:           cached?.beta,
+    remindAfter:    cached?.remindAfter,
   });
 
   const updateAvailable = latest !== null && safeCompare(latest, installed) > 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-runtime",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-runtime",
-      "version": "4.19.0",
+      "version": "4.19.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -70,8 +70,8 @@
         "ws": "^8.20.1"
       },
       "bin": {
-        "aiden": "dist/cli/v4/aidenCLI.js",
-        "aiden-runtime": "dist/cli/v4/aidenCLI.js"
+        "aiden": "bin/aiden-bootstrap.cjs",
+        "aiden-runtime": "bin/aiden-bootstrap.cjs"
       },
       "devDependencies": {
         "@types/archiver": "^7.0.0",
@@ -105,7 +105,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20 <21 || >=22 <23"
       },
       "optionalDependencies": {
         "decibri": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-runtime",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "publishConfig": {
     "access": "public"
   },
@@ -32,14 +32,16 @@
     "tool-use"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20 <21 || >=22 <23"
   },
   "bin": {
-    "aiden": "./dist/cli/v4/aidenCLI.js",
-    "aiden-runtime": "./dist/cli/v4/aidenCLI.js"
+    "aiden": "./bin/aiden-bootstrap.cjs",
+    "aiden-runtime": "./bin/aiden-bootstrap.cjs"
   },
   "main": "./dist/cli/v4/aidenCLI.js",
   "files": [
+    "bin/aiden-bootstrap.cjs",
+    "bin/aiden-updater.cjs",
     "dist/",
     "skills/",
     "!skills/installed/*/**",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,6 +5,27 @@ const fs   = require('fs')
 const path = require('path')
 const root = path.join(__dirname, '..')
 
+// Record only installation provenance needed by the bootstrap updater. This
+// stays inside the package directory and never contains credentials or user
+// configuration. A later launch can keep the active Node executable while
+// targeting the exact prefix that owns this installation.
+try {
+  const receipt = {
+    schemaVersion: 1,
+    global: (process.env.npm_config_global || process.env.NPM_CONFIG_GLOBAL) === 'true',
+    prefix: process.env.npm_config_prefix || process.env.NPM_CONFIG_PREFIX || null,
+    npmCli: process.env.npm_execpath || process.env.NPM_EXECPATH || null,
+    nodeExecutable: process.execPath,
+    installedAt: Date.now(),
+  }
+  const receiptPath = path.join(root, '.aiden-install.json')
+  const temporary = `${receiptPath}.tmp-${process.pid}`
+  fs.writeFileSync(temporary, JSON.stringify(receipt), { encoding: 'utf8', mode: 0o600 })
+  fs.renameSync(temporary, receiptPath)
+} catch {
+  // Installation remains usable; manual repair guidance is the fallback.
+}
+
 const dirs = [
   'workspace/sandbox',
   'workspace/uploads',

--- a/tests/v4/bootstrap/bootstrap.test.ts
+++ b/tests/v4/bootstrap/bootstrap.test.ts
@@ -1,0 +1,228 @@
+import { mkdtempSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(__dirname, '../../..');
+const bootstrap = require(path.join(root, 'bin', 'aiden-bootstrap.cjs')) as {
+  SUPPORTED_NODE_MAJORS: readonly number[];
+  checkPackageHealth(options: {
+    packageRoot: string;
+    nodeVersion?: string;
+    nodeAbi?: string;
+  }): { ok: boolean; kind?: string; version?: string };
+  classifyStartupFailure(value: unknown): {
+    kind: string;
+    installedAbi?: string;
+    requiredAbi?: string;
+  };
+  formatStartupFailure(
+    failure: { kind: string; installedAbi?: string; requiredAbi?: string },
+    context: { installedVersion?: string; nodeVersion: string; nodeAbi: string },
+    options?: { debug?: boolean; detail?: string },
+  ): string;
+  compareVersions(a: string, b: string): number;
+  selectUpdateCandidate(options: {
+    installed: string;
+    latest: string | null;
+    beta?: string | null;
+    channel: 'stable' | 'beta' | 'off';
+  }): string | null;
+  normalizeUpdateState(value: unknown): {
+    enabled: boolean;
+    channel: 'stable' | 'beta' | 'off';
+    skippedVersion?: string;
+    remindAfter?: number;
+  };
+  shouldOfferUpdate(options: {
+    installed: string;
+    candidate: string | null;
+    state: Record<string, unknown>;
+    now: number;
+  }): boolean;
+  parseUpdateArgs(args: string[]): {
+    mode: 'none' | 'check' | 'install';
+    assumeYes: boolean;
+    version?: string;
+    error?: string;
+  };
+  inferOwningPrefix(packageRoot: string, platform?: NodeJS.Platform): string | null;
+  resolveNpmEnvironment(options: { packageRoot: string; env: NodeJS.ProcessEnv }): { ok: boolean; reason?: string };
+};
+
+function packageFixture(options: {
+  version?: string;
+  packageJson?: string;
+  cli?: boolean;
+  runtime?: boolean;
+} = {}): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'aiden-bootstrap-'));
+  if (options.packageJson !== undefined) {
+    writeFileSync(path.join(dir, 'package.json'), options.packageJson, 'utf8');
+  } else {
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'aiden-runtime', version: options.version ?? '4.19.0' }),
+      'utf8',
+    );
+  }
+  if (options.cli !== false) {
+    mkdirSync(path.join(dir, 'dist', 'cli', 'v4'), { recursive: true });
+    writeFileSync(path.join(dir, 'dist', 'cli', 'v4', 'aidenCLI.js'), '', 'utf8');
+  }
+  if (options.runtime !== false) {
+    mkdirSync(path.join(dir, 'dist', 'core'), { recursive: true });
+    writeFileSync(path.join(dir, 'dist', 'core', 'version.js'), '', 'utf8');
+  }
+  mkdirSync(path.join(dir, 'bin'), { recursive: true });
+  writeFileSync(path.join(dir, 'bin', 'aiden-updater.cjs'), '', 'utf8');
+  return dir;
+}
+
+describe('dependency-light command bootstrap', () => {
+  it('supports the accepted Node 20 and Node 22 runtimes only', () => {
+    expect(bootstrap.SUPPORTED_NODE_MAJORS).toEqual([20, 22]);
+    expect(bootstrap.checkPackageHealth({ packageRoot: packageFixture(), nodeVersion: '20.20.2', nodeAbi: '115' }).ok).toBe(true);
+    expect(bootstrap.checkPackageHealth({ packageRoot: packageFixture(), nodeVersion: '22.23.1', nodeAbi: '127' }).ok).toBe(true);
+    expect(bootstrap.checkPackageHealth({ packageRoot: packageFixture(), nodeVersion: '24.13.1', nodeAbi: '137' })).toMatchObject({
+      ok: false,
+      kind: 'unsupported-node',
+    });
+    const unsupported = bootstrap.formatStartupFailure(
+      { kind: 'unsupported-node' },
+      { installedVersion: '4.19.1', nodeVersion: '24.13.1', nodeAbi: '137' },
+    );
+    expect(unsupported).toContain('Supported runtimes: Node 20 and Node 22');
+    expect(unsupported).toContain('npm install -g aiden-runtime@latest');
+  });
+
+  it('detects missing, malformed, and incomplete packages before the full CLI loads', () => {
+    expect(bootstrap.checkPackageHealth({ packageRoot: path.join(tmpdir(), 'absent-aiden-package'), nodeVersion: '22.23.1' })).toMatchObject({
+      ok: false,
+      kind: 'missing-package',
+    });
+    expect(bootstrap.checkPackageHealth({ packageRoot: packageFixture({ packageJson: '{' }), nodeVersion: '22.23.1' })).toMatchObject({
+      ok: false,
+      kind: 'malformed-package',
+    });
+    expect(bootstrap.checkPackageHealth({ packageRoot: packageFixture({ cli: false }), nodeVersion: '22.23.1' })).toMatchObject({
+      ok: false,
+      kind: 'missing-cli',
+    });
+    expect(bootstrap.checkPackageHealth({ packageRoot: packageFixture({ runtime: false }), nodeVersion: '22.23.1' })).toMatchObject({
+      ok: false,
+      kind: 'missing-runtime',
+    });
+    const withoutUpdater = packageFixture();
+    const updaterPath = path.join(withoutUpdater, 'bin', 'aiden-updater.cjs');
+    unlinkSync(updaterPath);
+    expect(bootstrap.checkPackageHealth({ packageRoot: withoutUpdater, nodeVersion: '22.23.1' })).toMatchObject({
+      ok: false,
+      kind: 'missing-updater',
+    });
+  });
+
+  it('classifies the observed native ABI mismatch without exposing a raw stack', () => {
+    const detail = [
+      'Error: The module better_sqlite3.node was compiled against a different Node.js version using',
+      'NODE_MODULE_VERSION 137. This version of Node.js requires NODE_MODULE_VERSION 127.',
+      '    at Module._extensions..node',
+    ].join('\n');
+    const classified = bootstrap.classifyStartupFailure(detail);
+    expect(classified).toMatchObject({ kind: 'native-abi', installedAbi: '137', requiredAbi: '127' });
+    const friendly = bootstrap.formatStartupFailure(classified, {
+      installedVersion: '4.19.0',
+      nodeVersion: '22.23.1',
+      nodeAbi: '127',
+    }, { detail });
+    expect(friendly).toContain('installed using a different Node version');
+    expect(friendly).toContain('ABI 127');
+    expect(friendly).toContain('npm install -g aiden-runtime@latest');
+    expect(friendly).not.toContain('Module._extensions');
+  });
+
+  it('classifies missing modules, generic native load failures, and unknown failures safely', () => {
+    expect(bootstrap.classifyStartupFailure({ code: 'MODULE_NOT_FOUND', message: 'missing' }).kind).toBe('missing-module');
+    expect(bootstrap.classifyStartupFailure({ code: 'ERR_MODULE_NOT_FOUND', message: 'missing' }).kind).toBe('missing-module');
+    expect(bootstrap.classifyStartupFailure({ code: 'ERR_DLOPEN_FAILED', message: 'bad native image' }).kind).toBe('native-load');
+    const unknown = bootstrap.formatStartupFailure(
+      { kind: 'unknown' },
+      { installedVersion: '4.19.0', nodeVersion: '22.23.1', nodeAbi: '127' },
+      { detail: 'Error: private stack\n at internal-file:1' },
+    );
+    expect(unknown).toMatch(/diagnostic/i);
+    expect(unknown).not.toContain('internal-file');
+    const debug = bootstrap.formatStartupFailure(
+      { kind: 'unknown' },
+      { installedVersion: '4.19.0', nodeVersion: '22.23.1', nodeAbi: '127' },
+      { detail: 'Error: private stack\n at internal-file:1', debug: true },
+    );
+    expect(debug).toContain('internal-file');
+  });
+});
+
+describe('bootstrap update policy', () => {
+  it('infers the exact owning global prefix without using the current working directory', () => {
+    expect(bootstrap.inferOwningPrefix('C:\\isolated prefix\\node_modules\\aiden-runtime', 'win32'))
+      .toBe(path.win32.normalize('C:\\isolated prefix'));
+    expect(bootstrap.inferOwningPrefix('/opt/aiden/lib/node_modules/aiden-runtime', 'linux'))
+      .toBe(path.posix.normalize('/opt/aiden'));
+  });
+
+  it('refuses to replace a project-local package or a mismatched owning prefix', () => {
+    const local = packageFixture();
+    writeFileSync(path.join(local, '.aiden-install.json'), JSON.stringify({
+      schemaVersion: 1,
+      global: false,
+      prefix: path.dirname(local),
+    }));
+    expect(bootstrap.resolveNpmEnvironment({
+      packageRoot: local,
+      env: { ...process.env, npm_command: '' },
+    })).toMatchObject({ ok: false, reason: 'local-install' });
+
+    writeFileSync(path.join(local, '.aiden-install.json'), JSON.stringify({
+      schemaVersion: 1,
+      global: true,
+      prefix: path.join(tmpdir(), 'different-prefix'),
+    }));
+    expect(bootstrap.resolveNpmEnvironment({
+      packageRoot: local,
+      env: { ...process.env, npm_command: '' },
+    })).toMatchObject({ ok: false, reason: 'install-receipt-mismatch' });
+  });
+
+  it('compares stable and prerelease versions without offering a prerelease to stable users', () => {
+    expect(bootstrap.compareVersions('4.19.1', '4.19.0')).toBeGreaterThan(0);
+    expect(bootstrap.compareVersions('4.20.0', '4.19.9')).toBeGreaterThan(0);
+    expect(bootstrap.compareVersions('5.0.0', '4.99.99')).toBeGreaterThan(0);
+    expect(bootstrap.selectUpdateCandidate({ installed: '4.19.0', latest: '4.19.1-beta.1', channel: 'stable' })).toBeNull();
+    expect(bootstrap.selectUpdateCandidate({ installed: '4.19.0', latest: '4.19.1', beta: '4.20.0-beta.1', channel: 'stable' })).toBe('4.19.1');
+    expect(bootstrap.selectUpdateCandidate({ installed: '4.19.0', latest: '4.19.1', beta: '4.20.0-beta.1', channel: 'beta' })).toBe('4.20.0-beta.1');
+    expect(bootstrap.selectUpdateCandidate({ installed: '4.19.0', latest: '4.19.1', channel: 'off' })).toBeNull();
+  });
+
+  it('normalizes corrupt state and respects skip and remind-after decisions', () => {
+    expect(bootstrap.normalizeUpdateState(null)).toMatchObject({ enabled: true, channel: 'stable' });
+    expect(bootstrap.normalizeUpdateState({ enabled: 'bad', channel: 'nightly' })).toMatchObject({ enabled: true, channel: 'stable' });
+    expect(bootstrap.shouldOfferUpdate({ installed: '4.19.0', candidate: '4.19.1', state: {}, now: 2_000 })).toBe(true);
+    expect(bootstrap.shouldOfferUpdate({ installed: '4.19.0', candidate: '4.19.1', state: { skippedVersion: '4.19.1' }, now: 2_000 })).toBe(false);
+    expect(bootstrap.shouldOfferUpdate({ installed: '4.19.0', candidate: '4.19.2', state: { skippedVersion: '4.19.1' }, now: 2_000 })).toBe(true);
+    expect(bootstrap.shouldOfferUpdate({ installed: '4.19.0', candidate: '4.19.1', state: { remindAfter: 2_001 }, now: 2_000 })).toBe(false);
+  });
+
+  it('parses manual update commands without accepting unsafe versions', () => {
+    expect(bootstrap.parseUpdateArgs([])).toEqual({ mode: 'none', assumeYes: false });
+    expect(bootstrap.parseUpdateArgs(['update', '--check'])).toEqual({ mode: 'check', assumeYes: false });
+    expect(bootstrap.parseUpdateArgs(['update', '--yes'])).toEqual({ mode: 'install', assumeYes: true });
+    expect(bootstrap.parseUpdateArgs(['update', '--version', '4.19.1'])).toEqual({
+      mode: 'install',
+      assumeYes: false,
+      version: '4.19.1',
+    });
+    expect(bootstrap.parseUpdateArgs(['update', '--version', '4.19.1 & whoami']).error).toMatch(/version/i);
+  });
+});

--- a/tests/v4/bootstrap/bootstrapUpdate.pty.test.ts
+++ b/tests/v4/bootstrap/bootstrapUpdate.pty.test.ts
@@ -1,0 +1,154 @@
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import * as pty from 'node-pty';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const currentNodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
+const localNode22 = path.join(process.env.LOCALAPPDATA ?? '', 'node-v22.23.1-win-x64', 'node.exe');
+const supportedNode = currentNodeMajor === 20 || currentNodeMajor === 22 ? process.execPath : localNode22;
+const cleanup: string[] = [];
+let server: Server | null = null;
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = null;
+  for (const directory of cleanup.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function waitFor(predicate: () => boolean, output: () => string, timeoutMs = 20_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const timer = setInterval(() => {
+      if (predicate()) {
+        clearInterval(timer);
+        resolve();
+      } else if (Date.now() - started >= timeoutMs) {
+        clearInterval(timer);
+        reject(new Error(`PTY timeout:\n${output().slice(-4_000)}`));
+      }
+    }, 25);
+  });
+}
+
+describe.skipIf(process.platform !== 'win32')('bootstrap update ConPTY', () => {
+  it.each(['4.18.0', '4.19.0'])(
+    'updates v%s through the owning prefix, verifies, preserves data, and exits cleanly',
+    async (previousVersion) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'aiden update physical fixture '));
+    cleanup.push(root);
+    const prefix = path.join(root, 'prefix with spaces');
+    const packageRoot = path.join(prefix, 'node_modules', 'aiden-runtime');
+    const cliDir = path.join(packageRoot, 'dist', 'cli', 'v4');
+    const coreDir = path.join(packageRoot, 'dist', 'core');
+    const binDir = path.join(packageRoot, 'bin');
+    const nativeDir = path.join(packageRoot, 'node_modules', 'better-sqlite3');
+    const npmDir = path.join(root, 'fake npm with spaces');
+    const npmCli = path.join(npmDir, 'npm-cli.js');
+    const aidenHome = path.join(root, 'aiden-home');
+    const tempRoot = path.join(root, 'temporary-updaters');
+    mkdirSync(cliDir, { recursive: true });
+    mkdirSync(coreDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(nativeDir, { recursive: true });
+    mkdirSync(npmDir, { recursive: true });
+    mkdirSync(aidenHome, { recursive: true });
+    mkdirSync(tempRoot, { recursive: true });
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'aiden-runtime', version: previousVersion }), 'utf8');
+    writeFileSync(path.join(aidenHome, 'preserved-workspace-marker.txt'), 'preserve-me', 'utf8');
+    writeFileSync(path.join(coreDir, 'version.js'), '', 'utf8');
+    writeFileSync(path.join(cliDir, 'aidenCLI.js'), [
+      "const manifest=require('../../../package.json');",
+      "if(process.argv.includes('--version')){process.stdout.write(manifest.version+'\\n');}",
+      "else{if(process.send)process.send({type:'aiden-bootstrap-ready'});process.stdout.write('MAIN_STARTED\\n');}",
+    ].join(''), 'utf8');
+    writeFileSync(path.join(nativeDir, 'index.js'), [
+      'module.exports=class Database{',
+      "constructor(_name){} prepare(){return {get(){return {ok:1}}}} close(){}",
+      '};',
+    ].join(''), 'utf8');
+    writeFileSync(npmCli, [
+      "const fs=require('node:fs');const path=require('node:path');",
+      "const args=process.argv.slice(2);",
+      "if(args[0]==='prefix'){process.stdout.write(process.env.FIXTURE_PREFIX+'\\n');process.exit(0);}",
+      "if(args[0]==='root'){process.stdout.write(path.join(process.env.FIXTURE_PREFIX,'node_modules')+'\\n');process.exit(0);}",
+      "if(args[0]==='install'){setTimeout(()=>{const file=path.join(process.env.FIXTURE_PACKAGE_ROOT,'package.json');const p=JSON.parse(fs.readFileSync(file,'utf8'));p.version='4.19.1';fs.writeFileSync(file,JSON.stringify(p));process.exit(0);},350);}",
+      "else{process.exit(2);}",
+    ].join(''), 'utf8');
+    writeFileSync(path.join(packageRoot, '.aiden-install.json'), JSON.stringify({
+      schemaVersion: 1,
+      global: true,
+      prefix,
+      npmCli,
+      nodeExecutable: supportedNode,
+      installedAt: Date.now(),
+    }), 'utf8');
+    for (const file of ['aiden-bootstrap.cjs', 'aiden-updater.cjs']) {
+      writeFileSync(path.join(binDir, file), readFileSync(path.join(repoRoot, 'bin', file), 'utf8'), 'utf8');
+    }
+
+    server = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        'dist-tags': { latest: '4.19.1' },
+        versions: { '4.18.0': {}, '4.19.0': {}, '4.19.1': {} },
+      }));
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('missing registry address');
+
+    const child = pty.spawn(supportedNode, [path.join(binDir, 'aiden-bootstrap.cjs')], {
+      name: 'xterm-color',
+      cols: 100,
+      rows: 30,
+      cwd: root,
+      env: {
+        ...process.env,
+        AIDEN_HOME: aidenHome,
+        AIDEN_UPDATE_REGISTRY_URL: `http://127.0.0.1:${address.port}/aiden-runtime`,
+        FIXTURE_PREFIX: prefix,
+        FIXTURE_PACKAGE_ROOT: packageRoot,
+        npm_execpath: npmCli,
+        NPM_EXECPATH: npmCli,
+        npm_command: '',
+        NPM_COMMAND: '',
+        TEMP: tempRoot,
+        TMP: tempRoot,
+        FORCE_COLOR: '1',
+        NO_COLOR: '',
+      },
+    });
+    let raw = '';
+    let exitCode: number | null = null;
+    const dataSubscription = child.onData((chunk) => { raw += chunk; });
+    const exitSubscription = child.onExit((event) => { exitCode = event.exitCode; });
+    try {
+      await waitFor(() => raw.includes('A new Aiden update is available'), () => raw);
+      child.write('u');
+      await waitFor(() => raw.includes('Installing package'), () => raw);
+      child.resize(44, 20);
+      child.resize(100, 30);
+      await waitFor(() => raw.includes('Aiden was updated successfully'), () => raw);
+      await waitFor(() => exitCode !== null, () => raw);
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8')).version).toBe('4.19.1');
+      expect(raw.match(/Aiden was updated successfully/g)).toHaveLength(1);
+      expect(raw).toContain('Installation verified');
+      expect(raw).toContain('Restart Aiden');
+      expect(raw).not.toContain('MAIN_STARTED');
+      expect(raw).not.toMatch(/NODE_MODULE_VERSION|at Module\._/);
+      expect(readFileSync(path.join(aidenHome, 'preserved-workspace-marker.txt'), 'utf8')).toBe('preserve-me');
+      expect(readdirSync(tempRoot).filter((name) => name.startsWith('aiden-update-'))).toHaveLength(0);
+    } finally {
+      dataSubscription.dispose();
+      exitSubscription.dispose();
+      if (exitCode === null) child.kill();
+    }
+    },
+    30_000,
+  );
+});

--- a/tests/v4/bootstrap/choicePersistence.test.ts
+++ b/tests/v4/bootstrap/choicePersistence.test.ts
@@ -1,0 +1,90 @@
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { createRequire } from 'node:module';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(__dirname, '../../..');
+const bootstrap = require(path.join(repoRoot, 'bin', 'aiden-bootstrap.cjs'));
+let server: Server | null = null;
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = null;
+});
+
+function fixture(): { packageRoot: string; home: string } {
+  const root = mkdtempSync(path.join(tmpdir(), 'aiden-bootstrap-choice-'));
+  const packageRoot = path.join(root, 'node_modules', 'aiden-runtime');
+  const home = path.join(root, 'home');
+  mkdirSync(path.join(packageRoot, 'dist', 'cli', 'v4'), { recursive: true });
+  mkdirSync(path.join(packageRoot, 'dist', 'core'), { recursive: true });
+  mkdirSync(path.join(packageRoot, 'bin'), { recursive: true });
+  mkdirSync(home, { recursive: true });
+  writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'aiden-runtime', version: '4.19.0' }));
+  writeFileSync(path.join(packageRoot, 'dist', 'core', 'version.js'), '');
+  writeFileSync(path.join(packageRoot, 'dist', 'cli', 'v4', 'aidenCLI.js'), "if(process.send)process.send({type:'aiden-bootstrap-ready'});");
+  writeFileSync(path.join(packageRoot, 'bin', 'aiden-updater.cjs'), '');
+  return { packageRoot, home };
+}
+
+function ttyPair() {
+  const stdin = new PassThrough() as PassThrough & { isTTY: boolean; isRaw: boolean; setRawMode(value: boolean): void };
+  stdin.isTTY = true;
+  stdin.isRaw = false;
+  stdin.setRawMode = (value: boolean) => { stdin.isRaw = value; };
+  const stdout = new PassThrough() as PassThrough & { isTTY: boolean };
+  stdout.isTTY = true;
+  return { stdin, stdout };
+}
+
+async function registry(): Promise<string> {
+  server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({
+      'dist-tags': { latest: '4.19.1' },
+      versions: { '4.19.0': {}, '4.19.1': {} },
+    }));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing registry address');
+  return `http://127.0.0.1:${address.port}/aiden-runtime`;
+}
+
+describe.skipIf(![20, 22].includes(Number.parseInt(process.versions.node.split('.')[0], 10)))(
+  'bootstrap update choice persistence',
+  () => {
+  it.each([
+    { key: 'l', field: 'remindAfter' },
+    { key: 's', field: 'skippedVersion' },
+  ])('persists $field outside the npm package and starts the current runtime', async ({ key, field }) => {
+    const { packageRoot, home } = fixture();
+    const io = ttyPair();
+    const registryUrl = await registry();
+    const run = bootstrap.runBootstrap({
+      packageRoot,
+      args: [],
+      env: {
+        ...process.env,
+        AIDEN_HOME: home,
+        AIDEN_UPDATE_REGISTRY_URL: registryUrl,
+      },
+      stdin: io.stdin,
+      stdout: io.stdout,
+      stderr: new PassThrough(),
+      cwd: home,
+    });
+    io.stdin.write(key);
+    await expect(run).resolves.toBe(0);
+    const state = JSON.parse(readFileSync(path.join(home, '.update_check.json'), 'utf8'));
+    if (field === 'remindAfter') expect(state.remindAfter).toBeGreaterThan(Date.now());
+    else expect(state.skippedVersion).toBe('4.19.1');
+    expect(path.dirname(path.join(home, '.update_check.json'))).toBe(home);
+  });
+  },
+);

--- a/tests/v4/bootstrap/installReceipt.test.ts
+++ b/tests/v4/bootstrap/installReceipt.test.ts
@@ -1,0 +1,51 @@
+import { copyFileSync, existsSync, mkdtempSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(__dirname, '../../..');
+
+describe('installation provenance receipt', () => {
+  it('records the owning prefix without copying user data into the package', () => {
+    const packageRoot = mkdtempSync(path.join(tmpdir(), 'aiden receipt package '));
+    const scripts = path.join(packageRoot, 'scripts');
+    mkdirSync(scripts, { recursive: true });
+    copyFileSync(path.join(root, 'scripts', 'postinstall.js'), path.join(scripts, 'postinstall.js'));
+    const prefix = path.join(tmpdir(), 'aiden isolated prefix with spaces');
+    const npmCli = path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+    const childEnv = { ...process.env };
+    for (const key of Object.keys(childEnv)) {
+      if (/^npm_(?:config_(?:global|prefix)|execpath)$/i.test(key)) delete childEnv[key];
+    }
+    const result = spawnSync(process.execPath, [path.join(scripts, 'postinstall.js')], {
+      encoding: 'utf8',
+      env: {
+        ...childEnv,
+        npm_config_global: 'true',
+        npm_config_prefix: prefix,
+        npm_execpath: npmCli,
+      },
+    });
+    expect(result.status).toBe(0);
+    const receiptPath = path.join(packageRoot, '.aiden-install.json');
+    expect(existsSync(receiptPath)).toBe(true);
+    expect(JSON.parse(readFileSync(receiptPath, 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      global: true,
+      prefix,
+      npmCli,
+      nodeExecutable: process.execPath,
+    });
+    expect(existsSync(path.join(packageRoot, 'sessions.db'))).toBe(false);
+    expect(existsSync(path.join(packageRoot, 'config.yaml'))).toBe(false);
+    expect(existsSync(path.join(packageRoot, 'auth.json'))).toBe(false);
+  });
+
+  it('does not put secrets or environment contents in the receipt', () => {
+    const source = readFileSync(path.join(root, 'scripts', 'postinstall.js'), 'utf8');
+    expect(source).not.toMatch(/process\.env\.(?:GROQ_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY)/);
+    expect(source).not.toMatch(/JSON\.stringify\(process\.env/);
+  });
+});

--- a/tests/v4/bootstrap/processHandoff.test.ts
+++ b/tests/v4/bootstrap/processHandoff.test.ts
@@ -42,10 +42,9 @@ describe('bootstrap process handoff', () => {
     ].join(''));
     const result = runFixture(packageRoot, ['--flag', 'value with spaces', '--', 'literal'], unrelated);
     expect(result.status).toBe(7);
-    expect(JSON.parse(result.stdout)).toEqual({
-      args: ['--flag', 'value with spaces', '--', 'literal'],
-      cwd: realpathSync.native(unrelated),
-    });
+    const handoff = JSON.parse(result.stdout) as { args: string[]; cwd: string };
+    expect(handoff.args).toEqual(['--flag', 'value with spaces', '--', 'literal']);
+    expect(realpathSync.native(handoff.cwd)).toBe(realpathSync.native(unrelated));
   });
 
   it('translates a pre-ready ABI crash and suppresses its raw stack by default', () => {

--- a/tests/v4/bootstrap/processHandoff.test.ts
+++ b/tests/v4/bootstrap/processHandoff.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(__dirname, '../../..');
+const bootstrap = path.join(root, 'bin', 'aiden-bootstrap.cjs');
+const currentNodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
+const localNode22 = path.join(process.env.LOCALAPPDATA ?? '', 'node-v22.23.1-win-x64', 'node.exe');
+const supportedNode = currentNodeMajor === 20 || currentNodeMajor === 22 ? process.execPath : localNode22;
+
+function fixture(cliSource: string): string {
+  const packageRoot = mkdtempSync(path.join(tmpdir(), 'aiden-handoff-'));
+  mkdirSync(path.join(packageRoot, 'dist', 'cli', 'v4'), { recursive: true });
+  mkdirSync(path.join(packageRoot, 'dist', 'core'), { recursive: true });
+  mkdirSync(path.join(packageRoot, 'bin'), { recursive: true });
+  writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'aiden-runtime', version: '4.19.0' }));
+  writeFileSync(path.join(packageRoot, 'dist', 'core', 'version.js'), '', 'utf8');
+  writeFileSync(path.join(packageRoot, 'bin', 'aiden-updater.cjs'), '', 'utf8');
+  writeFileSync(path.join(packageRoot, 'dist', 'cli', 'v4', 'aidenCLI.js'), cliSource, 'utf8');
+  return packageRoot;
+}
+
+function runFixture(packageRoot: string, args: string[], cwd = tmpdir()) {
+  const driver = [
+    `const bootstrap=require(${JSON.stringify(bootstrap)});`,
+    `bootstrap.runBootstrap({packageRoot:${JSON.stringify(packageRoot)},args:${JSON.stringify(args)},cwd:${JSON.stringify(cwd)},env:{...process.env,AIDEN_BOOTSTRAP_SKIP_UPDATE:'1',AIDEN_NO_UPDATE_CHECK:'1'}})`,
+    `.then(code=>{process.exitCode=code});`,
+  ].join('');
+  return spawnSync(supportedNode, ['-e', driver], { encoding: 'utf8', cwd, timeout: 20_000 });
+}
+
+describe('bootstrap process handoff', () => {
+  it('forwards arguments, working directory, and child exit code exactly', () => {
+    const unrelated = mkdtempSync(path.join(tmpdir(), 'aiden unrelated path '));
+    const packageRoot = fixture([
+      "if(process.send)process.send({type:'aiden-bootstrap-ready'});",
+      "process.stdout.write(JSON.stringify({args:process.argv.slice(2),cwd:process.cwd()}));",
+      'process.exitCode=7;',
+    ].join(''));
+    const result = runFixture(packageRoot, ['--flag', 'value with spaces', '--', 'literal'], unrelated);
+    expect(result.status).toBe(7);
+    expect(JSON.parse(result.stdout)).toEqual({
+      args: ['--flag', 'value with spaces', '--', 'literal'],
+      cwd: unrelated,
+    });
+  });
+
+  it('translates a pre-ready ABI crash and suppresses its raw stack by default', () => {
+    const packageRoot = fixture([
+      "process.stderr.write('Error: better_sqlite3.node was compiled against NODE_MODULE_VERSION 137. This version requires NODE_MODULE_VERSION 127.\\n at native-loader:1\\n');",
+      'process.exitCode=1;',
+    ].join(''));
+    const result = runFixture(packageRoot, []);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('installed using a different Node version');
+    expect(result.stderr).toContain('npm install -g aiden-runtime@latest');
+    expect(result.stderr).not.toContain('native-loader');
+  });
+
+  it('forwards an intentional command failure without inventing a startup diagnostic', () => {
+    const packageRoot = fixture("process.stdout.write('doctor found a configuration problem\\n');process.exitCode=1;");
+    const result = runFixture(packageRoot, ['doctor']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('configuration problem');
+    expect(result.stderr).toBe('');
+  });
+
+  it('preserves unknown diagnostics only when debug output is explicitly enabled', () => {
+    const packageRoot = fixture("process.stderr.write('Error: unusual startup failure\\n at hidden-detail:1\\n');process.exitCode=1;");
+    const normal = runFixture(packageRoot, []);
+    expect(normal.stderr).toMatch(/Diagnostic:/);
+    expect(normal.stderr).not.toContain('hidden-detail');
+
+    const driver = [
+      `const bootstrap=require(${JSON.stringify(bootstrap)});`,
+      `bootstrap.runBootstrap({packageRoot:${JSON.stringify(packageRoot)},args:[],env:{...process.env,AIDEN_BOOTSTRAP_SKIP_UPDATE:'1',AIDEN_NO_UPDATE_CHECK:'1',AIDEN_BOOTSTRAP_DEBUG:'1'}})`,
+      `.then(code=>{process.exitCode=code});`,
+    ].join('');
+    const debug = spawnSync(supportedNode, ['-e', driver], { encoding: 'utf8', timeout: 20_000 });
+    expect(debug.stderr).toContain('hidden-detail');
+  });
+});

--- a/tests/v4/bootstrap/processHandoff.test.ts
+++ b/tests/v4/bootstrap/processHandoff.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -44,7 +44,7 @@ describe('bootstrap process handoff', () => {
     expect(result.status).toBe(7);
     expect(JSON.parse(result.stdout)).toEqual({
       args: ['--flag', 'value with spaces', '--', 'literal'],
-      cwd: unrelated,
+      cwd: realpathSync.native(unrelated),
     });
   });
 

--- a/tests/v4/bootstrap/updatePolicy.test.ts
+++ b/tests/v4/bootstrap/updatePolicy.test.ts
@@ -1,0 +1,208 @@
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { createRequire } from 'node:module';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(__dirname, '../../..');
+const bootstrap = require(path.join(root, 'bin', 'aiden-bootstrap.cjs'));
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+async function registry(body: unknown, delayMs = 0): Promise<string> {
+  const server = createServer((_request, response) => {
+    setTimeout(() => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(typeof body === 'string' ? body : JSON.stringify(body));
+    }, delayMs);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return `http://127.0.0.1:${address.port}/aiden-runtime`;
+}
+
+function stateFile(): string {
+  return path.join(mkdtempSync(path.join(tmpdir(), 'aiden-update-state-')), '.update_check.json');
+}
+
+describe('bootstrap update checks', () => {
+  it('caches stable and beta tags and reuses a fresh result', async () => {
+    const file = stateFile();
+    const url = await registry({
+      'dist-tags': { latest: '4.19.1', beta: '4.20.0-beta.1' },
+      versions: { '4.19.1': {}, '4.20.0-beta.1': {} },
+    });
+    const first = await bootstrap.checkRegistry({
+      stateFile: file,
+      installed: '4.19.0',
+      env: {},
+      force: true,
+      registryUrl: url,
+      now: () => 10_000,
+    });
+    expect(first).toMatchObject({ checked: true, offline: false, candidate: '4.19.1' });
+    const written = JSON.parse(readFileSync(file, 'utf8'));
+    expect(written).toMatchObject({ installed: '4.19.0', latest: '4.19.1', beta: '4.20.0-beta.1' });
+
+    const cached = await bootstrap.checkRegistry({
+      stateFile: file,
+      installed: '4.19.0',
+      env: {},
+      registryUrl: 'http://127.0.0.1:1/unreachable',
+      now: () => 10_001,
+    });
+    expect(cached).toMatchObject({ checked: false, offline: false, candidate: '4.19.1' });
+  });
+
+  it('fails open for invalid JSON, offline, TLS-like, and timeout failures', async () => {
+    const invalidUrl = await registry('{');
+    const invalid = await bootstrap.checkRegistry({
+      stateFile: stateFile(), installed: '4.19.0', env: {}, force: true, registryUrl: invalidUrl,
+    });
+    expect(invalid).toMatchObject({ candidate: null, offline: true });
+
+    const offline = await bootstrap.checkRegistry({
+      stateFile: stateFile(), installed: '4.19.0', env: {}, force: true,
+      registryUrl: 'http://127.0.0.1:1/unreachable', timeoutMs: 100,
+    });
+    expect(offline).toMatchObject({ candidate: null, offline: true });
+
+    const slowUrl = await registry({ 'dist-tags': { latest: '4.19.1' } }, 250);
+    const started = Date.now();
+    const timedOut = await bootstrap.checkRegistry({
+      stateFile: stateFile(), installed: '4.19.0', env: {}, force: true,
+      registryUrl: slowUrl, timeoutMs: 30,
+    });
+    expect(timedOut).toMatchObject({ candidate: null, offline: true });
+    expect(Date.now() - started).toBeLessThan(200);
+
+    const trickleServer = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      const timer = setInterval(() => response.write(' '), 10);
+      response.once('close', () => clearInterval(timer));
+    });
+    servers.push(trickleServer);
+    await new Promise<void>((resolve) => trickleServer.listen(0, '127.0.0.1', resolve));
+    const trickleAddress = trickleServer.address();
+    if (!trickleAddress || typeof trickleAddress === 'string') throw new Error('missing trickle server address');
+    const trickleStarted = Date.now();
+    const trickled = await bootstrap.checkRegistry({
+      stateFile: stateFile(), installed: '4.19.0', env: {}, force: true,
+      registryUrl: `http://127.0.0.1:${trickleAddress.port}/aiden-runtime`, timeoutMs: 30,
+    });
+    expect(trickled).toMatchObject({ candidate: null, offline: true });
+    expect(Date.now() - trickleStarted).toBeLessThan(200);
+
+    const cachedFailureFile = stateFile();
+    const firstFailure = await bootstrap.checkRegistry({
+      stateFile: cachedFailureFile, installed: '4.19.0', env: {}, force: false,
+      registryUrl: 'http://127.0.0.1:1/unreachable', timeoutMs: 30, now: () => 40_000,
+    });
+    expect(firstFailure).toMatchObject({ checked: true, offline: true });
+    const cachedFailure = await bootstrap.checkRegistry({
+      stateFile: cachedFailureFile, installed: '4.19.0', env: {}, force: false,
+      registryUrl: 'http://127.0.0.1:1/unreachable', timeoutMs: 30, now: () => 40_001,
+    });
+    expect(cachedFailure).toMatchObject({ checked: false, offline: false, candidate: null });
+  });
+
+  it('honours disabled checks, cache expiry, corrupt state, skip, and remind-after', async () => {
+    const disabledFile = stateFile();
+    writeFileSync(disabledFile, JSON.stringify({ enabled: false, channel: 'stable' }));
+    const disabled = await bootstrap.checkRegistry({
+      stateFile: disabledFile, installed: '4.19.0', env: {}, force: true,
+      registryUrl: 'http://127.0.0.1:1/unreachable',
+    });
+    expect(disabled).toMatchObject({ checked: false, candidate: null, offline: false });
+
+    const corruptFile = stateFile();
+    writeFileSync(corruptFile, '{', 'utf8');
+    const url = await registry({ 'dist-tags': { latest: '4.19.1' } });
+    const recovered = await bootstrap.checkRegistry({
+      stateFile: corruptFile, installed: '4.19.0', env: {}, force: true, registryUrl: url,
+    });
+    expect(recovered.candidate).toBe('4.19.1');
+    expect(() => JSON.parse(readFileSync(corruptFile, 'utf8'))).not.toThrow();
+
+    const envDisabled = await bootstrap.checkRegistry({
+      stateFile: stateFile(), installed: '4.19.0', env: { AIDEN_UPDATE_CHANNEL: 'off' }, force: true,
+      registryUrl: 'http://127.0.0.1:1/unreachable',
+    });
+    expect(envDisabled).toMatchObject({ checked: false, candidate: null, offline: false });
+  });
+});
+
+describe('bootstrap update prompt', () => {
+  function ttyPair() {
+    const input = new PassThrough() as PassThrough & { isTTY: boolean; isRaw: boolean; setRawMode(value: boolean): void };
+    input.isTTY = true;
+    input.isRaw = false;
+    input.setRawMode = (value: boolean) => { input.isRaw = value; };
+    const output = new PassThrough() as PassThrough & { isTTY: boolean };
+    output.isTTY = true;
+    let text = '';
+    output.on('data', (chunk) => { text += chunk.toString(); });
+    return { input, output, text: () => text };
+  }
+
+  for (const [key, expected] of [['u', 'update'], ['U', 'update'], ['l', 'later'], ['L', 'later'], ['s', 'skip'], ['S', 'skip']] as const) {
+    it(`accepts ${key} as ${expected}`, async () => {
+      const pair = ttyPair();
+      const choice = bootstrap.promptForUpdate({
+        stdin: pair.input,
+        stdout: pair.output,
+        installed: '4.19.0',
+        candidate: '4.19.1',
+        timeoutMs: 1_000,
+      });
+      pair.input.write(key);
+      pair.input.write('u');
+      await expect(choice).resolves.toBe(expected);
+      expect(pair.text().match(/A new Aiden update is available/g)).toHaveLength(1);
+      expect(pair.input.listenerCount('data')).toBe(0);
+      expect(pair.input.isRaw).toBe(false);
+    });
+  }
+
+  it('defaults to later on Enter, closed input, timeout, and non-TTY use', async () => {
+    const enter = ttyPair();
+    const entered = bootstrap.promptForUpdate({ stdin: enter.input, stdout: enter.output, installed: '4.19.0', candidate: '4.19.1' });
+    enter.input.write('\r');
+    await expect(entered).resolves.toBe('later');
+
+    const closed = ttyPair();
+    const closedChoice = bootstrap.promptForUpdate({ stdin: closed.input, stdout: closed.output, installed: '4.19.0', candidate: '4.19.1', timeoutMs: 20 });
+    closed.input.end();
+    await expect(closedChoice).resolves.toBe('later');
+
+    const nonTtyInput = new PassThrough() as PassThrough & { isTTY: boolean };
+    nonTtyInput.isTTY = false;
+    const nonTtyOutput = new PassThrough() as PassThrough & { isTTY: boolean };
+    nonTtyOutput.isTTY = false;
+    await expect(bootstrap.promptForUpdate({ stdin: nonTtyInput, stdout: nonTtyOutput, installed: '4.19.0', candidate: '4.19.1' })).resolves.toBe('later');
+  });
+
+  it('treats Ctrl+C as cancellation and restores terminal input', async () => {
+    const pair = ttyPair();
+    const choice = bootstrap.promptForUpdate({
+      stdin: pair.input,
+      stdout: pair.output,
+      installed: '4.19.0',
+      candidate: '4.19.1',
+      timeoutMs: 1_000,
+    });
+    pair.input.write('\u0003');
+    await expect(choice).resolves.toBe('cancel');
+    expect(pair.input.isRaw).toBe(false);
+    expect(pair.input.listenerCount('data')).toBe(0);
+  });
+});

--- a/tests/v4/bootstrap/updater.test.ts
+++ b/tests/v4/bootstrap/updater.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { PassThrough } from 'node:stream';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(__dirname, '../../..');
+const updater = require(path.join(root, 'bin', 'aiden-updater.cjs'));
+
+function state(overrides: Record<string, unknown> = {}) {
+  return {
+    targetVersion: '4.19.1',
+    previousVersion: '4.19.0',
+    packageName: 'aiden-runtime',
+    nodeExecutable: process.execPath,
+    npmCli: process.execPath,
+    prefix: path.join(root, 'tmp prefix'),
+    globalRoot: path.join(root, 'tmp prefix', 'node_modules'),
+    packagePath: path.join(root, 'tmp prefix', 'node_modules', 'aiden-runtime'),
+    tty: false,
+    color: false,
+    ...overrides,
+  };
+}
+
+function outputSink() {
+  const output = new PassThrough();
+  let text = '';
+  output.on('data', (chunk) => { text += chunk.toString(); });
+  return { output, text: () => text };
+}
+
+describe('external update helper', () => {
+  it('requires the permanent bootstrap for new releases but can verify a restored 4.19.0 layout', () => {
+    const packagePath = mkdtempSync(path.join(tmpdir(), 'aiden-updater-files-'));
+    mkdirSync(path.join(packagePath, 'dist', 'cli', 'v4'), { recursive: true });
+    mkdirSync(path.join(packagePath, 'dist', 'core'), { recursive: true });
+    writeFileSync(path.join(packagePath, 'dist', 'cli', 'v4', 'aidenCLI.js'), '');
+    writeFileSync(path.join(packagePath, 'dist', 'core', 'version.js'), '');
+    writeFileSync(path.join(packagePath, 'package.json'), JSON.stringify({ name: 'aiden-runtime', version: '4.19.0' }));
+    expect(updater.verifyFiles(state({ packagePath, targetVersion: '4.19.0' }))).toMatchObject({ ok: true });
+    writeFileSync(path.join(packagePath, 'package.json'), JSON.stringify({ name: 'aiden-runtime', version: '4.19.1' }));
+    expect(updater.verifyFiles(state({ packagePath, targetVersion: '4.19.1' }))).toMatchObject({
+      ok: false,
+      kind: 'file-verification',
+    });
+  });
+
+  it('rejects unsafe versions before invoking the package manager', async () => {
+    const install = vi.fn();
+    const sink = outputSink();
+    const code = await updater.runUpdater(state({ targetVersion: '4.19.1 & whoami' }), {
+      output: sink.output,
+      installVersion: install,
+    });
+    expect(code).toBe(2);
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it('installs an exact version, verifies it, and settles one receipt', async () => {
+    const install = vi.fn(async () => ({ ok: true }));
+    const verify = vi.fn(async () => ({ ok: true }));
+    const sink = outputSink();
+    const code = await updater.runUpdater(state(), {
+      output: sink.output,
+      installVersion: install,
+      verifyInstalledPackage: verify,
+    });
+    expect(code).toBe(0);
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(install.mock.calls[0][1]).toBe('4.19.1');
+    expect(verify).toHaveBeenCalledTimes(1);
+    expect(sink.text().match(/Aiden was updated successfully/g)).toHaveLength(1);
+    expect(sink.text()).toContain('Restart Aiden');
+    expect(sink.text()).not.toContain('\x1b');
+  });
+
+  it('attempts a verified rollback and does not claim target success when installation fails', async () => {
+    const install = vi.fn()
+      .mockResolvedValueOnce({ ok: false, kind: 'network' })
+      .mockResolvedValueOnce({ ok: true });
+    const sink = outputSink();
+    const code = await updater.runUpdater(state(), {
+      output: sink.output,
+      installVersion: install,
+      verifyInstalledPackage: vi.fn(async () => ({ ok: true })),
+    });
+    expect(code).toBe(1);
+    expect(install).toHaveBeenNthCalledWith(2, expect.anything(), '4.19.0', { signal: expect.any(AbortSignal) });
+    expect(sink.text()).toContain('Installation failed (network)');
+    expect(sink.text()).toContain('4.19.0 was restored and verified');
+    expect(sink.text()).not.toContain('Aiden was updated successfully');
+  });
+
+  it('reports repair required when installation and rollback both fail', async () => {
+    const sink = outputSink();
+    const code = await updater.runUpdater(state(), {
+      output: sink.output,
+      installVersion: vi.fn(async () => ({ ok: false, kind: 'package-manager' })),
+      verifyInstalledPackage: vi.fn(async () => ({ ok: true })),
+    });
+    expect(code).toBe(1);
+    expect(sink.text()).toContain('The previous version could not be verified.');
+    expect(sink.text()).toContain('npm install -g aiden-runtime@latest');
+    expect(sink.text()).not.toContain('Aiden was updated successfully');
+  });
+
+  it('attempts a verified rollback after target verification fails', async () => {
+    const install = vi.fn(async () => ({ ok: true }));
+    const verify = vi.fn()
+      .mockResolvedValueOnce({ ok: false, kind: 'native-verification' })
+      .mockResolvedValueOnce({ ok: true });
+    const sink = outputSink();
+    const code = await updater.runUpdater(state(), {
+      output: sink.output,
+      installVersion: install,
+      verifyInstalledPackage: verify,
+    });
+    expect(code).toBe(1);
+    expect(install).toHaveBeenNthCalledWith(1, expect.anything(), '4.19.1', { signal: expect.any(AbortSignal) });
+    expect(install).toHaveBeenNthCalledWith(2, expect.anything(), '4.19.0', { signal: expect.any(AbortSignal) });
+    expect(sink.text()).toContain('4.19.0 was restored and verified');
+    expect(sink.text()).not.toContain('Aiden was updated successfully');
+  });
+
+  it('uses one shared animation timer and restores the cursor on settlement', () => {
+    vi.useFakeTimers();
+    const sink = outputSink();
+    Object.assign(sink.output, { isTTY: true });
+    const renderer = updater.createRenderer({ output: sink.output, tty: true, color: true });
+    renderer.start('Installing package');
+    expect(renderer.hasTimer()).toBe(true);
+    vi.advanceTimersByTime(400);
+    renderer.settle('Installation complete');
+    expect(renderer.hasTimer()).toBe(false);
+    renderer.stop();
+    expect(sink.text()).toContain('\x1b[?25h');
+    vi.useRealTimers();
+  });
+
+  it('uses stable text without ANSI or duplicate settlement when color is disabled', () => {
+    const sink = outputSink();
+    Object.assign(sink.output, { isTTY: true });
+    const renderer = updater.createRenderer({ output: sink.output, tty: true, color: false });
+    renderer.start('Verifying installation');
+    renderer.settle('Verification complete');
+    renderer.settle('Verification complete');
+    renderer.stop();
+    expect(sink.text()).not.toContain('\x1b');
+    expect(sink.text().match(/Verification complete/g)).toHaveLength(1);
+    expect(renderer.hasTimer()).toBe(false);
+  });
+});

--- a/tests/v4/bootstrap/updaterInvocation.test.ts
+++ b/tests/v4/bootstrap/updaterInvocation.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(__dirname, '../../..');
+const updater = require(path.join(root, 'bin', 'aiden-updater.cjs'));
+
+describe('package-manager invocation', () => {
+  it('passes an exact package spec and a prefix containing spaces as separate arguments', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'aiden npm fixture '));
+    const log = path.join(dir, 'args.json');
+    const npmCli = path.join(dir, 'fake npm cli.js');
+    writeFileSync(npmCli, `require('node:fs').writeFileSync(process.env.ARG_LOG, JSON.stringify({ args: process.argv.slice(2), path: process.env.Path || process.env.PATH }));`, 'utf8');
+    const prefix = path.join(dir, 'isolated prefix with spaces');
+    const result = await updater.installVersion({
+      nodeExecutable: process.execPath,
+      npmCli,
+      prefix,
+      packageName: 'aiden-runtime',
+    }, '4.19.1', { signal: new AbortController().signal, env: { ...process.env, ARG_LOG: log } });
+    expect(result).toMatchObject({ ok: true });
+    const invocation = JSON.parse(readFileSync(log, 'utf8'));
+    expect(invocation.args).toEqual([
+      'install',
+      '--global',
+      '--prefix',
+      prefix,
+      'aiden-runtime@4.19.1',
+      '--no-audit',
+      '--no-fund',
+    ]);
+    expect(invocation.path.split(path.delimiter)[0]).toBe(path.dirname(process.execPath));
+  });
+
+  it('rejects an injected package version before a child process starts', async () => {
+    const result = await updater.installVersion({
+      nodeExecutable: process.execPath,
+      npmCli: path.join(tmpdir(), 'should-not-run.js'),
+      prefix: tmpdir(),
+      packageName: 'aiden-runtime',
+    }, '4.19.1 && whoami');
+    expect(result).toEqual({ ok: false, kind: 'invalid-version' });
+  });
+
+  it('terminates a timed-out child without leaving its timer active', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'aiden child cleanup '));
+    const script = path.join(dir, 'wait.js');
+    writeFileSync(script, 'setInterval(() => {}, 1000);', 'utf8');
+    const started = Date.now();
+    const result = await updater.runChild(process.execPath, [script], { timeoutMs: 100 });
+    expect(result).toMatchObject({ code: -1, timeout: true });
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+});

--- a/tests/v4/cli/entrypointContract.test.ts
+++ b/tests/v4/cli/entrypointContract.test.ts
@@ -18,9 +18,12 @@ describe('CLI entrypoint contract', () => {
       files: string[];
     };
     expect(manifest.bin).toEqual({
-      aiden: './dist/cli/v4/aidenCLI.js',
-      'aiden-runtime': './dist/cli/v4/aidenCLI.js',
+      aiden: './bin/aiden-bootstrap.cjs',
+      'aiden-runtime': './bin/aiden-bootstrap.cjs',
     });
+    expect(manifest.files).toContain('bin/aiden-bootstrap.cjs');
+    expect(manifest.files).toContain('bin/aiden-updater.cjs');
+    expect(manifest.files).not.toContain('bin/');
     expect(manifest.files).not.toContain('dist-bundle/');
     expect(manifest.files).not.toContain('packages/aiden-os/');
     expect(manifest.files).not.toContain('release-notes-v4.16.0.md');

--- a/tests/v4/update/checkUpdate.test.ts
+++ b/tests/v4/update/checkUpdate.test.ts
@@ -176,4 +176,40 @@ describe('checkForUpdate', () => {
     expect(status.failureBackoffActive).toBe(true);
     expect(status.skipped).toBe(false);
   });
+
+  it('preserves bootstrap update preferences when the legacy registry cache refreshes', async () => {
+    const paths = resolveAidenPaths({ rootOverride: tmpRoot });
+    await ensureAidenDirsExist(paths);
+    const cacheFile = path.join(tmpRoot, '.update_check.json');
+    await fs.writeFile(
+      cacheFile,
+      JSON.stringify({
+        ts: 1,
+        latest: '4.19.0',
+        beta: '4.20.0-beta.1',
+        installed: '4.19.0',
+        enabled: true,
+        channel: 'beta',
+        remindAfter: 50_000,
+      }),
+    );
+
+    await checkForUpdate({
+      paths,
+      installedVersion: '4.19.0',
+      cacheTtlMs: 1,
+      now: () => 10_000,
+      fetchImpl: async () => ({ version: '4.19.1' }),
+    });
+
+    const refreshed = JSON.parse(await fs.readFile(cacheFile, 'utf8'));
+    expect(refreshed).toMatchObject({
+      latest: '4.19.1',
+      beta: '4.20.0-beta.1',
+      installed: '4.19.0',
+      enabled: true,
+      channel: 'beta',
+      remindAfter: 50_000,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- add a dependency-light bootstrap before the full CLI and native modules
- classify incomplete installs, unsupported Node versions, native-load failures, and Node ABI mismatches with actionable repair guidance
- add cached stable/beta/off update checks with Update, Later, and per-version Skip choices
- add a detached updater that targets the owning npm prefix, verifies the installed package and native runtime, and verifies rollback before reporting restoration
- preserve Aiden data outside the replaceable npm package
- prepare runtime-only v4.19.1 metadata and release notes

## Root cause

The public commands previously entered the full runtime directly. A partial global install or native ABI mismatch could therefore fail before Aiden could explain or repair the installation. The in-session update path was also unavailable when startup itself was broken.

## Scope

- `aiden-runtime` only
- supported runtimes: Node 20 and Node 22
- package version: 4.19.1
- obsolete workspace launcher remains 4.18.0 and outside public release scope
- no publication, tag, or release created

## Validation

- focused bootstrap/update/entrypoint tests: 51 passed, 2 skipped
- supported-runtime choice and update PTY tests: 4 passed
- updater and invocation tests: 11 passed
- legacy update compatibility matrix: 74 passed
- Windows Node 20 non-network suite: passed, exit 0
- Windows Node 22 non-network suite: 7,626 passed, 48 skipped
- Windows Node 20 PTY suite: 47 passed
- Windows Node 22 PTY suite: 47 passed
- Node 20 integration: 37 passed, 9 credential-dependent skipped
- Node 22 integration: 37 passed, 9 credential-dependent skipped
- typecheck: passed
- production build: passed
- package inspection and isolated Node 20/22 installs: passed
- both installed commands report 4.19.1
- native runtime load, startup, `/quit`, process cleanup, cross-Node repair guidance, and unsupported-Node guidance: passed

## Package inspection

- tarball: `aiden-runtime-4.19.1.tgz`
- packed size: 2,416,889 bytes
- unpacked size: 9,210,247 bytes
- files: 1,078
- SHA-256: `6FC025214E214D286FE9F1F84101625F2CDCF3302724082E9C6E4ED638C0521B`
- protected local notes, credentials, logs, databases, fixtures, and temporary files are excluded

## Remaining acceptance

A final human visual check in Windows PowerShell/Windows Terminal remains required before merge. Automated process-level and PTY acceptance is green on Node 20 and Node 22.
## Cross-platform path correction

The first CI pass exposed path-alias assumptions in one process-handoff test. macOS can report `/private/var` for `/var`, and Windows can report a DOS 8.3 path for the same long directory. The test now compares canonical filesystem identity while preserving exact argument and exit-code assertions. Production code was unchanged. The replacement matrix is green.
## Final CI

- Windows Node 20 non-PTY: 7,626 passed, 47 skipped
- Windows Node 20 PTY: 47 passed
- Windows Node 22 non-PTY: 7,626 passed, 47 skipped
- Windows Node 22 PTY: 47 passed
- Ubuntu Node 20/22: passed
- macOS Node 20/22: passed
- security, CodeQL, CLA, and aggregate build/type gate: passed