### PR TITLE
release: v4.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-runtime",
-  "version": "4.19.1",
+  "version": "4.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-runtime",
-      "version": "4.19.1",
+      "version": "4.20.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-runtime",
-  "version": "4.19.1",
+  "version": "4.20.0",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
+++ b/tests/v4/worker/readOnlyRepositoryWorker.e2e.test.ts
@@ -240,5 +240,5 @@ describe('read-only repository Worker durable dispatcher path', () => {
     expect(reopened.proof.getVerdict(parent.jobId)).toBeNull();
     expect(await readFile(path.join(root, 'source.ts'), 'utf8')).toBe(sourceBytes);
     reopenedDb.close();
-  }, 45_000);
+  }, 90_000);
 });


### PR DESCRIPTION
## Summary\n\nPrepares the stable iden-runtime@4.20.0 release after the fully validated v4.20 implementation merged through PR #139.\n\n## Changes\n\n- updates the root runtime version to 4.20.0\n- updates the matching root lockfile metadata\n- extends one existing Worker dispatcher end-to-end test's local hosted-runner budget after isolated Node 20 and Node 22 stress proved correct execution and cleanup\n- makes no production-code, dependency, licensing, or documentation changes\n\n## Validation\n\n- exact Worker dispatcher test: Node 20 20/20, Node 22 20/20\n- complete Worker matrix: 123/123\n- SQLite-heavy neighboring matrix: 97/97\n- typecheck passed\n- production build passed\n- diff check passed\n\n## Release guard\n\n- public package remains iden-runtime only\n- protected local release notes remain untracked and excluded\n- publication, tag, and GitHub Release remain pending exact-artifact certification\n- author and committer remain Shiva Deore