### PR TITLE
fix: custom endpoint without custom-default model failing

### DIFF
--- a/cli/v4/setupWizard.ts
+++ b/cli/v4/setupWizard.ts
@@ -1092,13 +1092,7 @@ async function runSetupWizardWithLedger(opts: SetupOptions): Promise<SetupResult
   // when the live endpoint is unreachable.
 
   // Step 2: credentials (moved up from old step 3 for key/subscription).
-  //
-  // `custom` keeps the legacy "model id first, then baseUrl + apiKey"
-  // order — it has no live-fetch endpoint we could call with the key
-  // anyway, so the reorder bought nothing there. Existing test
-  // fixtures provide inputs in legacy order; preserving custom's
-  // order keeps them green.
-  if (provider.kind === 'key' || provider.kind === 'subscription' || provider.kind === 'local') {
+  if (provider.kind === 'key' || provider.kind === 'subscription' || provider.kind === 'local' || provider.kind === 'custom') {
     display.write(stepHeader(2));
   }
   let apiKey: string | undefined;
@@ -1163,8 +1157,15 @@ async function runSetupWizardWithLedger(opts: SetupOptions): Promise<SetupResult
       await persistCurrentCredential();
     }
   }
-  // provider.kind === 'custom' — defer credential prompts until AFTER
-  // the model picker below.
+  if (provider.kind === 'custom') {
+    const burl = await prompts.input('Base URL (e.g. https://api.example.com/v1)');
+    if (burl === BACK) continue outer;
+    baseUrl = burl;
+    const akey = await collectRequiredCredential('API key');
+    if (akey === BACK) continue outer;
+    apiKey = akey;
+    await persistCurrentCredential();
+  }
 
   display.write(stepHeader(3));
   // Step 3: live model fetch + pick.
@@ -1251,7 +1252,7 @@ async function runSetupWizardWithLedger(opts: SetupOptions): Promise<SetupResult
         modelId = ans;
         modelVerification = 'unverified';
       }
-    } else if (fetchResult.models.length === 1 && fetchResult.source === 'fallback') {
+    } else if (fetchResult.models.length === 1) {
       modelId = fetchResult.models[0].id;
       modelVerification = fetchResult.source === 'live'
         ? 'live'
@@ -1332,18 +1333,6 @@ async function runSetupWizardWithLedger(opts: SetupOptions): Promise<SetupResult
         }
       }
     }
-  }
-
-  // Custom-provider credentials: deferred from step 2 above so the
-  // legacy input order (model → baseUrl → apiKey) is preserved.
-  if (provider.kind === 'custom') {
-    const burl = await prompts.input('Base URL (e.g. https://api.example.com/v1)');
-    if (burl === BACK) continue outer;
-    baseUrl = burl;
-    const akey = await collectRequiredCredential('API key');
-    if (akey === BACK) continue outer;
-    apiKey = akey;
-    await persistCurrentCredential();
   }
 
   // Step 3.5: validate the API key against the provider endpoint.

--- a/core/v4/providers/modelFetch.ts
+++ b/core/v4/providers/modelFetch.ts
@@ -400,6 +400,16 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
       case 'ollama':
         raws = await fetchLocalRuntimeModels(opts.baseUrl ?? 'http://localhost:11434', { timeoutMs, fetchImpl });
         break;
+      case 'custom_openai': {
+        const root = (opts.baseUrl ?? '').replace(/\/+$/, '');
+        if (!root || !apiKey) return fallbackFor('custom_openai', 'no base URL or API key');
+        const { response, body } = await fetchJson('custom_openai', `${root}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        }, timeoutMs, fetchImpl);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        raws = Array.isArray(body) ? body as RawModel[] : ((body as { data?: RawModel[] }).data ?? []);
+        break;
+      }
       default:
         // Every other provider — together, nvidia, deepseek, mistral, custom,
         // chatgpt-plus, etc. — uses the curated catalog.

--- a/tests/v4/cli/setupWizard.test.ts
+++ b/tests/v4/cli/setupWizard.test.ts
@@ -357,8 +357,7 @@ describe('SetupWizard', () => {
       display,
       prompts: scriptedPrompts({
         choose: [customIdx],
-        input: ['', 'https://api.example.com/v1', 'custom-key'],
-        // first input is the model id (provider has no defaultModel)
+        input: ['https://api.example.com/v1', 'custom-key', ''],
       }),
       skipValidation: true,
     });


### PR DESCRIPTION
Fixes #142

custom_openai had no case in fetchModels, so it fell through to the curated catalog and returned the placeholder custom-default, which then failed verification as a model not in the catalog.
  
  - Collect baseUrl + API key before the model picker (the picker needs both to query the endpoint)
  - Add a custom_openai live-fetch case, accepting {data:[...]} and bare-array /models envelopes
  - Auto-select a single live model, not just a single fallback one

  Known gap: an unreachable endpoint still falls back to custom-default and fails the same way.